### PR TITLE
Add github secret check action

### DIFF
--- a/.github/actions/check_secrets/action.yml
+++ b/.github/actions/check_secrets/action.yml
@@ -1,0 +1,19 @@
+name: 'Check For Secrets'
+description: 'Prints out SECRETS MISSING if github secrets are not present'
+inputs:
+  expected-secret:
+    description: 'Pass in a github secret. If the action gets empty string it triggers the output.'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - run: |
+        echo "Checking for Secret"
+        if [[ -z "${{ inputs.expected-secret }}" ]]; then
+          echo "SECRETS MISSING"
+          exit 1
+        else
+          echo "SECRETS FOUND"
+          exit 0
+        fi
+      shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
+      - name: Check for secrets
+        uses: ./.github/actions/check_secrets
+        with:
+          expected-secret: ${{ secrets.REACT_APP_AUTH_MODE }}
       - name: set branch_name
         run: |
           echo "branch_name=$(./scripts/stage_name_for_branch.sh ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

In order to adopt shimona’s github action re-runner, we need a github action that prints out log info indicating wether we have secrets or not. This also lets us fail these runs faster. Not much to test here, we’ll want to merge this and see if it reports correctly on the next dependabot PR
