### PR TITLE
Pin ua-parser-js to 0.7.24 to avoid a poisioned package

### DIFF
--- a/services/app-graphql/package.json
+++ b/services/app-graphql/package.json
@@ -7,6 +7,9 @@
         "gqlgen": "graphql-codegen",
         "gqlgen-watch": "graphql-codegen --watch"
     },
+    "resolutions": {
+        "**/ua-parser-js": "0.7.24"
+    },
     "devDependencies": {
         "@graphql-codegen/cli": "^2.2.1",
         "@graphql-codegen/introspection": "^2.1.0",


### PR DESCRIPTION
Per https://github.com/faisalman/ua-parser-js/issues/536
a set of versions of ua-parser-js were released that had
malware in them. This resolves our version to the version
we had locked at the time of the incident. Eventually
we will want to remove this once the dust has settled
but this prevents us from accidentally installing the
bad package for now.

## Summary

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
