### PR TITLE
Hotfix: Uploads bucket name

### DIFF
--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -27,13 +27,13 @@ provider:
             - s3:PutObjectVersionTagging
             - s3:ListBucket
           Resource:
-            - !Sub arn:aws:s3:::${self:service.name}-${self:custom.stage}-uploads-${AWS::AccountId}/*
+            - !Sub ${DocumentUploadsBucket.Arn}/*
             - !Sub arn:aws:s3:::${self:service.name}-${self:custom.stage}-avscan-${AWS::AccountId}/*
         - Effect: 'Allow'
           Action:
             - s3:ListBucket
           Resource:
-            - !Sub arn:aws:s3:::${self:service.name}-${self:custom.stage}-uploads-${AWS::AccountId}
+            - !Sub ${DocumentUploadsBucket.Arn}/*
             - !Sub arn:aws:s3:::${self:service.name}-${self:custom.stage}-avscan-${AWS::AccountId}/*
 
 custom:
@@ -97,7 +97,6 @@ resources:
     DocumentUploadsBucket:
       Type: AWS::S3::Bucket
       Properties:
-        BucketName: !Sub ${self:service.name}-${self:custom.stage}-uploads-${AWS::AccountId}
         BucketEncryption:
           ServerSideEncryptionConfiguration:
             - ServerSideEncryptionByDefault:


### PR DESCRIPTION
## Summary
When I merged in #248 the promote script failed as it tried to recreate the uploads bucket. The `BucketName` wasn't explicitly defined before, which was causing a circular dependency resolution error when I was adding in the AV scanning work.

This is an attempt to work around that so we don't have to recreate the bucket in the higher environments.

#### Related issues
https://qmacbis.atlassian.net/browse/OY2-10998

<!---These are developer instructions on how to test or validate the work -->
