### PR TITLE
Size down Aurora minimum capacity in review apps

### DIFF
--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -68,6 +68,10 @@ custom:
     other: 'Delete'
     val: 'Retain'
     prod: 'Retain'
+  auroraMinCapacity:
+    other: 0.5
+    val: 1
+    prod: 1
 
 package:
   individually: true
@@ -125,7 +129,7 @@ resources:
         EnableCloudwatchLogsExports:
           - postgresql
         ServerlessV2ScalingConfiguration:
-          MinCapacity: 1
+          MinCapacity: ${self:custom.auroraMinCapacity.${opt:stage}, self:custom.auroraMinCapacity.other}
           MaxCapacity: 32
 
     PostgresAuroraV2Instance:


### PR DESCRIPTION
## Summary

We received a ticket (MDSO-187) saying our costs have gone up in the past 5 weeks in dev. It looks like it's mainly Aurora RDS related, probably due to some combination of provisioned capacity and how for a little while there we had both v1 and v2 aurora DBs deployed due to our upgrade (v1 is now fully removed).

This provisions our Aurora DBs in PR environments with the smallest possible deployment size.

#### Related issues
https://qmacbis.atlassian.net/browse/MR-3228
