### PR TITLE
fix: Address focus issues in state contacts

### DIFF
--- a/services/app-web/src/hooks/useFocus.ts
+++ b/services/app-web/src/hooks/useFocus.ts
@@ -1,0 +1,14 @@
+import { useRef } from 'react'
+
+// Dynamically set focus to a specific html element. The element must be present on the page on initialization.
+export const useFocus = (): [
+    React.MutableRefObject<HTMLButtonElement | null>,
+    () => void
+] => {
+    const htmlElRef = useRef<HTMLButtonElement | null>(null)
+    const setFocus = () => {
+        htmlElRef.current && htmlElRef.current.focus()
+    }
+
+    return [htmlElRef, setFocus]
+}

--- a/services/app-web/src/pages/StateSubmissionForm/Contacts/Contacts.test.tsx
+++ b/services/app-web/src/pages/StateSubmissionForm/Contacts/Contacts.test.tsx
@@ -99,7 +99,7 @@ describe('Contacts', () => {
         })
     })
 
-    it('when clicking "Add state contact" button, should focus on the field name of the new contact', async () => {
+    it('after "Add state contact" button click, should focus on the field name of the new contact', async () => {
         const mock = mockDraft()
         const mockUpdateDraftFn = jest.fn()
 
@@ -129,6 +129,36 @@ describe('Contacts', () => {
 
             expect(secondContactName).toHaveValue('')
             expect(secondContactName).toHaveFocus()
+        })
+    })
+
+    it('after "Remove contact" button click, should focus on add new contact button', async () => {
+        const mock = mockDraft()
+        const mockUpdateDraftFn = jest.fn()
+
+        renderWithProviders(
+            <Contacts draftSubmission={mock} updateDraft={mockUpdateDraftFn} />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+        )
+        const addStateContactButton = screen.getByRole('button', {
+            name: 'Add state contact',
+        })
+        addStateContactButton.click()
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('button', { name: 'Remove contact' })
+            ).toBeInTheDocument()
+
+            userEvent.click(
+                screen.getByRole('button', { name: 'Remove contact' })
+            )
+
+            expect(addStateContactButton).toHaveFocus()
         })
     })
 })

--- a/services/app-web/src/pages/StateSubmissionForm/Contacts/Contacts.tsx
+++ b/services/app-web/src/pages/StateSubmissionForm/Contacts/Contacts.tsx
@@ -30,6 +30,8 @@ import {
     stripTypename,
 } from '../updateSubmissionTransform'
 import { MCRouterState } from '../../../constants/routerState'
+import { useFocus } from '../../../hooks/useFocus'
+
 export interface ContactsFormValues {
     stateContacts: StateContactValue[]
 }
@@ -82,15 +84,24 @@ export const Contacts = ({
     ) => Promise<DraftSubmission | undefined>
 }): React.ReactElement => {
     const [shouldValidate, setShouldValidate] = React.useState(showValidations)
-    const redirectToDashboard = React.useRef(false)
-    const autoFocusRef = React.useRef<HTMLElement | null>(null)
     const [focusNewContact, setFocusNewContact] = React.useState(false)
+
+    const redirectToDashboard = React.useRef(false)
+    const newStateContactNameRef = React.useRef<HTMLElement | null>(null) // This ref.current is reset to the newest contact name field each time new contact is added
+    const [newStateContactButtonRef, setNewStateContactButtonFocus] = useFocus() // This ref.current is always the same element
+
     const history = useHistory<MCRouterState>()
 
+    /* 
+     Set focus to contact name field when adding new contacts. 
+     Clears ref and focusNewContact component state immediately after. The reset allows additional contacts to be added and preserves expected focus behavior.
+    */
     React.useEffect(() => {
         if (focusNewContact) {
-            autoFocusRef.current && autoFocusRef.current.focus()
+            newStateContactNameRef.current &&
+                newStateContactNameRef.current.focus()
             setFocusNewContact(false)
+            newStateContactNameRef.current = null
         }
     }, [focusNewContact])
 
@@ -241,7 +252,7 @@ export const Contacts = ({
                                                                         innerRef={(
                                                                             el: HTMLElement
                                                                         ) =>
-                                                                            (autoFocusRef.current =
+                                                                            (newStateContactNameRef.current =
                                                                                 el)
                                                                         }
                                                                     />
@@ -319,11 +330,12 @@ export const Contacts = ({
                                                                         className={
                                                                             styles.removeContactBtn
                                                                         }
-                                                                        onClick={() =>
+                                                                        onClick={() => {
                                                                             remove(
                                                                                 index
                                                                             )
-                                                                        }
+                                                                            setNewStateContactButtonFocus()
+                                                                        }}
                                                                     >
                                                                         Remove
                                                                         contact
@@ -334,17 +346,17 @@ export const Contacts = ({
                                                     )
                                                 )}
 
-                                            <Button
+                                            <button
                                                 type="button"
-                                                outline
-                                                className={styles.addContactBtn}
+                                                className={`usa-button usa-button---outline ${styles.addContactBtn}`}
                                                 onClick={() => {
                                                     push(emptyStateContact)
                                                     setFocusNewContact(true)
                                                 }}
+                                                ref={newStateContactButtonRef}
                                             >
                                                 Add state contact
-                                            </Button>
+                                            </button>
                                         </div>
                                     )}
                                 </FieldArray>


### PR DESCRIPTION
## Summary
1. After you add a new contact, should focus the first field in the newest contact (the name field)
2. After you remove a contact, should focus the add new contact button

Notes: 
-  Prettier wasn't run on contacts page (?) so the first commit contains those changes.  
- Added new hook `useFocus` after some online research. Right now it is just used for the focus on "Add new state contact" button.  We can use this for other cases where we want to remove to a specific element in the app.  It will _not_ work for elements that are dynamically added after render  or are dynamically calculated (e.g. it won't for our formik on error use case or for things like state contacts that are added and removed). Those need other solutions.
-  Seems like we should refactor this for actuary contacts once it is on main. Clear opportunity to share code between state and actuary contacts and refactor out a shared component for this adding/removing behavior (maybe @xtine already did this.)

#### Related issues
https://qmacbis.atlassian.net/browse/OY2-5550 

## Testing guidance
- add and remove contacts by keyboard only actions and click actions
- voiceover run through