### PR TITLE
MR-3281: Add sha data migration

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -154,6 +154,20 @@ functions:
 
   add_sha:
     handler: src/handlers/add_sha.main
+    events:
+      - http:
+          path: reports
+          method: get
+          cors: true
+          authorizer: aws_iam
+    layers:
+      - !Ref PrismaClientEngineLambdaLayer
+      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-9-1:1
+    timeout: 60
+    vpc:
+      securityGroupIds:
+        - ${self:custom.sgId}
+      subnetIds: ${self:custom.privateSubnets}
 
   health:
     handler: src/handlers/health_check.main

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -152,6 +152,9 @@ functions:
   email_submit:
     handler: src/handlers/email_submit.main
 
+  add_sha:
+    handler: src/handlers/add_sha.main
+
   health:
     handler: src/handlers/health_check.main
     events:

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -154,12 +154,6 @@ functions:
 
   add_sha:
     handler: src/handlers/add_sha.main
-    events:
-      - http:
-          path: reports
-          method: get
-          cors: true
-          authorizer: aws_iam
     layers:
       - !Ref PrismaClientEngineLambdaLayer
       - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-9-1:1

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -157,7 +157,7 @@ functions:
     layers:
       - !Ref PrismaClientEngineLambdaLayer
       - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-9-1:1
-    timeout: 60
+    timeout: 300
     vpc:
       securityGroupIds:
         - ${self:custom.sgId}

--- a/services/app-api/src/handlers/add_sha.test.ts
+++ b/services/app-api/src/handlers/add_sha.test.ts
@@ -1,0 +1,138 @@
+import { main } from './add_sha'
+import * as add_sha from './add_sha'
+import { SubmissionDocument } from 'app-web/src/common-code/healthPlanFormDataType'
+import { unlockedWithALittleBitOfEverything } from 'app-web/src/common-code/healthPlanFormDataMocks'
+import { Context } from 'aws-lambda'
+import { HealthPlanRevisionTable } from '@prisma/client'
+import { Store } from '../postgres'
+import { Event } from '@aws-sdk/client-s3'
+import { toProtoBuffer } from 'app-web/src/common-code/proto/healthPlanFormDataProto'
+
+const mockStore: Store = {
+    findAllRevisions: jest.fn(),
+    updateHealthPlanRevision: jest.fn(),
+} as unknown as Store
+
+jest.mock('@aws-sdk/client-secrets-manager', () => {
+    return {
+        SecretsManagerClient: jest.fn(() => {
+            /* empty callback */
+        }),
+        GetSecretValueCommand: jest.fn(() => {
+            /* empty callback */
+        }),
+    }
+})
+
+describe('add_sha', () => {
+    beforeEach(() => {
+        jest.resetAllMocks()
+        jest.spyOn(add_sha, 'getDatabaseConnection').mockImplementation(() =>
+            Promise.resolve(mockStore)
+        )
+        jest.spyOn(add_sha, 'calculateSHA256').mockImplementation(() => {
+            return Promise.resolve('mockSHA256')
+        })
+    })
+
+    function createRevisions(documents: SubmissionDocument[]) {
+        return [
+            {
+                id: 'mockId',
+                createdAt: new Date(),
+                pkgID: 'mockPkgID',
+                formDataProto: Buffer.from(
+                    toProtoBuffer({
+                        ...unlockedWithALittleBitOfEverything(),
+                        documents,
+                    })
+                ),
+                submittedAt: new Date(),
+                unlockedAt: new Date(),
+                unlockedBy: 'mockUnlockedBy',
+                unlockedReason: 'mockUnlockedReason',
+                submittedBy: 'mockSubmittedBy',
+                submittedReason: 'mockSubmittedReason',
+            },
+        ]
+    }
+
+    it('should add a sha256 property to documents when it is missing', async () => {
+        // Create a revision with a missing sha256 property in the document
+        const revisions: HealthPlanRevisionTable[] = createRevisions([
+            {
+                s3URL: 's3://bucketname/key/foo.png',
+                name: 'contract doc',
+                documentCategories: ['CONTRACT_RELATED'],
+                // Omit the sha256 property
+            },
+        ])
+
+        const storeFindAllRevisionsSpy = jest.spyOn(
+            mockStore,
+            'findAllRevisions'
+        )
+        storeFindAllRevisionsSpy.mockResolvedValue(revisions)
+
+        const updateHealthPlanRevisionSpy = jest.spyOn(
+            mockStore,
+            'updateHealthPlanRevision'
+        )
+
+        await main({} as Event, {} as Context, () => {
+            /*empty callback*/
+        })
+
+        // the sha should be set to the mock value defined above
+        expect(updateHealthPlanRevisionSpy).toHaveBeenCalledWith(
+            'mockPkgID',
+            'mockId',
+            expect.objectContaining({
+                documents: expect.arrayContaining([
+                    expect.objectContaining({
+                        sha256: 'mockSHA256',
+                    }),
+                ]),
+            })
+        )
+    })
+    it('should not overwrite a sha256 property when it already exists', async () => {
+        // Create a revision with an existing sha256 property in the document
+        const revisions: HealthPlanRevisionTable[] = createRevisions([
+            {
+                s3URL: 's3://bucketname/key/foo.png',
+                name: 'contract doc',
+                documentCategories: ['CONTRACT_RELATED'],
+                sha256: 'doNotReplaceMe',
+            },
+        ])
+
+        const storeFindAllRevisionsSpy = jest.spyOn(
+            mockStore,
+            'findAllRevisions'
+        )
+        storeFindAllRevisionsSpy.mockResolvedValue(revisions)
+
+        const updateHealthPlanRevisionSpy = jest.spyOn(
+            mockStore,
+            'updateHealthPlanRevision'
+        )
+
+        await main({} as Event, {} as Context, () => {
+            /*empty callback*/
+        })
+
+        // the sha should remain unchanged, and not be overwritten by the mock value defined above
+        expect(updateHealthPlanRevisionSpy).toHaveBeenCalledWith(
+            'mockPkgID',
+            'mockId',
+            expect.objectContaining({
+                documents: expect.arrayContaining([
+                    expect.objectContaining({
+                        sha256: 'doNotReplaceMe',
+                    }),
+                ]),
+            })
+        )
+    })
+})

