### PR TITLE
Fix up stage naming script for new error

### DIFF
--- a/scripts/stage_name_for_branch.sh
+++ b/scripts/stage_name_for_branch.sh
@@ -74,7 +74,7 @@ if [ ${#branch_name} -gt 23 ]; then
 
     >&2 echo "hash $branch_hash"
 
-    branch_name="${branch_name:0:17}${branch_hash:0:5}"
+    branch_name="${branch_name:0:18}${branch_hash:0:5}"
 
     >&2 echo "combined $branch_name"
 

--- a/scripts/stage_name_for_branch_test.js
+++ b/scripts/stage_name_for_branch_test.js
@@ -17,32 +17,25 @@ function testStageNames() {
         ['ch@ra☃️ters', 'chraters'],
         [
             'a-very-very-long-so-long-too-long-branch-name',
-            'averyverylongsolongtoolo0bb6d',
+            'averyverylongsolon0bb6d',
         ],
         [
             'dependabot/github_actions/actions/setup-node-2.3.0',
-            'dependabotgithubactionsa291dc',
+            'dependabotgithubac291dc',
         ],
         ['this/that', 'thisthat'],
         ['under_score', 'underscore'],
         ['under-hyphen-_score', 'underhyphenscore'],
         ['under__under____score', 'underunderscore'],
         ['twentythreecharactersok', 'twentythreecharactersok'],
-        ['twentyfourcharactersnope', 'twentyfourcharactersnope9497e'],
-        ['jf-items-amended-definitions-help', 'jfitemsamendeddefinition19712'],
+        ['twentyfourcharactersnope', 'twentyfourcharacte9497e'],
+        ['jf-items-amended-definitions-help', 'jfitemsamendeddefi19712'],
         ['two3four5', 'two3four5'],
         [
             'dependabot/npm_and_yarn/testing-library/cypress-8.0.0',
-            'dependabotnpmandyarntest37b10',
+            'dependabotnpmandya37b10',
         ],
-        [
-            'dependabot/npm_and_yarn/aws-sdk-2.991.0',
-            'dependabotnpmandyarnsdk289abe',
-        ],
-        [
-            'dependabot/npm_and_yarn/yargs-17.2.1',
-            'dependabotnpmandyarnyarga596a',
-        ],
+        ['dependabot/npm_and_yarn/aws-sdk-2.991.0', 'dependabotnpmandya89abe'],
     ];
 
     const testErrors = [];


### PR DESCRIPTION
## Summary

Since the IAM permissions plugin for serverless has been added everywhere, there is a new role being created in `stream-functions` that causes our stage naming script to break on dependabot. This should fix that by dialing down the number of characters we allow for.

#### Related issues
https://qmacbis.atlassian.net/browse/OY2-12413

