### PR TITLE
Trying to figure out the flake with document upload not registering

### DIFF
--- a/tests/cypress/integration/stateSubmission.spec.ts
+++ b/tests/cypress/integration/stateSubmission.spec.ts
@@ -591,6 +591,8 @@ describe('State Submission', () => {
                 const draftSubmissionId = pathname.split('/')[2]
                 cy.visit(`/submissions/${draftSubmissionId}/documents`)
 
+                cy.log("trying to drag a bad file in")
+
                 // Drop invalid files and invalid type message appears
                 cy.findByTestId('file-input-droptarget')
                     .should('exist')
@@ -598,6 +600,8 @@ describe('State Submission', () => {
                         subjectType: 'drag-n-drop',
                         force: true,
                     })
+
+                cy.log("dragged a bad file in")
                 cy.findByTestId('file-input-error').should(
                     'have.text',
                     'This is not a valid file type.'


### PR DESCRIPTION
## Summary

We have a persistent flake where the document upload screen doesn't show an error when we drag a .png onto it. I'm trying to track that down. 

#### Related issues

#### Screenshots

## Testing guidance

<!---These are developer instructions on how to test or validate the work -->
