### PR TITLE
Update Github Actions Env var setting to avoid deprecation

### DIFF
--- a/.github/build_vars.sh
+++ b/.github/build_vars.sh
@@ -20,13 +20,13 @@ set_value() {
   varname=${1}
   if [ ! -z "${!varname}" ]; then
     echo "Setting $varname"
-    echo "::set-env name=${varname}::${!varname}"
+    echo "${varname}=${!varname}" >> $GITHUB_ENV
   fi
 }
 
 set_name() {
   varname=${1}
-  echo "::set-env name=BRANCH_SPECIFIC_VARNAME_$varname::${branch_name//-/_}_$varname"
+  echo "BRANCH_SPECIFIC_VARNAME_$varname=${branch_name//-/_}_$varname" >> $GITHUB_ENV
 }
 
 action=${1}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: set branch_name
-        run: echo "::set-env name=branch_name::${GITHUB_REF#refs/heads/}"
+        run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
       - name: Check branch name is a legal serverless stage name
         run: |
           if [[ ! $branch_name =~ ^[a-zA-Z][a-zA-Z0-9-]*$ ]] || [[ $branch_name -gt 128 ]]; then

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: set branch_name
-        run: echo "::set-env name=branch_name::${{ github.event.ref }}"
+        run: echo "branch_name=${{ github.event.ref }}" >> $GITHUB_ENV
       - uses: actions/checkout@v1
       - name: set branch specific variable names
         run: ./.github/build_vars.sh set_names


### PR DESCRIPTION
This change is being merged in from our [upstream quickstart app](https://github.com/CMSgov/macpro-quickstart-serverless/pull/95). 

Github Actions [depreciated the way they let you set environment variables](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) in your scripts due to a security vulnerability. 

This moves us to the new, more secure system. 