### PR TITLE
Set IDP Logout for our IDM identity provider

### DIFF
--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -117,6 +117,7 @@ resources:
           - IdpIdentifier
         ProviderDetails:
           MetadataURL: ${self:custom.okta_metadata_url}
+          IDPSignout: 'true'
         ProviderName: Okta
         ProviderType: SAML
         UserPoolId: !Ref CognitoUserPool


### PR DESCRIPTION
## Summary
This PR attempts to configure IDM logout to log us out of IDM as well as logging us out of Cognito. As is, it’s confusing behavior to a user that logging out of our app does not log you out of IDM, since after clicking log out, if you click log in you are once again in our app without having to enter a username and password. 

I have been unable to find a true example of the syntax for this config change, I think this is right but it’s not actually clear from [the docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolidentityprovider.html). 

#### Related issues

https://qmacbis.atlassian.net/browse/OY2-7601

## QA guidance

Since this is an IDM related change, we will really have to wait until this is deployed to dev for us to test the change. 

<!---These are developer instructions on how to test or validate the work -->
