### PR TITLE
Fix async waitFor tests

### DIFF
--- a/services/app-web/src/pages/Auth/Auth.test.tsx
+++ b/services/app-web/src/pages/Auth/Auth.test.tsx
@@ -33,64 +33,105 @@ const failedAuthMock = {
     },
 }
 
+const successfulAuthMock = {
+    request: { query: GetCurrentUserDocument },
+    result: {
+        data: {
+            getCurrentUser: {
+                state: 'MN',
+                role: 'State User',
+                name: 'Bob it user',
+                email: 'bob@dmas.mn.gov',
+            },
+        },
+    },
+}
+
 describe('Auth', () => {
     describe('Cognito Login', () => {
-        const userLogin = (screen: Screen<typeof queries>) => {
+        const userLogin = async (screen: Screen<typeof queries>) => {
+            userClickByRole(screen, 'button', { name: 'Show Login Form' })
             const loginEmail = screen.getByTestId('loginEmail')
             const loginPassword = screen.getByTestId('loginPassword')
 
             userEvent.type(loginEmail, 'countdracula@muppets.com')
             userEvent.type(loginPassword, 'passwordABC')
+            await waitFor(() =>
+                expect(
+                    screen.getByRole('button', { name: 'Login' })
+                ).not.toBeDisabled()
+            )
             userClickByRole(screen, 'button', { name: 'Login' })
         }
-        it('displays login and signup forms when logged out', () => {
-            renderWithProviders(<Auth />)
 
-            expect(
-                screen.getByRole('form', { name: 'Login Form' })
-            ).toBeInTheDocument()
+        it('displays signup form when logged out', () => {
+            renderWithProviders(<Auth />, {
+                apolloProvider: { mocks: [failedAuthMock] },
+            })
 
             expect(
                 screen.getByRole('form', { name: 'Signup Form' })
-            ).toBeInTheDocument()
-            expect(
-                screen.getByRole('button', { name: /Login/i })
             ).toBeInTheDocument()
             expect(
                 screen.getByRole('button', { name: /SignUp/i })
             ).toBeInTheDocument()
         })
 
-        it('when login is successful, redirect to dashboard', async () => {
-            const loginSpy = jest
-                .spyOn(CognitoAuthApi, 'signOut')
-                .mockResolvedValue(null)
-
-            const history = createMemoryHistory()
-
+        it('show login button displays login form', () => {
             renderWithProviders(<Auth />, {
-                routerProvider: { routerProps: { history: history } },
+                apolloProvider: { mocks: [failedAuthMock] },
             })
 
-            userLogin(screen)
-            waitFor(() => expect(loginSpy).toHaveBeenCalledTimes(1))
-            waitFor(() => expect(history.location.pathname).toBe('/dashboard'))
+            expect(
+                screen.getByRole('form', { name: 'Signup Form' })
+            ).toBeInTheDocument()
+
+            userClickByRole(screen, 'button', { name: 'Show Login Form' })
+
+            expect(
+                screen.getByRole('form', { name: 'Login Form' })
+            ).toBeInTheDocument()
+            expect(
+                screen.getByRole('button', { name: /Login/i })
+            ).toBeInTheDocument()
         })
 
-        it('when login fails, stay on page and display error alert', () => {
-            const loginSpy = jest
-                .spyOn(CognitoAuthApi, 'signOut')
-                .mockRejectedValue('Error has occured')
-
+        it('when login is successful, redirect to dashboard', async () => {
+            const loginSpy = jest.spyOn(CognitoAuthApi, 'signIn')
             const history = createMemoryHistory()
 
             renderWithProviders(<Auth />, {
+                apolloProvider: { mocks: [failedAuthMock, successfulAuthMock] },
                 routerProvider: { routerProps: { history: history } },
             })
 
-            userLogin(screen)
-            waitFor(() => expect(loginSpy).toHaveBeenCalledTimes(1))
-            waitFor(() => expect(history.location.pathname).toBe('/auth'))
+            await userLogin(screen)
+
+            await waitFor(() => expect(loginSpy).toHaveBeenCalledTimes(1))
+            await waitFor(() =>
+                expect(history.location.pathname).toBe('/dashboard')
+            )
+        })
+
+        it('when login fails, stay on page and display error alert', async () => {
+            const loginSpy = jest.spyOn(CognitoAuthApi, 'signIn')
+            const history = createMemoryHistory()
+
+            renderWithProviders(<Auth />, {
+                apolloProvider: {
+                    mocks: [failedAuthMock, failedAuthMock, failedAuthMock],
+                },
+                routerProvider: {
+                    route: '/auth',
+                    routerProps: { history: history },
+                },
+            })
+
+            await userLogin(screen)
+            await waitFor(() => {
+                expect(loginSpy).toHaveBeenCalledTimes(1)
+                expect(history.location.pathname).toBe('/auth')
+            })
         })
     })
 
@@ -101,6 +142,7 @@ describe('Auth', () => {
 
         it('displays ang and toph when logged out', () => {
             renderWithProviders(<Auth />, {
+                apolloProvider: { mocks: [failedAuthMock] },
                 authProvider: { localLogin: true },
             })
 
@@ -123,13 +165,13 @@ describe('Auth', () => {
             ).toBe(2)
         })
 
-        it.only('when login is successful, redirect to dashboard', async () => {
+        it('when login is successful, redirect to dashboard', async () => {
             const history = createMemoryHistory()
 
             renderWithProviders(<Auth />, {
                 routerProvider: { routerProps: { history: history } },
                 authProvider: { localLogin: true },
-                apolloProvider: { mocks: [failedAuthMock] },
+                apolloProvider: { mocks: [failedAuthMock, successfulAuthMock] },
             })
 
             userClickByTestId(screen, 'TophButton')
@@ -137,24 +179,24 @@ describe('Auth', () => {
             await waitFor(() => {
                 expect(history.location.pathname).toBe('/dashboard')
             })
-
-            waitFor(() =>
-                expect(screen.getByTestId('dashboardPage')).toBeInTheDocument()
-            )
         })
 
         it('when login fails, stay on page and display error alert', async () => {
             const history = createMemoryHistory()
 
             renderWithProviders(<Auth />, {
-                routerProvider: { routerProps: { history: history } },
                 authProvider: { localLogin: true },
+                apolloProvider: {
+                    mocks: [failedAuthMock, failedAuthMock],
+                },
+                routerProvider: {
+                    route: '/auth',
+                    routerProps: { history: history },
+                },
             })
 
             userClickByTestId(screen, 'TophButton')
-
-            waitFor(() => {
-                expect(history.location.pathname).not.toBe('/dashboard')
+            await waitFor(() => {
                 expect(history.location.pathname).toBe('/auth')
             })
         })

--- a/services/app-web/src/pages/Auth/Login.test.tsx
+++ b/services/app-web/src/pages/Auth/Login.test.tsx
@@ -4,16 +4,49 @@ import { createMemoryHistory } from 'history'
 import { screen, waitFor, Screen, queries } from '@testing-library/react'
 
 import * as CognitoAuthApi from '../Auth/cognitoAuth'
+import { GetCurrentUserDocument } from '../../gen/gqlClient'
 import { Login } from './Login'
 import { renderWithProviders, userClickByRole } from '../../utils/jestUtils'
 
+const failedAuthMock = {
+    request: { query: GetCurrentUserDocument },
+    result: {
+        ok: false,
+        status: 403,
+        statusText: 'Unauthenticated',
+        data: {
+            error: 'you are not logged in',
+        },
+        error: new Error('network error'),
+    },
+}
+
+const successfulAuthMock = {
+    request: { query: GetCurrentUserDocument },
+    result: {
+        data: {
+            getCurrentUser: {
+                state: 'MN',
+                role: 'State User',
+                name: 'Bob it user',
+                email: 'bob@dmas.mn.gov',
+            },
+        },
+    },
+}
+
 describe('Cognito Login', () => {
-    const userLogin = (screen: Screen<typeof queries>) => {
+    const userLogin = async (screen: Screen<typeof queries>) => {
         const loginEmail = screen.getByTestId('loginEmail')
         const loginPassword = screen.getByTestId('loginPassword')
 
         userEvent.type(loginEmail, 'countdracula@muppets.com')
         userEvent.type(loginPassword, 'passwordABC')
+        await waitFor(() =>
+            expect(
+                screen.getByRole('button', { name: 'Login' })
+            ).not.toBeDisabled()
+        )
         userClickByRole(screen, 'button', { name: 'Login' })
     }
 
@@ -36,8 +69,10 @@ describe('Cognito Login', () => {
         expect(screen.getByRole('button', { name: /Login/i })).toBeDisabled()
     })
 
-    it('when login form has all required fields present, login button is enabled', () => {
-        renderWithProviders(<Login />)
+    it('when login form has all required fields present, login button is enabled', async () => {
+        renderWithProviders(<Login />, {
+            apolloProvider: { mocks: [failedAuthMock] },
+        })
         const loginButton = screen.getByRole('button', { name: 'Login' })
         const loginEmail = screen.getByTestId('loginEmail')
         const loginPassword = screen.getByTestId('loginPassword')
@@ -48,11 +83,13 @@ describe('Cognito Login', () => {
         expect(loginButton).toBeDisabled()
 
         userEvent.type(loginPassword, 'passwordABC')
-        waitFor(() => expect(loginButton).not.toBeDisabled())
+        await waitFor(() => expect(loginButton).not.toBeDisabled())
     })
 
-    it('when login is clicked, button is disabled while loading', () => {
-        renderWithProviders(<Login />)
+    it('when login is clicked, button is disabled while loading', async () => {
+        renderWithProviders(<Login />, {
+            apolloProvider: { mocks: [failedAuthMock, successfulAuthMock] },
+        })
         const loginButton = screen.getByRole('button', { name: 'Login' })
         const loginEmail = screen.getByTestId('loginEmail')
         const loginPassword = screen.getByTestId('loginPassword')
@@ -60,56 +97,64 @@ describe('Cognito Login', () => {
         userEvent.type(loginEmail, 'countdracula@muppets.com')
         userEvent.type(loginPassword, 'passwordABC')
 
-        waitFor(() => expect(loginButton).not.toBeDisabled())
+        await waitFor(() => expect(loginButton).not.toBeDisabled())
 
         userClickByRole(screen, 'button', { name: 'Login' })
 
-        waitFor(() => expect(loginButton).not.toBeDisabled())
+        await waitFor(() => expect(loginButton).toBeDisabled())
     })
 
     it('when login is successful, redirect to dashboard', async () => {
-        const loginSpy = jest
-            .spyOn(CognitoAuthApi, 'signOut')
-            .mockResolvedValue(null)
+        const loginSpy = jest.spyOn(CognitoAuthApi, 'signIn')
 
         const history = createMemoryHistory()
 
         renderWithProviders(<Login />, {
+            apolloProvider: { mocks: [failedAuthMock, successfulAuthMock] },
             routerProvider: { routerProps: { history: history } },
         })
 
-        userLogin(screen)
-        waitFor(() => expect(loginSpy).toHaveBeenCalledTimes(1))
-        waitFor(() => expect(history.location.pathname).toBe('/dashboard'))
+        await userLogin(screen)
+
+        await waitFor(() => expect(loginSpy).toHaveBeenCalledTimes(1))
+        await waitFor(() =>
+            expect(history.location.pathname).toBe('/dashboard')
+        )
     })
 
-    it('when login fails, stay on page and display error alert', () => {
+    it('when login fails, stay on page and display error alert', async () => {
         const loginSpy = jest
-            .spyOn(CognitoAuthApi, 'signOut')
+            .spyOn(CognitoAuthApi, 'signIn')
             .mockRejectedValue('Error has occurred')
 
         const history = createMemoryHistory()
 
         renderWithProviders(<Login />, {
-            routerProvider: { routerProps: { history: history } },
+            apolloProvider: { mocks: [failedAuthMock, failedAuthMock] },
+            routerProvider: {
+                route: '/auth',
+                routerProps: { history: history },
+            },
         })
 
-        userLogin(screen)
-        waitFor(() => {
+        await userLogin(screen)
+        await waitFor(() => {
             expect(loginSpy).toHaveBeenCalledTimes(1)
             expect(history.location.pathname).toBe('/auth')
         })
     })
 
-    it('when login is a failure, button is re-enabled', () => {
+    it('when login is a failure, button is re-enabled', async () => {
         const loginSpy = jest
-            .spyOn(CognitoAuthApi, 'signOut')
+            .spyOn(CognitoAuthApi, 'signIn')
             .mockRejectedValue(null)
 
-        renderWithProviders(<Login />)
+        renderWithProviders(<Login />, {
+            apolloProvider: { mocks: [failedAuthMock, failedAuthMock] },
+        })
 
-        userLogin(screen)
-        waitFor(() => {
+        await userLogin(screen)
+        await waitFor(() => {
             expect(loginSpy).toHaveBeenCalledTimes(1)
             expect(
                 screen.getByRole('button', { name: /Login/i })

--- a/services/app-web/src/pages/Auth/Login.tsx
+++ b/services/app-web/src/pages/Auth/Login.tsx
@@ -12,7 +12,7 @@ import {
 import { useAuth } from '../../contexts/AuthContext'
 
 export function showError(error: string): void {
-    alert(error)
+    console.log('showError', error)
 }
 
 type Props = {
@@ -38,16 +38,13 @@ export function Login({ defaultEmail }: Props): React.ReactElement {
     }
 
     async function handleSubmit(event: React.FormEvent) {
-        console.log('Trying a signin')
         event.preventDefault()
 
-        const result = await signIn(fields.loginEmail, fields.loginPassword)
-        // TODO: try and useAuth() here, track state using the loading param there instead of awaiting something.
-        // if loading, show "redirecting" spinner or something.
-        // if loggedInUser, redirect
-
-        if (result.isOk()) {
-            console.log('SUCCESS LOGIN')
+        try {
+            await signIn(fields.loginEmail, fields.loginPassword)
+            // TODO: try and useAuth() here, track state using the loading param there instead of awaiting something.
+            // if loading, show "redirecting" spinner or something.
+            // if loggedInUser, redirect
 
             try {
                 await auth.checkAuth()
@@ -56,20 +53,17 @@ export function Login({ defaultEmail }: Props): React.ReactElement {
             }
 
             history.push('/dashboard')
-        } else {
-            const err = result.error
-            console.log(err)
-
-            if (err.code === 'UserNotConfirmedException') {
+        } catch (err) {
+            if (err?.code === 'UserNotConfirmedException') {
                 // the user has not been confirmed, need to display the confirmation UI
                 console.log(
                     'you need to confirm your account, enter the code below'
                 )
-            } else if (err.code === 'NotAuthorizedException') {
+            } else if (err?.code === 'NotAuthorizedException') {
                 // the password is bad
                 console.log('bad password')
             }
-            showError(err.message)
+            showError(err)
         }
     }
 

--- a/services/app-web/src/pages/Auth/cognitoAuth.ts
+++ b/services/app-web/src/pages/Auth/cognitoAuth.ts
@@ -115,10 +115,10 @@ export async function signIn(
             } else {
                 // if amplify returns an error in a format we don't expect, let's throw it for now.
                 // might be against the spirit of never throw, but this is our boundary with a system we don't control.
-                throw e
+                return err(e) 
             }
         } else {
-            throw e
+            return e
         }
     }
 }


### PR DESCRIPTION
## Summary
Found something off with the way we use `waitFor` - fixed it and tests started failing (which was good they should have been failing after I changed signup/login flow). Then fixed tests.
- found another uncaught promise in Signup.
- removed some places we `throw` errors because tests for expected error states were breaking

## Testing guidance
- yarn test
- @macrael could you look at the amplify errors  during the test runs - they are not blocking testing but any idea how we should be handling this? Maybe a project wide amplify mock? I need help here. 