### PR TITLE
Add Tabs to Storybook

### DIFF
--- a/services/app-web/src/components/Tabs/TabPanel.tsx
+++ b/services/app-web/src/components/Tabs/TabPanel.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import classnames from 'classnames'
+
+import styles from './Tabs.module.scss'
+
+type TabPanelProps = {
+    id: string
+    tabName: string
+    children: React.ReactNode
+    isActive?: boolean
+}
+
+/**
+ * TabPanel is a compound component. TabPanel MUST BE a direct child of Tabs.
+ * The `isActive` prop isn't passed in declaratively. `isActive` is passed
+ * from the Tabs render from the React.Children cloneElement.
+ */
+export const TabPanel = ({
+    id,
+    tabName,
+    isActive,
+    children,
+}: TabPanelProps): React.ReactElement => {
+    if (isActive) {
+        return (
+            <div
+                id={id}
+                className={styles['easi-tabs__tab-panel']}
+                role="tabpanel"
+                data-tabname={tabName}
+            >
+                {children}
+            </div>
+        )
+    }
+    return (
+        <div
+            id={id}
+            className={classnames(
+                styles['easi-tabs__tab-panel'],
+                styles['easi-only-print']
+            )}
+            data-tabname={tabName}
+        >
+            {children}
+        </div>
+    )
+}

--- a/services/app-web/src/components/Tabs/Tabs.module.scss
+++ b/services/app-web/src/components/Tabs/Tabs.module.scss
@@ -1,0 +1,82 @@
+@import '../../styles/uswdsImports.scss';
+@import '../../styles/custom';
+
+.easi-only-print {
+    display: none;
+}
+
+.easi-tabs {
+    overflow: hidden;
+
+    &__navigation {
+        display: flex;
+        justify-content: space-between;
+        position: relative;
+        border-bottom: 1px solid $theme-color-base-lighter;
+    }
+
+    &__tab-list {
+        display: inline-block;
+        padding: 0;
+        margin: 0 0 -1px;
+        list-style-type: none;
+        white-space: nowrap;
+    }
+
+    &__tab {
+        display: inline-flex;
+        align-items: center;
+        height: 54px;
+        flex-shrink: 0;
+        position: relative;
+        border: 1px solid $theme-color-base-lighter;
+        border-right: 1px solid $theme-color-base-lighter;
+
+        &:after {
+            background-color: $theme-color-primary;
+            content: '';
+            height: 4px;
+            left: -1px;
+            opacity: 0;
+            position: absolute;
+            right: -1px;
+            top: -1px;
+            transform: scaleX(0);
+        }
+
+        &--selected {
+            border-bottom: 1px solid #fff;
+
+            .easi-tabs__tab-btn {
+                color: $theme-color-primary;
+            }
+
+            &:after {
+                opacity: 1;
+                transform: scaleX(1);
+            }
+        }
+    }
+
+    &__tab-btn {
+        height: 100%;
+        padding: 0;
+        background: none;
+        border: 0;
+        font-weight: bold;
+
+        &:hover {
+            cursor: pointer;
+        }
+    }
+
+    &__tab-text {
+        margin: 0 1.5em;
+    }
+
+    &__tab-panel {
+        overflow: auto;
+        border: 1px solid $theme-color-base-lighter;
+        border-top: none;
+    }
+}

--- a/services/app-web/src/components/Tabs/Tabs.stories.tsx
+++ b/services/app-web/src/components/Tabs/Tabs.stories.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { GridContainer, Grid } from '@trussworks/react-uswds'
+
+import { Tabs } from './Tabs'
+import { TabPanel } from './TabPanel'
+
+export default {
+    title: 'Components/Tabs',
+    component: Tabs,
+}
+
+const TabPanelWrapper: React.FC = ({ children }) => {
+    return <div style={{ margin: '10px', height: '500px' }}>{children}</div>
+}
+export const Default = (): React.ReactElement => {
+    return (
+        <Tabs>
+            <TabPanel id="Test-Pepperoni" tabName="Pepperoni">
+                <TabPanelWrapper>
+                    <h1>Pepperoni</h1>
+                    <p>
+                        Great Pizza! A tale of two pizzas. Pizza now and in the
+                        future.
+                    </p>
+                </TabPanelWrapper>
+            </TabPanel>
+            <TabPanel id="Test-Sausage" tabName="Sausage">
+                <TabPanelWrapper>
+                    <h1>Sausage</h1>
+                    <p>Great Pizza!</p>
+                </TabPanelWrapper>
+            </TabPanel>
+            <TabPanel id="Test-Mushroom" tabName="Mushroom">
+                <TabPanelWrapper>
+                    <h1>Mushroom</h1>
+                    <p>Great Pizza!</p>
+                </TabPanelWrapper>
+            </TabPanel>
+            <TabPanel id="Test-Bacon" tabName="Bacon">
+                <TabPanelWrapper>
+                    <h1>Bacon</h1>
+                    <p>Great Pizza!</p>
+                    <p>
+                        Great Pizza! A tale of two pizzas. Pizza now and in the
+                        future.
+                    </p>
+                    <p>
+                        Great Pizza! A tale of two pizzas. Pizza now and in the
+                        future.
+                    </p>
+                </TabPanelWrapper>
+            </TabPanel>
+        </Tabs>
+    )
+}
+
+export const CustomDefaultTab = (): React.ReactElement => {
+    return (
+        <Tabs defaultActiveTab="Tab 3">
+            <TabPanel id="Test-Tab-1" tabName="Tab 1">
+                <h1>Tab 1</h1>
+            </TabPanel>
+            <TabPanel id="Test-Tab-2" tabName="Tab 2">
+                <h1>Tab 2</h1>
+            </TabPanel>
+            <TabPanel id="Test-Tab-3" tabName="Tab 3">
+                <h1>Tab 3</h1>
+            </TabPanel>
+        </Tabs>
+    )
+}
+CustomDefaultTab.storyName = 'w/ custom default tab selected'

