### PR TITLE
fix ./dev test web and add clearing jest cache to clean command

### DIFF
--- a/dev_tool/src/test/web.ts
+++ b/dev_tool/src/test/web.ts
@@ -1,5 +1,4 @@
 import LabeledProcessRunner from '../runner.js'
-import { spawn } from 'child_process'
 
 import {
     compileGraphQLTypesWatchOnce,
@@ -17,17 +16,11 @@ export async function runWebTestsWatch(jestArgs: string[]) {
 
     await installWebDepsOnce(runner)
 
-    // because we are inheriting stdio for this process,
-    // we need to not run spawnSync or else all the output
-    // for the graphql compiler will be swallowed.
-    const proc = spawn('yarn', ['test'].concat(jestArgs), {
-        cwd: 'services/app-web',
-        stdio: 'inherit',
-    })
-
-    proc.on('close', (code) => {
-        process.exit(code ? code : 0)
-    })
+    return await runner.runCommandAndOutput(
+        'web - unit',
+        ['lerna', 'run', 'test', '--scope=app-web'],
+        ''
+    )
 }
 
 export async function runWebTests(
@@ -39,7 +32,7 @@ export async function runWebTests(
 
     return await runner.runCommandAndOutput(
         'web - unit',
-        ['yarn', 'test:once', '--coverage'],
-        'services/app-web'
+        ['lerna', 'run', 'test:once', '--scope=app-web'],
+        ''
     )
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "test": "tests"
     },
     "scripts": {
-        "clean": "lerna clean",
+        "clean": "lerna clean && lerna run test:clean  --scope=app-web --scope=app-api",
         "format": "yarn prettier --write",
         "prettier": "prettier --ignore-path .gitignore \"**/*.+(ts|tsx|json)\"",
         "cypress:open": "cypress open --env AUTH_MODE=LOCAL",

--- a/services/app-api/README.md
+++ b/services/app-api/README.md
@@ -22,6 +22,10 @@ Clear yarn cache and reinstall.\
 
 Launches the test runner in the interactive watch mode.\
 
+### `yarn test:clean`
+
+Clears jest cache, this can resolve false negatives in unit tests.
+
 ## Organization and important files
 
 ### `/authn`

--- a/services/app-api/package.json
+++ b/services/app-api/package.json
@@ -9,6 +9,7 @@
         "test": "jest --watch",
         "test:once": "jest --runInBand --ci",
         "test:coverage": "yarn test --coverage --watchAll=false",
+        "test:clean": "yarn test --clearCache",
         "lint": "tsc --noEmit && eslint . --max-warnings=0",
         "clean": "rm -rf node_modules && yarn cache clean",
         "generate": "yarn prisma generate",

--- a/services/app-web/README.md
+++ b/services/app-web/README.md
@@ -38,10 +38,6 @@ See the section about [running tests](https://facebook.github.io/create-react-ap
 
 ### `yarn test:update`
 
-<<<<<<< Updated upstream
-Override failing snapshot tests with the new markup. Use sparingly - may be a valid failure.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-=======
 Override failing snapshot tests and update existing snapshot tests with new markup. Use sparingly - may be a valid failure.
 
 ### `yarn test:coverage`
@@ -51,7 +47,6 @@ Generate code coverage.
 ### `yarn test:clean`
 
 Clears jest cache, this can resolve false negatives in unit tests.
->>>>>>> Stashed changes
 
 ## `yarn storybook`
 

--- a/services/app-web/README.md
+++ b/services/app-web/README.md
@@ -38,8 +38,20 @@ See the section about [running tests](https://facebook.github.io/create-react-ap
 
 ### `yarn test:update`
 
+<<<<<<< Updated upstream
 Override failing snapshot tests with the new markup. Use sparingly - may be a valid failure.\
 See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+=======
+Override failing snapshot tests and update existing snapshot tests with new markup. Use sparingly - may be a valid failure.
+
+### `yarn test:coverage`
+
+Generate code coverage.
+
+### `yarn test:clean`
+
+Clears jest cache, this can resolve false negatives in unit tests.
+>>>>>>> Stashed changes
 
 ## `yarn storybook`
 

--- a/services/app-web/package.json
+++ b/services/app-web/package.json
@@ -16,6 +16,10 @@
         "test:once": "TZ=UTC react-scripts test --watchAll=false --runInBand --ci",
         "test:update": "react-scripts test -u",
         "test:coverage": "yarn test --coverage --watchAll=false",
+<<<<<<< Updated upstream
+=======
+        "test:clean": "react-scripts test --clearCache",
+>>>>>>> Stashed changes
         "storybook": "start-storybook -p 6006 -s public --quiet",
         "build-storybook": "build-storybook -s public --quiet",
         "prettier": "npx prettier -u --write \"**/*.+(ts|tsx|json)\""


### PR DESCRIPTION
## Summary
Adding on some changes to developer scripts after trying to debug tests issue this sprint.

- `./dev test web` works without crashing your computer
- `yarn clean` still works and also clear jest cache in app web and app api


TODO:
- get jest --watch behaviors working again when running via lerna.