### PR TITLE
[OY2-12630] Don't show empty (null) multi list items for review/submission summaries

### DIFF
--- a/services/app-web/src/components/SubmissionSummary/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummary/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -59,12 +59,16 @@ export const ContractDetailsSummarySection = ({
             : `${AmendableItemsRecord['CAPITATION_RATES']} (${RateChangeReasonRecord[reason]})`
     }
 
+    // Capture the "other" fields in Items being amended
+    // Including Capitation rates (Other) and Other
+    // to pass through to multi checkbox list
     const itemsAmendedOtherList = []
 
     if (
         submission?.contractAmendmentInfo?.itemsBeingAmended.includes(
             'CAPITATION_RATES'
-        )
+        ) &&
+        capitationRateChangeReason() !== null
     ) {
         itemsAmendedOtherList.push(capitationRateChangeReason())
     }


### PR DESCRIPTION
## Summary
Prevent null values that show up as blank list items when showing multiple checkbox items in the Contract Details summary section.

#### Related issues
https://qmacbis.atlassian.net/browse/OY2-12630

#### Screenshots
Before:
<img width="338" alt="Screen Shot 2021-10-05 at 11 56 00 AM" src="https://user-images.githubusercontent.com/24054/136085849-1b46c9e6-ec92-4e30-a764-f40e7aed6050.png">

After:
<img width="325" alt="Screen Shot 2021-10-05 at 11 55 39 AM" src="https://user-images.githubusercontent.com/24054/136085863-d3c17790-87d2-4311-b3f9-ea8a9f095103.png">

