### PR TITLE
Hide rate details section on the submission summary page

### DIFF
--- a/services/app-web/src/pages/StateSubmissionForm/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/StateSubmissionForm/SubmissionSummary/SubmissionSummary.tsx
@@ -138,6 +138,9 @@ export const SubmissionSummary = (): React.ReactElement => {
     }
 
     const isContractAmendment = submission.contractType === 'AMENDMENT'
+    const isContractActionAndRateCertification =
+        submission.submissionType === 'CONTRACT_AND_RATES'
+
     return (
         <div className={styles.background}>
             <GridContainer
@@ -314,72 +317,74 @@ export const SubmissionSummary = (): React.ReactElement => {
                             )}
                     </dl>
                 </section>
-                <section id="rateDetails">
-                    <dl>
-                        <SectionHeader
-                            header="Rate details"
-                            to="rate-details"
-                        />
-                        <DoubleColumnRow
-                            left={
-                                <DataDetail
-                                    id="rateType"
-                                    label="Rate certification type"
-                                    data={
-                                        submission.rateAmendmentInfo
-                                            ? 'Amendment to prior rate certification'
-                                            : 'New rate certification'
-                                    }
-                                />
-                            }
-                            right={
-                                <DataDetail
-                                    id="ratingPeriod"
-                                    label={
-                                        submission.rateAmendmentInfo
-                                            ? 'Rating period of original rate certification'
-                                            : 'Rating period'
-                                    }
-                                    data={`${dayjs(
-                                        submission.rateDateStart
-                                    ).format('MM/DD/YYYY')} - ${dayjs(
-                                        submission.rateDateEnd
-                                    ).format('MM/DD/YYYY')}`}
-                                />
-                            }
-                        />
-                        <DoubleColumnRow
-                            left={
-                                <DataDetail
-                                    id="dateCertified"
-                                    label={
-                                        submission.rateAmendmentInfo
-                                            ? 'Date certified for rate amendment'
-                                            : 'Date certified'
-                                    }
-                                    data={dayjs(
-                                        submission.rateDateCertified
-                                    ).format('MM/DD/YYYY')}
-                                />
-                            }
-                            right={
-                                submission.rateAmendmentInfo ? (
+                {isContractActionAndRateCertification && (
+                    <section id="rateDetails">
+                        <dl>
+                            <SectionHeader
+                                header="Rate details"
+                                to="rate-details"
+                            />
+                            <DoubleColumnRow
+                                left={
                                     <DataDetail
-                                        id="effectiveRatingPeriod"
-                                        label="Effective dates of rate amendment"
+                                        id="rateType"
+                                        label="Rate certification type"
+                                        data={
+                                            submission.rateAmendmentInfo
+                                                ? 'Amendment to prior rate certification'
+                                                : 'New rate certification'
+                                        }
+                                    />
+                                }
+                                right={
+                                    <DataDetail
+                                        id="ratingPeriod"
+                                        label={
+                                            submission.rateAmendmentInfo
+                                                ? 'Rating period of original rate certification'
+                                                : 'Rating period'
+                                        }
                                         data={`${dayjs(
-                                            submission.rateAmendmentInfo
-                                                .effectiveDateStart
+                                            submission.rateDateStart
                                         ).format('MM/DD/YYYY')} - ${dayjs(
-                                            submission.rateAmendmentInfo
-                                                .effectiveDateEnd
+                                            submission.rateDateEnd
                                         ).format('MM/DD/YYYY')}`}
                                     />
-                                ) : null
-                            }
-                        />
-                    </dl>
-                </section>
+                                }
+                            />
+                            <DoubleColumnRow
+                                left={
+                                    <DataDetail
+                                        id="dateCertified"
+                                        label={
+                                            submission.rateAmendmentInfo
+                                                ? 'Date certified for rate amendment'
+                                                : 'Date certified'
+                                        }
+                                        data={dayjs(
+                                            submission.rateDateCertified
+                                        ).format('MM/DD/YYYY')}
+                                    />
+                                }
+                                right={
+                                    submission.rateAmendmentInfo ? (
+                                        <DataDetail
+                                            id="effectiveRatingPeriod"
+                                            label="Effective dates of rate amendment"
+                                            data={`${dayjs(
+                                                submission.rateAmendmentInfo
+                                                    .effectiveDateStart
+                                            ).format('MM/DD/YYYY')} - ${dayjs(
+                                                submission.rateAmendmentInfo
+                                                    .effectiveDateEnd
+                                            ).format('MM/DD/YYYY')}`}
+                                        />
+                                    ) : null
+                                }
+                            />
+                        </dl>
+                    </section>
+                )}
                 <section id="documents">
                     <SectionHeader header="Documents" to="documents" />
                     <span className="text-bold">{documentsSummary}</span>


### PR DESCRIPTION
## Summary
This PR hides the rate details section on the submission summary page if the submission is contract only.

## Testing guidance
Create two state submissions, one contract only and another with contract and rates. The contract only submission should not have a rate details section on the submission summary page, and the contract and rates submission should have a rate details section on the submission summary page.
