### PR TITLE
Fix QATable component using the wrong s3 bucket.

### DIFF
--- a/services/app-web/src/pages/QuestionResponse/QATable/QATable.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/QATable.tsx
@@ -86,7 +86,7 @@ export const QATable = ({
         const refreshDocuments = async () => {
             const newDocuments = await getDocumentsUrl(
                 tableDocuments,
-                'HEALTH_PLAN_DOCS'
+                'QUESTION_ANSWER_DOCS'
             )
             if (newDocuments.length) {
                 setRefreshedDocs(newDocuments)


### PR DESCRIPTION
## Summary

`QATable` component was using the wrong bucket when retrieving document links.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
