### PR TITLE
Create a DraftSubmission -> DraftSubmissionUpdates mapper

### DIFF
--- a/services/app-web/src/pages/StateSubmissionForm/Documents/Documents.tsx
+++ b/services/app-web/src/pages/StateSubmissionForm/Documents/Documents.tsx
@@ -17,6 +17,7 @@ import {
     S3FileData,
 } from '../../../components/FileUpload/FileUpload'
 import { FileItemT } from '../../../components/FileUpload/FileItem'
+import { updatesFromSubmission } from '../updateSubmissionTransform'
 
 /* 
     Documents should error alerts for overall errors related to invalid documents for a submission, including no files added.
@@ -128,12 +129,10 @@ export const Documents = ({
             }
         })
 
-        const updatedDraft = {
-            programID: draftSubmission.programID,
-            submissionType: draftSubmission.submissionType,
-            submissionDescription: draftSubmission.submissionDescription,
-            documents,
-        }
+        const updatedDraft = updatesFromSubmission(draftSubmission)
+
+        updatedDraft.documents = documents
+
         try {
             const data = await updateDraftSubmission({
                 variables: {

--- a/services/app-web/src/pages/StateSubmissionForm/NewStateSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmissionForm/NewStateSubmissionForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { GridContainer } from '@trussworks/react-uswds'
-import { SubmissionType } from './SubmissionType'
+import { SubmissionType } from './SubmissionType/SubmissionType'
 
 export const NewStateSubmissionForm = (): React.ReactElement => {
     return (

--- a/services/app-web/src/pages/StateSubmissionForm/StateSubmissionForm.test.tsx
+++ b/services/app-web/src/pages/StateSubmissionForm/StateSubmissionForm.test.tsx
@@ -8,7 +8,11 @@ import {
     fetchDraftSubmissionMock,
     updateDraftSubmissionMock,
 } from '../../utils/apolloUtils'
-import { SubmissionType as SubmissionTypeT } from '../../gen/gqlClient'
+import {
+    SubmissionType as SubmissionTypeT,
+    DraftSubmission,
+    Document,
+} from '../../gen/gqlClient'
 import { renderWithProviders } from '../../utils/jestUtils'
 
 import { StateSubmissionForm } from './StateSubmissionForm'
@@ -131,6 +135,85 @@ describe('StateSubmissionForm', () => {
                                         'A real submission but updated something',
                                     programID: 'snbc',
                                     documents: [],
+                                },
+                                statusCode: 200,
+                            }),
+                            fetchDraftSubmissionMock({
+                                id: '15',
+                                statusCode: 200,
+                            }),
+                        ],
+                    },
+                    routerProvider: { route: '/submissions/15/type' },
+                }
+            )
+
+            const heading = await screen.findByRole('heading', {
+                name: 'Submission type',
+            })
+            expect(heading).toBeInTheDocument()
+
+            const textarea = await screen.findByRole('textbox', {
+                name: 'Submission description',
+            })
+            userEvent.type(textarea, ' but updated something')
+
+            const continueButton = await screen.findByRole('button', {
+                name: 'Continue',
+            })
+            continueButton.click()
+
+            await screen.findByRole('heading', {
+                name: 'Contract details',
+            })
+        })
+
+        it('works even if other sections of the form have been filled out', async () => {
+            const mockDocs: Document[] = [
+                {
+                    name: 'somedoc.pdf',
+                    url: 'whatsinaurl',
+                    s3URL: 's3://bucketName/key',
+                },
+            ]
+            const mockDraftSubmissionWithDocs: DraftSubmission = {
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                id: 'test-abc-123',
+                stateCode: 'MN',
+                programID: 'snbc',
+                program: {
+                    id: 'snbc',
+                    name: 'SNBC',
+                },
+                name: 'MN-MSHO-0001',
+                submissionType: 'CONTRACT_ONLY' as SubmissionTypeT.ContractOnly,
+                submissionDescription: 'A real submission',
+                documents: mockDocs,
+            }
+
+            renderWithProviders(
+                <Route
+                    path={RoutesRecord.SUBMISSIONS_FORM}
+                    component={StateSubmissionForm}
+                />,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({ statusCode: 200 }),
+                            fetchDraftSubmissionMock({
+                                id: '15',
+                                draftSubmission: mockDraftSubmissionWithDocs,
+                                statusCode: 200,
+                            }),
+                            updateDraftSubmissionMock({
+                                id: '15',
+                                updates: {
+                                    submissionType: 'CONTRACT_ONLY' as SubmissionTypeT,
+                                    submissionDescription:
+                                        'A real submission but updated something',
+                                    programID: 'snbc',
+                                    documents: mockDocs,
                                 },
                                 statusCode: 200,
                             }),

--- a/services/app-web/src/pages/StateSubmissionForm/StateSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmissionForm/StateSubmissionForm.tsx
@@ -11,7 +11,7 @@ import { RoutesRecord } from '../../constants/routes'
 import { ContractDetails } from './ContractDetails/ContractDetails'
 import { Documents } from './Documents/Documents'
 import { ReviewSubmit } from './ReviewSubmit/ReviewSubmit'
-import { SubmissionType } from './SubmissionType'
+import { SubmissionType } from './SubmissionType/SubmissionType'
 
 import { useFetchDraftSubmissionQuery } from '../../gen/gqlClient'
 

--- a/services/app-web/src/pages/StateSubmissionForm/SubmissionType/SubmissionType.test.tsx
+++ b/services/app-web/src/pages/StateSubmissionForm/SubmissionType/SubmissionType.test.tsx
@@ -6,8 +6,8 @@ import { screen, waitFor } from '@testing-library/react'
 import {
     fetchCurrentUserMock,
     mockDraftSubmission,
-} from '../../utils/apolloUtils'
-import { renderWithProviders } from '../../utils/jestUtils'
+} from '../../../utils/apolloUtils'
+import { renderWithProviders } from '../../../utils/jestUtils'
 import { SubmissionType, SubmissionTypeFormValues } from './SubmissionType'
 import { Formik } from 'formik'
 

--- a/services/app-web/src/pages/StateSubmissionForm/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmissionForm/SubmissionType/SubmissionType.tsx
@@ -12,21 +12,23 @@ import {
 } from '@trussworks/react-uswds'
 import { Formik, FormikHelpers, FormikErrors, useFormikContext } from 'formik'
 import { NavLink, useHistory } from 'react-router-dom'
-import PageHeading from '../../components/PageHeading'
 import { useMutation } from '@apollo/client'
 
-import styles from './StateSubmissionForm.module.scss'
+import PageHeading from '../../../components/PageHeading'
 import {
     CreateDraftSubmissionDocument,
     DraftSubmission,
     SubmissionType as SubmissionTypeT,
     useUpdateDraftSubmissionMutation,
-} from '../../gen/gqlClient'
-import { useAuth } from '../../contexts/AuthContext'
-import { FieldTextarea } from '../../components/Form/FieldTextarea/FieldTextarea'
-import { FieldDropdown } from '../../components/Form/FieldDropdown/FieldDropdown'
-import { FieldRadio } from '../../components/Form/FieldRadio/FieldRadio'
-import { SubmissionTypeRecord } from '../../constants/submissions'
+} from '../../../gen/gqlClient'
+import { useAuth } from '../../../contexts/AuthContext'
+import { FieldTextarea } from '../../../components/Form/FieldTextarea/FieldTextarea'
+import { FieldDropdown } from '../../../components/Form/FieldDropdown/FieldDropdown'
+import { FieldRadio } from '../../../components/Form/FieldRadio/FieldRadio'
+import { SubmissionTypeRecord } from '../../../constants/submissions'
+import { updatesFromSubmission } from '../updateSubmissionTransform'
+
+import styles from '../StateSubmissionForm.module.scss'
 
 /*
     Add focus to "first" form element that is invalid when errors exist
@@ -139,14 +141,11 @@ export const SubmissionType = ({
                 return
             }
 
-            // TODO: once we have more values, we'll need to pick the other values out
-            // off of the existing draft.
-            const updatedDraft = {
-                programID: values.programID,
-                submissionType: values.submissionType as SubmissionTypeT,
-                submissionDescription: values.submissionDescription,
-                documents: [],
-            }
+            const updatedDraft = updatesFromSubmission(draftSubmission)
+
+            updatedDraft.programID = values.programID
+            updatedDraft.submissionType = values.submissionType as SubmissionTypeT
+            updatedDraft.submissionDescription = values.submissionDescription
 
             try {
                 await updateDraftSubmission({
@@ -183,7 +182,6 @@ export const SubmissionType = ({
             {({
                 values,
                 errors,
-                handleChange,
                 handleSubmit,
                 isSubmitting,
                 isValidating,
@@ -297,7 +295,8 @@ export const SubmissionType = ({
                                                 }
                                                 target="_blank"
                                             >
-                                                View description examples (opens in new window)
+                                                View description examples (opens
+                                                in new window)
                                             </Link>
 
                                             <p>

--- a/services/app-web/src/pages/StateSubmissionForm/updateSubmissionTransform.ts
+++ b/services/app-web/src/pages/StateSubmissionForm/updateSubmissionTransform.ts
@@ -1,0 +1,30 @@
+import {
+    DraftSubmission,
+    DraftSubmissionUpdates,
+    Document,
+    DocumentInput,
+} from '../../gen/gqlClient'
+
+// this function takes a DraftSubmission and picks off all the keys that are valid
+// keys for DraftSubmissionUpdates. This facilitates making an update request given
+// an extant draft
+// There's probably some Typescript Cleverness™ we could do for this mapping function
+// but for now the compiler complains if you forget anything so ¯\_(ツ)_/¯
+export function updatesFromSubmission(
+    draft: DraftSubmission
+): DraftSubmissionUpdates {
+    return {
+        programID: draft.programID,
+        submissionType: draft.submissionType,
+        submissionDescription: draft.submissionDescription,
+        documents: draft.documents.map(
+            (doc: Document): DocumentInput => {
+                return {
+                    name: doc.name,
+                    url: doc.url,
+                    s3URL: doc.s3URL,
+                }
+            }
+        ),
+    }
+}


### PR DESCRIPTION
## Summary

We were creating the DraftSubmissionUpdates by hand in both of our pages so far, this meant that there were multiple places we needed to make sure we passed all the keys from the existing Draft into the new Updates object. This resulted in a bug where if you update the submission type for a submission that already had documents we wrote over the documents. 

This change centralizes that process. As we add new keys to DraftSubmission and DraftSubmissionUpdates, we'll have to keep the mapper function up to date, but the other pages will hopefully then get that for free. 

#### Related issues

https://qmacbis.atlassian.net/browse/OY2-8699

## Testing guidance

Try these steps on the review app:

STEPS TO REPRODUCE
Create a new submission
Fill out the type info
Add a couple documents
Go back to /type
edit info in the type and click CONTINUE
go back to /documents

EXPECTED RESULTS
the documents you uploaded should still be there in the same states
