### PR TITLE
Add more OTEL to s3 error paths

### DIFF
--- a/services/app-web/src/otelHelpers/index.ts
+++ b/services/app-web/src/otelHelpers/index.ts
@@ -2,5 +2,6 @@ export {
     getTracer,
     recordSpan,
     recordJSException,
+    recordJSExceptionWithContext,
     recordUserInputException,
 } from './tracingHelper'

--- a/services/app-web/src/otelHelpers/tracingHelper.ts
+++ b/services/app-web/src/otelHelpers/tracingHelper.ts
@@ -47,6 +47,16 @@ function recordJSException(error: string | Error): void {
     span.end()
 }
 
+export function recordJSExceptionWithContext(
+    error: string | Error,
+    spanName: string
+) {
+    const tracer = getTracer()
+    const span = tracer.startSpan(spanName)
+    span.recordException(error)
+    console.error(error)
+}
+
 function recordUserInputException(error: string | Error): void {
     const tracer = getTracer()
     const span = tracer.startSpan('UserInputException')

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import type { S3ClientT } from './s3Client'
 import type { S3Error } from './s3Error'
-import { recordJSException } from '../otelHelpers'
+import { recordJSException, recordJSExceptionWithContext } from '../otelHelpers'
 
 // TYPES AND TYPE GUARDS
 type s3PutError = {
@@ -120,7 +120,11 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
                         })
                     })
                 } catch (err) {
-                    recordJSException(err)
+                    recordJSExceptionWithContext(
+                        err,
+                        'serviceName',
+                        'scanFile.retryWithBackoff'
+                    )
                     throw err
                 }
                 return

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -112,12 +112,17 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
         ): Promise<void | S3Error> => {
             try {
                 await waitFor(20000)
-                await retryWithBackoff(async () => {
-                    await Storage.get(filename, {
-                        bucket: bucketConfig[bucket],
-                        download: true,
+                try {
+                    await retryWithBackoff(async () => {
+                        await Storage.get(filename, {
+                            bucket: bucketConfig[bucket],
+                            download: true,
+                        })
                     })
-                })
+                } catch (err) {
+                    recordJSException(err)
+                    throw err
+                }
                 return
             } catch (err) {
                 assertIsS3PutError(err)

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -122,7 +122,6 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
                 } catch (err) {
                     recordJSExceptionWithContext(
                         err,
-                        'serviceName',
                         'scanFile.retryWithBackoff'
                     )
                     throw err


### PR DESCRIPTION
## Summary

We had a user encounter some issues with file uploads today, but there were no errors in the OTEL logs to indicate their particular issue. This adds some error recording to the error paths of the s3 context in hopes of getting more insight from that level of `app-web`.