### PR TITLE
Add branch length protection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       rev: v2.2.1
       hooks:
           - id: no-commit-to-branch
-            args: ['--pattern', '^(?!([a-zA-Z0-9\-\/]{1,64})$).*']
+            args: ['--pattern', '^(?!([a-zA-Z0-9\-\/]{1,47})$).*']
 
     - repo: https://github.com/pre-commit/mirrors-prettier
       rev: 'v2.3.2' # Use the sha / tag you want to point at


### PR DESCRIPTION
## Summary

This is a pre-commit check that limits git branch name length. As the related issue outlines, there is a hard limit of 64 characters on AWS Lambda function names. Since our lambdas are named after our git branches, this can cause dev deploys to fail if git branch names are long. We will fail `pre-commit` if you attempt to commit to a branch that is longer than 47 characters long (as lambda is named `stream-functions-` (17 characters) + branch name).

#### Related issues
https://qmacbis.atlassian.net/browse/OY2-8984

#### Screenshots
This is what happens when you name a branch long and try to commit:

<img width="746" alt="Screen Shot 2021-07-23 at 4 43 14 PM" src="https://user-images.githubusercontent.com/7256/126840169-b878a7ed-7f06-4f05-9e2d-e4f24d02e650.png">

This is the regex -- the highlighted blue means we've matched and `pre-commit` will fail it:

<img width="1720" alt="Screen Shot 2021-07-23 at 4 51 07 PM" src="https://user-images.githubusercontent.com/7256/126840227-0cd8810f-53e1-43f9-bde3-65317473b387.png">


## Testing guidance

<!---These are developer instructions on how to test or validate the work -->
