### PR TITLE
Remove Aurora v1 resources

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -26,7 +26,6 @@ custom:
   appApiWafAclArn: ${env:CF_CONFIG_IGNORED_LOCALLY, cf:infra-api-${sls:stage}.WafPluginAclArn}
   emailerMode: ${env:EMAILER_MODE, ssm:/configuration/emailer_mode}
   parameterStoreMode: ${env:PARAMETER_STORE_MODE, ssm:/configuration/parameterStoreMode}
-  auroraArn: ${env:CF_CONFIG_IGNORED_LOCALLY, cf:postgres-${sls:stage}.PostgresAuroraArn }
   auroraV2Arn: ${env:CF_CONFIG_IGNORED_LOCALLY, cf:postgres-${sls:stage}.PostgresAuroraV2Arn }
   document_uploads_bucket_arn: ${env:CF_CONFIG_IGNORED_LOCALLY, cf:uploads-${sls:stage}.DocumentUploadsBucketArn}
   qa_uploads_bucket_arn: ${env:CF_CONFIG_IGNORED_LOCALLY, cf:uploads-${sls:stage}.QAUploadsBucketArn}

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -96,7 +96,6 @@ provider:
           Action:
             - rds-db:connect
           Resource:
-            - ${self:custom.auroraArn}
             - ${self:custom.auroraV2Arn}
         - Effect: 'Allow'
           Action:

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -110,20 +110,6 @@ resources:
           PasswordLength: 30
           ExcludePunctuation: true
 
-    PostgresAurora:
-      Type: AWS::RDS::DBCluster
-      DeletionPolicy: ${self:custom.deletionPolicy.${opt:stage}, self:custom.deletionPolicy.other}
-      Properties:
-        Engine: aurora-postgresql
-        EngineMode: serverless
-        DatabaseName: '${self:custom.databaseName}'
-        MasterUsername: !Sub '{{resolve:secretsmanager:${PostgresSecret}::username}}'
-        MasterUserPassword: !Sub '{{resolve:secretsmanager:${PostgresSecret}::password}}'
-        DBSubnetGroupName: !Ref PostgresSubnetGroup
-        VpcSecurityGroupIds: ['${self:custom.sgId}']
-        ScalingConfiguration:
-          AutoPause: ${self:custom.pauseAurora.${opt:stage}, self:custom.pauseAurora.other}
-
     PostgresAuroraV2:
       Type: AWS::RDS::DBCluster
       DeletionPolicy: ${self:custom.deletionPolicy.${opt:stage}, self:custom.deletionPolicy.other}
@@ -185,7 +171,5 @@ resources:
         Principal: 'secretsmanager.amazonaws.com'
 
   Outputs:
-    PostgresAuroraArn:
-      Value: !Sub 'arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:${PostgresAurora}'
     PostgresAuroraV2Arn:
       Value: !Sub 'arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:${PostgresAuroraV2}'


### PR DESCRIPTION
## Summary

When we upgraded to Postgres Aurora v2 we left the old v1 database around to make sure everything was working properly with the upgrade. Since things seem to be fine it should be ok to remove the old resources.

#### Related issues
https://qmacbis.atlassian.net/browse/MR-3200