### PR TITLE
MR-3184 MR-3179  Email config adjustments 

### DIFF
--- a/services/app-api/src/emailer/emails/newPackageCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/newPackageCMSEmail.test.ts
@@ -81,6 +81,38 @@ test('to addresses list includes OACT and DMCP group emails for contract and rat
     })
 })
 
+test('to addresses list  does not include OACT and DMCP group emails for CHIP submission', async () => {
+    const sub = mockContractOnlyFormData({ populationCovered: 'CHIP' })
+    const statePrograms = mockMNState().programs
+    const template = await newPackageCMSEmail(
+        sub,
+        testEmailConfig,
+        [],
+        statePrograms
+    )
+
+    if (template instanceof Error) {
+        console.error(template)
+        return
+    }
+
+    testEmailConfig.oactEmails.forEach((emailAddress) => {
+        expect(template).not.toEqual(
+            expect.objectContaining({
+                toAddresses: expect.arrayContaining([emailAddress]),
+            })
+        )
+    })
+
+    testEmailConfig.dmcpEmails.forEach((emailAddress) => {
+        expect(template).not.toEqual(
+            expect.objectContaining({
+                toAddresses: expect.arrayContaining([emailAddress]),
+            })
+        )
+    })
+})
+
 test('to addresses list does not include help addresses', async () => {
     const sub = mockContractOnlyFormData()
     const statePrograms = mockMNState().programs
@@ -129,6 +161,7 @@ test('to addresses list does not include duplicate review email addresses', asyn
 
     expect(template.toAddresses).toEqual(['duplicate@example.com'])
 })
+
 test('subject line is correct', async () => {
     const sub = mockContractOnlyFormData()
     const statePrograms = mockMNState().programs

--- a/services/app-api/src/emailer/emails/newPackageCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/newPackageCMSEmail.test.ts
@@ -40,7 +40,7 @@ test('to addresses list includes review team email addresses', async () => {
     })
 })
 
-test('to addresses list includes all division emails for contract and rate package', async () => {
+test('to addresses list includes OACT and DMCP group emails for contract and rate package', async () => {
     const sub = mockContractAndRatesFormData()
     const statePrograms = mockMNState().programs
     const template = await newPackageCMSEmail(
@@ -63,7 +63,7 @@ test('to addresses list includes all division emails for contract and rate packa
         )
     })
 
-    testEmailConfig.dmcoEmails.forEach((emailAddress) => {
+    testEmailConfig.dmcpEmails.forEach((emailAddress) => {
         expect(template).toEqual(
             expect.objectContaining({
                 toAddresses: expect.arrayContaining([emailAddress]),
@@ -71,8 +71,9 @@ test('to addresses list includes all division emails for contract and rate packa
         )
     })
 
-    testEmailConfig.dmcpEmails.forEach((emailAddress) => {
-        expect(template).toEqual(
+    // do not include dmco group emails - rely on state analysts instead
+    testEmailConfig.dmcoEmails.forEach((emailAddress) => {
+        expect(template).not.toEqual(
             expect.objectContaining({
                 toAddresses: expect.arrayContaining([emailAddress]),
             })

--- a/services/app-api/src/emailer/emails/resubmitPackageCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/resubmitPackageCMSEmail.test.ts
@@ -297,7 +297,7 @@ describe('with rates', () => {
             })
         )
     })
-    test('to addresses list includes all division emails for contract and rate package', async () => {
+    test('to addresses list includes DMCP and OACT group emails for contract and rate package', async () => {
         const template = await resubmitPackageCMSEmail(
             submission,
             resubmitData,
@@ -311,14 +311,6 @@ describe('with rates', () => {
             return
         }
 
-        testEmailConfig.dmcoEmails.forEach((emailAddress) => {
-            expect(template).toEqual(
-                expect.objectContaining({
-                    toAddresses: expect.arrayContaining([emailAddress]),
-                })
-            )
-        })
-
         testEmailConfig.dmcpEmails.forEach((emailAddress) => {
             expect(template).toEqual(
                 expect.objectContaining({
@@ -329,6 +321,15 @@ describe('with rates', () => {
 
         testEmailConfig.oactEmails.forEach((emailAddress) => {
             expect(template).toEqual(
+                expect.objectContaining({
+                    toAddresses: expect.arrayContaining([emailAddress]),
+                })
+            )
+        })
+
+        // do not include dmco group emails - rely on state analysts instead
+        testEmailConfig.dmcoEmails.forEach((emailAddress) => {
+            expect(template).not.toEqual(
                 expect.objectContaining({
                     toAddresses: expect.arrayContaining([emailAddress]),
                 })

--- a/services/app-api/src/emailer/emails/unlockPackageCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/unlockPackageCMSEmail.test.ts
@@ -298,7 +298,7 @@ describe('unlockPackageCMSEmail', () => {
             })
         )
     })
-    test('to addresses list includes all division emails for contract and rate package', async () => {
+    test('to addresses list includes DMCP and OACT emails for contract and rate package', async () => {
         const template = await unlockPackageCMSEmail(
             sub,
             unlockData,
@@ -328,8 +328,9 @@ describe('unlockPackageCMSEmail', () => {
             )
         })
 
+        // do not include dmco group emails - rely on state analysts instead
         testEmailConfig.dmcoEmails.forEach((emailAddress) => {
-            expect(template).toEqual(
+            expect(template).not.toEqual(
                 expect.objectContaining({
                     toAddresses: expect.arrayContaining([emailAddress]),
                 })

--- a/services/app-api/src/emailer/templateHelpers.test.ts
+++ b/services/app-api/src/emailer/templateHelpers.test.ts
@@ -1,8 +1,7 @@
 import {
-    CHIP_PROGRAMS_UUID,
     filterChipAndPRSubmissionReviewers,
     generateCMSReviewerEmails,
-    includesChipPrograms,
+    handleAsCHIPSubmission,
 } from './templateHelpers'
 import { UnlockedHealthPlanFormDataType } from 'app-web/src/common-code/healthPlanFormDataType'
 import {
@@ -145,19 +144,41 @@ describe('templateHelpers', () => {
 
     test.each([
         {
-            programIds: ['234-cfsdf-234324', CHIP_PROGRAMS_UUID['MS']],
-            testDescription: 'valid CHIP ids in list',
+            pkg: mockUnlockedContractAndRatesFormData({
+                populationCovered: 'CHIP',
+            }),
+            testDescription: 'for valid CHIP submission',
             expectedResult: true,
         },
         {
-            programIds: ['23432-df-123', 'not-chip'],
-            testDescription: 'without CHIP ids in list',
+            pkg: mockUnlockedContractAndRatesFormData({
+                stateCode: 'MS',
+                populationCovered: undefined,
+                programIDs: ['36c54daf-7611-4a15-8c3b-cdeb3fd7e25a'],
+            }),
+            testDescription:
+                'for MS submission with a CHIP associated ID for legacy reasons',
+            expectedResult: true,
+        },
+        {
+            pkg: mockUnlockedContractAndRatesFormData({
+                stateCode: 'AZ',
+                populationCovered: undefined,
+            }),
+            testDescription: 'for non MS submission with no population covered',
+            expectedResult: false,
+        },
+        {
+            pkg: mockUnlockedContractAndRatesFormData({
+                populationCovered: 'MEDICAID',
+            }),
+            testDescription: 'for non CHIP submission',
             expectedResult: false,
         },
     ])(
-        'includesChipPrograms: $testDescription',
-        ({ programIds, expectedResult }) => {
-            expect(includesChipPrograms(programIds)).toEqual(expectedResult)
+        'handleAsCHIPSubmission: $testDescription',
+        ({ pkg, expectedResult }) => {
+            expect(handleAsCHIPSubmission(pkg)).toEqual(expectedResult)
         }
     )
 

--- a/services/app-api/src/emailer/templateHelpers.test.ts
+++ b/services/app-api/src/emailer/templateHelpers.test.ts
@@ -29,7 +29,6 @@ describe('templateHelpers', () => {
             expectedResult: [
                 ...testEmailConfig.devReviewTeamEmails,
                 ...testStateAnalystsEmails,
-                ...testEmailConfig.dmcoEmails,
                 ...testEmailConfig.dmcpEmails,
             ],
         },
@@ -41,7 +40,6 @@ describe('templateHelpers', () => {
             expectedResult: [
                 ...testEmailConfig.devReviewTeamEmails,
                 ...testStateAnalystsEmails,
-                ...testEmailConfig.dmcoEmails,
                 ...testEmailConfig.dmcpEmails,
                 ...testEmailConfig.oactEmails,
             ],
@@ -60,7 +58,6 @@ describe('templateHelpers', () => {
                 'devreview2@example.com',
                 '"State Analyst 1" <StateAnalyst1@example.com>',
                 '"State Analyst 2" <StateAnalyst2@example.com>',
-                ...testEmailConfig.dmcoEmails,
             ],
         },
         {
@@ -105,7 +102,6 @@ describe('templateHelpers', () => {
                 'devreview2@example.com',
                 '"State Analyst 1" <StateAnalyst1@example.com>',
                 '"State Analyst 2" <StateAnalyst2@example.com>',
-                ...testEmailConfig.dmcoEmails,
             ],
         },
         {
@@ -120,7 +116,6 @@ describe('templateHelpers', () => {
                 'devreview2@example.com',
                 '"State Analyst 1" <StateAnalyst1@example.com>',
                 '"State Analyst 2" <StateAnalyst2@example.com>',
-                ...testEmailConfig.dmcoEmails,
             ],
         },
         {
@@ -188,23 +183,6 @@ describe('templateHelpers', () => {
             expectedResult: [
                 'Bobloblaw@example.com',
                 'Lucille.Bluth@example.com',
-            ],
-        },
-        {
-            reviewers: [
-                'Bobloblaw@example.com',
-                'Lucille.Bluth@example.com',
-                testEmailConfig.dmcpEmails[0],
-                testEmailConfig.dmcoEmails[0],
-                testEmailConfig.oactEmails[0],
-            ],
-            config: testEmailConfig,
-            testDescription:
-                'does not remove dmco emails, they should get all emails',
-            expectedResult: [
-                'Bobloblaw@example.com',
-                'Lucille.Bluth@example.com',
-                testEmailConfig.dmcoEmails[0],
             ],
         },
     ])(

--- a/services/app-api/src/emailer/templateHelpers.ts
+++ b/services/app-api/src/emailer/templateHelpers.ts
@@ -83,9 +83,9 @@ const filterChipAndPRSubmissionReviewers = (
 /* 
     Determine reviewers for a given health plan package and state
     - devReviewTeamEmails added to all emails by default
-    - dmcoEmails added to all emails by default
     - dmcpEmails added in both CONTRACT_ONLY and CONTRACT_AND_RATES
     - oactEmails added for CONTRACT_AND_RATES
+    - dmco is added to emails via state analysts
     
     Return should be wrapped in pruneDuplicate to ensure even if config is added twice, we get unique list of reviewers
 */
@@ -103,7 +103,7 @@ const generateCMSReviewerEmails = (
         )
     }
 
-    const { oactEmails, dmcpEmails, dmcoEmails } = config
+    const { oactEmails, dmcpEmails } = config
 
     const programIDs = findAllPackageProgramIds(pkg)
     let reviewers: string[] = []
@@ -113,7 +113,6 @@ const generateCMSReviewerEmails = (
         reviewers = [
             ...config.devReviewTeamEmails,
             ...stateAnalystsEmails,
-            ...dmcoEmails,
             ...dmcpEmails,
         ]
     } else if (pkg.submissionType === 'CONTRACT_AND_RATES') {
@@ -121,7 +120,6 @@ const generateCMSReviewerEmails = (
         reviewers = [
             ...config.devReviewTeamEmails,
             ...stateAnalystsEmails,
-            ...dmcoEmails,
             ...dmcpEmails,
             ...oactEmails,
         ]

--- a/services/app-web/src/pages/Settings/EmailSettingsTables/EmailSettingsTables.tsx
+++ b/services/app-web/src/pages/Settings/EmailSettingsTables/EmailSettingsTables.tsx
@@ -61,7 +61,7 @@ const EmailsGeneralTable = ({ config }: { config: EmailConfiguration }) => {
                     <tr>
                         <td>{formatEmails(config?.dmcoEmails)}</td>
                         <td>DMCO division emails</td>
-                        <td>All submissions</td>
+                        <td>None</td>
                     </tr>
                     <tr>
                         <td>{formatEmails(config?.dmcpEmails)}</td>


### PR DESCRIPTION
## Summary
- Remove the DMCOMCOGActions@cms.hhs.gov mailbox from receiving all system notifications
- DMCP & OACT do not receive emails for CHIP only submissions

#### Related issues
https://qmacbis.atlassian.net/browse/MR-3179
https://qmacbis.atlassian.net/browse/MR-3184

#### Test cases covered
Updated tests any tests checking for "all" division emails to only check for OACT and DMCP.
also added test for `to addresses list  does not include OACT and DMCP group emails for CHIP submission` 

## QA guidance
- No emails go to DMCO (but still sends to state analysts)
- CHIP submission emails do not go to DMCP or OACT 
