### PR TITLE
Strip 'aws' string from stage name

### DIFF
--- a/scripts/stage_name_for_branch.sh
+++ b/scripts/stage_name_for_branch.sh
@@ -48,6 +48,11 @@ branch_name=$(echo "$branch_name" | sed "s/---*/-/g")
 
 >&2 echo "dash $branch_name"
 
+# remove aws string from branch name
+branch_name=${branch_name//aws/}
+
+>&2 echo "aws $branch_name"
+
 # downcase everything
 branch_name=$(echo "$branch_name" | awk '{print tolower($0)}')
 

--- a/scripts/stage_name_for_branch_test.js
+++ b/scripts/stage_name_for_branch_test.js
@@ -35,6 +35,10 @@ function testStageNames() {
             'dependabot/npm_and_yarn/testing-library/cypress-8.0.0',
             'dependabotnpmandyarntest37b10',
         ],
+        [
+            'dependabot/npm_and_yarn/aws-sdk-2.991.0',
+            'dependabotnpmandyarnsdk29910',
+        ],
     ];
 
     const testErrors = [];


### PR DESCRIPTION
## Summary

This strips the string `aws` from any stage name generation, as it is a reserved string inside AWS.

