### PR TITLE
Move sha back to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,7 +144,7 @@ jobs:
 
   deploy-branch:
     needs: [build-prisma-client-lambda-layer, get-branch-name-vars]
-    uses: CMSgov/managed-care-review/.github/workflows/deploy-to-env.yml@d1ad7bf286a650364f2f453943e1b0bfe633192b
+    uses: CMSgov/managed-care-review/.github/workflows/deploy-to-env.yml@main
     with:
       stage_name: ${{ needs.get-branch-name-vars.outputs.branch-name}}
     secrets:


### PR DESCRIPTION
## Summary

Just a quick fix to move the `deploy-to-env` workflow to point to `main` again. CI failing otherwise.
