### PR TITLE
Fix github locking script

### DIFF
--- a/.github/github-lock.sh
+++ b/.github/github-lock.sh
@@ -10,9 +10,9 @@ set -e -o xtrace -o errexit -o pipefail -o nounset -u
 branch=${GITHUB_REF#refs/heads/}
 rest=()
 github_base_url="api.github.com"
-api_url="https://$github_base_url/repos/$GITHUB_REPOSITORY/actions/runs?status=in_progress&branch=$branch"
+api_url="https://$github_base_url/repos/$GITHUB_REPOSITORY/actions/runs?branch=$branch"
 
-jq_prog=".workflow_runs | .[] | select(.run_number < $GITHUB_RUN_NUMBER) | .run_number"
+jq_prog=".workflow_runs | .[] | select(.status == \"in_progress\") | select(.run_number < $GITHUB_RUN_NUMBER) | .run_number"
 
 echo "Checking for running builds..."
 


### PR DESCRIPTION
## Summary
Currently the github actions API has broken the ability to filter for `in_progress` runs. This changes how we query for `in_progress` runs by doing the filtering ourselves.

We have a [GitHub Support](https://support.github.com/ticket/personal/0/2125067) issue open reporting the API regression. Others have [noticed this as well](https://github.com/orgs/community/discussions/53266).

### Related Tickets
https://qmacbis.atlassian.net/browse/MR-3303
