### PR TITLE
MR-3177 State sees relevant yes/no provision options and citations for CHIP-Only

### DIFF
--- a/services/app-api/src/resolvers/healthPlanPackage/submitHealthPlanPackage.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/submitHealthPlanPackage.ts
@@ -12,6 +12,7 @@ import {
     removeRatesData,
     hasValidRateCertAssurance,
     hasValidPopulationCoverage,
+    removeNonCHIPData,
 } from '../../../../app-web/src/common-code/healthPlanFormDataType'
 import {
     UpdateInfoType,
@@ -275,6 +276,14 @@ export function submitHealthPlanPackageResolver(
             hasAnyValidRateData(draftResult)
         ) {
             Object.assign(draftResult, removeRatesData(draftResult))
+        }
+
+        // CHIP submissions should not contain any provision relevant to other populations
+        if (
+            draftResult.contractType === 'AMENDMENT' &&
+            draftResult.populationCovered === 'CHIP'
+        ) {
+            Object.assign(draftResult, removeNonCHIPData(draftResult))
         }
 
         // attempt to parse into a StateSubmission

--- a/services/app-web/src/common-code/healthPlanFormDataType/ModifiedProvisions.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/ModifiedProvisions.ts
@@ -21,6 +21,25 @@ const modifiedProvisionKeys = [
     'modifiedNonRiskPaymentArrangements',
 ] as const
 
-export type { ModifiedProvisions }
+type ProvisionType = typeof modifiedProvisionKeys[number]
 
-export { modifiedProvisionKeys }
+const excludedProvisionsForCHIP: ProvisionType[] = [
+    'modifiedRiskSharingStrategy',
+    'modifiedIncentiveArrangements',
+    'modifiedWitholdAgreements',
+    'modifiedStateDirectedPayments',
+    'modifiedPassThroughPayments',
+    'modifiedPaymentsForMentalDiseaseInstitutions',
+]
+
+const allowedProvisionsForCHIP = modifiedProvisionKeys.filter(
+    (p) => !excludedProvisionsForCHIP.includes(p)
+)
+
+export type { ModifiedProvisions, ProvisionType }
+
+export {
+    modifiedProvisionKeys,
+    excludedProvisionsForCHIP,
+    allowedProvisionsForCHIP,
+}

--- a/services/app-web/src/common-code/healthPlanFormDataType/index.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/index.ts
@@ -22,9 +22,12 @@ export type {
     PopulationCoveredType,
 } from './UnlockedHealthPlanFormDataType'
 
-export type { ModifiedProvisions } from './ModifiedProvisions'
+export type { ModifiedProvisions, ProvisionType } from './ModifiedProvisions'
 
-export { modifiedProvisionKeys } from './ModifiedProvisions'
+export {
+    modifiedProvisionKeys,
+    allowedProvisionsForCHIP,
+} from './ModifiedProvisions'
 
 export type { LockedHealthPlanFormDataType } from './LockedHealthPlanFormDataType'
 export {

--- a/services/app-web/src/common-code/healthPlanFormDataType/index.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/index.ts
@@ -44,6 +44,7 @@ export {
     packageName,
     generateRateName,
     convertRateSupportingDocs,
+    removeNonCHIPData,
     removeRatesData,
     hasValidRateCertAssurance,
     hasValidPopulationCoverage,

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
@@ -378,7 +378,7 @@ describe('ContractDetailsSummarySection', () => {
         ])
     })
 
-    it('shows missing field error on amended provisions when expected', () => {
+    it('shows missing field error on contract amendment when provisions list is empty', () => {
         const contractWithUnansweredProvisions: UnlockedHealthPlanFormDataType =
             {
                 ...mockContractAndRatesDraft(),
@@ -411,10 +411,104 @@ describe('ContractDetailsSummarySection', () => {
             )
         ).toBeInTheDocument()
     })
-    it('does not show missing field error on amended provisions when expected when valid fields present', () => {
+    it('shows missing field error on contract amendment when provisions list is is incomplete', () => {
+        const contractWithUnansweredProvisions: UnlockedHealthPlanFormDataType =
+            {
+                ...mockContractAndRatesDraft(),
+                populationCovered: 'MEDICAID',
+                contractAmendmentInfo: {
+                    // intentionally putting CHIP population provisions here which is more limited list than is required for Medicaid contrat
+                    modifiedProvisions: {
+                        modifiedBenefitsProvided: false,
+                        modifiedGeoAreaServed: false,
+                        modifiedMedicaidBeneficiaries: true,
+                        modifiedMedicalLossRatioStandards: false,
+                        modifiedOtherFinancialPaymentIncentive: false,
+                        modifiedEnrollmentProcess: false,
+                        modifiedGrevienceAndAppeal: false,
+                        modifiedNetworkAdequacyStandards: false,
+                        modifiedLengthOfContract: true,
+                        modifiedNonRiskPaymentArrangements: false,
+                    },
+                },
+            }
+        renderWithProviders(
+            <ContractDetailsSummarySection
+                submission={contractWithUnansweredProvisions}
+                submissionName="MN-PMAP-0001"
+            />
+        )
+
+        const modifiedProvisions = screen.getByLabelText(
+            'This contract action includes new or modified provisions related to the following'
+        )
+        expect(
+            within(modifiedProvisions).queryByText(
+                /You must provide this information/
+            )
+        ).toBeInTheDocument()
+
+        const unmodifiedProvisions = screen.getByLabelText(
+            'This contract action does NOT include new or modified provisions related to the following'
+        )
+        expect(
+            within(unmodifiedProvisions).queryByText(
+                /You must provide this information/
+            )
+        ).toBeInTheDocument()
+    })
+
+    it('does not show missing field error on contract amendment for CHIP when all provisions required are valid', () => {
         const contractWithAllUnmodifiedProvisions: UnlockedHealthPlanFormDataType =
             {
                 ...mockContractAndRatesDraft(),
+                populationCovered: 'CHIP',
+                contractAmendmentInfo: {
+                    modifiedProvisions: {
+                        modifiedBenefitsProvided: false,
+                        modifiedGeoAreaServed: false,
+                        modifiedMedicaidBeneficiaries: true,
+                        modifiedMedicalLossRatioStandards: false,
+                        modifiedOtherFinancialPaymentIncentive: false,
+                        modifiedEnrollmentProcess: false,
+                        modifiedGrevienceAndAppeal: false,
+                        modifiedNetworkAdequacyStandards: false,
+                        modifiedLengthOfContract: true,
+                        modifiedNonRiskPaymentArrangements: false,
+                    },
+                },
+            }
+        renderWithProviders(
+            <ContractDetailsSummarySection
+                submission={contractWithAllUnmodifiedProvisions}
+                submissionName="MN-PMAP-0001"
+            />
+        )
+
+        const modifiedProvisions = screen.getByLabelText(
+            'This contract action includes new or modified provisions related to the following'
+        )
+        expect(
+            within(modifiedProvisions).queryByText(
+                /You must provide this information/
+            )
+        ).toBeNull()
+
+        const unmodifiedProvisions = screen.getByLabelText(
+            'This contract action does NOT include new or modified provisions related to the following'
+        )
+        expect(
+            within(unmodifiedProvisions).queryByText(
+                /You must provide this information/
+            )
+        ).toBeNull()
+    })
+
+    it('does not show missing field error on contract amendment for Medicaid when all provisions required are valid', () => {
+        const contractWithAllUnmodifiedProvisions: UnlockedHealthPlanFormDataType =
+            {
+                ...mockContractAndRatesDraft(),
+                populationCovered: 'MEDICAID',
                 contractAmendmentInfo: {
                     modifiedProvisions: {
                         modifiedBenefitsProvided: false,

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
@@ -276,9 +276,7 @@ describe('ContractDetailsSummarySection', () => {
             )
         ).toBeInTheDocument()
         expect(
-            within(modifiedProvisions).getByText(
-                'Pass-through payments in accordance with 42 CFR § 438.6(d)'
-            )
+            within(modifiedProvisions).getByText(/Pass-through payment/)
         ).toBeInTheDocument()
 
         const unmodifiedProvisions = screen.getByLabelText(
@@ -296,7 +294,7 @@ describe('ContractDetailsSummarySection', () => {
         ).toBeInTheDocument()
     })
 
-    it('sorts amended provisions correctly', () => {
+    it('sorts amended provisions correctly for non-CHIP amendment', () => {
         const amendedItems: ModifiedProvisions = {
             modifiedBenefitsProvided: true,
             modifiedGeoAreaServed: false,
@@ -316,7 +314,7 @@ describe('ContractDetailsSummarySection', () => {
             modifiedNonRiskPaymentArrangements: true,
         }
 
-        const [mod, unmod] = sortModifiedProvisions(amendedItems)
+        const [mod, unmod] = sortModifiedProvisions(amendedItems, false)
 
         expect(mod).toEqual([
             'modifiedBenefitsProvided',
@@ -335,6 +333,46 @@ describe('ContractDetailsSummarySection', () => {
             'modifiedIncentiveArrangements',
             'modifiedWitholdAgreements',
             'modifiedStateDirectedPayments',
+            'modifiedOtherFinancialPaymentIncentive',
+            'modifiedLengthOfContract',
+        ])
+    })
+
+    it('sorts amended provisions correctly and removes risk provisions from unmodified list for CHIP amendment', () => {
+        // removing provisions from modified list is not necessary because we remove that data at the API level on submit.
+        // Thi is to ensure we don't improperly display undefined provisions as not assigned when actually they are not applicable for CHIP cases
+        const amendedItems: ModifiedProvisions = {
+            modifiedBenefitsProvided: true,
+            modifiedGeoAreaServed: false,
+            modifiedMedicaidBeneficiaries: true,
+            modifiedRiskSharingStrategy: false,
+            modifiedIncentiveArrangements: false,
+            modifiedWitholdAgreements: false,
+            modifiedStateDirectedPayments: false,
+            modifiedPassThroughPayments: false,
+            modifiedPaymentsForMentalDiseaseInstitutions: false,
+            modifiedMedicalLossRatioStandards: true,
+            modifiedOtherFinancialPaymentIncentive: false,
+            modifiedEnrollmentProcess: true,
+            modifiedGrevienceAndAppeal: true,
+            modifiedNetworkAdequacyStandards: true,
+            modifiedLengthOfContract: false,
+            modifiedNonRiskPaymentArrangements: true,
+        }
+
+        const [mod, unmod] = sortModifiedProvisions(amendedItems, true)
+
+        expect(mod).toEqual([
+            'modifiedBenefitsProvided',
+            'modifiedMedicaidBeneficiaries',
+            'modifiedMedicalLossRatioStandards',
+            'modifiedEnrollmentProcess',
+            'modifiedGrevienceAndAppeal',
+            'modifiedNetworkAdequacyStandards',
+            'modifiedNonRiskPaymentArrangements',
+        ])
+        expect(unmod).toEqual([
+            'modifiedGeoAreaServed',
             'modifiedOtherFinancialPaymentIncentive',
             'modifiedLengthOfContract',
         ])

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -18,6 +18,7 @@ import styles from '../SubmissionSummarySection.module.scss'
 import {
     allowedProvisionsForCHIP,
     HealthPlanFormDataType,
+    modifiedProvisionKeys,
     ModifiedProvisions,
     ProvisionType,
 } from '../../../common-code/healthPlanFormDataType'
@@ -32,7 +33,6 @@ export type ContractDetailsSummarySectionProps = {
 }
 
 // This function takes a ContractAmendmentInfo and returns two lists of keys sorted by whether they are set true/false
-// remove fields that not allowed for CHIP from unmodified list entirely
 export function sortModifiedProvisions(
     amendmentInfo: ModifiedProvisions | undefined,
     isCHIPOnly: boolean
@@ -55,7 +55,7 @@ export function sortModifiedProvisions(
             }
         }
     }
-
+    // remove any lingering fields that not allowed for CHIP from unmodified list entirely. They will be removed server side on submit.
     if (isCHIPOnly) {
         unmodifiedProvisions = unmodifiedProvisions.filter((unmodified) =>
             allowedProvisionsForCHIP.includes(unmodified)
@@ -122,8 +122,14 @@ export const ContractDetailsSummarySection = ({
         submission.populationCovered === 'CHIP'
     )
 
+    // Ensure that missing field validations for modified provisions works properly even though required provisions list shifts depending on submission
+    const requiredProvisions =
+        submission.populationCovered === 'CHIP'
+            ? allowedProvisionsForCHIP
+            : modifiedProvisionKeys
     const amendmentProvisionsUnanswered =
-        modifiedProvisions.length === 0 && unmodifiedProvisions.length === 0
+        modifiedProvisions.length + unmodifiedProvisions.length !==
+        requiredProvisions.length
 
     return (
         <section id="contractDetailsSection" className={styles.summarySection}>

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -16,8 +16,10 @@ import { DownloadButton } from '../../DownloadButton'
 import { usePreviousSubmission } from '../../../hooks/usePreviousSubmission'
 import styles from '../SubmissionSummarySection.module.scss'
 import {
+    allowedProvisionsForCHIP,
     HealthPlanFormDataType,
     ModifiedProvisions,
+    ProvisionType,
 } from '../../../common-code/healthPlanFormDataType'
 import { DataDetailCheckboxList } from '../../DataDetail/DataDetailCheckboxList'
 
@@ -30,11 +32,13 @@ export type ContractDetailsSummarySectionProps = {
 }
 
 // This function takes a ContractAmendmentInfo and returns two lists of keys sorted by whether they are set true/false
+// remove fields that not allowed for CHIP from unmodified list entirely
 export function sortModifiedProvisions(
-    amendmentInfo: ModifiedProvisions | undefined
-): [string[], string[]] {
-    const modifiedProvisions = []
-    const unmodifiedProvisions = []
+    amendmentInfo: ModifiedProvisions | undefined,
+    isCHIPOnly: boolean
+): [ProvisionType[], ProvisionType[]] {
+    const modifiedProvisions: ProvisionType[] = []
+    let unmodifiedProvisions: ProvisionType[] = []
 
     if (amendmentInfo) {
         // We type cast this to be the list of keys in the ContractAmendmentInfo
@@ -52,6 +56,11 @@ export function sortModifiedProvisions(
         }
     }
 
+    if (isCHIPOnly) {
+        unmodifiedProvisions = unmodifiedProvisions.filter((unmodified) =>
+            allowedProvisionsForCHIP.includes(unmodified)
+        )
+    }
     return [modifiedProvisions, unmodifiedProvisions]
 }
 
@@ -109,7 +118,8 @@ export const ContractDetailsSummarySection = ({
     ])
 
     const [modifiedProvisions, unmodifiedProvisions] = sortModifiedProvisions(
-        submission.contractAmendmentInfo?.modifiedProvisions
+        submission.contractAmendmentInfo?.modifiedProvisions,
+        submission.populationCovered === 'CHIP'
     )
 
     const amendmentProvisionsUnanswered =

--- a/services/app-web/src/constants/healthPlanPackages.ts
+++ b/services/app-web/src/constants/healthPlanPackages.ts
@@ -66,14 +66,18 @@ const ModifiedProvisionsRecord: Record<keyof ModifiedProvisions, string> = {
     modifiedPaymentsForMentalDiseaseInstitutions:
         'Payments to MCOs and PIHPs for enrollees that are a patient in an institution for mental disease in accordance with 42 CFR § 438.6(e)',
     modifiedMedicalLossRatioStandards:
-        'Medical loss ratio standards in accordance with 42 CFR § 438.8',
+        'Medical loss ratio standards in accordance with 42 CFR § 457. 1203',
     modifiedOtherFinancialPaymentIncentive:
         'Other financial, payment, incentive or related contractual provisions',
-    modifiedEnrollmentProcess: 'Enrollment/disenrollment process',
-    modifiedGrevienceAndAppeal: 'Grievance and appeal system',
-    modifiedNetworkAdequacyStandards: 'Network adequacy standards',
+    modifiedEnrollmentProcess:
+        'Enrollment/disenrollment process 42 CFR § 457.1210 and 457.1212',
+    modifiedGrevienceAndAppeal:
+        'Grievance and appeal system 42 CFR  § 457.1260',
+    modifiedNetworkAdequacyStandards:
+        'Network adequacy standards 42 CFR  § 457.1218',
     modifiedLengthOfContract: 'Length of the contract period',
-    modifiedNonRiskPaymentArrangements: 'Non-risk payment arrangements',
+    modifiedNonRiskPaymentArrangements:
+        'Non-risk payment arrangements 42 CFR 457.10 and 457.1201(c)',
 }
 
 const ActuaryFirmsRecord: Record<ActuarialFirmType, string> = {

--- a/services/app-web/src/constants/healthPlanPackages.ts
+++ b/services/app-web/src/constants/healthPlanPackages.ts
@@ -71,10 +71,9 @@ const ModifiedProvisionsRecord: Record<keyof ModifiedProvisions, string> = {
         'Other financial, payment, incentive or related contractual provisions',
     modifiedEnrollmentProcess:
         'Enrollment/disenrollment process 42 CFR § 457.1210 and 457.1212',
-    modifiedGrevienceAndAppeal:
-        'Grievance and appeal system 42 CFR  § 457.1260',
+    modifiedGrevienceAndAppeal: 'Grievance and appeal system 42 CFR § 457.1260',
     modifiedNetworkAdequacyStandards:
-        'Network adequacy standards 42 CFR  § 457.1218',
+        'Network adequacy standards 42 CFR § 457.1218',
     modifiedLengthOfContract: 'Length of the contract period',
     modifiedNonRiskPaymentArrangements:
         'Non-risk payment arrangements 42 CFR 457.10 and 457.1201(c)',

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetailsSchema.ts
@@ -1,24 +1,35 @@
 import * as Yup from 'yup'
 import dayjs from 'dayjs'
 import { validateDateFormat } from '../../../formHelpers'
-import { ContractType } from '../../../common-code/healthPlanFormDataType'
+import {
+    allowedProvisionsForCHIP,
+    ProvisionType,
+} from '../../../common-code/healthPlanFormDataType'
 
 Yup.addMethod(Yup.date, 'validateDateFormat', validateDateFormat)
 
-const yesNoError = (contractType: ContractType) => {
-    return Yup.string().test(
-        'yesORno',
-        'You must select yes or no',
-        (value) => {
-            // true means 'is valid' and no error is shown
-            return contractType === 'BASE' || value !== undefined
-        }
-    )
-}
+export const ContractDetailsFormSchema = (
+    isContractAmendment: boolean,
+    isCHIPOnly: boolean
+) => {
+    const ignoreFieldForCHIP = (string: ProvisionType) => {
+        return isCHIPOnly && !allowedProvisionsForCHIP.includes(string)
+    }
 
-// Formik setup
-export const ContractDetailsFormSchema = (contractType: ContractType) =>
-    Yup.object().shape({
+    const yesNoError = (provision: ProvisionType) => {
+        const noValidation = Yup.string().nullable()
+        if (!isContractAmendment) {
+            return noValidation
+        }
+
+        if (ignoreFieldForCHIP(provision)) {
+            return noValidation
+        }
+
+        return Yup.string().defined('You must select yes or no')
+    }
+
+    return Yup.object().shape({
         contractExecutionStatus: Yup.string().defined(
             'You must select a contract status'
         ),
@@ -64,20 +75,37 @@ export const ContractDetailsFormSchema = (contractType: ContractType) =>
             }
         ),
 
-        modifiedBenefitsProvided: yesNoError(contractType),
-        modifiedGeoAreaServed: yesNoError(contractType),
-        modifiedMedicaidBeneficiaries: yesNoError(contractType),
-        modifiedRiskSharingStrategy: yesNoError(contractType),
-        modifiedIncentiveArrangements: yesNoError(contractType),
-        modifiedWitholdAgreements: yesNoError(contractType),
-        modifiedStateDirectedPayments: yesNoError(contractType),
-        modifiedPassThroughPayments: yesNoError(contractType),
-        modifiedPaymentsForMentalDiseaseInstitutions: yesNoError(contractType),
-        modifiedMedicalLossRatioStandards: yesNoError(contractType),
-        modifiedOtherFinancialPaymentIncentive: yesNoError(contractType),
-        modifiedEnrollmentProcess: yesNoError(contractType),
-        modifiedGrevienceAndAppeal: yesNoError(contractType),
-        modifiedNetworkAdequacyStandards: yesNoError(contractType),
-        modifiedLengthOfContract: yesNoError(contractType),
-        modifiedNonRiskPaymentArrangements: yesNoError(contractType),
+        modifiedBenefitsProvided: yesNoError('modifiedBenefitsProvided'),
+        modifiedGeoAreaServed: yesNoError('modifiedGeoAreaServed'),
+        modifiedMedicaidBeneficiaries: yesNoError(
+            'modifiedMedicaidBeneficiaries'
+        ),
+        modifiedRiskSharingStrategy: yesNoError('modifiedRiskSharingStrategy'),
+        modifiedIncentiveArrangements: yesNoError(
+            'modifiedIncentiveArrangements'
+        ),
+        modifiedWitholdAgreements: yesNoError('modifiedWitholdAgreements'),
+        modifiedStateDirectedPayments: yesNoError(
+            'modifiedStateDirectedPayments'
+        ),
+        modifiedPassThroughPayments: yesNoError('modifiedPassThroughPayments'),
+        modifiedPaymentsForMentalDiseaseInstitutions: yesNoError(
+            'modifiedPaymentsForMentalDiseaseInstitutions'
+        ),
+        modifiedMedicalLossRatioStandards: yesNoError(
+            'modifiedMedicalLossRatioStandards'
+        ),
+        modifiedOtherFinancialPaymentIncentive: yesNoError(
+            'modifiedOtherFinancialPaymentIncentive'
+        ),
+        modifiedEnrollmentProcess: yesNoError('modifiedEnrollmentProcess'),
+        modifiedGrevienceAndAppeal: yesNoError('modifiedGrevienceAndAppeal'),
+        modifiedNetworkAdequacyStandards: yesNoError(
+            'modifiedNetworkAdequacyStandards'
+        ),
+        modifiedLengthOfContract: yesNoError('modifiedLengthOfContract'),
+        modifiedNonRiskPaymentArrangements: yesNoError(
+            'modifiedNonRiskPaymentArrangements'
+        ),
     })
+}

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetailsSchema.ts
@@ -12,6 +12,7 @@ export const ContractDetailsFormSchema = (
     isContractAmendment: boolean,
     isCHIPOnly: boolean
 ) => {
+    // There are certain validations we can just validate if the submission is CHIP. The CHIP supported provisions are a smaller subset.
     const ignoreFieldForCHIP = (string: ProvisionType) => {
         return isCHIPOnly && !allowedProvisionsForCHIP.includes(string)
     }

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -899,7 +899,7 @@ describe('RateDetails', () => {
                     'Remove MCR-MN-0006-MSC+-PMAP-SNBC (Draft)'
                 )
             ).not.toBeInTheDocument()
-        })
+        }, 10000)
 
         it('cannot continue when shared rate radio is unchecked', async () => {
             ldUseClientSpy({ 'packages-with-shared-rates': true })

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -732,13 +732,19 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Medical loss ratio standards/)
+                    screen.getByText(
+                        'Medical loss ratio standards in accordance with 42 CFR § 457. 1203'
+                    )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Network adequacy standards/)
+                    screen.getByText(
+                        'Network adequacy standards 42 CFR § 457.1218'
+                    )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Non-risk payment arrangements/)
+                    screen.getByText(
+                        'Non-risk payment arrangements 42 CFR 457.10 and 457.1201(c)'
+                    )
                 ).toBeInTheDocument()
                 expect(
                     screen.getByRole('definition', {
@@ -761,7 +767,9 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Withhold arrangements/)
+                    screen.getByText(
+                        'Withhold arrangements in accordance with 42 CFR § 438.6(b)(3)'
+                    )
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText(
@@ -774,7 +782,9 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Grievance and appeal system/)
+                    screen.getByText(
+                        'Grievance and appeal system 42 CFR § 457.1260'
+                    )
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText('Length of the contract period')
@@ -1099,13 +1109,19 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Medical loss ratio standards/)
+                    screen.getByText(
+                        'Medical loss ratio standards in accordance with 42 CFR § 457. 1203'
+                    )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Network adequacy standards/)
+                    screen.getByText(
+                        'Network adequacy standards 42 CFR § 457.1218'
+                    )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Non-risk payment arrangements/)
+                    screen.getByText(
+                        'Non-risk payment arrangements 42 CFR 457.10 and 457.1201(c)'
+                    )
                 ).toBeInTheDocument()
                 expect(
                     screen.getByRole('definition', {
@@ -1143,7 +1159,7 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Grievance and appeal system/)
+                    'Grievance and appeal system 42 CFR § 457.1260'
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText('Length of the contract period')
@@ -1453,10 +1469,14 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/State directed payment/)
+                    screen.getByText(
+                        'State directed payments in accordance with 42 CFR § 438.6(c)'
+                    )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Pass-through payments /)
+                    screen.getByText(
+                        'Pass-through payments in accordance with 42 CFR § 438.6(d)'
+                    )
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText(
@@ -1464,13 +1484,19 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Medical loss ratio standards/)
+                    screen.getByText(
+                        'Medical loss ratio standards in accordance with 42 CFR § 457. 1203'
+                    )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Network adequacy standards/)
+                    screen.getByText(
+                        'Network adequacy standards 42 CFR § 457.1218'
+                    )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Non-risk payment arrangements/)
+                    screen.getByText(
+                        'Non-risk payment arrangements 42 CFR 457.10 and 457.1201(c)'
+                    )
                 ).toBeInTheDocument()
                 expect(
                     screen.getByRole('definition', {
@@ -1488,10 +1514,14 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Incentive arrangements/)
+                    screen.getByText(
+                        'Incentive arrangements in accordance with 42 CFR § 438.6(b)(2)'
+                    )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Withhold arrangements/)
+                    screen.getByText(
+                        'Withhold arrangements in accordance with 42 CFR § 438.6(b)(3)'
+                    )
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText(
@@ -1504,7 +1534,7 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Grievance and appeal system/)
+                    'Grievance and appeal system 42 CFR § 457.1260'
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText(/Length of the contract period/)
@@ -1829,13 +1859,19 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Medical loss ratio standards/)
+                    screen.getByText(
+                        'Medical loss ratio standards in accordance with 42 CFR § 457. 1203'
+                    )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Network adequacy standards/)
+                    screen.getByText(
+                        'Network adequacy standards 42 CFR § 457.1218'
+                    )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Non-risk payment arrangements/)
+                    screen.getByText(
+                        'Non-risk payment arrangements 42 CFR 457.10 and 457.1201(c)'
+                    )
                 ).toBeInTheDocument()
                 expect(
                     screen.getByRole('definition', {
@@ -1853,10 +1889,14 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Incentive arrangement/)
+                    screen.getByText(
+                        'Incentive arrangements in accordance with 42 CFR § 438.6(b)(2)'
+                    )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Withhold arrangements/)
+                    screen.getByText(
+                        'Withhold arrangements in accordance with 42 CFR § 438.6(b)(3)'
+                    )
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText(
@@ -1869,7 +1909,7 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(/Grievance and appeal system/)
+                    'Grievance and appeal system 42 CFR § 457.1260'
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText('Length of the contract period')

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -1159,7 +1159,9 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    'Grievance and appeal system 42 CFR § 457.1260'
+                    screen.getByText(
+                        'Grievance and appeal system 42 CFR § 457.1260'
+                    )
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText('Length of the contract period')
@@ -1534,7 +1536,9 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    'Grievance and appeal system 42 CFR § 457.1260'
+                    screen.getByText(
+                        'Grievance and appeal system 42 CFR § 457.1260'
+                    )
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText(/Length of the contract period/)
@@ -1909,7 +1913,9 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    'Grievance and appeal system 42 CFR § 457.1260'
+                    screen.getByText(
+                        'Grievance and appeal system 42 CFR § 457.1260'
+                    )
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText('Length of the contract period')

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -732,15 +732,13 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Medical loss ratio standards in accordance with 42 CFR § 438.8'
-                    )
+                    screen.getByText(/Medical loss ratio standards/)
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText('Network adequacy standards')
+                    screen.getByText(/Network adequacy standards/)
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText('Non-risk payment arrangements')
+                    screen.getByText(/Non-risk payment arrangements/)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByRole('definition', {
@@ -763,9 +761,7 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Withhold arrangements in accordance with 42 CFR § 438.6(b)(3)'
-                    )
+                    screen.getByText(/Withhold arrangements/)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText(
@@ -773,10 +769,12 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText('Enrollment/disenrollment process')
+                    screen.getByText(
+                        'Enrollment/disenrollment process 42 CFR § 457.1210 and 457.1212'
+                    )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText('Grievance and appeal system')
+                    screen.getByText(/Grievance and appeal system/)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText('Length of the contract period')
@@ -1101,15 +1099,13 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Medical loss ratio standards in accordance with 42 CFR § 438.8'
-                    )
+                    screen.getByText(/Medical loss ratio standards/)
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText('Network adequacy standards')
+                    screen.getByText(/Network adequacy standards/)
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText('Non-risk payment arrangements')
+                    screen.getByText(/Non-risk payment arrangements/)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByRole('definition', {
@@ -1142,10 +1138,12 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText('Enrollment/disenrollment process')
+                    screen.getByText(
+                        'Enrollment/disenrollment process 42 CFR § 457.1210 and 457.1212'
+                    )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText('Grievance and appeal system')
+                    screen.getByText(/Grievance and appeal system/)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText('Length of the contract period')
@@ -1455,14 +1453,10 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'State directed payments in accordance with 42 CFR § 438.6(c)'
-                    )
+                    screen.getByText(/State directed payment/)
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Pass-through payments in accordance with 42 CFR § 438.6(d)'
-                    )
+                    screen.getByText(/Pass-through payments /)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText(
@@ -1470,15 +1464,13 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Medical loss ratio standards in accordance with 42 CFR § 438.8'
-                    )
+                    screen.getByText(/Medical loss ratio standards/)
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText('Network adequacy standards')
+                    screen.getByText(/Network adequacy standards/)
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText('Non-risk payment arrangements')
+                    screen.getByText(/Non-risk payment arrangements/)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByRole('definition', {
@@ -1496,14 +1488,10 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Incentive arrangements in accordance with 42 CFR § 438.6(b)(2)'
-                    )
+                    screen.getByText(/Incentive arrangements/)
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Withhold arrangements in accordance with 42 CFR § 438.6(b)(3)'
-                    )
+                    screen.getByText(/Withhold arrangements/)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText(
@@ -1511,13 +1499,15 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText('Enrollment/disenrollment process')
+                    screen.getByText(
+                        'Enrollment/disenrollment process 42 CFR § 457.1210 and 457.1212'
+                    )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText('Grievance and appeal system')
+                    screen.getByText(/Grievance and appeal system/)
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText('Length of the contract period')
+                    screen.getByText(/Length of the contract period/)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText('Contract supporting documents')
@@ -1839,15 +1829,13 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Medical loss ratio standards in accordance with 42 CFR § 438.8'
-                    )
+                    screen.getByText(/Medical loss ratio standards/)
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText('Network adequacy standards')
+                    screen.getByText(/Network adequacy standards/)
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText('Non-risk payment arrangements')
+                    screen.getByText(/Non-risk payment arrangements/)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByRole('definition', {
@@ -1865,14 +1853,10 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Incentive arrangements in accordance with 42 CFR § 438.6(b)(2)'
-                    )
+                    screen.getByText(/Incentive arrangement/)
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Withhold arrangements in accordance with 42 CFR § 438.6(b)(3)'
-                    )
+                    screen.getByText(/Withhold arrangements/)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText(
@@ -1880,10 +1864,12 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText('Enrollment/disenrollment process')
+                    screen.getByText(
+                        'Enrollment/disenrollment process 42 CFR § 457.1210 and 457.1212'
+                    )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText('Grievance and appeal system')
+                    screen.getByText(/Grievance and appeal system/)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText('Length of the contract period')

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -185,20 +185,20 @@ Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
             cy.findByText('Yes').click()
         })
     cy.findByText(
-        /Withhold arrangements/
+        'Withhold arrangements in accordance with 42 CFR § 438.6(b)(3)'
     )
         .parent()
         .within(() => {
             cy.findByText('No').click()
         })
     cy.findByText(
-        /State directed payments/
+        'State directed payments in accordance with 42 CFR § 438.6(c)'
     )
         .parent()
         .within(() => {
             cy.findByText('No').click()
         })
-    cy.findByText(/Pass-through payments/)
+    cy.findByText('Pass-through payments in accordance with 42 CFR § 438.6(d)')
         .parent()
         .within(() => {
             cy.findByText('No').click()
@@ -211,7 +211,7 @@ Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
             cy.findByText('Yes').click()
         })
     cy.findByText(
-        /Medical loss ratio standards/
+        'Medical loss ratio standards in accordance with 42 CFR § 457. 1203'
     )
         .parent()
         .within(() => {
@@ -231,12 +231,12 @@ Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
         .within(() => {
             cy.findByText('Yes').click()
         })
-    cy.findByText(/Grievance and appeal system/)
+    cy.findByText('Grievance and appeal system 42 CFR § 457.1260')
         .parent()
         .within(() => {
             cy.findByText('No').click()
         })
-    cy.findByText(/Network adequacy standards/)
+    cy.findByText('Network adequacy standards 42 CFR § 457.1218')
         .parent()
         .within(() => {
             cy.findByText('Yes').click()
@@ -246,7 +246,7 @@ Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
         .within(() => {
             cy.findByText('No').click()
         })
-    cy.findByText(/Non-risk payment arrangements/)
+    cy.findByText('Non-risk payment arrangements 42 CFR 457.10 and 457.1201(c)')
         .parent()
         .within(() => {
             cy.findByText('Yes').click()

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -185,20 +185,20 @@ Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
             cy.findByText('Yes').click()
         })
     cy.findByText(
-        'Withhold arrangements in accordance with 42 CFR § 438.6(b)(3)'
+        /Withhold arrangements/
     )
         .parent()
         .within(() => {
             cy.findByText('No').click()
         })
     cy.findByText(
-        'State directed payments in accordance with 42 CFR § 438.6(c)'
+        /State directed payments/
     )
         .parent()
         .within(() => {
             cy.findByText('No').click()
         })
-    cy.findByText('Pass-through payments in accordance with 42 CFR § 438.6(d)')
+    cy.findByText(/Pass-through payments/)
         .parent()
         .within(() => {
             cy.findByText('No').click()
@@ -211,7 +211,7 @@ Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
             cy.findByText('Yes').click()
         })
     cy.findByText(
-        'Medical loss ratio standards in accordance with 42 CFR § 438.8'
+        /Medical loss ratio standards/
     )
         .parent()
         .within(() => {
@@ -224,17 +224,17 @@ Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
         .within(() => {
             cy.findByText('Yes').click()
         })
-    cy.findByText('Enrollment/disenrollment process')
+    cy.findByText('Enrollment/disenrollment process 42 CFR § 457.1210 and 457.1212')
         .parent()
         .within(() => {
             cy.findByText('Yes').click()
         })
-    cy.findByText('Grievance and appeal system')
+    cy.findByText(/Grievance and appeal system/)
         .parent()
         .within(() => {
             cy.findByText('No').click()
         })
-    cy.findByText('Network adequacy standards')
+    cy.findByText(/Network adequacy standards/)
         .parent()
         .within(() => {
             cy.findByText('Yes').click()

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -224,7 +224,9 @@ Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
         .within(() => {
             cy.findByText('Yes').click()
         })
-    cy.findByText('Enrollment/disenrollment process 42 CFR § 457.1210 and 457.1212')
+    cy.findByText(
+        'Enrollment/disenrollment process 42 CFR § 457.1210 and 457.1212'
+    )
         .parent()
         .within(() => {
             cy.findByText('Yes').click()
@@ -244,7 +246,7 @@ Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
         .within(() => {
             cy.findByText('No').click()
         })
-    cy.findByText('Non-risk payment arrangements')
+    cy.findByText(/Non-risk payment arrangements/)
         .parent()
         .within(() => {
             cy.findByText('Yes').click()


### PR DESCRIPTION
## Summary

Adjusted yes/no logic to have a different set of provisions for CHIP only (six provisions related to risks and payments are simply not included or displayed for CHIP subs). Also made copy changes that were in Figma to the MLR references.

#### Related issues
https://qmacbis.atlassian.net/browse/MR-3177 

#### Test cases covered
New tests
- ` shows correct validations for CHIP only submissions`
-  `does not allow setting risk related or payments provisions for CHIP only submissions`. 
- `removes any risk related modified provisions from CHIP submission and submits successfully`
- `sorts amended provisions correctly and removes risk provisions from unmodified list for CHIP amendment`

## QA guidance
 
I suggest testing CHIP and non CHIP modified provisions behaviors.
