### PR TITLE
Bump max_old_space_size for node in promote

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -59,6 +59,7 @@ jobs:
         env:
           REACT_APP_AUTH_MODE: IDM
           DATABASE_URL: postgresql://postgres:shhhsecret@localhost:5432/postgres?schema=public&connection_limit=5 #pragma: allowlist secret
+          NODE_OPTIONS: --max_old_space_size=6000
         run: ./dev test --unit
 
       - name: publish code coverage


### PR DESCRIPTION
## Summary

Our promote script is hitting an OOM in the unit test phase. When we hit this in our branch deploy CI in the past we had set `max_old_space_size`, but had never hit it during promote. This sets it in promote to try to avoid the OOM.
