### PR TITLE
Add encryption to uploads bucket

### DIFF
--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -29,27 +29,6 @@ custom:
 
 resources:
   Resources:
-    AttachmentsBucket:
-      Type: AWS::S3::Bucket
-      Properties:
-        BucketEncryption:
-          ServerSideEncryptionConfiguration:
-            - ServerSideEncryptionByDefault:
-                SSEAlgorithm: AES256
-        # Set the CORS policy
-        CorsConfiguration:
-          CorsRules:
-            - AllowedOrigins:
-                - '*'
-              AllowedHeaders:
-                - '*'
-              AllowedMethods:
-                - GET
-                - PUT
-                - POST
-                - DELETE
-                - HEAD
-              MaxAge: 3000
     DocumentUploadsBucket:
       Type: AWS::S3::Bucket
       Properties:


### PR DESCRIPTION
## Summary

This adds encryption to our `attachments` and `uploads` buckets, as required to pass the upcoming security audit. 

The findings that this was pulled from in [the quickstart](https://github.com/CMSgov/macpro-quickstart-serverless/pull/235) also enables encryption on the `clamav` bucket, but since we have not incorporated the virus scanning work yet there is no bucket to apply that to. I've made a note in the virus scanning ticket to remember to incorporate `clamav` bucket encryption.

#### Related issues

https://qmacbis.atlassian.net/browse/OY2-9634

<!---These are developer instructions on how to test or validate the work -->