--- a/services/app-api/src/handlers/add_sha.ts
+++ b/services/app-api/src/handlers/add_sha.ts
@@ -21,7 +21,7 @@ const s3 = new S3()
 const calculateSHA256 = async (s3URL: string): Promise<string> => {
     const s3Object = await s3
         .getObject({
-            Bucket: process.env.S3_BUCKET_NAME as string,
+            Bucket: 'uploads-ma3281shainproto-uploads-121499393294/allusers/' as string,
             Key: s3URL,
         })
         .promise()

--- a/services/app-api/src/handlers/add_sha.ts
+++ b/services/app-api/src/handlers/add_sha.ts
@@ -1,0 +1,136 @@
+import { APIGatewayProxyHandler } from 'aws-lambda'
+import { configurePostgres } from './configuration'
+import { NewPostgresStore } from '../postgres/postgresStore'
+import { HealthPlanRevisionTable } from '@prisma/client'
+import { HealthPlanFormDataType } from '../../../app-web/src/common-code/healthPlanFormDataType'
+import { SubmissionDocument } from '../../../app-web/src/common-code/healthPlanFormDataType'
+import { toDomain } from '../../../app-web/src/common-code/proto/healthPlanFormDataProto'
+import { isStoreError, StoreError } from '../postgres/storeError'
+import { S3 } from 'aws-sdk'
+import { createHash } from 'crypto'
+import {
+    userFromCognitoAuthProvider,
+    userFromLocalAuthProvider,
+} from '../authn'
+import { Store } from '../postgres'
+
+const s3 = new S3()
+
+const calculateSHA256 = async (s3URL: string): Promise<string> => {
+    const s3Object = await s3
+        .getObject({
+            Bucket: process.env.S3_BUCKET_NAME as string,
+            Key: s3URL,
+        })
+        .promise()
+
+    const hash = createHash('sha256')
+    hash.update(s3Object.Body as Buffer)
+    return hash.digest('hex')
+}
+
+const updateDocumentsSHA256 = async (
+    documents: SubmissionDocument[]
+): Promise<SubmissionDocument[]> => {
+    for (const document of documents) {
+        const sha256 = await calculateSHA256(document.s3URL)
+        document.sha256 = sha256
+    }
+    return documents
+}
+
+const processRevisions = async (
+    store: Store, // Use the store parameter
+    pkgID: string,
+    revisions: HealthPlanRevisionTable[]
+): Promise<void> => {
+    for (const revision of revisions) {
+        const decodedFormDataProto = toDomain(revision.formDataProto)
+        if (!(decodedFormDataProto instanceof Error)) {
+            const formData = decodedFormDataProto as HealthPlanFormDataType
+
+            formData.documents = await updateDocumentsSHA256(formData.documents)
+            formData.contractDocuments = await updateDocumentsSHA256(
+                formData.contractDocuments
+            )
+            for (const rateInfo of formData.rateInfos) {
+                rateInfo.rateDocuments = await updateDocumentsSHA256(
+                    rateInfo.rateDocuments
+                )
+            }
+
+            await store.updateHealthPlanRevision(pkgID, revision.id, formData)
+        }
+    }
+}
+
+export const main: APIGatewayProxyHandler = async (event, context) => {
+    const authProvider =
+        event.requestContext.identity.cognitoAuthenticationProvider || ''
+    const dbURL = process.env.DATABASE_URL
+    const secretsManagerSecret = process.env.SECRETS_MANAGER_SECRET
+
+    if (!dbURL) {
+        console.error('DATABASE_URL not set')
+        throw new Error('Init Error: DATABASE_URL is required to run app-api')
+    }
+    if (!secretsManagerSecret) {
+        console.error('SECRETS_MANAGER_SECRET not set')
+    }
+
+    const pgResult = await configurePostgres(dbURL, secretsManagerSecret)
+    if (pgResult instanceof Error) {
+        console.error(
+            "Init Error: Postgres couldn't be configured in data exporter"
+        )
+        throw pgResult
+    } else {
+        console.info('Postgres configured in data exporter')
+    }
+    const store = NewPostgresStore(pgResult)
+
+    // Get the package ID from the event object
+    const pkgID = event.queryStringParameters?.pkgID
+    if (!pkgID) {
+        console.error('Package ID is missing in query parameters')
+        throw new Error('Package ID is required')
+    }
+    const authMode = process.env.REACT_APP_AUTH_MODE
+
+    // reject the request if it's not from a CMS or ADMIN user
+    const userFetcher =
+        authMode === 'LOCAL'
+            ? userFromLocalAuthProvider
+            : userFromCognitoAuthProvider
+    const userResult = await userFetcher(authProvider, store)
+    if (userResult.isErr()) {
+        console.error('Error getting user from auth provider')
+        throw new Error('Error getting user from auth provider')
+    }
+    if (
+        userResult.value.role !== 'CMS_USER' &&
+        userResult.value.role !== 'ADMIN_USER'
+    ) {
+        console.error('User is not authorized to run reports')
+        throw new Error('User is not authorized to run reports')
+    }
+    console.info('User is authorized to run reports')
+
+    const result: HealthPlanRevisionTable[] | StoreError =
+        await store.findAllRevisions()
+    if (isStoreError(result)) {
+        console.error('Error getting revisions from db')
+        throw new Error('Error getting records; cannot generate report')
+    }
+
+    await processRevisions(store, pkgID, result)
+
+    return {
+        statusCode: 200,
+        body: JSON.stringify({ message: 'SHA256 update complete' }),
+        headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Credentials': true,
+        },
+    }
+}

