### PR TITLE
Add vscode settings to version control

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "eslint.workingDirectories": [
+    "services/app-web",
+    "services/app-api"
+    ]
+}


### PR DESCRIPTION
## Summary
These settings are necessary for vscode eslint to work well with the monorepo so I think its worth adding to vc. 

Any service that should show eslint warnings should be included here, thought we could start with web and api. 

## Testing guidance
Turn a type to `any` in app-web and the warning should appear inline
