### PR TITLE
Reduce Lambda Layer Size

### DIFF
--- a/services/app-api/scripts/prepare-prisma-layer.sh
+++ b/services/app-api/scripts/prepare-prisma-layer.sh
@@ -30,6 +30,7 @@ function preparePrismaLayer() {
 
     echo "Remove non-RHEL bins to save space ..."
     rm -rf lambda-layers-prisma-client/nodejs/node_modules/.prisma/client/libquery_engine-debian-openssl-1.1.x.so.node
+    rm -rf lambda-layers-prisma-client/nodejs/node_modules/.prisma/client/libquery_engine-rhel-openssl-1.0.x.so.node 
     rm -rf lambda-layers-prisma-client/nodejs/node_modules/prisma/engines
     rm -rf lambda-layers-prisma-client/nodejs/node_modules/prisma/libquery_engine-debian-openssl-1.1.x.so.node
     rm -rf lambda-layers-prisma-client/nodejs/node_modules/@prisma/introspection-engine-debian-openssl-1.1.x 


### PR DESCRIPTION
## Summary

During [promote](https://github.com/CMSgov/managed-care-review/actions/runs/1364679378) the Lambda size was too large to deploy. This removes some dangling files that are copied in from `node_modules/.prisma`, but are either duplicates or from a different architecture.
