### PR TITLE
bugfix: Correct modified provisions MLR reference for non CHIP submission

### DIFF
--- a/services/app-web/src/common-code/healthPlanFormDataType/ModifiedProvisions.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/ModifiedProvisions.ts
@@ -1,7 +1,3 @@
-type ModifiedProvisions = {
-    [K in (typeof modifiedProvisionKeys)[number]]: boolean
-} // constructs a type that requires all of the below keys
-
 const modifiedProvisionKeys = [
     'modifiedBenefitsProvided',
     'modifiedGeoAreaServed',
@@ -23,7 +19,15 @@ const modifiedProvisionKeys = [
 
 type ProvisionType = (typeof modifiedProvisionKeys)[number]
 
-const excludedProvisionsForCHIP: ProvisionType[] = [
+type ModifiedProvisions = {
+    [K in (typeof modifiedProvisionKeys)[number]]: boolean
+} // form data type that requires all of the keys
+
+/*
+    CHIP only logic
+    CHIP provisions are a smaller subset of the provisions required for other contracts. They do not include the risk related provisions.
+*/
+const excludedProvisionsForCHIP = [
     'modifiedRiskSharingStrategy',
     'modifiedIncentiveArrangements',
     'modifiedWitholdAgreements',
@@ -31,16 +35,32 @@ const excludedProvisionsForCHIP: ProvisionType[] = [
     'modifiedPassThroughPayments',
     'modifiedPaymentsForMentalDiseaseInstitutions',
     'modifiedOtherFinancialPaymentIncentive',
-]
+] as const
 
-const allowedProvisionsForCHIP = modifiedProvisionKeys.filter(
-    (p) => !excludedProvisionsForCHIP.includes(p)
-)
+type CHIPExcludedProvisionType = (typeof excludedProvisionsForCHIP)[number]
+type CHIPValidProvisionType = Exclude<ProvisionType, CHIPExcludedProvisionType>
 
-export type { ModifiedProvisions, ProvisionType }
+type CHIPModifiedProvisions = Omit<
+    ModifiedProvisions,
+    CHIPExcludedProvisionType
+> // form data type that requires all of the keys
+
+function isCHIPProvision(
+    provision: CHIPValidProvisionType | ProvisionType
+): provision is CHIPValidProvisionType {
+    return !excludedProvisionsForCHIP.includes(
+        provision as CHIPExcludedProvisionType
+    )
+}
+const allowedProvisionKeysForCHIP = modifiedProvisionKeys.filter((p) =>
+    isCHIPProvision(p)
+) as CHIPValidProvisionType[] // type coercion to narrow return type, we already used a type guard earlier so feel can feel confident
+
+export type { ModifiedProvisions, CHIPModifiedProvisions, ProvisionType }
 
 export {
     modifiedProvisionKeys,
     excludedProvisionsForCHIP,
-    allowedProvisionsForCHIP,
+    allowedProvisionKeysForCHIP,
+    isCHIPProvision,
 }

--- a/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.ts
@@ -5,7 +5,7 @@ import {
     ActuaryContact,
 } from './UnlockedHealthPlanFormDataType'
 import {
-    allowedProvisionsForCHIP,
+    allowedProvisionKeysForCHIP,
     excludedProvisionsForCHIP,
     modifiedProvisionKeys,
     ModifiedProvisions,
@@ -34,7 +34,7 @@ const hasValidModifiedProvisions = (
 ): boolean =>
     isCHIP
         ? provisions !== undefined &&
-          allowedProvisionsForCHIP.every(
+          allowedProvisionKeysForCHIP.every(
               (provision) => provisions[provision] !== undefined
           )
         : provisions !== undefined &&

--- a/services/app-web/src/common-code/healthPlanFormDataType/index.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/index.ts
@@ -22,11 +22,16 @@ export type {
     PopulationCoveredType,
 } from './UnlockedHealthPlanFormDataType'
 
-export type { ModifiedProvisions, ProvisionType } from './ModifiedProvisions'
+export type {
+    ModifiedProvisions,
+    CHIPModifiedProvisions,
+    ProvisionType,
+} from './ModifiedProvisions'
 
 export {
     modifiedProvisionKeys,
-    allowedProvisionsForCHIP,
+    allowedProvisionKeysForCHIP,
+    isCHIPProvision,
 } from './ModifiedProvisions'
 
 export type { LockedHealthPlanFormDataType } from './LockedHealthPlanFormDataType'

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
@@ -256,10 +256,105 @@ describe('ContractDetailsSummarySection', () => {
         ).toBeNull()
     })
 
-    it('renders amended provisions', () => {
+    it('renders amended provisions and MLR references for a medicaid contract correctly', () => {
         renderWithProviders(
             <ContractDetailsSummarySection
                 submission={mockContractAndRatesDraft()}
+                submissionName="MN-PMAP-0001"
+            />
+        )
+
+        expect(
+            screen.getByText('Benefits provided by the managed care plans')
+        ).toBeInTheDocument()
+
+        const modifiedProvisions = screen.getByLabelText(
+            'This contract action includes new or modified provisions related to the following'
+        )
+        expect(
+            within(modifiedProvisions).getByText(
+                'Benefits provided by the managed care plans'
+            )
+        ).toBeInTheDocument()
+        expect(
+            within(modifiedProvisions).getByText(
+                'Pass-through payments in accordance with 42 CFR § 438.6(d)'
+            )
+        ).toBeInTheDocument()
+
+        expect(
+            within(modifiedProvisions).getByText(
+                'Risk-sharing strategy (e.g., risk corridor, minimum medical loss ratio with a remittance, stop loss limits, reinsurance, etc.in accordance with 42 CFR § 438.6(b)(1)'
+            )
+        ).toBeInTheDocument()
+        expect(
+            within(modifiedProvisions).getByText(
+                'State directed payments in accordance with 42 CFR § 438.6(c)'
+            )
+        ).toBeInTheDocument()
+
+        expect(
+            within(modifiedProvisions).getByText(
+                'Medical loss ratio standards in accordance with 42 CFR § 438.8'
+            )
+        ).toBeInTheDocument()
+        expect(
+            within(modifiedProvisions).getByText('Network adequacy standards')
+        ).toBeInTheDocument()
+        expect(
+            within(modifiedProvisions).getByText(
+                'Enrollment/disenrollment process'
+            )
+        ).toBeInTheDocument()
+        expect(
+            within(modifiedProvisions).getByText(
+                'Non-risk payment arrangements'
+            )
+        ).toBeInTheDocument()
+
+        const unmodifiedProvisions = screen.getByLabelText(
+            'This contract action does NOT include new or modified provisions related to the following'
+        )
+        expect(
+            within(unmodifiedProvisions).getByText(
+                'Geographic areas served by the managed care plans'
+            )
+        ).toBeInTheDocument()
+        expect(
+            within(unmodifiedProvisions).getByText(
+                'Payments to MCOs and PIHPs for enrollees that are a patient in an institution for mental disease in accordance with 42 CFR § 438.6(e)'
+            )
+        ).toBeInTheDocument()
+        expect(
+            within(unmodifiedProvisions).getByText(
+                'Incentive arrangements in accordance with 42 CFR § 438.6(b)(2)'
+            )
+        ).toBeInTheDocument()
+        expect(
+            within(unmodifiedProvisions).getByText(
+                'Grievance and appeal system'
+            )
+        ).toBeInTheDocument()
+
+        expect(
+            within(unmodifiedProvisions).getByText(
+                'Length of the contract period'
+            )
+        ).toBeInTheDocument()
+
+        expect(
+            within(unmodifiedProvisions).getByText(
+                'Other financial, payment, incentive or related contractual provisions'
+            )
+        ).toBeInTheDocument()
+    })
+    it('renders amended provisions with correct MLR references for CHIP contract', () => {
+        renderWithProviders(
+            <ContractDetailsSummarySection
+                submission={{
+                    ...mockContractAndRatesDraft(),
+                    populationCovered: 'CHIP',
+                }}
                 submissionName="MN-PMAP-0001"
             />
         )
@@ -276,7 +371,19 @@ describe('ContractDetailsSummarySection', () => {
             )
         ).toBeInTheDocument()
         expect(
-            within(modifiedProvisions).getByText(/Pass-through payment/)
+            within(modifiedProvisions).getByText(
+                'Network adequacy standards 42 CFR § 457.1218'
+            )
+        ).toBeInTheDocument()
+        expect(
+            within(modifiedProvisions).getByText(
+                'Enrollment/disenrollment process 42 CFR § 457.1210 and 457.1212'
+            )
+        ).toBeInTheDocument()
+        expect(
+            within(modifiedProvisions).getByText(
+                'Non-risk payment arrangements 42 CFR 457.10 and 457.1201(c)'
+            )
         ).toBeInTheDocument()
 
         const unmodifiedProvisions = screen.getByLabelText(
@@ -284,14 +391,28 @@ describe('ContractDetailsSummarySection', () => {
         )
         expect(
             within(unmodifiedProvisions).getByText(
-                'Geographic areas served by the managed care plans'
+                'Grievance and appeal system 42 CFR § 457.1260'
             )
         ).toBeInTheDocument()
+
         expect(
             within(unmodifiedProvisions).getByText(
-                'Other financial, payment, incentive or related contractual provisions'
+                'Grievance and appeal system 42 CFR § 457.1260'
             )
         ).toBeInTheDocument()
+
+        expect(
+            within(unmodifiedProvisions).getByText(
+                'Length of the contract period'
+            )
+        ).toBeInTheDocument()
+
+        // not a CHIP provision, even if saved from an unlock, it should not show up on summary page once population is CHIP
+        expect(
+            within(unmodifiedProvisions).queryByText(
+                'Other financial, payment, incentive or related contractual provisions'
+            )
+        ).toBeNull()
     })
 
     it('sorts amended provisions correctly for non-CHIP amendment', () => {

--- a/services/app-web/src/constants/healthPlanPackages.ts
+++ b/services/app-web/src/constants/healthPlanPackages.ts
@@ -8,6 +8,7 @@ import {
     ContractExecutionStatus,
     ModifiedProvisions,
     PopulationCoveredType,
+    CHIPModifiedProvisions,
 } from '../common-code/healthPlanFormDataType'
 import { HealthPlanPackageStatus } from '../gen/gqlClient'
 
@@ -66,15 +67,32 @@ const ModifiedProvisionsRecord: Record<keyof ModifiedProvisions, string> = {
     modifiedPaymentsForMentalDiseaseInstitutions:
         'Payments to MCOs and PIHPs for enrollees that are a patient in an institution for mental disease in accordance with 42 CFR § 438.6(e)',
     modifiedMedicalLossRatioStandards:
-        'Medical loss ratio standards in accordance with 42 CFR § 457. 1203',
+        'Medical loss ratio standards in accordance with 42 CFR § 438.8',
     modifiedOtherFinancialPaymentIncentive:
         'Other financial, payment, incentive or related contractual provisions',
+    modifiedEnrollmentProcess: 'Enrollment/disenrollment process',
+    modifiedGrevienceAndAppeal: 'Grievance and appeal system',
+    modifiedNetworkAdequacyStandards: 'Network adequacy standards',
+    modifiedLengthOfContract: 'Length of the contract period',
+    modifiedNonRiskPaymentArrangements: 'Non-risk payment arrangements',
+}
+
+const CHIPModifiedProvisionsRecord: Record<
+    keyof CHIPModifiedProvisions,
+    string
+> = {
+    modifiedBenefitsProvided: ModifiedProvisionsRecord.modifiedBenefitsProvided,
+    modifiedGeoAreaServed: ModifiedProvisionsRecord.modifiedGeoAreaServed,
+    modifiedMedicaidBeneficiaries:
+        ModifiedProvisionsRecord.modifiedMedicaidBeneficiaries,
+    modifiedMedicalLossRatioStandards:
+        'Medical loss ratio standards in accordance with 42 CFR § 457. 1203',
     modifiedEnrollmentProcess:
         'Enrollment/disenrollment process 42 CFR § 457.1210 and 457.1212',
     modifiedGrevienceAndAppeal: 'Grievance and appeal system 42 CFR § 457.1260',
     modifiedNetworkAdequacyStandards:
         'Network adequacy standards 42 CFR § 457.1218',
-    modifiedLengthOfContract: 'Length of the contract period',
+    modifiedLengthOfContract: ModifiedProvisionsRecord.modifiedLengthOfContract,
     modifiedNonRiskPaymentArrangements:
         'Non-risk payment arrangements 42 CFR 457.10 and 457.1201(c)',
 }
@@ -112,4 +130,5 @@ export {
     ContractExecutionStatusRecord,
     SubmissionStatusRecord,
     PopulationCoveredRecord,
+    CHIPModifiedProvisionsRecord,
 }

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
@@ -17,7 +17,7 @@ import {
 import { ACCEPTED_SUBMISSION_FILE_TYPES } from '../../../components/FileUpload'
 import { ContractDetails } from './'
 import {
-    allowedProvisionsForCHIP,
+    allowedProvisionKeysForCHIP,
     modifiedProvisionKeys,
 } from '../../../common-code/healthPlanFormDataType'
 
@@ -324,7 +324,7 @@ describe('ContractDetails', () => {
             await waitFor(() => {
                 expect(
                     screen.getAllByText('You must select yes or no')
-                ).toHaveLength(allowedProvisionsForCHIP.length * 2)
+                ).toHaveLength(allowedProvisionKeysForCHIP.length * 2)
             })
 
             expect(screen.queryByText(/Risk-sharing strategy/)).toBeNull()
@@ -363,7 +363,7 @@ describe('ContractDetails', () => {
             await waitFor(() => {
                 expect(
                     screen.getAllByText('You must select yes or no')
-                ).toHaveLength(allowedProvisionsForCHIP.length * 2)
+                ).toHaveLength(allowedProvisionKeysForCHIP.length * 2)
             })
 
             const benefitsGroup = screen.getByText(
@@ -398,7 +398,7 @@ describe('ContractDetails', () => {
             await waitFor(() => {
                 expect(
                     screen.queryAllByText('You must select yes or no')
-                ).toHaveLength(allowedProvisionsForCHIP.length * 2 - 6)
+                ).toHaveLength(allowedProvisionKeysForCHIP.length * 2 - 6)
             })
         })
     })

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -39,12 +39,14 @@ import {
     SubmissionDocument,
     ContractExecutionStatus,
     FederalAuthority,
-    allowedProvisionsForCHIP,
+    allowedProvisionKeysForCHIP,
+    isCHIPProvision,
 } from '../../../common-code/healthPlanFormDataType'
 import {
     ManagedCareEntityRecord,
     FederalAuthorityRecord,
     ModifiedProvisionsRecord,
+    CHIPModifiedProvisionsRecord,
 } from '../../../constants/healthPlanPackages'
 import { PageActions } from '../PageActions'
 import type { HealthPlanFormPageProps } from '../StateSubmissionForm'
@@ -222,7 +224,7 @@ export const ContractDetails = ({
     const isCHIPOnly = draftSubmission.populationCovered === 'CHIP'
     const isContractAmendment = draftSubmission.contractType === 'AMENDMENT'
     const applicableProvisions = isCHIPOnly
-        ? allowedProvisionsForCHIP
+        ? allowedProvisionKeysForCHIP
         : modifiedProvisionKeys
 
     const contractDetailsInitialValues: ContractDetailsFormValues = {
@@ -834,9 +836,16 @@ export const ContractDetails = ({
                                                                 modifiedProvisionName
                                                             }
                                                             label={
-                                                                ModifiedProvisionsRecord[
+                                                                isCHIPOnly &&
+                                                                isCHIPProvision(
                                                                     modifiedProvisionName
-                                                                ]
+                                                                )
+                                                                    ? CHIPModifiedProvisionsRecord[
+                                                                          modifiedProvisionName
+                                                                      ]
+                                                                    : ModifiedProvisionsRecord[
+                                                                          modifiedProvisionName
+                                                                      ]
                                                             }
                                                             showError={showFieldErrors(
                                                                 errors[

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetailsSchema.ts
@@ -2,7 +2,7 @@ import * as Yup from 'yup'
 import dayjs from 'dayjs'
 import { validateDateFormat } from '../../../formHelpers'
 import {
-    allowedProvisionsForCHIP,
+    isCHIPProvision,
     ProvisionType,
 } from '../../../common-code/healthPlanFormDataType'
 
@@ -14,7 +14,7 @@ export const ContractDetailsFormSchema = (
 ) => {
     // There are certain validations we can just validate if the submission is CHIP. The CHIP supported provisions are a smaller subset.
     const ignoreFieldForCHIP = (string: ProvisionType) => {
-        return isCHIPOnly && !allowedProvisionsForCHIP.includes(string)
+        return isCHIPOnly && !isCHIPProvision(string)
     }
 
     const yesNoError = (provision: ProvisionType) => {

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -733,18 +733,14 @@ describe('SubmissionSummary', () => {
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText(
-                        'Medical loss ratio standards in accordance with 42 CFR § 457. 1203'
+                        'Medical loss ratio standards in accordance with 42 CFR § 438.8'
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Network adequacy standards 42 CFR § 457.1218'
-                    )
+                    screen.getByText('Network adequacy standards')
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Non-risk payment arrangements 42 CFR 457.10 and 457.1201(c)'
-                    )
+                    screen.getByText('Non-risk payment arrangements')
                 ).toBeInTheDocument()
                 expect(
                     screen.getByRole('definition', {
@@ -777,14 +773,10 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Enrollment/disenrollment process 42 CFR § 457.1210 and 457.1212'
-                    )
+                    screen.getByText('Enrollment/disenrollment process')
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Grievance and appeal system 42 CFR § 457.1260'
-                    )
+                    screen.getByText('Grievance and appeal system')
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText('Length of the contract period')
@@ -1110,18 +1102,14 @@ describe('SubmissionSummary', () => {
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText(
-                        'Medical loss ratio standards in accordance with 42 CFR § 457. 1203'
+                        'Medical loss ratio standards in accordance with 42 CFR § 438.8'
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Network adequacy standards 42 CFR § 457.1218'
-                    )
+                    screen.getByText('Network adequacy standards')
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Non-risk payment arrangements 42 CFR 457.10 and 457.1201(c)'
-                    )
+                    screen.getByText('Non-risk payment arrangements')
                 ).toBeInTheDocument()
                 expect(
                     screen.getByRole('definition', {
@@ -1154,14 +1142,10 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Enrollment/disenrollment process 42 CFR § 457.1210 and 457.1212'
-                    )
+                    screen.getByText('Enrollment/disenrollment process')
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Grievance and appeal system 42 CFR § 457.1260'
-                    )
+                    screen.getByText('Grievance and appeal system')
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText('Length of the contract period')
@@ -1487,18 +1471,14 @@ describe('SubmissionSummary', () => {
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText(
-                        'Medical loss ratio standards in accordance with 42 CFR § 457. 1203'
+                        'Medical loss ratio standards in accordance with 42 CFR § 438.8'
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Network adequacy standards 42 CFR § 457.1218'
-                    )
+                    screen.getByText('Network adequacy standards')
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Non-risk payment arrangements 42 CFR 457.10 and 457.1201(c)'
-                    )
+                    screen.getByText('Non-risk payment arrangements')
                 ).toBeInTheDocument()
                 expect(
                     screen.getByRole('definition', {
@@ -1531,14 +1511,10 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Enrollment/disenrollment process 42 CFR § 457.1210 and 457.1212'
-                    )
+                    screen.getByText('Enrollment/disenrollment process')
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Grievance and appeal system 42 CFR § 457.1260'
-                    )
+                    screen.getByText('Grievance and appeal system')
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText(/Length of the contract period/)
@@ -1864,18 +1840,14 @@ describe('SubmissionSummary', () => {
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText(
-                        'Medical loss ratio standards in accordance with 42 CFR § 457. 1203'
+                        'Medical loss ratio standards in accordance with 42 CFR § 438.8'
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Network adequacy standards 42 CFR § 457.1218'
-                    )
+                    screen.getByText('Network adequacy standards')
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Non-risk payment arrangements 42 CFR 457.10 and 457.1201(c)'
-                    )
+                    screen.getByText('Non-risk payment arrangements')
                 ).toBeInTheDocument()
                 expect(
                     screen.getByRole('definition', {
@@ -1908,14 +1880,10 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Enrollment/disenrollment process 42 CFR § 457.1210 and 457.1212'
-                    )
+                    screen.getByText('Enrollment/disenrollment process')
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        'Grievance and appeal system 42 CFR § 457.1260'
-                    )
+                    screen.getByText('Grievance and appeal system')
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText('Length of the contract period')

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -211,7 +211,7 @@ Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
             cy.findByText('Yes').click()
         })
     cy.findByText(
-        'Medical loss ratio standards in accordance with 42 CFR § 457. 1203'
+        'Medical loss ratio standards in accordance with 42 CFR § 438.8'
     )
         .parent()
         .within(() => {
@@ -225,18 +225,18 @@ Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
             cy.findByText('Yes').click()
         })
     cy.findByText(
-        'Enrollment/disenrollment process 42 CFR § 457.1210 and 457.1212'
+        'Enrollment/disenrollment process'
     )
         .parent()
         .within(() => {
             cy.findByText('Yes').click()
         })
-    cy.findByText('Grievance and appeal system 42 CFR § 457.1260')
+    cy.findByText('Grievance and appeal system')
         .parent()
         .within(() => {
             cy.findByText('No').click()
         })
-    cy.findByText('Network adequacy standards 42 CFR § 457.1218')
+    cy.findByText('Network adequacy standards')
         .parent()
         .within(() => {
             cy.findByText('Yes').click()
@@ -246,7 +246,7 @@ Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
         .within(() => {
             cy.findByText('No').click()
         })
-    cy.findByText('Non-risk payment arrangements 42 CFR 457.10 and 457.1201(c)')
+    cy.findByText('Non-risk payment arrangements')
         .parent()
         .within(() => {
             cy.findByText('Yes').click()


### PR DESCRIPTION
## Summary
The MLR references copy updates should be conditional (only apply to provisions when population covered = CHIP). This is from product design review.

#### Related issues
https://qmacbis.atlassian.net/browse/MR-3177

#### Screenshots
Look at this [figma](https://www.figma.com/file/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?t=mbHghBniks1zDfro-0) - left side is non-CHIP behavior and right side is CHIP amendments

#### Test cases covered
Updated tests again to cover expected behavior.

 Also added new tests for MLR copy specifically
- renders amended provisions with MLR references for a Medicaid contract
- renders amended provisions with correct MLR references for CHIP contract

## QA guidance
Create contract amendment submission. When you go between population covered = CHIP and other population covered options the MLR references will change subtly. 