### PR TITLE
Add stream functions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,9 @@ updates:
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 2
+
+  - package-ecosystem: 'npm'
+    directory: '/services/stream-functions'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 2


### PR DESCRIPTION
## Summary

I was just looking at security alerts and a bunch of them are from the `stream-functions` service. Adding it to dependabot to keep up with those updates.
