### PR TITLE
remove the old KEYS_ONLY index on the submissions table

### DIFF
--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -47,14 +47,6 @@ resources:
           - AttributeName: id
             KeyType: HASH
         GlobalSecondaryIndexes:
-          - IndexName: StateStateNumberIndex
-            KeySchema:
-              - AttributeName: stateCode
-                KeyType: HASH
-              - AttributeName: stateNumber
-                KeyType: RANGE
-            Projection:
-              ProjectionType: KEYS_ONLY
           - IndexName: StateStateNumberAllIndex
             KeySchema:
               - AttributeName: stateCode


### PR DESCRIPTION
## Summary
Cloudformation required this be done in a separate step from creating the new index. 
