### PR TITLE
[OY2-12605] All react components use index.ts for exports - Form

### DIFF
--- a/services/app-web/src/components/Form/FieldCheckbox/FieldCheckbox.stories.tsx
+++ b/services/app-web/src/components/Form/FieldCheckbox/FieldCheckbox.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Story } from '@storybook/react'
 import { Formik } from 'formik'
 import { FieldCheckbox, FieldCheckboxProps } from './FieldCheckbox'

--- a/services/app-web/src/components/Form/FieldCheckbox/FieldCheckbox.test.tsx
+++ b/services/app-web/src/components/Form/FieldCheckbox/FieldCheckbox.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { screen, render } from '@testing-library/react'
 import { FieldCheckbox } from './FieldCheckbox'
 

--- a/services/app-web/src/components/Form/FieldDropdown/FieldDropdown.stories.tsx
+++ b/services/app-web/src/components/Form/FieldDropdown/FieldDropdown.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import * as Yup from 'yup'
 import { Story } from '@storybook/react'
 import { Formik } from 'formik'

--- a/services/app-web/src/components/Form/FieldDropdown/FieldDropdown.test.tsx
+++ b/services/app-web/src/components/Form/FieldDropdown/FieldDropdown.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { screen, render } from '@testing-library/react'
 import { FieldDropdown } from './FieldDropdown'
 

--- a/services/app-web/src/components/Form/FieldRadio/FieldRadio.stories.tsx
+++ b/services/app-web/src/components/Form/FieldRadio/FieldRadio.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Story } from '@storybook/react'
 import { Formik } from 'formik'
 import { FieldRadio, FieldRadioProps } from './FieldRadio'

--- a/services/app-web/src/components/Form/FieldRadio/FieldRadio.test.tsx
+++ b/services/app-web/src/components/Form/FieldRadio/FieldRadio.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { screen, render } from '@testing-library/react'
 import { FieldRadio } from './FieldRadio'
 

--- a/services/app-web/src/components/Form/FieldTextInput/FieldTextInput.stories.tsx
+++ b/services/app-web/src/components/Form/FieldTextInput/FieldTextInput.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import * as Yup from 'yup'
 import { Story } from '@storybook/react'
 import { Formik } from 'formik'

--- a/services/app-web/src/components/Form/FieldTextInput/FieldTextInput.test.tsx
+++ b/services/app-web/src/components/Form/FieldTextInput/FieldTextInput.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { screen, render } from '@testing-library/react'
 import { FieldTextInput } from './FieldTextInput'
 

--- a/services/app-web/src/components/Form/FieldTextarea/FieldTextarea.stories.tsx
+++ b/services/app-web/src/components/Form/FieldTextarea/FieldTextarea.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import * as Yup from 'yup'
 import { Story } from '@storybook/react'
 import { Formik } from 'formik'

--- a/services/app-web/src/components/Form/FieldTextarea/FieldTextarea.test.tsx
+++ b/services/app-web/src/components/Form/FieldTextarea/FieldTextarea.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { screen, render } from '@testing-library/react'
 import { FieldTextarea } from './FieldTextarea'
 import { Link } from '@trussworks/react-uswds'

--- a/services/app-web/src/components/Form/index.ts
+++ b/services/app-web/src/components/Form/index.ts
@@ -1,0 +1,5 @@
+export { FieldCheckbox } from './FieldCheckbox/FieldCheckbox'
+export { FieldDropdown } from './FieldDropdown/FieldDropdown'
+export { FieldRadio } from './FieldRadio/FieldRadio'
+export { FieldTextarea } from './FieldTextarea/FieldTextarea'
+export { FieldTextInput } from './FieldTextInput/FieldTextInput'

--- a/services/app-web/src/pages/StateSubmissionForm/Contacts/Contacts.tsx
+++ b/services/app-web/src/pages/StateSubmissionForm/Contacts/Contacts.tsx
@@ -27,7 +27,7 @@ import {
     UpdateDraftSubmissionInput,
 } from '../../../gen/gqlClient'
 
-import { FieldRadio } from '../../../components/Form/FieldRadio/FieldRadio'
+import { FieldRadio } from '../../../components/Form'
 
 import {
     updatesFromSubmission,

--- a/services/app-web/src/pages/StateSubmissionForm/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmissionForm/ContractDetails/ContractDetails.tsx
@@ -16,9 +16,11 @@ import { Formik, FormikHelpers, FormikErrors } from 'formik'
 
 import styles from '../StateSubmissionForm.module.scss'
 
-import { FieldRadio } from '../../../components/Form/FieldRadio/FieldRadio'
-import { FieldCheckbox } from '../../../components/Form/FieldCheckbox/FieldCheckbox'
-import { FieldTextInput } from '../../../components/Form/FieldTextInput/FieldTextInput'
+import {
+    FieldRadio,
+    FieldCheckbox,
+    FieldTextInput,
+} from '../../../components/Form'
 import {
     formatForApi,
     formatForForm,

--- a/services/app-web/src/pages/StateSubmissionForm/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmissionForm/RateDetails/RateDetails.tsx
@@ -30,7 +30,7 @@ import {
     formatUserInputDate,
     validateDateFormat,
 } from '../../../formHelpers'
-import { FieldRadio } from '../../../components/Form/FieldRadio/FieldRadio'
+import { FieldRadio } from '../../../components/Form'
 import { updatesFromSubmission } from '../updateSubmissionTransform'
 import { MCRouterState } from '../../../constants/routerState'
 

--- a/services/app-web/src/pages/StateSubmissionForm/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmissionForm/SubmissionType/SubmissionType.tsx
@@ -26,9 +26,11 @@ import {
 import styles from '../StateSubmissionForm.module.scss'
 
 import { useAuth } from '../../../contexts/AuthContext'
-import { FieldTextarea } from '../../../components/Form/FieldTextarea/FieldTextarea'
-import { FieldDropdown } from '../../../components/Form/FieldDropdown/FieldDropdown'
-import { FieldRadio } from '../../../components/Form/FieldRadio/FieldRadio'
+import {
+    FieldTextarea,
+    FieldDropdown,
+    FieldRadio,
+} from '../../../components/Form'
 import { SubmissionTypeRecord } from '../../../constants/submissions'
 import {
     cleanDraftSubmission,


### PR DESCRIPTION
## Summary
This PR is part of a series to export React components using an `index.ts` file. Benefits of this method are
1. Explicitly managing what is and isn't exported out of the component
2. Standardizing how we manage exporting in our components
3. Removing the need for redundant path names when importing components and types elsewhere

#### Related issues
[[OY2-12598]](https://qmacbis.atlassian.net/browse/OY2-12598)