### PR TITLE
Add precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,8 @@ repos:
       rev: v4.0.1
       hooks:
           - id: detect-private-key
+
+    - repo: https://github.com/pre-commit/mirrors-prettier
+      rev: 'v2.3.2' # Use the sha / tag you want to point at
+      hooks:
+          - id: prettier


### PR DESCRIPTION
## Summary

This adds [pre-commit](https://pre-commit.com/) to our repo, which will run various checks when `git commit` is run locally. This will help us check for basic errors on our code locally before things are committed and pushed to GitHub.

#### Related Issues
https://qmacbis.atlassian.net/browse/OY2-5082