### PR TITLE
Add termination protection only to named branches

### DIFF
--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -48,6 +48,12 @@ custom:
     - ${ssm:/configuration/${self:custom.stage}/vpc/subnets/private/b/id, ssm:/configuration/default/vpc/subnets/private/b/id}
     - ${ssm:/configuration/${self:custom.stage}/vpc/subnets/private/c/id, ssm:/configuration/default/vpc/subnets/private/c/id}
   rotatorArn: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${self:custom.stage}-rotator'
+  serverlessTerminationProtection:
+    stages:
+      - dev
+      - val
+      - prod
+      - main
 
 package:
   individually: true


### PR DESCRIPTION
## Summary

This adds termination protection to only the named environments of dev/val/prod/main. PR branches will not have termination protection enabled.

<!---These are developer instructions on how to test or validate the work -->
