### PR TITLE
Fix color contrast issue for inverse outline button in main header

### DIFF
--- a/services/app-web/src/styles/custom.scss
+++ b/services/app-web/src/styles/custom.scss
@@ -24,3 +24,14 @@
     display: block;
     margin-top: units(1);
 }
+
+.usa-button--outline.usa-button--inverse {
+    // Accessibility button contrast fix for inverse button. I couldn't get the color value to set properly unless I set it to !important... not ideal.
+    box-shadow: inset 0 0 0 2px $cms-color-white;
+    color: $cms-color-white !important; 
+
+    &:hover {
+        box-shadow: inset 0 0 0 2px #dfe1e2;
+        color: #dfe1e2 !important;
+    }
+}


### PR DESCRIPTION
## Summary
The inverse outline button on the main header does not pass WCAG AA color contrast checks. We needed to swap the default and hover state colors. **NOTE** This happens in USWDS but wouldn't have happened in CMSDS because their default and hover states are flipped. 

https://design.cms.gov/components/button/
https://designsystem.digital.gov/components/button/

#### Screenshots
**Before**
![Screen Shot 2021-04-12 at 11 46 57 AM](https://user-images.githubusercontent.com/4196834/114423098-d8c96e00-9b84-11eb-87ba-106be7500e9e.png)

**After**
![Screen Shot 2021-04-12 at 11 47 04 AM](https://user-images.githubusercontent.com/4196834/114423117-dd8e2200-9b84-11eb-9b86-92f960b3119c.png)

