### PR TITLE
Fix document error styling on rate details page

### DIFF
--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -306,7 +306,7 @@ export const RateDetails = ({
                                 <legend className="srOnly">Rate Details</legend>
                                 {formAlert && formAlert}
                                 <span>All fields are required</span>
-                                <FormGroup>
+                                <FormGroup error={showDocumentErrors}>
                                     <FileUpload
                                         id="rateDocuments"
                                         name="rateDocuments"


### PR DESCRIPTION
## Summary
The document uploads error styles on the rate details page did not match the styling on the contract details page. This PR fixes that issue.

#### Screenshots
Before
<img width="654" alt="Before" src="https://user-images.githubusercontent.com/4032377/142018234-6c5373ce-5803-4086-888e-8e7ff3ac4339.png">

After
<img width="691" alt="After" src="https://user-images.githubusercontent.com/4032377/142018254-04d090a8-c1bf-4764-8e0c-8d7491297f33.png">

