### PR TITLE
Set proper vars in cypress promote runs

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -71,6 +71,25 @@ jobs:
       - name: Setup env
         uses: ./.github/actions/setup_env
 
+      - name: set variable values
+        run: ./.github/build_vars.sh set_values
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          INFRASTRUCTURE_TYPE: ${{ secrets.INFRASTRUCTURE_TYPE || 'development' }}
+          SES_SOURCE_EMAIL_ADDRESS: ${{ secrets.SES_SOURCE_EMAIL_ADDRESS }}
+          SES_REVIEW_TEAM_EMAIL_ADDRESS: ${{ secrets.SES_REVIEW_TEAM_EMAIL_ADDRESS }}
+          OKTA_METADATA_URL: ${{ secrets.OKTA_METADATA_URL }}
+          IAM_PATH: ${{ secrets.IAM_PATH }}
+          FULL_IAM_PERMISSIONS_BOUNDARY_POLICY: ${{ secrets.FULL_IAM_PERMISSIONS_BOUNDARY_POLICY }}
+          DYNAMO_CONNECTION: ${{ secrets.DYNAMO_CONNECTION}}
+          CLOUDFRONT_CERTIFICATE_ARN: ${{ secrets.DEV_CLOUDFRONT_CERTIFICATE_ARN }}
+          CLOUDFRONT_DOMAIN_NAME: ${{ secrets.DEV_CLOUDFRONT_DOMAIN_NAME }}
+          CLOUDFRONT_STORYBOOK_DOMAIN_NAME: ${{ secrets.DEV_CLOUDFRONT_STORYBOOK_DOMAIN_NAME }}
+          TEST_USERS_PASS: ${{ secrets.TEST_USERS_PASS}}
+          REACT_APP_AUTH_MODE: IDM
+
       - name: Install packages in root
         run: yarn install --frozen-lockfile
 
@@ -141,6 +160,25 @@ jobs:
       - name: Setup env
         uses: ./.github/actions/setup_env
 
+      - name: set variable values
+        run: ./.github/build_vars.sh set_values
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.VAL_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.VAL_AWS_SECRET_ACCESS_KEY }}
+          CLOUDFRONT_CERTIFICATE_ARN: ${{ secrets.VAL_CLOUDFRONT_CERTIFICATE_ARN }}
+          CLOUDFRONT_DOMAIN_NAME: ${{ secrets.VAL_CLOUDFRONT_DOMAIN_NAME }}
+          CLOUDFRONT_STORYBOOK_DOMAIN_NAME: ${{ secrets.VAL_CLOUDFRONT_STORYBOOK_DOMAIN_NAME }}
+          OKTA_METADATA_URL: ${{ secrets.VAL_OKTA_METADATA_URL }}
+          FULL_IAM_PERMISSIONS_BOUNDARY_POLICY: ${{ secrets.VAL_FULL_IAM_PERMISSIONS_BOUNDARY_POLICY }}
+          REACT_APP_AUTH_MODE: IDM
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          INFRASTRUCTURE_TYPE: ${{ secrets.INFRASTRUCTURE_TYPE || 'development' }}
+          SES_SOURCE_EMAIL_ADDRESS: ${{ secrets.SES_SOURCE_EMAIL_ADDRESS }}
+          SES_REVIEW_TEAM_EMAIL_ADDRESS: ${{ secrets.SES_REVIEW_TEAM_EMAIL_ADDRESS }}
+          IAM_PATH: ${{ secrets.IAM_PATH }}
+          DYNAMO_CONNECTION: ${{ secrets.DYNAMO_CONNECTION}}
+          TEST_USERS_PASS: ${{ secrets.TEST_USERS_PASS}}
+
       - name: Install packages in root
         run: yarn install --frozen-lockfile
 
@@ -210,6 +248,25 @@ jobs:
 
       - name: Setup env
         uses: ./.github/actions/setup_env
+
+      - name: set variable values
+        run: ./.github/build_vars.sh set_values
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+          CLOUDFRONT_CERTIFICATE_ARN: ${{ secrets.PROD_CLOUDFRONT_CERTIFICATE_ARN }}
+          CLOUDFRONT_DOMAIN_NAME: ${{ secrets.PROD_CLOUDFRONT_DOMAIN_NAME }}
+          CLOUDFRONT_STORYBOOK_DOMAIN_NAME: ${{ secrets.PROD_CLOUDFRONT_STORYBOOK_DOMAIN_NAME }}
+          OKTA_METADATA_URL: ${{ secrets.PROD_OKTA_METADATA_URL }}
+          FULL_IAM_PERMISSIONS_BOUNDARY_POLICY: ${{ secrets.PROD_FULL_IAM_PERMISSIONS_BOUNDARY_POLICY }}
+          REACT_APP_AUTH_MODE: IDM
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          INFRASTRUCTURE_TYPE: ${{ secrets.INFRASTRUCTURE_TYPE || 'development' }}
+          SES_SOURCE_EMAIL_ADDRESS: ${{ secrets.SES_SOURCE_EMAIL_ADDRESS }}
+          SES_REVIEW_TEAM_EMAIL_ADDRESS: ${{ secrets.SES_REVIEW_TEAM_EMAIL_ADDRESS }}
+          IAM_PATH: ${{ secrets.IAM_PATH }}
+          DYNAMO_CONNECTION: ${{ secrets.DYNAMO_CONNECTION}}
+          TEST_USERS_PASS: ${{ secrets.TEST_USERS_PASS}}
 
       - name: Install packages in root
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
## Summary

This sets the vars properly in the Cypress runs during promote. They were missing during [this run](https://github.com/CMSgov/managed-care-review/actions/runs/1364955808).