--- a/services/app-api/src/handlers/add_sha.ts
+++ b/services/app-api/src/handlers/add_sha.ts
@@ -110,6 +110,11 @@ export const processRevisions = async (
                 console.error(`Error updating revision ${revision.id}: ${err}`)
                 throw err
             }
+        } else {
+            console.error(
+                `Error decoding formDataProto for revision ${revision.id} in sha migration: ${decodedFormDataProto}`
+            )
+            throw new Error('Error decoding formDataProto in sha migration')
         }
     }
 }

--- a/services/app-api/src/handlers/add_sha.ts
+++ b/services/app-api/src/handlers/add_sha.ts
@@ -27,8 +27,6 @@ const streamToBuffer = async (stream: Readable): Promise<Buffer> => {
 
 const calculateSHA256 = async (s3URL: string): Promise<string> => {
     const key = `allusers/${parseKey(s3URL)}`
-    // console.info('s3URL: ', s3URL)
-    // console.info('key: ', key)
     try {
         const getObjectCommand = new GetObjectCommand({
             Bucket: 'uploads-ma3281shainprotoretry-uploads-121499393294' as string,
@@ -54,16 +52,19 @@ const updateDocumentsSHA256 = async (
     try {
         await Promise.all(
             documents.map(async (document) => {
-                try {
-                    const sha256 = await calculateSHA256(document.s3URL)
-                    document.sha256 = `${sha256}-testing`
-                } catch (error) {
-                    console.error('Error calculating SHA256:', error)
+                if (
+                    !Object.prototype.hasOwnProperty.call(document, 'sha256') ||
+                    !document.sha256
+                ) {
+                    try {
+                        const sha256 = await calculateSHA256(document.s3URL)
+                        document.sha256 = `${sha256}`
+                    } catch (error) {
+                        console.error('Error calculating SHA256:', error)
+                    }
                 }
             })
         )
-
-        console.info('modified documents: ', JSON.stringify(documents))
         return documents
     } catch (error) {
         console.error('Error in updateDocumentsSHA256:', error)
@@ -84,26 +85,11 @@ const processRevisions = async (
             formData.contractDocuments = await updateDocumentsSHA256(
                 formData.contractDocuments
             )
-            if (formData.documents.length > 0) {
-                console.info(
-                    'formData.documents after update: ',
-                    JSON.stringify(formData.documents)
-                )
-            }
-            // console.info(
-            //     'formData.contractDocuments: ',
-            //     JSON.stringify(formData.contractDocuments)
-            // )
             for (const rateInfo of formData.rateInfos) {
                 rateInfo.rateDocuments = await updateDocumentsSHA256(
                     rateInfo.rateDocuments
                 )
-                // console.info(
-                //     'rateInfo.rateDocuments: ',
-                //     JSON.stringify(rateInfo.rateDocuments)
-                // )
             }
-            // console.info('formData: ', JSON.stringify(formData))
             try {
                 const update = await store.updateHealthPlanRevision(
                     pkgID,
@@ -112,17 +98,12 @@ const processRevisions = async (
                 )
                 if (isStoreError(update)) {
                     console.error(
-                        `Error updating revision ${
+                        `StoreError updating revision ${
                             revision.id
                         }: ${JSON.stringify(update)}`
                     )
                     throw new Error('Error updating revision')
                 }
-                console.info(
-                    `Updated revision: formData: ${JSON.stringify(
-                        formData
-                    )} update: ${update}`
-                )
             } catch (err) {
                 console.error(`Error updating revision ${revision.id}: ${err}`)
                 throw err

--- a/services/app-api/src/handlers/add_sha.ts
+++ b/services/app-api/src/handlers/add_sha.ts
@@ -12,6 +12,7 @@ import { isStoreError, StoreError } from '../postgres/storeError'
 import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'
 import { createHash } from 'crypto'
 import { Store } from '../postgres'
+import { parseKey } from '../../../app-web/src/common-code/s3URLEncoding'
 
 const s3 = new S3Client({ region: 'us-east-1' })
 
@@ -24,8 +25,17 @@ const streamToBuffer = async (stream: Readable): Promise<Buffer> => {
     })
 }
 
+// const parseKey = (maybeS3URL: string): string | Error => {
+//     const url = new Url(maybeS3URL)
+//     if (!isValidS3URLFormat(url)) throw new Error('Not valid S3URL')
+//     return url.pathname.split('/')[1]
+// }
+
 const calculateSHA256 = async (s3URL: string): Promise<string> => {
-    const key = `allusers${s3URL}}`
+    const key = parseKey(s3URL)
+    if (key instanceof Error) {
+        throw key
+    }
     try {
         const getObjectCommand = new GetObjectCommand({
             Bucket: 'uploads-ma3281shainprotoretry-uploads-121499393294' as string,

--- a/services/app-api/src/handlers/add_sha.ts
+++ b/services/app-api/src/handlers/add_sha.ts
@@ -12,7 +12,10 @@ import { isStoreError, StoreError } from '../postgres/storeError'
 import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'
 import { createHash } from 'crypto'
 import { Store } from '../postgres'
-import { parseKey } from '../../../app-web/src/common-code/s3URLEncoding'
+import {
+    parseKey,
+    parseBucketName,
+} from '../../../app-web/src/common-code/s3URLEncoding'
 
 const s3 = new S3Client({ region: 'us-east-1' })
 
@@ -26,11 +29,10 @@ const streamToBuffer = async (stream: Readable): Promise<Buffer> => {
 }
 
 const calculateSHA256 = async (s3URL: string): Promise<string> => {
-    const key = `allusers/${parseKey(s3URL)}`
     try {
         const getObjectCommand = new GetObjectCommand({
-            Bucket: 'uploads-ma3281shainprotoretry-uploads-121499393294' as string,
-            Key: key,
+            Bucket: parseBucketName(s3URL) as string,
+            Key: `allusers/${parseKey(s3URL)}`,
         })
 
         const s3Object = await s3.send(getObjectCommand)

--- a/services/app-api/src/handlers/add_sha.ts
+++ b/services/app-api/src/handlers/add_sha.ts
@@ -113,7 +113,7 @@ export const main: Handler = async (event, context) => {
     const result: HealthPlanRevisionTable[] | StoreError =
         await store.findAllRevisions()
     if (isStoreError(result)) {
-        console.error('Error getting revisions from db')
+        console.error(`Error getting revisions from db ${result}`)
         throw new Error('Error getting records; cannot generate report')
     }
 

--- a/services/app-api/src/handlers/add_sha.ts
+++ b/services/app-api/src/handlers/add_sha.ts
@@ -25,10 +25,11 @@ const streamToBuffer = async (stream: Readable): Promise<Buffer> => {
 }
 
 const calculateSHA256 = async (s3URL: string): Promise<string> => {
+    const key = `allusers${s3URL}}`
     try {
         const getObjectCommand = new GetObjectCommand({
             Bucket: 'uploads-ma3281shainprotoretry-uploads-121499393294' as string,
-            Key: s3URL,
+            Key: key,
         })
 
         const s3Object = await s3.send(getObjectCommand)

--- a/services/app-api/src/handlers/add_sha.ts
+++ b/services/app-api/src/handlers/add_sha.ts
@@ -27,7 +27,7 @@ const streamToBuffer = async (stream: Readable): Promise<Buffer> => {
 const calculateSHA256 = async (s3URL: string): Promise<string> => {
     try {
         const getObjectCommand = new GetObjectCommand({
-            Bucket: 'uploads-ma3281shainproto-uploads-121499393294/allusers/' as string,
+            Bucket: 'uploads-ma3281shainprotoretry-uploads-121499393294' as string,
             Key: s3URL,
         })
 

--- a/services/app-api/src/handlers/add_sha.ts
+++ b/services/app-api/src/handlers/add_sha.ts
@@ -37,7 +37,7 @@ const updateDocumentsSHA256 = async (
 ): Promise<SubmissionDocument[]> => {
     for (const document of documents) {
         const sha256 = await calculateSHA256(document.s3URL)
-        document.sha256 = sha256
+        document.sha256 = `${sha256}-test`
     }
     return documents
 }

--- a/services/app-api/src/handlers/add_sha.ts
+++ b/services/app-api/src/handlers/add_sha.ts
@@ -2,8 +2,10 @@ import { APIGatewayProxyHandler } from 'aws-lambda'
 import { configurePostgres } from './configuration'
 import { NewPostgresStore } from '../postgres/postgresStore'
 import { HealthPlanRevisionTable } from '@prisma/client'
-import { HealthPlanFormDataType } from '../../../app-web/src/common-code/healthPlanFormDataType'
-import { SubmissionDocument } from '../../../app-web/src/common-code/healthPlanFormDataType'
+import {
+    HealthPlanFormDataType,
+    SubmissionDocument,
+} from '../../../app-web/src/common-code/healthPlanFormDataType'
 import { toDomain } from '../../../app-web/src/common-code/proto/healthPlanFormDataProto'
 import { isStoreError, StoreError } from '../postgres/storeError'
 import { S3 } from 'aws-sdk'
@@ -40,7 +42,7 @@ const updateDocumentsSHA256 = async (
 }
 
 const processRevisions = async (
-    store: Store, // Use the store parameter
+    store: Store,
     pkgID: string,
     revisions: HealthPlanRevisionTable[]
 ): Promise<void> => {

--- a/services/app-api/src/postgres/healthPlanPackage/updateHealthPlanRevision.ts
+++ b/services/app-api/src/postgres/healthPlanPackage/updateHealthPlanRevision.ts
@@ -67,7 +67,6 @@ export async function updateHealthPlanRevision(
     submitInfo?: UpdateInfoType
 ): Promise<HealthPlanPackageType | StoreError> {
     formData.updatedAt = new Date()
-    console.info('jjj formData in postgres updates: ', JSON.stringify(formData))
     const proto = toProtoBuffer(formData)
     const buffer = Buffer.from(proto)
 

--- a/services/app-api/src/postgres/healthPlanPackage/updateHealthPlanRevision.ts
+++ b/services/app-api/src/postgres/healthPlanPackage/updateHealthPlanRevision.ts
@@ -67,7 +67,7 @@ export async function updateHealthPlanRevision(
     submitInfo?: UpdateInfoType
 ): Promise<HealthPlanPackageType | StoreError> {
     formData.updatedAt = new Date()
-    console.info('jjj formData in postgres update: ', formData)
+    console.info('jjj formData in postgres update: ', JSON.stringify(formData))
     const proto = toProtoBuffer(formData)
     const buffer = Buffer.from(proto)
 

--- a/services/app-api/src/postgres/healthPlanPackage/updateHealthPlanRevision.ts
+++ b/services/app-api/src/postgres/healthPlanPackage/updateHealthPlanRevision.ts
@@ -67,7 +67,7 @@ export async function updateHealthPlanRevision(
     submitInfo?: UpdateInfoType
 ): Promise<HealthPlanPackageType | StoreError> {
     formData.updatedAt = new Date()
-    console.info('jjj formData in postgres update: ', JSON.stringify(formData))
+    console.info('jjj formData in postgres updates: ', JSON.stringify(formData))
     const proto = toProtoBuffer(formData)
     const buffer = Buffer.from(proto)
 

--- a/services/app-api/src/postgres/healthPlanPackage/updateHealthPlanRevision.ts
+++ b/services/app-api/src/postgres/healthPlanPackage/updateHealthPlanRevision.ts
@@ -67,7 +67,7 @@ export async function updateHealthPlanRevision(
     submitInfo?: UpdateInfoType
 ): Promise<HealthPlanPackageType | StoreError> {
     formData.updatedAt = new Date()
-
+    console.info('jjj formData in postgres update: ', formData)
     const proto = toProtoBuffer(formData)
     const buffer = Buffer.from(proto)
 

--- a/services/app-api/src/postgres/healthPlanPackage/updateHealthPlanRevision.ts
+++ b/services/app-api/src/postgres/healthPlanPackage/updateHealthPlanRevision.ts
@@ -67,6 +67,7 @@ export async function updateHealthPlanRevision(
     submitInfo?: UpdateInfoType
 ): Promise<HealthPlanPackageType | StoreError> {
     formData.updatedAt = new Date()
+
     const proto = toProtoBuffer(formData)
     const buffer = Buffer.from(proto)
 

--- a/services/app-web/src/common-code/proto/healthPlanFormDataProto/toProtoBuffer.ts
+++ b/services/app-web/src/common-code/proto/healthPlanFormDataProto/toProtoBuffer.ts
@@ -218,6 +218,7 @@ const toProtoBuffer = (
                                   mcreviewproto.DocumentCategory,
                                   doc.documentCategories
                               ),
+                              sha256: doc.sha256,
                           })),
                           rateCertificationName: generateRateName(
                               domainData,
@@ -290,6 +291,7 @@ const toProtoBuffer = (
                 mcreviewproto.DocumentCategory,
                 doc.documentCategories
             ),
+            sha256: doc.sha256,
         })),
     }
 


### PR DESCRIPTION
## Summary

In a previous PR, we started add a `sha256` property to every uploaded document.  This gives us a unique identifier for each file, which will eventually be queryable in the database.  In this PR, we're making a lambda to go back and add the sha256 to every file that was uploaded before the previous PR.  

In addition to the machinery to read the file, generate a sha, and put it on the file in the proto, the one bit of logic is that we should add the sha if it doesn't exist, but not overwrite it if it does.  This is what the new tests cover.

The way I tested this in the review app was to set the generated sha to ``${generateSha()}-testing`` in the first lambda run, followed by running the reports and manually examining the CSV output, and then finally setting the generated sha to something different in a second lambda run, and seeing if values were overwritten.
