### PR TITLE
Get rid of an unnecessary type for the Dashboard list view

### DIFF
--- a/services/app-web/src/pages/Dashboard/Dashboard.test.tsx
+++ b/services/app-web/src/pages/Dashboard/Dashboard.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { createMemoryHistory } from 'history'
 import { screen, waitFor } from '@testing-library/react'
 
-import { Dashboard, ListedSubmission, sortDraftsToTop } from './Dashboard'
+import { Dashboard, sortDraftsToTop } from './Dashboard'
 import {
     fetchCurrentUserMock,
     indexSubmissionsMockSuccess,
@@ -150,51 +150,26 @@ describe('Dashboard', () => {
     })
 
     it('has a stable Draft sort', async () => {
-        const input: ListedSubmission[] = [
+        const input: { __typename: string; id: string }[] = [
             {
                 __typename: 'DraftSubmission',
                 id: '4',
-                submissionType: 'CONTRACT_ONLY',
-                submissionDescription: 'string',
-                programID: 'msho',
-                name: 'MSHO-0001',
-                submittedAt: undefined,
             },
             {
                 __typename: 'StateSubmission',
                 id: '3',
-                submissionType: 'CONTRACT_ONLY',
-                submissionDescription: 'string',
-                programID: 'msho',
-                name: 'MSHO-0001',
-                submittedAt: undefined,
             },
             {
                 __typename: 'DraftSubmission',
                 id: '2',
-                submissionType: 'CONTRACT_ONLY',
-                submissionDescription: 'string',
-                programID: 'msho',
-                name: 'MSHO-0001',
-                submittedAt: undefined,
             },
             {
                 __typename: 'StateSubmission',
                 id: '1',
-                submissionType: 'CONTRACT_ONLY',
-                submissionDescription: 'string',
-                programID: 'msho',
-                name: 'MSHO-0001',
-                submittedAt: undefined,
             },
             {
                 __typename: 'DraftSubmission',
                 id: '0',
-                submissionType: 'CONTRACT_ONLY',
-                submissionDescription: 'string',
-                programID: 'msho',
-                name: 'MSHO-0001',
-                submittedAt: undefined,
             },
         ]
 


### PR DESCRIPTION
## Summary

I merged the other PR before I took the time to try and address your comment about types. This is much better I think. LMK if I can actually just get rid of the enums in SubmissionCard all together, but I didn't try yet b/c it seemed like maybe a part of letting storybook show the different config buttons. 

#### Related issues

#### Screenshots

## Testing guidance

<!---These are developer instructions on how to test or validate the work -->
