### PR TITLE
Feature flag "packages with shared rates" dropdown

### DIFF
--- a/docs/technical-design/launch-darkly-testing-approach.md
+++ b/docs/technical-design/launch-darkly-testing-approach.md
@@ -87,7 +87,7 @@ The unit testing implementation uses a test version of the `ldService` dependenc
 
 ```typescript
   function testLDService(
-      mockFeatureFlags?: Partial<FeatureFlagObject>
+      mockFeatureFlags?: FeatureFlagSettings
   ): LDService {
       const featureFlags = defaultFeatureFlags
 

--- a/docs/technical-design/launch-darkly-testing-approach.md
+++ b/docs/technical-design/launch-darkly-testing-approach.md
@@ -94,10 +94,10 @@ The unit testing implementation uses a test version of the `ldService` dependenc
       //Update featureFlags with mock flag values.
       if (mockFeatureFlags) {
         for (const flag in mockFeatureFlags) {
-          const featureFlag = flag as FeatureFlagTypes
+          const featureFlag = flag
           featureFlags[featureFlag] = mockFeatureFlags[
                   featureFlag
-                  ] as FlagValueTypes
+                  ] as FeatureFlagSettings
         }
       }
 

--- a/services/app-api/src/launchDarkly/launchDarkly.ts
+++ b/services/app-api/src/launchDarkly/launchDarkly.ts
@@ -1,18 +1,18 @@
 import {
-    featureFlagEnums,
+    featureFlagKeys,
     featureFlags,
-    FeatureFlagTypes,
-    FlagValueTypes,
+    FlagValue,
+    FeatureFlagLDConstant,
 } from '../../../app-web/src/common-code/featureFlags'
 import { LDClient } from 'launchdarkly-node-server-sdk'
 import { Context } from '../handlers/apollo_gql'
 import { logError } from '../logger'
 import { setErrorAttributesOnActiveSpan } from '../resolvers/attributeHelper'
 
-type FeatureFlagObject = Record<FeatureFlagTypes, FlagValueTypes>
+type FeatureFlagObject = Record<FeatureFlagLDConstant, FlagValue>
 
 //Set up default feature flag values used to returned data
-const defaultFeatureFlags: FeatureFlagObject = featureFlagEnums.reduce(
+const defaultFeatureFlags: FeatureFlagObject = featureFlagKeys.reduce(
     (a, c) => {
         const flag = featureFlags[c].flag
         const defaultValue = featureFlags[c].defaultValue
@@ -24,8 +24,8 @@ const defaultFeatureFlags: FeatureFlagObject = featureFlagEnums.reduce(
 type LDService = {
     getFeatureFlag: (
         context: Context,
-        flag: FeatureFlagTypes
-    ) => Promise<FlagValueTypes>
+        flag: FeatureFlagLDConstant
+    ) => Promise<FlagValue>
 }
 
 function ldService(ldClient: LDClient): LDService {

--- a/services/app-api/src/launchDarkly/launchDarkly.ts
+++ b/services/app-api/src/launchDarkly/launchDarkly.ts
@@ -3,29 +3,28 @@ import {
     featureFlags,
     FlagValue,
     FeatureFlagLDConstant,
+    FeatureFlagSettings,
 } from '../../../app-web/src/common-code/featureFlags'
 import { LDClient } from 'launchdarkly-node-server-sdk'
 import { Context } from '../handlers/apollo_gql'
 import { logError } from '../logger'
 import { setErrorAttributesOnActiveSpan } from '../resolvers/attributeHelper'
 
-type FeatureFlagObject = Record<FeatureFlagLDConstant, FlagValue>
-
 //Set up default feature flag values used to returned data
-const defaultFeatureFlags: FeatureFlagObject = featureFlagKeys.reduce(
+const defaultFeatureFlags: FeatureFlagSettings = featureFlagKeys.reduce(
     (a, c) => {
         const flag = featureFlags[c].flag
         const defaultValue = featureFlags[c].defaultValue
         return Object.assign(a, { [flag]: defaultValue })
     },
-    {} as FeatureFlagObject
+    {} as FeatureFlagSettings
 )
 
 type LDService = {
     getFeatureFlag: (
         context: Context,
         flag: FeatureFlagLDConstant
-    ) => Promise<FlagValue>
+    ) => Promise<FlagValue | undefined>
 }
 
 function ldService(ldClient: LDClient): LDService {
@@ -57,4 +56,4 @@ function offlineLDService(): LDService {
 }
 
 export { ldService, offlineLDService, defaultFeatureFlags }
-export type { LDService, FeatureFlagObject }
+export type { LDService, FeatureFlagSettings }

--- a/services/app-api/src/resolvers/healthPlanPackage/submitHealthPlanPackage.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/submitHealthPlanPackage.ts
@@ -33,10 +33,7 @@ import { toDomain } from '../../../../app-web/src/common-code/proto/healthPlanFo
 import { EmailParameterStore } from '../../parameterStore'
 import { LDService } from '../../launchDarkly/launchDarkly'
 import { GraphQLError } from 'graphql'
-import {
-    FeatureFlagTypes,
-    FlagValueTypes,
-} from 'app-web/src/common-code/featureFlags'
+import { FeatureFlagSettings } from 'app-web/src/common-code/featureFlags'
 
 export const SubmissionErrorCodes = ['INCOMPLETE', 'INVALID'] as const
 type SubmissionErrorCode = typeof SubmissionErrorCodes[number] // iterable union type
@@ -71,7 +68,7 @@ export function isSubmissionError(err: unknown): err is SubmissionError {
 // "parse, don't validate" article: https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/
 function submit(
     draft: UnlockedHealthPlanFormDataType,
-    featureFlags?: Partial<Record<FeatureFlagTypes, FlagValueTypes>>
+    featureFlags?: FeatureFlagSettings
 ): LockedHealthPlanFormDataType | SubmissionError {
     const maybeStateSubmission: Record<string, unknown> = {
         ...draft,

--- a/services/app-api/src/testHelpers/launchDarklyHelpers.ts
+++ b/services/app-api/src/testHelpers/launchDarklyHelpers.ts
@@ -1,7 +1,7 @@
 import { LDService } from '../launchDarkly/launchDarkly'
 import {
-    FeatureFlagTypes,
-    FlagValueTypes,
+    FeatureFlagLDConstant,
+    FeatureFlagSettings,
 } from 'app-web/src/common-code/featureFlags'
 
 import {
@@ -17,10 +17,10 @@ function testLDService(
     //Update featureFlags with mock flag values.
     if (mockFeatureFlags) {
         for (const flag in mockFeatureFlags) {
-            const featureFlag = flag as FeatureFlagTypes
+            const featureFlag = flag as FeatureFlagLDConstant
             featureFlags[featureFlag] = mockFeatureFlags[
                 featureFlag
-            ] as FlagValueTypes
+            ] as FeatureFlagSettings
         }
     }
 

--- a/services/app-api/src/testHelpers/launchDarklyHelpers.ts
+++ b/services/app-api/src/testHelpers/launchDarklyHelpers.ts
@@ -4,14 +4,9 @@ import {
     FeatureFlagSettings,
 } from 'app-web/src/common-code/featureFlags'
 
-import {
-    defaultFeatureFlags,
-    FeatureFlagObject,
-} from '../launchDarkly/launchDarkly'
+import { defaultFeatureFlags } from '../launchDarkly/launchDarkly'
 
-function testLDService(
-    mockFeatureFlags?: Partial<FeatureFlagObject>
-): LDService {
+function testLDService(mockFeatureFlags?: FeatureFlagSettings): LDService {
     const featureFlags = defaultFeatureFlags
 
     //Update featureFlags with mock flag values.

--- a/services/app-web/src/common-code/featureFlags/flags.ts
+++ b/services/app-web/src/common-code/featureFlags/flags.ts
@@ -50,6 +50,13 @@ export const featureFlags = {
         defaultValue: false,
     },
     /**
+     * Enables packages with shared rates dropdown on rate details page. This was an early version of rates across subs functionality.
+     */
+    PACKAGES_WITH_SHARED_RATES: {
+        flag: 'packages-with-shared-rates',
+        defaultValue: false,
+    },
+    /**
      * Enables Chip-only form changes
      */
     CHIP_ONLY_FORM: {

--- a/services/app-web/src/common-code/featureFlags/flags.ts
+++ b/services/app-web/src/common-code/featureFlags/flags.ts
@@ -1,12 +1,11 @@
 /**
- * Contains a list of all our feature flags in Launch Darkly each flag should contain a default value. This is used to
- * give us type safety around flag names when we're enabling/disabling features in our code.
+ * Source of truth for feature flags in application.
+ * Ensures some type safety around flag names when we're enabling/disabling features in our code.
  *
- * This list is also used to generate Types for our Unit and Cypress tests. Our Cypress LD integration heavily relies
- * on this list to help constrain tests to flag's in LD, autocompletion, generate Types and flag state management
+ * This file also used to generate types for our Jest unit tests, Cypress tests, and for Yup validation logic.
  */
 
-export const featureFlags = {
+const featureFlags = {
     /**
      Toggles the site maintenance alert on the landing page
     */
@@ -73,23 +72,24 @@ export const featureFlags = {
     },
 } as const
 
-export type FlagEnumType = keyof typeof featureFlags
-
 /**
- * featureFlags object top level property keys in an array. Used for LD integration into Cypress
+ * Feature flags constants used in application. Uppercased and snake_cased
  */
-export const featureFlagEnums: FlagEnumType[] = Object.keys(featureFlags).map(
-    (flag): keyof typeof featureFlags => flag as FlagEnumType
+const featureFlagKeys = Object.keys(featureFlags).map(
+    (flag): keyof typeof featureFlags => flag as FlagKey
 )
 
 /**
- * Get a union type of all `flag` values of `featureFlags`. This type will constrain code to only use feature flags defined
- * in the featureFlag object. Mainly used in testing to restrict testing to actual feature flags.
+ * Feature flag constants used in Launch Darkly. Lowercased and kebab-cased
  */
-export type FeatureFlagTypes =
+type FeatureFlagLDConstant =
     typeof featureFlags[keyof typeof featureFlags]['flag']
 
-/**
- * Flag value types from Launch Darkly and used to restrict feature flag default types as well as values in testing.
- */
-export type FlagValueTypes = boolean | string | number | object | []
+type FlagKey = keyof typeof featureFlags
+type FlagValue = boolean | string | number | object | [] // this is  an approximate mapping to available LD flag value types
+
+type FeatureFlagSettings = Partial<Record<FeatureFlagLDConstant, FlagValue>>
+
+export type { FlagKey, FlagValue, FeatureFlagLDConstant, FeatureFlagSettings }
+
+export { featureFlagKeys, featureFlags }

--- a/services/app-web/src/common-code/featureFlags/index.ts
+++ b/services/app-web/src/common-code/featureFlags/index.ts
@@ -1,2 +1,8 @@
-export { featureFlags, featureFlagEnums } from './flags'
-export type { FeatureFlagTypes, FlagValueTypes, FlagEnumType } from './flags'
+export type {
+    FlagKey,
+    FlagValue,
+    FeatureFlagLDConstant,
+    FeatureFlagSettings,
+} from './flags'
+
+export { featureFlagKeys, featureFlags } from './flags'

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -938,10 +938,10 @@ describe('RateDetails', () => {
                     }),
                     id: 'test-id-125',
                 },
-                // {
-                //     ...mockUnlockedHealthPlanPackage(currentSubmission),
-                //     id: 'test-shared-rate',
-                // },
+                {
+                    ...mockUnlockedHealthPlanPackage(currentSubmission),
+                    id: 'test-shared-rate',
+                },
             ]
 
             renderWithProviders(

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -38,8 +38,6 @@ describe('RateDetails', () => {
         jest.setTimeout(10000)
         // TODO: These tests are too long and need to be fully refactored. They are starting to flake in recent versions of RTL, particularly the multi-rate and contract amendment  ests
         // See this guidance for waitFor and getBy Role: https://github.com/testing-library/dom-testing-library/issues/820
-
-        ldUseClientSpy({ 'packages-with-shared-rates': true })
     })
 
     afterEach(() => {
@@ -242,6 +240,7 @@ describe('RateDetails', () => {
         })
 
         it('progressively disclose new rate form fields as expected', async () => {
+            ldUseClientSpy({ 'packages-with-shared-rates': true })
             renderWithProviders(
                 <RateDetails
                     draftSubmission={emptyRateDetailsDraft}
@@ -671,6 +670,7 @@ describe('RateDetails', () => {
 
     describe('handles rates across submissions', () => {
         it('correctly checks shared rate certification radios and selects shared packages', async () => {
+            ldUseClientSpy({ 'packages-with-shared-rates': true })
             //Spy on useStatePrograms hook to get up-to-date state programs
             jest.spyOn(useStatePrograms, 'useStatePrograms').mockReturnValue(
                 mockMNState().programs
@@ -730,6 +730,7 @@ describe('RateDetails', () => {
                     },
                 }
             )
+
             const rateCertsOnLoad = rateCertifications(screen)
             expect(rateCertsOnLoad).toHaveLength(1)
 
@@ -901,6 +902,7 @@ describe('RateDetails', () => {
         })
 
         it('cannot continue when shared rate radio is unchecked', async () => {
+            ldUseClientSpy({ 'packages-with-shared-rates': true })
             //Spy on useStatePrograms hook to get up-to-date state programs
             jest.spyOn(useStatePrograms, 'useStatePrograms').mockReturnValue(
                 mockMNState().programs
@@ -936,10 +938,10 @@ describe('RateDetails', () => {
                     }),
                     id: 'test-id-125',
                 },
-                {
-                    ...mockUnlockedHealthPlanPackage(currentSubmission),
-                    id: 'test-shared-rate',
-                },
+                // {
+                //     ...mockUnlockedHealthPlanPackage(currentSubmission),
+                //     id: 'test-shared-rate',
+                // },
             ]
 
             renderWithProviders(
@@ -1030,6 +1032,7 @@ describe('RateDetails', () => {
         })
 
         it('cannot continue when shared rate radio is checked and no package is selected', async () => {
+            ldUseClientSpy({ 'packages-with-shared-rates': true })
             //Spy on useStatePrograms hook to get up-to-date state programs
             jest.spyOn(useStatePrograms, 'useStatePrograms').mockReturnValue(
                 mockMNState().programs
@@ -1692,6 +1695,7 @@ describe('RateDetails', () => {
 // Helper functions
 
 const fillOutIndexRate = async (screen: Screen, index: number) => {
+    ldUseClientSpy({ 'packages-with-shared-rates': true })
     const targetRateCert = rateCertifications(screen)[index]
     expect(targetRateCert).toBeDefined()
     const withinTargetRateCert = within(targetRateCert)

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -32,7 +32,6 @@ import { ACCEPTED_SUBMISSION_FILE_TYPES } from '../../../components/FileUpload'
 import selectEvent from 'react-select-event'
 import * as useStatePrograms from '../../../hooks/useStatePrograms'
 import { unlockedWithALittleBitOfEverything } from '../../../common-code/healthPlanFormDataMocks'
-import { featureFlags } from '../../../common-code/featureFlags/flags'
 
 describe('RateDetails', () => {
     beforeAll(() => {
@@ -40,7 +39,7 @@ describe('RateDetails', () => {
         // TODO: These tests are too long and need to be fully refactored. They are starting to flake in recent versions of RTL, particularly the multi-rate and contract amendment  ests
         // See this guidance for waitFor and getBy Role: https://github.com/testing-library/dom-testing-library/issues/820
 
-        ldUseClientSpy({ [featureFlags.PACKAGES_WITH_SHARED_RATES.flag]: true })
+        ldUseClientSpy({ 'packages-with-shared-rates': true })
     })
 
     afterEach(() => {

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -25,18 +25,22 @@ import {
     TEST_PNG_FILE,
     dragAndDrop,
     updateDateRange,
+    ldUseClientSpy,
 } from '../../../testHelpers'
 import { RateDetails } from './RateDetails'
 import { ACCEPTED_SUBMISSION_FILE_TYPES } from '../../../components/FileUpload'
 import selectEvent from 'react-select-event'
 import * as useStatePrograms from '../../../hooks/useStatePrograms'
 import { unlockedWithALittleBitOfEverything } from '../../../common-code/healthPlanFormDataMocks'
+import { featureFlags } from '../../../common-code/featureFlags/flags'
 
 describe('RateDetails', () => {
     beforeAll(() => {
         jest.setTimeout(10000)
         // TODO: These tests are too long and need to be fully refactored. They are starting to flake in recent versions of RTL, particularly the multi-rate and contract amendment  ests
         // See this guidance for waitFor and getBy Role: https://github.com/testing-library/dom-testing-library/issues/820
+
+        ldUseClientSpy({ [featureFlags.PACKAGES_WITH_SHARED_RATES.flag]: true })
     })
 
     afterEach(() => {

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -120,7 +120,7 @@ export const RateDetails = ({
 
     // Feature flags state management
     const ldClient = useLDClient()
-    const showPackagesWithSharedRatesDropdown = ldClient?.variation(
+    const showPackagesWithSharedRatesDropdown: boolean = ldClient?.variation(
         featureFlags.PACKAGES_WITH_SHARED_RATES.flag,
         featureFlags.PACKAGES_WITH_SHARED_RATES.defaultValue
     )
@@ -137,7 +137,9 @@ export const RateDetails = ({
         PackageOptionType[]
     >([])
 
-    const rateDetailsFormSchema = RateDetailsFormSchema()
+    const rateDetailsFormSchema = RateDetailsFormSchema({
+        'packages-with-shared-rates': showPackagesWithSharedRatesDropdown,
+    })
 
     const { loading, error } = useIndexHealthPlanPackagesQuery({
         onCompleted: async (data) => {

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -56,6 +56,8 @@ import { recordJSException } from '../../../otelHelpers'
 import { dayjs } from '../../../common-code/dateHelpers'
 import { SharedRateCertDisplay } from '../../../common-code/healthPlanFormDataType/UnlockedHealthPlanFormDataType'
 import { getCurrentRevisionFromHealthPlanPackage } from '../../../gqlHelpers'
+import { featureFlags } from '../../../common-code/featureFlags'
+import { useLDClient } from 'launchdarkly-react-client-sdk'
 
 const RateDatesErrorMessage = ({
     startDate,
@@ -115,6 +117,13 @@ export const RateDetails = ({
     const { deleteFile, getKey, getS3URL, scanFile, uploadFile } = useS3()
     const navigate = useNavigate()
     const statePrograms = useStatePrograms()
+
+    // Feature flags state management
+    const ldClient = useLDClient()
+    const showPackagesWithSharedRatesDropdown = ldClient?.variation(
+        featureFlags.PACKAGES_WITH_SHARED_RATES.flag,
+        featureFlags.PACKAGES_WITH_SHARED_RATES.defaultValue
+    )
 
     // Rate documents state management
     const [focusErrorSummaryHeading, setFocusErrorSummaryHeading] =
@@ -726,35 +735,36 @@ export const RateDetails = ({
                                                                 }
                                                             />
                                                         </FormGroup>
-                                                        <FormGroup
-                                                            error={
-                                                                showFieldErrors(
-                                                                    rateErrorHandling(
-                                                                        errors
-                                                                            ?.rateInfos?.[
-                                                                            index
-                                                                        ]
+                                                        {showPackagesWithSharedRatesDropdown && (
+                                                            <FormGroup
+                                                                error={
+                                                                    showFieldErrors(
+                                                                        rateErrorHandling(
+                                                                            errors
+                                                                                ?.rateInfos?.[
+                                                                                index
+                                                                            ]
+                                                                        )
+                                                                            ?.hasSharedRateCert
+                                                                    ) ||
+                                                                    showFieldErrors(
+                                                                        rateErrorHandling(
+                                                                            errors
+                                                                                ?.rateInfos?.[
+                                                                                index
+                                                                            ]
+                                                                        )
+                                                                            ?.packagesWithSharedRateCerts
                                                                     )
-                                                                        ?.hasSharedRateCert
-                                                                ) ||
-                                                                showFieldErrors(
-                                                                    rateErrorHandling(
-                                                                        errors
-                                                                            ?.rateInfos?.[
-                                                                            index
-                                                                        ]
-                                                                    )
-                                                                        ?.packagesWithSharedRateCerts
-                                                                )
-                                                            }
-                                                        >
-                                                            <FieldYesNo
-                                                                className={
-                                                                    styles.radioGroup
                                                                 }
-                                                                id={`hasSharedRateCert.${index}.`}
-                                                                name={`rateInfos.${index}.hasSharedRateCert`}
-                                                                label="Was
+                                                            >
+                                                                <FieldYesNo
+                                                                    className={
+                                                                        styles.radioGroup
+                                                                    }
+                                                                    id={`hasSharedRateCert.${index}.`}
+                                                                    name={`rateInfos.${index}.hasSharedRateCert`}
+                                                                    label="Was
                                                                             this
                                                                             rate
                                                                             certification
@@ -763,117 +773,119 @@ export const RateDetails = ({
                                                                             any
                                                                             other
                                                                             submissions?"
-                                                                showError={showFieldErrors(
-                                                                    rateErrorHandling(
-                                                                        errors
-                                                                            ?.rateInfos?.[
-                                                                            index
-                                                                        ]
-                                                                    )
-                                                                        ?.hasSharedRateCert
-                                                                )}
-                                                            />
-
-                                                            {rateInfo.hasSharedRateCert ===
-                                                                'YES' && (
-                                                                <>
-                                                                    <Label
-                                                                        htmlFor={`rateInfos.${index}.packagesWithSharedRateCerts`}
-                                                                    >
-                                                                        Please
-                                                                        select
-                                                                        the
-                                                                        submissions
-                                                                        that
-                                                                        also
-                                                                        contain
-                                                                        this
-                                                                        rate
-                                                                        certification.
-                                                                    </Label>
-                                                                    <Link
-                                                                        aria-label="View all submissions (opens in new window)"
-                                                                        href={
-                                                                            '/dashboard'
-                                                                        }
-                                                                        variant="external"
-                                                                        target="_blank"
-                                                                    >
-                                                                        View all
-                                                                        submissions
-                                                                    </Link>
-                                                                    {showFieldErrors(
+                                                                    showError={showFieldErrors(
                                                                         rateErrorHandling(
                                                                             errors
                                                                                 ?.rateInfos?.[
                                                                                 index
                                                                             ]
                                                                         )
-                                                                            ?.packagesWithSharedRateCerts
-                                                                    ) && (
-                                                                        <PoliteErrorMessage>
-                                                                            {getIn(
-                                                                                errors,
-                                                                                `rateInfos.${index}.packagesWithSharedRateCerts`
-                                                                            )}
-                                                                        </PoliteErrorMessage>
+                                                                            ?.hasSharedRateCert
                                                                     )}
-                                                                    <PackageSelect
-                                                                        //This key is required here because the combination of react-select, defaultValue, formik and apollo useQuery
-                                                                        // causes issues with the default value when reloading the page
-                                                                        key={`${packageOptions}-${rateInfo.key}`}
-                                                                        inputId={`rateInfos.${index}.packagesWithSharedRateCerts`}
-                                                                        name={`rateInfos.${index}.packagesWithSharedRateCerts`}
-                                                                        statePrograms={
-                                                                            statePrograms
-                                                                        }
-                                                                        initialValues={rateInfo.packagesWithSharedRateCerts.map(
-                                                                            (
-                                                                                item
-                                                                            ) =>
-                                                                                item.packageId
-                                                                                    ? item.packageId
-                                                                                    : ''
-                                                                        )}
-                                                                        packageOptions={
-                                                                            packageOptions
-                                                                        }
-                                                                        draftSubmissionId={
-                                                                            draftSubmission.id
-                                                                        }
-                                                                        isLoading={
-                                                                            loading
-                                                                        }
-                                                                        error={
-                                                                            error instanceof
-                                                                            Error
-                                                                        }
-                                                                        onChange={(
-                                                                            selectedOptions
-                                                                        ) =>
-                                                                            setFieldValue(
-                                                                                `rateInfos.${index}.packagesWithSharedRateCerts`,
-                                                                                selectedOptions.map(
-                                                                                    (
-                                                                                        item: PackageOptionType
-                                                                                    ) => {
-                                                                                        return {
-                                                                                            packageName:
-                                                                                                item.label.replace(
-                                                                                                    /\s\(.*?\)/g,
-                                                                                                    ''
-                                                                                                ),
-                                                                                            packageId:
-                                                                                                item.value,
-                                                                                        }
-                                                                                    }
-                                                                                )
+                                                                />
+
+                                                                {rateInfo.hasSharedRateCert ===
+                                                                    'YES' && (
+                                                                    <>
+                                                                        <Label
+                                                                            htmlFor={`rateInfos.${index}.packagesWithSharedRateCerts`}
+                                                                        >
+                                                                            Please
+                                                                            select
+                                                                            the
+                                                                            submissions
+                                                                            that
+                                                                            also
+                                                                            contain
+                                                                            this
+                                                                            rate
+                                                                            certification.
+                                                                        </Label>
+                                                                        <Link
+                                                                            aria-label="View all submissions (opens in new window)"
+                                                                            href={
+                                                                                '/dashboard'
+                                                                            }
+                                                                            variant="external"
+                                                                            target="_blank"
+                                                                        >
+                                                                            View
+                                                                            all
+                                                                            submissions
+                                                                        </Link>
+                                                                        {showFieldErrors(
+                                                                            rateErrorHandling(
+                                                                                errors
+                                                                                    ?.rateInfos?.[
+                                                                                    index
+                                                                                ]
                                                                             )
-                                                                        }
-                                                                    />
-                                                                </>
-                                                            )}
-                                                        </FormGroup>
+                                                                                ?.packagesWithSharedRateCerts
+                                                                        ) && (
+                                                                            <PoliteErrorMessage>
+                                                                                {getIn(
+                                                                                    errors,
+                                                                                    `rateInfos.${index}.packagesWithSharedRateCerts`
+                                                                                )}
+                                                                            </PoliteErrorMessage>
+                                                                        )}
+                                                                        <PackageSelect
+                                                                            //This key is required here because the combination of react-select, defaultValue, formik and apollo useQuery
+                                                                            // causes issues with the default value when reloading the page
+                                                                            key={`${packageOptions}-${rateInfo.key}`}
+                                                                            inputId={`rateInfos.${index}.packagesWithSharedRateCerts`}
+                                                                            name={`rateInfos.${index}.packagesWithSharedRateCerts`}
+                                                                            statePrograms={
+                                                                                statePrograms
+                                                                            }
+                                                                            initialValues={rateInfo.packagesWithSharedRateCerts.map(
+                                                                                (
+                                                                                    item
+                                                                                ) =>
+                                                                                    item.packageId
+                                                                                        ? item.packageId
+                                                                                        : ''
+                                                                            )}
+                                                                            packageOptions={
+                                                                                packageOptions
+                                                                            }
+                                                                            draftSubmissionId={
+                                                                                draftSubmission.id
+                                                                            }
+                                                                            isLoading={
+                                                                                loading
+                                                                            }
+                                                                            error={
+                                                                                error instanceof
+                                                                                Error
+                                                                            }
+                                                                            onChange={(
+                                                                                selectedOptions
+                                                                            ) =>
+                                                                                setFieldValue(
+                                                                                    `rateInfos.${index}.packagesWithSharedRateCerts`,
+                                                                                    selectedOptions.map(
+                                                                                        (
+                                                                                            item: PackageOptionType
+                                                                                        ) => {
+                                                                                            return {
+                                                                                                packageName:
+                                                                                                    item.label.replace(
+                                                                                                        /\s\(.*?\)/g,
+                                                                                                        ''
+                                                                                                    ),
+                                                                                                packageId:
+                                                                                                    item.value,
+                                                                                            }
+                                                                                        }
+                                                                                    )
+                                                                                )
+                                                                            }
+                                                                        />
+                                                                    </>
+                                                                )}
+                                                            </FormGroup>
+                                                        )}
                                                         <FormGroup
                                                             error={showFieldErrors(
                                                                 rateErrorHandling(

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
@@ -13,13 +13,15 @@ const SingleRateCertSchema = (activeFeatureFlags: FeatureFlagSettings) =>
         packagesWithSharedRateCerts: activeFeatureFlags[
             'packages-with-shared-rates'
         ]
-            ? Yup.array().when('hasSharedRateCert', {
-                  is: 'YES',
-                  then: Yup.array().min(
-                      1,
-                      'You must select at least one submission'
-                  ),
-              })
+            ? Yup.array()
+                  .when('hasSharedRateCert', {
+                      is: 'YES',
+                      then: Yup.array().min(
+                          1,
+                          'You must select at least one submission'
+                      ),
+                  })
+                  .required()
             : Yup.array(),
         rateProgramIDs: Yup.array().min(1, 'You must select a program'),
         rateType: Yup.string().defined(
@@ -135,7 +137,7 @@ const SingleRateCertSchema = (activeFeatureFlags: FeatureFlagSettings) =>
 const RateDetailsFormSchema = (activeFeatureFlags?: FeatureFlagSettings) => {
     return Yup.object().shape({
         rateInfos: Yup.array().of(
-            SingleRateCertSchema((activeFeatureFlags = {}))
+            SingleRateCertSchema(activeFeatureFlags || {})
         ),
     })
 }

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
@@ -1,134 +1,144 @@
 import * as Yup from 'yup'
 import { dayjs } from '../../../common-code/dateHelpers'
-import { FeatureFlagTypes } from '../../../common-code/featureFlags'
+import { FeatureFlagSettings } from '../../../common-code/featureFlags'
 import { validateDateFormat } from '../../../formHelpers'
 
 Yup.addMethod(Yup.date, 'validateDateFormat', validateDateFormat)
 
-// Form validations that are always true, regardless of feature flag
-const SingleRateCertSchema = Yup.object().shape({
-    hasSharedRateCert: Yup.string().defined('You must select yes or no'),
-    packagesWithSharedRateCerts: Yup.array().when('hasSharedRateCert', {
-        is: 'YES',
-        then: Yup.array().min(1, 'You must select at least one submission'),
-    }),
-    rateProgramIDs: Yup.array().min(1, 'You must select a program'),
-    rateType: Yup.string().defined('You must choose a rate certification type'),
-    rateCapitationType: Yup.string().defined(
-        "You must select whether you're certifying rates or rate ranges"
-    ),
-    rateDateStart: Yup.date().when('rateType', (contractType) => {
-        if (contractType) {
-            return (
-                Yup.date()
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-ignore-next-line
-                    .validateDateFormat('YYYY-MM-DD', true)
-                    .defined('You must enter a start date')
-                    .typeError('The start date must be in MM/DD/YYYY format')
-            )
-        }
-    }),
-    rateDateEnd: Yup.date().when('rateType', (rateType) => {
-        if (rateType) {
-            return (
-                Yup.date()
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-ignore-next-line
-                    .validateDateFormat('YYYY-MM-DD', true)
-                    .defined('You must enter an end date')
-                    .typeError('The end date must be in MM/DD/YYYY format')
-                    .when(
-                        // RateDateEnd must be at minimum the day after Start
-                        'rateDateStart',
-                        (rateDateStart: Date, schema: Yup.DateSchema) => {
-                            const startDate = dayjs(rateDateStart)
-                            if (startDate.isValid()) {
-                                return schema.min(
-                                    startDate.add(1, 'day'),
-                                    'The end date must come after the start date'
-                                )
+const SingleRateCertSchema = (activeFeatureFlags: FeatureFlagSettings) =>
+    Yup.object().shape({
+        hasSharedRateCert: activeFeatureFlags['packages-with-shared-rates']
+            ? Yup.string().defined('You must select yes or no')
+            : Yup.string(),
+        packagesWithSharedRateCerts: activeFeatureFlags[
+            'packages-with-shared-rates'
+        ]
+            ? Yup.array().when('hasSharedRateCert', {
+                  is: 'YES',
+                  then: Yup.array().min(
+                      1,
+                      'You must select at least one submission'
+                  ),
+              })
+            : Yup.array(),
+        rateProgramIDs: Yup.array().min(1, 'You must select a program'),
+        rateType: Yup.string().defined(
+            'You must choose a rate certification type'
+        ),
+        rateCapitationType: Yup.string().defined(
+            "You must select whether you're certifying rates or rate ranges"
+        ),
+        rateDateStart: Yup.date().when('rateType', (contractType) => {
+            if (contractType) {
+                return (
+                    Yup.date()
+                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                        // @ts-ignore-next-line
+                        .validateDateFormat('YYYY-MM-DD', true)
+                        .defined('You must enter a start date')
+                        .typeError(
+                            'The start date must be in MM/DD/YYYY format'
+                        )
+                )
+            }
+        }),
+        rateDateEnd: Yup.date().when('rateType', (rateType) => {
+            if (rateType) {
+                return (
+                    Yup.date()
+                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                        // @ts-ignore-next-line
+                        .validateDateFormat('YYYY-MM-DD', true)
+                        .defined('You must enter an end date')
+                        .typeError('The end date must be in MM/DD/YYYY format')
+                        .when(
+                            // RateDateEnd must be at minimum the day after Start
+                            'rateDateStart',
+                            (rateDateStart: Date, schema: Yup.DateSchema) => {
+                                const startDate = dayjs(rateDateStart)
+                                if (startDate.isValid()) {
+                                    return schema.min(
+                                        startDate.add(1, 'day'),
+                                        'The end date must come after the start date'
+                                    )
+                                }
                             }
-                        }
-                    )
-            )
-        }
-    }),
-    rateDateCertified: Yup.date().when('rateType', (rateType) => {
-        if (rateType) {
-            return (
-                Yup.date()
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-ignore-next-line
-                    .validateDateFormat('YYYY-MM-DD', true)
-                    .defined(
-                        'You must enter the date the document was certified'
-                    )
-                    .typeError(
-                        'The certified date must be in MM/DD/YYYY format'
-                    )
-            )
-        }
-    }),
-    effectiveDateStart: Yup.date().when('rateType', {
-        is: 'AMENDMENT',
-        then: Yup.date()
-            .nullable()
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore-next-line
-            .validateDateFormat('YYYY-MM-DD', true)
-            .defined('You must enter a start date')
-            .typeError('The start date must be in MM/DD/YYYY format'),
-    }),
-    effectiveDateEnd: Yup.date().when('rateType', {
-        is: 'AMENDMENT',
-        then: Yup.date()
-            .nullable()
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore-next-line
-            .validateDateFormat('YYYY-MM-DD', true)
-            .defined('You must enter an end date')
-            .typeError('The end date must be in MM/DD/YYYY format')
-            .min(
-                Yup.ref('effectiveDateStart'),
-                'The end date must come after the start date'
-            ),
-    }),
-    actuaryContacts: Yup.array().of(
-        Yup.object().shape({
-            name: Yup.string().required('You must provide a name'),
-            titleRole: Yup.string().required('You must provide a title/role'),
-            email: Yup.string()
-                .email('You must enter a valid email address')
-                .required('You must provide an email address'),
-            actuarialFirm: Yup.string()
-                .required('You must select an actuarial firm')
-                .nullable(),
-            actuarialFirmOther: Yup.string()
-                .when('actuarialFirm', {
-                    is: 'OTHER',
-                    then: Yup.string()
-                        .required('You must enter a description')
-                        .nullable(),
-                })
-                .nullable(),
-        })
-    ),
-    actuaryCommunicationPreference: Yup.string().optional(),
-})
+                        )
+                )
+            }
+        }),
+        rateDateCertified: Yup.date().when('rateType', (rateType) => {
+            if (rateType) {
+                return (
+                    Yup.date()
+                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                        // @ts-ignore-next-line
+                        .validateDateFormat('YYYY-MM-DD', true)
+                        .defined(
+                            'You must enter the date the document was certified'
+                        )
+                        .typeError(
+                            'The certified date must be in MM/DD/YYYY format'
+                        )
+                )
+            }
+        }),
+        effectiveDateStart: Yup.date().when('rateType', {
+            is: 'AMENDMENT',
+            then: Yup.date()
+                .nullable()
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore-next-line
+                .validateDateFormat('YYYY-MM-DD', true)
+                .defined('You must enter a start date')
+                .typeError('The start date must be in MM/DD/YYYY format'),
+        }),
+        effectiveDateEnd: Yup.date().when('rateType', {
+            is: 'AMENDMENT',
+            then: Yup.date()
+                .nullable()
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore-next-line
+                .validateDateFormat('YYYY-MM-DD', true)
+                .defined('You must enter an end date')
+                .typeError('The end date must be in MM/DD/YYYY format')
+                .min(
+                    Yup.ref('effectiveDateStart'),
+                    'The end date must come after the start date'
+                ),
+        }),
+        actuaryContacts: Yup.array().of(
+            Yup.object().shape({
+                name: Yup.string().required('You must provide a name'),
+                titleRole: Yup.string().required(
+                    'You must provide a title/role'
+                ),
+                email: Yup.string()
+                    .email('You must enter a valid email address')
+                    .required('You must provide an email address'),
+                actuarialFirm: Yup.string()
+                    .required('You must select an actuarial firm')
+                    .nullable(),
+                actuarialFirmOther: Yup.string()
+                    .when('actuarialFirm', {
+                        is: 'OTHER',
+                        then: Yup.string()
+                            .required('You must enter a description')
+                            .nullable(),
+                    })
+                    .nullable(),
+            })
+        ),
+        actuaryCommunicationPreference: Yup.string().optional(),
+    })
 
 const RateDetailsFormSchema = (
     activeFeatureFlags?: Partial<Record<FeatureFlagTypes, boolean>>
 ) => {
-    // Configure schema when flags are passed in.
-    if (activeFeatureFlags) {
-        return Yup.object().shape({
-            rateInfos: Yup.array().of(SingleRateCertSchema),
-        })
-    }
-
     return Yup.object().shape({
-        rateInfos: Yup.array().of(SingleRateCertSchema),
+        rateInfos: Yup.array().of(
+            SingleRateCertSchema((activeFeatureFlags = {}))
+        ),
     })
 }
 

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
@@ -132,9 +132,7 @@ const SingleRateCertSchema = (activeFeatureFlags: FeatureFlagSettings) =>
         actuaryCommunicationPreference: Yup.string().optional(),
     })
 
-const RateDetailsFormSchema = (
-    activeFeatureFlags?: Partial<Record<FeatureFlagTypes, boolean>>
-) => {
+const RateDetailsFormSchema = (activeFeatureFlags?: FeatureFlagSettings) => {
     return Yup.object().shape({
         rateInfos: Yup.array().of(
             SingleRateCertSchema((activeFeatureFlags = {}))

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionTypeSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionTypeSchema.ts
@@ -1,14 +1,12 @@
 import * as Yup from 'yup'
-import { FeatureFlagTypes } from '../../../common-code/featureFlags'
+import { FeatureFlagSettings } from '../../../common-code/featureFlags'
 import { validateDateFormat } from '../../../formHelpers'
 
 Yup.addMethod(Yup.date, 'validateDateFormat', validateDateFormat)
 
-type FeatureFlagsForYup = Partial<Record<FeatureFlagTypes, boolean>>
-
 // Formik setup
 // Should be listed in order of appearance on field to allow errors to focus as expected
-const SubmissionTypeFormSchema = (flags: FeatureFlagsForYup = {}) =>
+const SubmissionTypeFormSchema = (flags: FeatureFlagSettings = {}) =>
     Yup.object().shape({
         populationCovered: flags['chip-only-form']
             ? Yup.string().required(

--- a/services/app-web/src/testHelpers/jestHelpers.tsx
+++ b/services/app-web/src/testHelpers/jestHelpers.tsx
@@ -17,7 +17,11 @@ import { S3Provider } from '../contexts/S3Context'
 import { testS3Client } from './s3Helpers'
 import { S3ClientT } from '../s3'
 import * as LaunchDarkly from 'launchdarkly-react-client-sdk'
-import { FeatureFlagTypes, FlagValueTypes } from '../common-code/featureFlags'
+import {
+    FeatureFlagLDConstant,
+    FlagValue,
+    FeatureFlagSettings,
+} from '../common-code/featureFlags'
 
 /* Render */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -67,9 +71,7 @@ const WithLocation = ({
 }
 
 //WARNING: This required tests using this function to clear mocks afterwards.
-const ldUseClientSpy = (
-    featureFlags: Partial<Record<FeatureFlagTypes, FlagValueTypes>>
-) => {
+const ldUseClientSpy = (featureFlags: FeatureFlagSettings) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     jest.spyOn(LaunchDarkly, 'useLDClient').mockImplementation((): any => {
         return {
@@ -84,8 +86,8 @@ const ldUseClientSpy = (
             identify: jest.fn(),
             alias: jest.fn(),
             variation: (
-                flag: FeatureFlagTypes,
-                defaultValue: FlagValueTypes | undefined
+                flag: FeatureFlagLDConstant,
+                defaultValue: FlagValue | undefined
             ) => {
                 if (
                     featureFlags[flag] === undefined &&

--- a/tests/cypress/support/index.ts
+++ b/tests/cypress/support/index.ts
@@ -20,8 +20,8 @@ import './questionResponseCommands'
 import './launchDarklyCommands'
 import './e2e'
 import {
-    FeatureFlagTypes,
-    FlagValueTypes,
+    FeatureFlagLDConstant,
+    FeatureFlagSettings,
 } from '../../../services/app-web/src/common-code/featureFlags'
 
 type FormButtonKey =
@@ -88,11 +88,11 @@ declare global {
             //Launch Darkly commands
             stubFeatureFlags(): void
             interceptFeatureFlags(
-                toggleFlags?: Partial<Record<FeatureFlagTypes, FlagValueTypes>>
+                toggleFlags?: FeatureFlagSettings
             ): void
             getFeatureFlagStore(
-                featureFlag?: FeatureFlagTypes[]
-            ): Promise<Partial<Record<FeatureFlagTypes, FlagValueTypes>>>
+                featureFlag?: FeatureFlagLDConstant[]
+            ): Promise<FeatureFlagSettings>
         }
     }
 }

--- a/tests/cypress/support/launchDarklyCommands.ts
+++ b/tests/cypress/support/launchDarklyCommands.ts
@@ -3,8 +3,12 @@ import '@testing-library/cypress/add-commands'
 import { FeatureFlagLDConstant, FeatureFlagSettings, featureFlags, FlagValue, featureFlagKeys } from '../../../services/app-web/src/common-code/featureFlags/flags'
 
 /**
+ * interceptFeatureFlags sets the flag to what is passed into it and sets other flags to default values. 
+ * Passing in an empty object will default all flags. 
+ * 
  * The code below was taken from this blog post and modified a bit for our use of Types in feature flags.
  * https://dev.to/muratkeremozcan/effective-test-strategies-for-testing-front-end-applications-using-launchdarkly-feature-flags-and-cypress-part2-testing-2c72#stubbing-a-feature-flag
+ *
  */
 
 // Intercepting LD "GET" calls for feature flag values and returns our default flags and values.
@@ -70,11 +74,12 @@ Cypress.Commands.add('stubFeatureFlags', () => {
     ).as('LDClientStream')
 
     /**
-     * Setting default values for flags for Cypress E2E tests only. Adding an entry here is not required. 
+     * Setting default values for flags for Cypress E2E tests. Only call `interceptFeatureFlags` once.
      * Useful if you want default feature flags for tests that are different than default values set in common-code featureFlags
      **/
-    cy.interceptFeatureFlags({'chip-only-form': true})
-    cy.interceptFeatureFlags({ 'packages-with-shared-rates': true })
+    cy.interceptFeatureFlags(
+        { 'chip-only-form': true, 'packages-with-shared-rates': true }
+    )
 
 })
 


### PR DESCRIPTION
## Summary

 Bring back feature flag to packages with shared rates dropdown so we have ability to remove the dorpdown from the form on demand if we want to. 

Notes: 
- Decided to leave the content displaying on submission summary, since we say that any data the states have filled out we want to display 
- Added `FeatureFlagSettings` type to use instead of hand typing the places we need this. 
-  Renamed the types a bit in flags file, I was getting confused when to expect the capitalized const enum we refer to versus the lowercased const from Launch Darkly. Open to renaming things back.

#### Related issues
https://qmacbis.atlassian.net/browse/MR-3214

#### Test cases covered
- no new tests added 

## QA guidance
- nothing should be changed about the packages with shared rates behavior with flag on.
- flag off should be an option 
