### PR TITLE
[OY2-10268] Update StepIndicator to ignore/hide Rate Details page

### DIFF
--- a/services/app-web/src/pages/StateSubmissionForm/StateSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmissionForm/StateSubmissionForm.tsx
@@ -29,6 +29,7 @@ import { SubmissionType } from './SubmissionType/SubmissionType'
 import {
     DraftSubmission,
     UpdateDraftSubmissionInput,
+    SubmissionType as SubmissionTypeT,
     useUpdateDraftSubmissionMutation,
     useFetchDraftSubmissionQuery,
 } from '../../gen/gqlClient'
@@ -102,13 +103,26 @@ export const StateSubmissionForm = (): React.ReactElement => {
         'SUBMISSIONS_REVIEW_SUBMIT',
     ] as RouteT[]
 
-    const DynamicStepIndicator = () => {
+    const DynamicStepIndicator = ({
+        submissionType = undefined,
+    }: {
+        submissionType?: SubmissionTypeT
+    }): React.ReactElement | null => {
         const currentFormPage = getRouteName(pathname)
 
         console.log(currentFormPage)
+        console.log('test', submissionType)
 
         let formStepCompleted = true
         let formStepStatus: 'current' | 'complete' | undefined
+
+        // If submission type is contract only, rate details is left out of the step indicator
+        const reachableFormPages = FormPages.filter((formPage) => {
+            return !(
+                submissionType === 'CONTRACT_ONLY' &&
+                formPage === 'SUBMISSIONS_RATE_DETAILS'
+            )
+        })
 
         if (currentFormPage === 'SUBMISSIONS_TYPE') {
             return null
@@ -116,7 +130,7 @@ export const StateSubmissionForm = (): React.ReactElement => {
             return (
                 <>
                     <StepIndicator>
-                        {FormPages.map((formPageName) => {
+                        {reachableFormPages.map((formPageName) => {
                             if (formPageName === currentFormPage) {
                                 formStepCompleted = false
                                 formStepStatus = 'current'
@@ -166,7 +180,7 @@ export const StateSubmissionForm = (): React.ReactElement => {
 
     return (
         <>
-            <DynamicStepIndicator />
+            <DynamicStepIndicator submissionType={draft.submissionType} />
 
             <GridContainer>
                 <Switch>


### PR DESCRIPTION
## Summary
This PR updates the step indicator to not display the Rate details step if the submission is contract action only.

#### Related issues
[JIRA Story](https://qmacbis.atlassian.net/browse/OY2-9766)
[JIRA Subtask](https://qmacbis.atlassian.net/browse/OY2-10268)

## Testing guidance
Start a new submission or edit an existing draft submission. On the Submission type page select contract action only. Continue through the form filling out necessary fields. When you click continue to proceed to the Contract details page, the step indicator should not display the Rate details step.