### PR TITLE
Do not interact directly with radio inputs in cypress

### DIFF
--- a/tests/cypress/integration/cmsWorkflow/viewSubmission.spec.ts
+++ b/tests/cypress/integration/cmsWorkflow/viewSubmission.spec.ts
@@ -6,7 +6,7 @@ describe('CMS User can view submission', () => {
     //         cy.navigateForm('Continue')
     //         cy.findByText(/^MN-PMAP-/).should('exist')
     //         // Fill out contract details
-    //         cy.findByLabelText('Base contract').safeClick()
+    //         cy.findByText('Base contract').click()
     //         cy.findByLabelText('Start date').type('04/01/2024')
     //         cy.findByLabelText('End date').type('03/31/2025').blur()
     //         cy.findByLabelText('Managed Care Organization (MCO)').safeClick()
@@ -14,7 +14,7 @@ describe('CMS User can view submission', () => {
     //         cy.findAllByTestId('errorMessage').should('have.length', 0)
     //         cy.navigateForm('Continue')
     //         //Fill out rate details
-    //         cy.findByLabelText('New rate certification').safeClick()
+    //         cy.findByText('New rate certification').click()
     //         cy.findByLabelText('Start date').type('02/29/2024')
     //         cy.findByLabelText('End date').type('02/28/2025')
     //         cy.findByLabelText('Date certified').type('03/01/2024')
@@ -29,9 +29,9 @@ describe('CMS User can view submission', () => {
     //         cy.findAllByLabelText('Email').eq(1).type('act@test.com')
     //         cy.findByLabelText('Mercer').safeClick()
     //         // actuary communication preference
-    //         cy.findByLabelText(
+    //         cy.findByText(
     //             `OACT can communicate directly with the state’s actuary but should copy the state on all written communication and all appointments for verbal discussions.`
-    //         ).safeClick()
+    //         ).click()
     //         // Continue button navigates to documents page
     //         cy.findByRole('button', {
     //             name: 'Continue',

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/contacts.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/contacts.spec.ts
@@ -16,9 +16,7 @@ describe('contacts', () => {
 
             // Navigate to type page to switch to contract and rates submission
             cy.visit(`/submissions/${draftSubmissionId}/type`)
-            cy.findByLabelText(
-                'Contract action and rate certification'
-            ).safeClick()
+            cy.findByText('Contract action and rate certification').click()
             cy.navigateForm('Continue')
 
             // Navigate to contacts page

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/contractDetails.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/contractDetails.spec.ts
@@ -31,9 +31,7 @@ describe('contract details', () => {
 
             // Navigate to type page to switch to contract and rates submission
             cy.visit(`/submissions/${draftSubmissionId}/type`)
-            cy.findByLabelText(
-                'Contract action and rate certification'
-            ).safeClick()
+            cy.findByText('Contract action and rate certification').click()
             cy.navigateForm('Continue')
 
             // Navigate to contract details page

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
@@ -34,9 +34,7 @@ describe('submission type', () => {
             const draftSubmissionId = pathnameArray[2]
             cy.visit(`/submissions/${draftSubmissionId}/type`)
 
-            cy.findByLabelText(
-                'Contract action and rate certification'
-            ).safeClick()
+            cy.findByText('Contract action and rate certification').click()
 
             // Navigate to contract details page by clicking continue for contract and rates submission
             cy.navigateForm('Continue')

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -29,7 +29,7 @@ Cypress.Commands.add('startNewContractAndRatesSubmission', () => {
 Cypress.Commands.add('fillOutContractActionOnly', () => {
     // Must be on '/submissions/new'
     cy.findByRole('combobox', { name: 'Program' }).select('pmap')
-    cy.findByLabelText('Contract action only').safeClick()
+    cy.findByText('Contract action only').click()
     cy.findByRole('textbox', { name: 'Submission description' }).type(
         'description of contract only submission'
     )
@@ -38,7 +38,7 @@ Cypress.Commands.add('fillOutContractActionOnly', () => {
 Cypress.Commands.add('fillOutContractActionAndRateCertification', () => {
     // Must be on '/submissions/new'
     cy.findByRole('combobox', { name: 'Program' }).select('pmap')
-    cy.findByLabelText('Contract action and rate certification').safeClick()
+    cy.findByText('Contract action and rate certification').click()
     cy.findByRole('textbox', { name: 'Submission description' }).type(
         'description of contract and rates submission'
     )
@@ -46,7 +46,7 @@ Cypress.Commands.add('fillOutContractActionAndRateCertification', () => {
 
 Cypress.Commands.add('fillOutBaseContractDetails', () => {
     // Must be on '/submissions/:id/contract-details'
-    cy.findByLabelText('Base contract').safeClick()
+    cy.findByText('Base contract').click()
     cy.wait(2000)
     cy.findByLabelText('Start date').type('04/01/2024')
     cy.findByLabelText('End date').type('03/31/2025').blur()
@@ -57,7 +57,7 @@ Cypress.Commands.add('fillOutBaseContractDetails', () => {
 
 Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
     // Must be on '/submissions/:id/contract-details'
-    cy.findByLabelText('Amendment to base contract').safeClick()
+    cy.findByText('Amendment to base contract').click()
     cy.wait(2000)
     cy.findByLabelText('Start date').type('04/01/2024')
     cy.findByLabelText('End date').type('03/31/2025').blur()
@@ -65,14 +65,14 @@ Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
     cy.findByLabelText('1932(a) State Plan Authority').safeClick()
     cy.findByLabelText('Benefits provided').safeClick()
     cy.findByLabelText('Financial incentives').safeClick()
-    cy.findByLabelText('No').safeClick()
+    cy.findByText('No').click()
     cy.findAllByTestId('errorMessage').should('have.length', 0)
 })
 
 Cypress.Commands.add('fillOutNewRateCertification', () => {
     // Must be on '/submissions/:id/rate-details'
     // Must be a contract and rates submission
-    cy.findByLabelText('New rate certification').safeClick()
+    cy.findByText('New rate certification').click()
     cy.wait(2000)
     cy.findByLabelText('Start date').type('02/29/2024')
     cy.findByLabelText('End date').type('02/28/2025')
@@ -83,7 +83,7 @@ Cypress.Commands.add('fillOutNewRateCertification', () => {
 Cypress.Commands.add('fillOutAmendmentToPriorRateCertification', () => {
     // Must be on '/submissions/:id/rate-details'
     // Must be a contract and rates submission
-    cy.findByLabelText('Amendment to prior rate certification').safeClick()
+    cy.findByText('Amendment to prior rate certification').click()
     cy.wait(2000)
     cy.findAllByLabelText('Start date').eq(0).type('02/29/2024')
     cy.findAllByLabelText('End date').eq(0).type('02/28/2025')
@@ -112,9 +112,9 @@ Cypress.Commands.add('fillOutActuaryContact', () => {
     cy.findAllByLabelText('Mercer').eq(0).safeClick()
 
     // Actuary communication preference
-    cy.findByLabelText(
+    cy.findByText(
         `OACT can communicate directly with the state’s actuary but should copy the state on all written communication and all appointments for verbal discussions.`
-    ).safeClick()
+    ).click()
     cy.findAllByTestId('errorMessage').should('have.length', 0)
 })
 


### PR DESCRIPTION
## Summary

Our top flake is attempting to click on the "Amendment to a base contract" radio button on the Contract Details page. Looking into it, I believe this flake stems from our using the cy.findByLabelText() function to get a handle on the actual input. This doesn't consistently work with our radio buttons because of how USWDS radio buttons are implemented. The browser provided checkboxes are shuttled off the screen and the selected icon is added to the label itself. So when we find the actual input related to a given label, it is way way off screen and cypress refuses to .click() it and appears to fail to  successfully safeClick() it a significant amount of time. 

This fix is to drop findByLabelText in favor of cy.findByText() for our radio inputs since in reality the label is all that is on screen anyway. 

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
Does this pass in cypress succesfully? 

<!---These are developer instructions on how to test or validate the work -->
