### PR TITLE
Add app-web and graphql to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,13 @@ updates:
     directory: '/services/app-api'
     schedule:
       interval: 'weekly'
+
+  - package-ecosystem: 'npm'
+    directory: '/services/app-graphql'
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'npm'
+    directory: '/services/app-web'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
## Summary

Since dependabot can create a lot of PRs when first introduced, we decided to split #218 into smaller chunks.

This adds dependabot monitoring to the `app-web` and `app-graphql` services. All of `app-api` PR changes have been merged.

<!---These are developer instructions on how to test or validate the work -->
