### PR TITLE
add waiting before logging in to cypress as a temporary fix

### DIFF
--- a/tests/cypress/support/login.ts
+++ b/tests/cypress/support/login.ts
@@ -1,6 +1,7 @@
 Cypress.Commands.add('login', () => {
     cy.visit('/')
     cy.findByRole('progressbar', { name: 'Loading' }).should('not.exist')
+    cy.wait(1000)
     cy.findByRole('link', { name: 'Sign In' }).click()
     const authMode = Cypress.env('AUTH_MODE')
     console.log(authMode, 'authmode')


### PR DESCRIPTION
## Summary

This fix is for our cypress flakiness. This fixes the "sign in button is detached from the Dom" issue by waiting a second for the page to coalesce. There is a better fix to be had but this should help dramatically with the cypress issues we've been having. 

#### Related issues

https://qmacbis.atlassian.net/browse/OY2-9195

#### Screenshots

## Testing guidance
hopefully, this PR won't hit that issue in CI 😅
