### PR TITLE
Bugfix: allow IDM users with multiple (non-mc review) roles to login

### DIFF
--- a/services/app-api/authn/cognitoAuthn.test.ts
+++ b/services/app-api/authn/cognitoAuthn.test.ts
@@ -92,6 +92,21 @@ describe('cognitoAuthn', () => {
                 },
                 {
                     attributes: {
+                        'custom:role': 'macmcrrs-cms-user,macmcrrs-state-user',
+                        'custom:state_code': 'FL',
+                        given_name: 'Generic',
+                        family_name: 'Person',
+                        email: 'gp@example.com',
+                    },
+                    expectedResult: ok({
+                        role: 'STATE_USER',
+                        email: 'gp@example.com',
+                        name: 'Generic Person',
+                        state_code: 'FL',
+                    }),
+                },
+                {
+                    attributes: {
                         'custom:role':
                             'SOME_OPE User,neid-lame-user,smacfi-enduser,twoell-mmc-user,wefoi-mmc-ab-auth-user,POSS_ENDUSER,strongweak-user,ma-user',
                         'custom:state_code': 'FL',

--- a/services/app-api/authn/cognitoAuthn.ts
+++ b/services/app-api/authn/cognitoAuthn.ts
@@ -99,10 +99,11 @@ export function userTypeFromAttributes(attributes: {
 
     const fullName = attributes.given_name + ' ' + attributes.family_name
     // Roles are a list of all the roles a user has in IDM.
-    // as of September 2021, it shouldn't be possible for someone to have more than one MC Review role
     const roleAttribute = attributes['custom:role']
     const roles = roleAttribute.split(',')
 
+    // Arbitrarily, we check for the state user role first. If a user managed to have both roles, this is a little weird.
+    // but as of September 2021, it shouldn't be possible for someone to have more than one MC Review role
     if (roles.includes(STATE_ROLE_ATTRIBUTE)) {
         if (!('custom:state_code' in attributes)) {
             return err(

--- a/src/scripts/add_cypress_test_users.ts
+++ b/src/scripts/add_cypress_test_users.ts
@@ -27,7 +27,7 @@ async function getUserPoolID(stageName: string): Promise<string> {
     return userPoolID
 }
 
-type UserRole = 'CMS_USER' | 'STATE_USER'
+type UserRole = 'CMS_USER' | 'STATE_USER' | 'UNKNOWN_USER'
 
 // these are the exact roles as they are set by IDM
 function IDMRole(role: UserRole): string {
@@ -36,6 +36,8 @@ function IDMRole(role: UserRole): string {
             return 'macmcrrs-cms-user'
         case 'STATE_USER':
             return 'macmcrrs-state-user'
+        case 'UNKNOWN_USER':
+            return 'foo-bar-user'
     }
 }
 
@@ -151,6 +153,12 @@ async function main() {
             name: 'Zuko',
             email: 'zuko@cms.hhs.gov',
             role: 'CMS_USER' as const,
+            state: undefined,
+        },
+        {
+            name: 'Cabbages',
+            email: 'cabbages@example.com',
+            role: 'UNKNOWN_USER' as const,
             state: undefined,
         },
     ]


### PR DESCRIPTION
## Summary
In the pen test prep meeting today, we granted one of their pen-test IDM accounts access to MC Review and they were unable to login. The reason was that their user had a bunch of different IDM roles associated with it, which are passed in as a comma separated list. All of our testing had been with users with a single role. 

Fix is to split the list and grant them access if it includes our MC Review accounts. 

#### Related issues

#### Screenshots

#### Test cases covered

Updated my table test for parsing incoming info from IDM to include an anonoymized version of the string that broke us in the meeting. 

## QA guidance

Not a super easy way to test this I don’t think since it’s IDM related. Consider if I missed any cases in my tests.

<!---These are developer instructions on how to test or validate the work -->
