### PR TITLE
Add s3 uploads policy

### DIFF
--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -44,6 +44,23 @@ resources:
                 - DELETE
                 - HEAD
               MaxAge: 3000
+    DocumentsUploadsBucketPolicy:
+      Type: AWS::S3::BucketPolicy
+      Properties:
+        Bucket: !Ref DocumentUploadsBucket
+        PolicyDocument:
+          Statement:
+            - Action: 's3:PutObject'
+              Effect: Deny
+              Principal: '*'
+              NotResource:
+                - !Sub ${DocumentUploadsBucket.Arn}/*.csv
+                - !Sub ${DocumentUploadsBucket.Arn}/*.doc
+                - !Sub ${DocumentUploadsBucket.Arn}/*.docx
+                - !Sub ${DocumentUploadsBucket.Arn}/*.pdf
+                - !Sub ${DocumentUploadsBucket.Arn}/*.txt
+                - !Sub ${DocumentUploadsBucket.Arn}/*.xls
+                - !Sub ${DocumentUploadsBucket.Arn}/*.xlsx
 
   Outputs:
     DocumentUploadsBucketName:


### PR DESCRIPTION
## Summary

This adds a policy to our S3 uploads bucket to only allow certain file types. Currently this is for doc/docx, xls/xlsx, pdf, csv, and txt files.

#### Related issues
https://qmacbis.atlassian.net/browse/OY2-8828

<!---These are developer instructions on how to test or validate the work -->
