### PR TITLE
Fix ui-auth termination protection in PR branches

### DIFF
--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -17,6 +17,12 @@ custom:
   iamPath: ${env:IAM_PATH, "/"}
   iamPermissionsBoundaryPolicy: ${env:FULL_IAM_PERMISSIONS_BOUNDARY_POLICY, ""}
   sesSourceEmailAddress: ${env:SES_SOURCE_EMAIL_ADDRESS, ""}
+  serverlessTerminationProtection:
+    stages:
+      - dev
+      - val
+      - prod
+      - main
 
 provider:
   name: aws


### PR DESCRIPTION
## Summary

This makes sure termination protection is only enabled on dev/val/prod/main. `ui-auth` previously had it enabled for everything, causing PR branches to fail to clean up properly.
