### PR TITLE
Run s3 serverless using local install instead of global

### DIFF
--- a/dev_tool/src/local/s3.ts
+++ b/dev_tool/src/local/s3.ts
@@ -11,7 +11,7 @@ export async function runS3Locally(runner: LabeledProcessRunner) {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     runner.runCommandAndOutput(
         's3',
-        ['serverless', 's3', 'start', '--stage', 'local'],
+        ['npx', 'serverless', 's3', 'start', '--stage', 'local'],
         'services/uploads'
     )
 }


### PR DESCRIPTION
## Summary

We had a local dev error where if your global serverless version is mismatched with what we have in package.json we’ll get an error b/c we were starting things with the global version. This change uses npx so that we always use the locally installed version with ./dev local 
