### PR TITLE
Add Hsts CloudFront functions

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -130,7 +130,7 @@ resources:
             ViewerProtocolPolicy: redirect-to-https
             FunctionAssociations:
               - EventType: viewer-response
-                FunctionARN: !GetAtt HstsCloudfrontFunction.FunctionMetadata.FunctionARN{}
+                FunctionARN: !GetAtt HstsCloudfrontFunction.FunctionMetadata.FunctionARN
           ViewerCertificate:
             Fn::If:
               - CreateCustomCloudFrontDomain


### PR DESCRIPTION
## Summary

This incorporates the findings from the [quickstart](https://github.com/CMSgov/macpro-quickstart-serverless/pull/250) which will enable HTTP Strict Transport Security on CloudFront.

#### Related issues

https://qmacbis.atlassian.net/browse/OY2-9640

<!---These are developer instructions on how to test or validate the work -->