--- a/services/app-web/src/components/Tabs/Tabs.test.tsx
+++ b/services/app-web/src/components/Tabs/Tabs.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { Tabs } from './Tabs'
+import { TabPanel } from './TabPanel'
+
+describe('Tabs', () => {
+    it('renders without errors', async () => {
+        const { getByTestId } = render(
+            <Tabs>
+                <TabPanel id="Test-Pepperoni" tabName="Pepperoni">
+                    <h1>Pepperoni</h1>
+                </TabPanel>
+                <TabPanel id="Test-Sausage" tabName="Sausage">
+                    <h1>Sausage</h1>
+                </TabPanel>
+                <TabPanel id="Test-Mushroom" tabName="Mushroom">
+                    <h1>Mushroom</h1>
+                </TabPanel>
+                <TabPanel id="Test-Bacon" tabName="Bacon">
+                    <h1>Bacon</h1>
+                </TabPanel>
+            </Tabs>
+        )
+        expect(getByTestId('tabs')).toBeInTheDocument()
+    })
+})

--- a/services/app-web/src/components/Tabs/Tabs.tsx
+++ b/services/app-web/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react'
+import classnames from 'classnames'
+
+import styles from './Tabs.module.scss'
+
+type TabsProps = {
+    defaultActiveTab?: string
+    children: React.ReactElement[]
+}
+
+export const Tabs = ({
+    defaultActiveTab,
+    children,
+}: TabsProps): React.ReactElement => {
+    const tabs = children.map((child) => ({
+        id: child.props.id,
+        name: child.props.tabName,
+    }))
+    const [activeTab, setActiveTab] = useState(defaultActiveTab || tabs[0].name)
+
+    return (
+        <div className={styles['easi-tabs']} data-testid="tabs">
+            <div className={styles['easi-tabs__navigation']}>
+                <ul className={styles['easi-tabs__tab-list']} role="tablist">
+                    {tabs.map((tab) => (
+                        <li
+                            key={tab.id}
+                            className={classnames(styles['easi-tabs__tab'], {
+                                [styles['easi-tabs__tab--selected']]:
+                                    activeTab === tab.name,
+                            })}
+                            role="tab"
+                        >
+                            <button
+                                type="button"
+                                className={styles['easi-tabs__tab-btn']}
+                                // aria-selected={activeTab === tab.name}
+                                aria-controls={tab.id}
+                                onClick={() => setActiveTab(tab.name)}
+                            >
+                                <span className={styles['easi-tabs__tab-text']}>
+                                    {tab.name}
+                                </span>
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            </div>
+            {React.Children.map(children, (child) => {
+                if (child.props.tabName === activeTab) {
+                    return React.cloneElement(child, {
+                        isActive: true,
+                    })
+                }
+                return child
+            })}
+        </div>
+    )
+}
+
+export default Tabs


### PR DESCRIPTION
## Summary

- Add easi tabs to Storybook.
-  minimal code changes: had to add more return types to meet our TS standards. Also had to change how styles were loading since we don't use a sass loader yet and easi codebase does. But didn't alter anything else.
- The storybook example now has`TabsPanelWrapper` which we can play around with.
- Once this gets 👍 from design I will add unit tests.

### Screenshots
![Screen Shot 2021-02-19 at 1 38 32 PM](https://user-images.githubusercontent.com/10750442/108553055-c4b96c80-72b7-11eb-941b-45380476c44c.png)

## Testing guidance
- Visit tabs in storybook and play around
- Consider do we need any other story examples in storybook?  
- I did not add any design polish besides changing the color of the tabs when selected to be our variable for the blue color. 


