### PR TITLE
Test breaking cypress out of deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,29 +103,6 @@ jobs:
       - name: set branch_name
         run: |
           echo "branch_name=$(./scripts/stage_name_for_branch.sh ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
-      - name: Check branch name is a legal serverless stage name
-        run: |
-          if [[ ! $branch_name =~ ^[a-zA-Z][a-zA-Z0-9-]*$ ]] || [[ $branch_name -gt 128 ]]; then
-            echo """
-              ------------------------------------------------------------------------------------------------------------------------------
-              ERROR:  Please read below
-              ------------------------------------------------------------------------------------------------------------------------------
-              Bad branch name detected; cannot continue.
-
-              The Serverless Application Framework has a concept of stages that facilitate multiple deployments of the same service.
-              In this setup, the git branch name gets passed to Serverless to serve as the stage name.
-              The stage name (branch name in this case) is tacked onto the end of the service name by Serverless.
-              Therefore, the branch name must be a valid service name.
-
-              From Serverless:
-                A service name should only contain alphanumeric (case sensitive) and hyphens. It should start with an alphabetic character and shouldnt exceed 128 characters.
-
-              For Github Actions support, please push your code to a new branch with a name that meets Serverless' service name requirements.
-              So, make a new branch with a name that begins with a letter and is made up of only letters, numbers, and hyphens... then delete this branch.
-              ------------------------------------------------------------------------------------------------------------------------------
-            """
-            exit 1
-          fi
       - name: set app version
         run: echo "APP_VERSION=$(scripts/app_version.sh)" >> $GITHUB_ENV
       - name: set branch specific variable names
@@ -184,29 +161,6 @@ jobs:
       - name: set branch_name
         run: |
           echo "branch_name=$(./scripts/stage_name_for_branch.sh ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
-      - name: Check branch name is a legal serverless stage name
-        run: |
-          if [[ ! $branch_name =~ ^[a-zA-Z][a-zA-Z0-9-]*$ ]] || [[ $branch_name -gt 128 ]]; then
-            echo """
-              ------------------------------------------------------------------------------------------------------------------------------
-              ERROR:  Please read below
-              ------------------------------------------------------------------------------------------------------------------------------
-              Bad branch name detected; cannot continue.
-
-              The Serverless Application Framework has a concept of stages that facilitate multiple deployments of the same service.
-              In this setup, the git branch name gets passed to Serverless to serve as the stage name.
-              The stage name (branch name in this case) is tacked onto the end of the service name by Serverless.
-              Therefore, the branch name must be a valid service name.
-
-              From Serverless:
-                A service name should only contain alphanumeric (case sensitive) and hyphens. It should start with an alphabetic character and shouldnt exceed 128 characters.
-
-              For Github Actions support, please push your code to a new branch with a name that meets Serverless' service name requirements.
-              So, make a new branch with a name that begins with a letter and is made up of only letters, numbers, and hyphens... then delete this branch.
-              ------------------------------------------------------------------------------------------------------------------------------
-            """
-            exit 1
-          fi
       - name: set app version
         run: echo "APP_VERSION=$(scripts/app_version.sh)" >> $GITHUB_ENV
       - name: set branch specific variable names


### PR DESCRIPTION
## Summary

With all these dependabot PRs I sort of hit my limit with needing to re-run the action for Cypress flakes. 

Just a quick test to see what it would take to break the GH action apart so I can just re-run the Cypress part on fail and not have to wait for long serverless deploys.

<!---These are developer instructions on how to test or validate the work -->
