### PR TITLE
Add dependabot to API service

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
     directory: '/tests/nightwatch'
     schedule:
       interval: 'weekly'
+
+  - package-ecosystem: 'npm'
+    directory: '/services/app-api'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
## Summary

Since dependabot can create a lot of PRs when first introduced, we decided to split #218 into smaller chunks.

This adds dependabot monitoring to the `app-api` service.
