### PR TITLE
Run unit tests direct in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,6 +151,10 @@ jobs:
         run: lerna run generate --scope=app-proto
 
       - name: Generate Prisma
+        env:
+          NODE_OPTIONS: --max_old_space_size=6000
+          REACT_APP_AUTH_MODE: AWS_COGNITO
+          DATABASE_URL: postgresql://postgres:shhhsecret@localhost:5432/postgres?schema=public&connection_limit=5 #pragma: allowlist secret
         working-directory: services/app-api
         run: |
           lerna run generate --scope=app-api

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -440,7 +440,7 @@ jobs:
         uses: paambaati/codeclimate-action@v3.2.0
         continue-on-error: true
         env:
-          CC_TEST_REPORTER_ID: cace182021fe88d327fa8d95355ac6081f420e094a214fe77feb5df2f0259e9d
+          CC_TEST_REPORTER_ID: f7474ffe9522492f5380eb86189480f352c841718c1fe6a63f169353c7cee243
         with:
           debug: true
           coverageLocations: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,6 +96,12 @@ jobs:
       - name: Setup env
         uses: ./.github/actions/setup_env
 
+      - name: Generate GraphQL
+        run: lerna run gqlgen
+
+      - name: Generate Protos
+        run: lerna run generate --scope=app-proto
+
       - name: Web Unit Tests
         env:
           REACT_APP_AUTH_MODE: AWS_COGNITO

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,7 +100,8 @@ jobs:
         env:
           REACT_APP_AUTH_MODE: AWS_COGNITO
           DATABASE_URL: postgresql://postgres:shhhsecret@localhost:5432/postgres?schema=public&connection_limit=5 #pragma: allowlist secret
-        run: ./dev test web --unit
+        working-directory: services/app-web
+        run: yarn test:once --coverage
 
       - name: upload unit test coverage
         uses: actions/upload-artifact@v3
@@ -143,12 +144,26 @@ jobs:
       - name: Setup env
         uses: ./.github/actions/setup_env
 
+      - name: Generate GraphQL
+        run: lerna run gqlgen
+
+      - name: Generate Protos
+        run: lerna run generate --scope=app-proto
+
+      - name: Generate Prisma
+        working-directory: services/app-api
+        run: |
+          lerna run generate --scope=app-api
+          npx prisma migrate reset --force
+
       - name: API Unit Tests
         env:
           NODE_OPTIONS: --max_old_space_size=6000
           REACT_APP_AUTH_MODE: AWS_COGNITO
           DATABASE_URL: postgresql://postgres:shhhsecret@localhost:5432/postgres?schema=public&connection_limit=5 #pragma: allowlist secret
-        run: ./dev test api --unit
+        working-directory: services/app-api
+        run: |
+          yarn test:once --coverage
 
       - name: upload api test coverage
         uses: actions/upload-artifact@v3

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -67,7 +67,7 @@ jobs:
         uses: paambaati/codeclimate-action@v3.2.0
         continue-on-error: true
         env:
-          CC_TEST_REPORTER_ID: cace182021fe88d327fa8d95355ac6081f420e094a214fe77feb5df2f0259e9d
+          CC_TEST_REPORTER_ID: f7474ffe9522492f5380eb86189480f352c841718c1fe6a63f169353c7cee243
         with:
           debug: true
           coverageLocations: |


### PR DESCRIPTION
## Summary

Running our unit tests via the `dev` tool is fine locally, but produces hard to read output when in CI (e.g. lines get wrapped making failures harder to read back). This moves them to be setup with their appropriate `lerna` commands and run direct via `yarn`.

I also noticed a couple places I missed updating the CodeClimate keys when writing this change, so that fix is here too.

