### PR TITLE
Set the id of our mocks so they match what we are querying

### DIFF
--- a/services/app-web/src/pages/StateSubmissionForm/StateSubmissionForm.test.tsx
+++ b/services/app-web/src/pages/StateSubmissionForm/StateSubmissionForm.test.tsx
@@ -124,9 +124,7 @@ describe('StateSubmissionForm', () => {
                                 statusCode: 200,
                             }),
                             updateDraftSubmissionMock({
-                                // Because we haven't changed the ID of the submission returned by fetchDraftSubmissionMock
-                                // we need to use the ID of the default mock going forward. Our logic uses that ID over the one in the URL.
-                                id: 'test-abc-123',
+                                id: '15',
                                 updates: {
                                     submissionType: 'CONTRACT_ONLY' as SubmissionTypeT,
                                     submissionDescription:
@@ -137,7 +135,7 @@ describe('StateSubmissionForm', () => {
                                 statusCode: 200,
                             }),
                             fetchDraftSubmissionMock({
-                                id: 'test-abc-123',
+                                id: '15',
                                 statusCode: 200,
                             }),
                         ],

--- a/services/app-web/src/utils/apolloUtils.tsx
+++ b/services/app-web/src/utils/apolloUtils.tsx
@@ -119,6 +119,8 @@ const fetchDraftSubmissionMock = ({
     id,
     statusCode, // eslint-disable-next-line @typescript-eslint/no-explicit-any
 }: fetchDraftSubmissionMockProps): MockedResponse<Record<string, any>> => {
+    // override the ID of the returned draft to match the queried id.
+    const mergedDraftSubmission = Object.assign({}, draftSubmission, { id })
     switch (statusCode) {
         case 200:
             return {
@@ -129,7 +131,7 @@ const fetchDraftSubmissionMock = ({
                 result: {
                     data: {
                         fetchDraftSubmission: {
-                            draftSubmission,
+                            draftSubmission: mergedDraftSubmission,
                         },
                     },
                 },
@@ -162,7 +164,8 @@ const updateDraftSubmissionMock = ({
     const mergedDraftSubmission = Object.assign(
         {},
         mockDraftSubmission,
-        updates
+        updates,
+        { id } // make sure the id matches what we queried
     )
     switch (statusCode) {
         case 200:


### PR DESCRIPTION
## Summary

I was thinking about this on my vacation. A better fix for that testing weirdness for the update test I wrote. 

#### Related issues

#### Screenshots

## Testing guidance
The tests should still pass but we aren't referencing a nonsense id in the tests.

