### PR TITLE
Add policy for documents uploads to limit files

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -189,6 +189,11 @@ resources:
           CloudWatchMetricsEnabled: true
           SampledRequestsEnabled: true
           MetricName: ${self:custom.webAclName}
+    ApiGwWebAclAssociation:
+      Type: AWS::WAFv2::WebACLAssociation
+      Properties:
+        ResourceArn: !Sub arn:aws:apigateway:${AWS::Region}::/restapis/${ApiGatewayRestApi}/stages/${self:custom.stage}
+        WebACLArn: !GetAtt ApiGwWebAcl.Arn
   Outputs:
     ApiGatewayRestApiName:
       Value: !Ref ApiGatewayRestApi


### PR DESCRIPTION
## Summary

This adds a policy to our S3 uploads bucket to only allow certain file types. Currently this is for doc/docx, xls/xlsx, pdf, csv, and txt files.

#### Related issues
https://qmacbis.atlassian.net/browse/OY2-8828

<!---These are developer instructions on how to test or validate the work -->
