### PR TITLE
Restore prod deploys, slack alerts are working now. 

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -35,10 +35,6 @@ jobs:
             exit 1
           fi
       - uses: actions/checkout@v1
-      # Find the PR associated with this push, if there is one.
-      # PR number is in steps.findPr.outputs.pr
-      - uses: jwalton/gh-find-current-pr@v1
-        id: findPr
       - name: set app version
         run: echo "APP_VERSION=$(scripts/app_version.sh)" >> $GITHUB_ENV
       - name: set branch specific variable names
@@ -143,8 +139,6 @@ jobs:
         with:
           name: test_results
           path: tests/nightwatch/tests_output
-      - name: this is gonna fail
-        run: exit 3
       - name: set prod env vars
         run: ./.github/build_vars.sh set_values
         env:
@@ -173,5 +167,5 @@ jobs:
           SLACK_USERNAME: Deploy Alerts
           SLACK_ICON_EMOJI: ':bell:'
           SLACK_COLOR: ${{job.status}}
-          SLACK_FOOTER: https://github.com/CMSgov/managed-care-review/pull/${{ steps.findPr.outputs.pr }}
+          SLACK_FOOTER: ''
           MSG_MINIMAL: actions url,commit


### PR DESCRIPTION
## Summary

nothing really to test. I'm cleaning up the message we get b/c the link to the PR didn't work. It might one day be worth trying to make our own action here that does the posting but it works as is. 