### PR TITLE
MR-3175 CHIP only federal authorities list

### DIFF
--- a/services/app-api/src/resolvers/healthPlanPackage/submitHealthPlanPackage.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/submitHealthPlanPackage.ts
@@ -37,7 +37,7 @@ import { GraphQLError } from 'graphql'
 import { FeatureFlagSettings } from 'app-web/src/common-code/featureFlags'
 
 export const SubmissionErrorCodes = ['INCOMPLETE', 'INVALID'] as const
-type SubmissionErrorCode = typeof SubmissionErrorCodes[number] // iterable union type
+type SubmissionErrorCode = (typeof SubmissionErrorCodes)[number] // iterable union type
 
 type SubmissionError = {
     code: SubmissionErrorCode
@@ -278,11 +278,8 @@ export function submitHealthPlanPackageResolver(
             Object.assign(draftResult, removeRatesData(draftResult))
         }
 
-        // CHIP submissions should not contain any provision relevant to other populations
-        if (
-            draftResult.contractType === 'AMENDMENT' &&
-            draftResult.populationCovered === 'CHIP'
-        ) {
+        // CHIP submissions should not contain any provision or authority relevant to other populations
+        if (draftResult.populationCovered === 'CHIP') {
             Object.assign(draftResult, removeNonCHIPData(draftResult))
         }
 

--- a/services/app-web/src/common-code/healthPlanFormDataType/FederalAuthorities.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/FederalAuthorities.ts
@@ -1,22 +1,17 @@
-const federalAuthorityKeys = [ 
-    'STATE_PLAN'
-    ,'WAIVER_1915B'
-    ,'WAIVER_1115'
-    ,'VOLUNTARY'
-    ,'BENCHMARK'
-    ,'TITLE_XXI'
+const federalAuthorityKeys = [
+    'STATE_PLAN',
+    'WAIVER_1915B',
+    'WAIVER_1115',
+    'VOLUNTARY',
+    'BENCHMARK',
+    'TITLE_XXI',
 ] as const
 
-const federalAuthorityKeysForCHIP = [ 
-    'STATE_PLAN'
-    ,'WAIVER_1915B'
-    ,'VOLUNTARY'
-    ,'BENCHMARK'
-] as const
+const federalAuthorityKeysForCHIP = ['WAIVER_1115', 'TITLE_XXI'] as const
 
 type FederalAuthority = (typeof federalAuthorityKeys)[number]
 
 type CHIPFederalAuthority = (typeof federalAuthorityKeysForCHIP)[number]
 
-export {federalAuthorityKeys, federalAuthorityKeysForCHIP}
-export type { FederalAuthority, CHIPFederalAuthority}
+export { federalAuthorityKeys, federalAuthorityKeysForCHIP }
+export type { FederalAuthority, CHIPFederalAuthority }

--- a/services/app-web/src/common-code/healthPlanFormDataType/FederalAuthorities.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/FederalAuthorities.ts
@@ -1,0 +1,22 @@
+const federalAuthorityKeys = [ 
+    'STATE_PLAN'
+    ,'WAIVER_1915B'
+    ,'WAIVER_1115'
+    ,'VOLUNTARY'
+    ,'BENCHMARK'
+    ,'TITLE_XXI'
+] as const
+
+const federalAuthorityKeysForCHIP = [ 
+    'STATE_PLAN'
+    ,'WAIVER_1915B'
+    ,'VOLUNTARY'
+    ,'BENCHMARK'
+] as const
+
+type FederalAuthority = (typeof federalAuthorityKeys)[number]
+
+type CHIPFederalAuthority = (typeof federalAuthorityKeysForCHIP)[number]
+
+export {federalAuthorityKeys, federalAuthorityKeysForCHIP}
+export type { FederalAuthority, CHIPFederalAuthority}

--- a/services/app-web/src/common-code/healthPlanFormDataType/ModifiedProvisions.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/ModifiedProvisions.ts
@@ -1,4 +1,4 @@
-// Order matters- we iterate through the list to generate questions and stakeholders want questions in specific order
+// Order matters- we iterate through the list to generate yes/no provision radio buttons.  Stakeholders want questions in specific order
 const modifiedProvisionKeys = [
     'modifiedBenefitsProvided',
     'modifiedGeoAreaServed',

--- a/services/app-web/src/common-code/healthPlanFormDataType/ModifiedProvisions.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/ModifiedProvisions.ts
@@ -1,7 +1,9 @@
+// Order matters- we iterate through the list to generate questions and stakeholders want questions in specific order
 const modifiedProvisionKeys = [
     'modifiedBenefitsProvided',
     'modifiedGeoAreaServed',
     'modifiedMedicaidBeneficiaries',
+    'modifiedEnrollmentProcess',
     'modifiedRiskSharingStrategy',
     'modifiedIncentiveArrangements',
     'modifiedWitholdAgreements',
@@ -10,7 +12,6 @@ const modifiedProvisionKeys = [
     'modifiedPaymentsForMentalDiseaseInstitutions',
     'modifiedMedicalLossRatioStandards',
     'modifiedOtherFinancialPaymentIncentive',
-    'modifiedEnrollmentProcess',
     'modifiedGrevienceAndAppeal',
     'modifiedNetworkAdequacyStandards',
     'modifiedLengthOfContract',

--- a/services/app-web/src/common-code/healthPlanFormDataType/UnlockedHealthPlanFormDataType.d.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/UnlockedHealthPlanFormDataType.d.ts
@@ -1,3 +1,5 @@
+import {FederalAuthority} from 'FederalAuthority'
+
 // Draft state submission is a health plan that a state user is still working on
 
 type SubmissionType = 'CONTRACT_ONLY' | 'CONTRACT_AND_RATES'
@@ -40,14 +42,6 @@ type ActuarialFirmType =
     | 'OTHER'
 
 type ActuaryCommunicationType = 'OACT_TO_ACTUARY' | 'OACT_TO_STATE'
-
-type FederalAuthority =
-    | 'STATE_PLAN'
-    | 'WAIVER_1915B'
-    | 'WAIVER_1115'
-    | 'VOLUNTARY'
-    | 'BENCHMARK'
-    | 'TITLE_XXI'
 
 type StateContact = {
     name: string
@@ -128,7 +122,6 @@ export type {
     ActuarialFirmType,
     ActuaryCommunicationType,
     ContractType,
-    FederalAuthority,
     ManagedCareEntity,
     UnlockedHealthPlanFormDataType,
     ContractAmendmentInfo,

--- a/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.ts
@@ -13,7 +13,7 @@ import {
 import { LockedHealthPlanFormDataType } from './LockedHealthPlanFormDataType'
 import { HealthPlanFormDataType } from './HealthPlanFormDataType'
 import { formatRateNameDate } from '../../common-code/dateHelpers'
-import { ProgramArgType } from '.'
+import { FederalAuthority, ProgramArgType, federalAuthorityKeysForCHIP } from '.'
 
 // TODO: Refactor into multiple files and add unit tests to these functions
 
@@ -27,6 +27,7 @@ const isContractAndRates = (
 
 const isRateAmendment = (rateInfo: RateInfoType): boolean =>
     rateInfo.rateType === 'AMENDMENT'
+
 
 const hasValidModifiedProvisions = (
     provisions: ModifiedProvisions | undefined,
@@ -315,11 +316,16 @@ const removeRatesData = (
 const removeNonCHIPData = (
     pkg: UnlockedHealthPlanFormDataType
 ): UnlockedHealthPlanFormDataType => {
+
+    // remove any provisions that aren't valid for CHIP (this can happen on unlock when populationCovered changes)
     excludedProvisionsForCHIP.forEach((provision) => {
         if (pkg.contractAmendmentInfo?.modifiedProvisions[provision]) {
             pkg.contractAmendmentInfo.modifiedProvisions[provision] = undefined
         }
     })
+
+     // remove any authorities that aren't valid for CHIP (this can happen on unlock when populationCovered changes)
+    pkg.federalAuthorities = pkg.federalAuthorities.filter((authority) =>   federalAuthorityKeysForCHIP.includes(authority))   
 
     return pkg
 }

--- a/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.ts
@@ -13,7 +13,7 @@ import {
 import { LockedHealthPlanFormDataType } from './LockedHealthPlanFormDataType'
 import { HealthPlanFormDataType } from './HealthPlanFormDataType'
 import { formatRateNameDate } from '../../common-code/dateHelpers'
-import { FederalAuthority, ProgramArgType, federalAuthorityKeysForCHIP } from '.'
+import { ProgramArgType, federalAuthorityKeysForCHIP } from '.'
 
 // TODO: Refactor into multiple files and add unit tests to these functions
 

--- a/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.ts
@@ -28,7 +28,6 @@ const isContractAndRates = (
 const isRateAmendment = (rateInfo: RateInfoType): boolean =>
     rateInfo.rateType === 'AMENDMENT'
 
-
 const hasValidModifiedProvisions = (
     provisions: ModifiedProvisions | undefined,
     isCHIP: boolean
@@ -316,16 +315,20 @@ const removeRatesData = (
 const removeNonCHIPData = (
     pkg: UnlockedHealthPlanFormDataType
 ): UnlockedHealthPlanFormDataType => {
-
     // remove any provisions that aren't valid for CHIP (this can happen on unlock when populationCovered changes)
-    excludedProvisionsForCHIP.forEach((provision) => {
-        if (pkg.contractAmendmentInfo?.modifiedProvisions[provision]) {
-            pkg.contractAmendmentInfo.modifiedProvisions[provision] = undefined
-        }
-    })
+    if (pkg.contractType === 'AMENDMENT') {
+        excludedProvisionsForCHIP.forEach((provision) => {
+            if (pkg.contractAmendmentInfo?.modifiedProvisions[provision]) {
+                pkg.contractAmendmentInfo.modifiedProvisions[provision] =
+                    undefined
+            }
+        })
+    }
 
-     // remove any authorities that aren't valid for CHIP (this can happen on unlock when populationCovered changes)
-    pkg.federalAuthorities = pkg.federalAuthorities.filter((authority) =>   federalAuthorityKeysForCHIP.includes(authority))   
+    // remove any authorities that aren't valid for CHIP (this can happen on unlock when populationCovered changes)
+    pkg.federalAuthorities = pkg.federalAuthorities.filter((authority) =>
+        federalAuthorityKeysForCHIP.includes(authority)
+    )
 
     return pkg
 }

--- a/services/app-web/src/common-code/healthPlanFormDataType/index.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/index.ts
@@ -11,7 +11,6 @@ export type {
     ContractType,
     DocumentCategoryType,
     UnlockedHealthPlanFormDataType,
-    FederalAuthority,
     ManagedCareEntity,
     RateType,
     RateCapitationType,
@@ -23,10 +22,20 @@ export type {
 } from './UnlockedHealthPlanFormDataType'
 
 export type {
+    FederalAuthority,
+    CHIPFederalAuthority
+} from './FederalAuthorities'
+
+export type {
     ModifiedProvisions,
     CHIPModifiedProvisions,
     ProvisionType,
 } from './ModifiedProvisions'
+
+export {
+    federalAuthorityKeys,
+    federalAuthorityKeysForCHIP
+} from './FederalAuthorities'
 
 export {
     modifiedProvisionKeys,

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
@@ -5,12 +5,14 @@ import {
     sortModifiedProvisions,
 } from './ContractDetailsSummarySection'
 import {
+    fetchCurrentUserMock,
     mockContractAndRatesDraft,
     mockStateSubmission,
 } from '../../../testHelpers/apolloMocks'
 import {
     ModifiedProvisions,
     UnlockedHealthPlanFormDataType,
+    federalAuthorityKeys,
 } from '../../../common-code/healthPlanFormDataType'
 
 describe('ContractDetailsSummarySection', () => {
@@ -256,7 +258,69 @@ describe('ContractDetailsSummarySection', () => {
         ).toBeNull()
     })
 
-    it('renders amended provisions and MLR references for a medicaid contract correctly', () => {
+    it('renders federal authorities for a medicaid contract', async () => {
+        renderWithProviders(
+            <ContractDetailsSummarySection
+                submission={{
+                    ...mockContractAndRatesDraft(),
+                    // Add all medicaid federal authorities, as if medicaid contract being unlocked
+                    federalAuthorities: [
+                     'STATE_PLAN'
+                    ,'WAIVER_1915B'
+                    ,'WAIVER_1115'
+                    ,'VOLUNTARY'
+                    ,'BENCHMARK'
+                    ,'TITLE_XXI'],
+                }}
+                submissionName="MN-PMAP-0001"
+            />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+
+        )
+        
+        expect(await screen.findByText('Title XXI Separate CHIP State Plan Authority')).toBeInTheDocument()
+        expect(await screen.findByText('1115 Waiver Authority')).toBeInTheDocument()
+        expect(await screen.findByText('1932(a) State Plan Authority')).toBeInTheDocument()
+        expect(await screen.findByText('1937 Benchmark Authority')).toBeInTheDocument()
+    })
+
+    it('renders federal authorities for a CHIP contract as expected, removing invalid authorities', async () => {
+        renderWithProviders(
+            <ContractDetailsSummarySection
+                submission={{
+                    ...mockContractAndRatesDraft(),
+                    populationCovered: 'CHIP',
+                    // Add all medicaid federal authorities, as if medicaid contract being unlocked
+                    federalAuthorities: [
+                     'STATE_PLAN'
+                    ,'WAIVER_1915B'
+                    ,'WAIVER_1115'
+                    ,'VOLUNTARY'
+                    ,'BENCHMARK'
+                    ,'TITLE_XXI'],
+                }}
+                submissionName="MN-PMAP-0001"
+            />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+
+        )
+        
+        expect(await screen.queryByText('Title XXI Separate CHIP State Plan Authority')).not.toBeInTheDocument()
+        expect(await screen.queryByText('1115 Waiver Authority')).not.toBeInTheDocument()
+        expect(await screen.findByText('1932(a) State Plan Authority')).toBeInTheDocument()
+        expect(await screen.findByText('1937 Benchmark Authority')).toBeInTheDocument()
+
+    })
+
+    it('renders amended provisions and MLR references for a medicaid contract correctly',  () => {
         renderWithProviders(
             <ContractDetailsSummarySection
                 submission={mockContractAndRatesDraft()}
@@ -356,7 +420,13 @@ describe('ContractDetailsSummarySection', () => {
                     populationCovered: 'CHIP',
                 }}
                 submissionName="MN-PMAP-0001"
-            />
+            />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+
         )
         expect(
             screen.getByText('Benefits provided by the managed care plans')
@@ -510,7 +580,13 @@ describe('ContractDetailsSummarySection', () => {
             <ContractDetailsSummarySection
                 submission={contractWithUnansweredProvisions}
                 submissionName="MN-PMAP-0001"
-            />
+            />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+
         )
 
         const modifiedProvisions = screen.getByLabelText(
@@ -556,7 +632,13 @@ describe('ContractDetailsSummarySection', () => {
             <ContractDetailsSummarySection
                 submission={contractWithUnansweredProvisions}
                 submissionName="MN-PMAP-0001"
-            />
+            />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+
         )
 
         const modifiedProvisions = screen.getByLabelText(
@@ -602,7 +684,13 @@ describe('ContractDetailsSummarySection', () => {
             <ContractDetailsSummarySection
                 submission={contractWithAllUnmodifiedProvisions}
                 submissionName="MN-PMAP-0001"
-            />
+            />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+
         )
 
         const modifiedProvisions = screen.getByLabelText(
@@ -654,7 +742,13 @@ describe('ContractDetailsSummarySection', () => {
             <ContractDetailsSummarySection
                 submission={contractWithAllUnmodifiedProvisions}
                 submissionName="MN-PMAP-0001"
-            />
+            />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+
         )
 
         const modifiedProvisions = screen.getByLabelText(

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
@@ -15,7 +15,7 @@ import {
 } from '../../../common-code/healthPlanFormDataType'
 
 describe('ContractDetailsSummarySection', () => {
-    it.only('can render draft submission without errors (review and submit behavior)', async () => {
+    it('can render draft submission without errors (review and submit behavior)', async () => {
         const testSubmission = {
             ...mockContractAndRatesDraft(),
             documents: [

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
@@ -12,11 +12,10 @@ import {
 import {
     ModifiedProvisions,
     UnlockedHealthPlanFormDataType,
-    federalAuthorityKeys,
 } from '../../../common-code/healthPlanFormDataType'
 
 describe('ContractDetailsSummarySection', () => {
-    it('can render draft submission without errors (review and submit behavior)', () => {
+    it.only('can render draft submission without errors (review and submit behavior)', async () => {
         const testSubmission = {
             ...mockContractAndRatesDraft(),
             documents: [
@@ -41,11 +40,15 @@ describe('ContractDetailsSummarySection', () => {
                 submission={testSubmission}
                 navigateTo="contract-details"
                 submissionName="MN-PMAP-0001"
-            />
+            />,  {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
         )
 
-        expect(
-            screen.getByRole('heading', {
+        expect(await 
+            screen.findByRole('heading', {
                 level: 2,
                 name: 'Contract details',
             })

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
@@ -40,15 +40,16 @@ describe('ContractDetailsSummarySection', () => {
                 submission={testSubmission}
                 navigateTo="contract-details"
                 submissionName="MN-PMAP-0001"
-            />,  {
+            />,
+            {
                 apolloProvider: {
                     mocks: [fetchCurrentUserMock({ statusCode: 200 })],
                 },
             }
         )
 
-        expect(await 
-            screen.findByRole('heading', {
+        expect(
+            await screen.findByRole('heading', {
                 level: 2,
                 name: 'Contract details',
             })
@@ -268,12 +269,13 @@ describe('ContractDetailsSummarySection', () => {
                     ...mockContractAndRatesDraft(),
                     // Add all medicaid federal authorities, as if medicaid contract being unlocked
                     federalAuthorities: [
-                     'STATE_PLAN'
-                    ,'WAIVER_1915B'
-                    ,'WAIVER_1115'
-                    ,'VOLUNTARY'
-                    ,'BENCHMARK'
-                    ,'TITLE_XXI'],
+                        'STATE_PLAN',
+                        'WAIVER_1915B',
+                        'WAIVER_1115',
+                        'VOLUNTARY',
+                        'BENCHMARK',
+                        'TITLE_XXI',
+                    ],
                 }}
                 submissionName="MN-PMAP-0001"
             />,
@@ -282,13 +284,22 @@ describe('ContractDetailsSummarySection', () => {
                     mocks: [fetchCurrentUserMock({ statusCode: 200 })],
                 },
             }
-
         )
-        
-        expect(await screen.findByText('Title XXI Separate CHIP State Plan Authority')).toBeInTheDocument()
-        expect(await screen.findByText('1115 Waiver Authority')).toBeInTheDocument()
-        expect(await screen.findByText('1932(a) State Plan Authority')).toBeInTheDocument()
-        expect(await screen.findByText('1937 Benchmark Authority')).toBeInTheDocument()
+
+        expect(
+            await screen.findByText(
+                'Title XXI Separate CHIP State Plan Authority'
+            )
+        ).toBeInTheDocument()
+        expect(
+            await screen.findByText('1115 Waiver Authority')
+        ).toBeInTheDocument()
+        expect(
+            await screen.findByText('1932(a) State Plan Authority')
+        ).toBeInTheDocument()
+        expect(
+            await screen.findByText('1937 Benchmark Authority')
+        ).toBeInTheDocument()
     })
 
     it('renders federal authorities for a CHIP contract as expected, removing invalid authorities', async () => {
@@ -299,12 +310,13 @@ describe('ContractDetailsSummarySection', () => {
                     populationCovered: 'CHIP',
                     // Add all medicaid federal authorities, as if medicaid contract being unlocked
                     federalAuthorities: [
-                     'STATE_PLAN'
-                    ,'WAIVER_1915B'
-                    ,'WAIVER_1115'
-                    ,'VOLUNTARY'
-                    ,'BENCHMARK'
-                    ,'TITLE_XXI'],
+                        'STATE_PLAN',
+                        'WAIVER_1915B',
+                        'WAIVER_1115',
+                        'VOLUNTARY',
+                        'BENCHMARK',
+                        'TITLE_XXI',
+                    ],
                 }}
                 submissionName="MN-PMAP-0001"
             />,
@@ -313,17 +325,25 @@ describe('ContractDetailsSummarySection', () => {
                     mocks: [fetchCurrentUserMock({ statusCode: 200 })],
                 },
             }
-
         )
-        
-        expect(await screen.queryByText('Title XXI Separate CHIP State Plan Authority')).not.toBeInTheDocument()
-        expect(await screen.queryByText('1115 Waiver Authority')).not.toBeInTheDocument()
-        expect(await screen.findByText('1932(a) State Plan Authority')).toBeInTheDocument()
-        expect(await screen.findByText('1937 Benchmark Authority')).toBeInTheDocument()
 
+        expect(
+            await screen.findByText(
+                'Title XXI Separate CHIP State Plan Authority'
+            )
+        ).toBeInTheDocument()
+        expect(
+            await screen.findByText('1115 Waiver Authority')
+        ).toBeInTheDocument()
+        expect(
+            await screen.queryByText('1932(a) State Plan Authority')
+        ).not.toBeInTheDocument()
+        expect(
+            await screen.queryByText('1937 Benchmark Authority')
+        ).not.toBeInTheDocument()
     })
 
-    it('renders amended provisions and MLR references for a medicaid contract correctly',  () => {
+    it('renders amended provisions and MLR references for a medicaid contract correctly', () => {
         renderWithProviders(
             <ContractDetailsSummarySection
                 submission={mockContractAndRatesDraft()}
@@ -429,7 +449,6 @@ describe('ContractDetailsSummarySection', () => {
                     mocks: [fetchCurrentUserMock({ statusCode: 200 })],
                 },
             }
-
         )
         expect(
             screen.getByText('Benefits provided by the managed care plans')
@@ -589,7 +608,6 @@ describe('ContractDetailsSummarySection', () => {
                     mocks: [fetchCurrentUserMock({ statusCode: 200 })],
                 },
             }
-
         )
 
         const modifiedProvisions = screen.getByLabelText(
@@ -641,7 +659,6 @@ describe('ContractDetailsSummarySection', () => {
                     mocks: [fetchCurrentUserMock({ statusCode: 200 })],
                 },
             }
-
         )
 
         const modifiedProvisions = screen.getByLabelText(
@@ -693,7 +710,6 @@ describe('ContractDetailsSummarySection', () => {
                     mocks: [fetchCurrentUserMock({ statusCode: 200 })],
                 },
             }
-
         )
 
         const modifiedProvisions = screen.getByLabelText(
@@ -751,7 +767,6 @@ describe('ContractDetailsSummarySection', () => {
                     mocks: [fetchCurrentUserMock({ statusCode: 200 })],
                 },
             }
-
         )
 
         const modifiedProvisions = screen.getByLabelText(

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -18,6 +18,8 @@ import { usePreviousSubmission } from '../../../hooks/usePreviousSubmission'
 import styles from '../SubmissionSummarySection.module.scss'
 import {
     allowedProvisionKeysForCHIP,
+    FederalAuthority,
+    federalAuthorityKeysForCHIP,
     HealthPlanFormDataType,
     isCHIPProvision,
     modifiedProvisionKeys,
@@ -89,6 +91,8 @@ export const ContractDetailsSummarySection = ({
     const isSubmitted = submission.status === 'SUBMITTED'
     const isEditing = !isSubmitted && navigateTo !== undefined
     const isCHIPOnly = submission.populationCovered === 'CHIP'
+    const applicableFederalAuthorities = isCHIPOnly ? submission.federalAuthorities.filter( (authority) => federalAuthorityKeysForCHIP.includes(authority)) : submission.federalAuthorities
+
     useEffect(() => {
         // get all the keys for the documents we want to zip
         async function fetchZipUrl() {
@@ -197,7 +201,7 @@ export const ContractDetailsSummarySection = ({
                         explainMissingData={!isSubmitted}
                         children={
                             <DataDetailCheckboxList
-                                list={submission.federalAuthorities}
+                                list={applicableFederalAuthorities}
                                 dict={FederalAuthorityRecord}
                             />
                         }

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -18,7 +18,6 @@ import { usePreviousSubmission } from '../../../hooks/usePreviousSubmission'
 import styles from '../SubmissionSummarySection.module.scss'
 import {
     allowedProvisionKeysForCHIP,
-    FederalAuthority,
     federalAuthorityKeysForCHIP,
     HealthPlanFormDataType,
     isCHIPProvision,

--- a/services/app-web/src/constants/healthPlanPackages.ts
+++ b/services/app-web/src/constants/healthPlanPackages.ts
@@ -84,7 +84,7 @@ const CHIPModifiedProvisionsRecord: Record<
     modifiedBenefitsProvided: ModifiedProvisionsRecord.modifiedBenefitsProvided,
     modifiedGeoAreaServed: ModifiedProvisionsRecord.modifiedGeoAreaServed,
     modifiedMedicaidBeneficiaries:
-        ModifiedProvisionsRecord.modifiedMedicaidBeneficiaries,
+        'CHIP beneficiaries served by the managed care plans (e.g. eligibility or enrollment criteria)',
     modifiedMedicalLossRatioStandards:
         'Medical loss ratio standards in accordance with 42 CFR § 457. 1203',
     modifiedEnrollmentProcess:

--- a/services/app-web/src/constants/healthPlanPackages.ts
+++ b/services/app-web/src/constants/healthPlanPackages.ts
@@ -1,7 +1,6 @@
 import {
     SubmissionType,
     ContractType,
-    CHIPFederalAuthority,
     FederalAuthority,
     ManagedCareEntity,
     ActuarialFirmType,

--- a/services/app-web/src/constants/healthPlanPackages.ts
+++ b/services/app-web/src/constants/healthPlanPackages.ts
@@ -1,6 +1,7 @@
 import {
     SubmissionType,
     ContractType,
+    CHIPFederalAuthority,
     FederalAuthority,
     ManagedCareEntity,
     ActuarialFirmType,
@@ -33,7 +34,7 @@ const ContractExecutionStatusRecord: Record<ContractExecutionStatus, string> = {
     UNEXECUTED: 'Unexecuted by some or all parties',
 }
 
-const FederalAuthorityRecord: Record<FederalAuthority, string> = {
+const FederalAuthorityRecord: Record< FederalAuthority, string> = {
     STATE_PLAN: '1932(a) State Plan Authority',
     WAIVER_1915B: '1915(b) Waiver Authority',
     WAIVER_1115: '1115 Waiver Authority',
@@ -41,7 +42,6 @@ const FederalAuthorityRecord: Record<FederalAuthority, string> = {
     BENCHMARK: '1937 Benchmark Authority',
     TITLE_XXI: 'Title XXI Separate CHIP State Plan Authority',
 }
-
 const ManagedCareEntityRecord: Record<ManagedCareEntity, string> = {
     MCO: 'Managed Care Organization (MCO)',
     PIHP: 'Prepaid Inpatient Health Plan (PIHP)',

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
@@ -145,7 +145,7 @@ describe('ContractDetails', () => {
     })
 
     describe('Federal authorities', () => {
-        it('dislays correct fields in dropdown for medicaid contract', () => {
+        it('displays correct form fields for federal authorities with medicaid contract', () => {
             renderWithProviders(
                 <ContractDetails
                     draftSubmission={{
@@ -156,21 +156,21 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />
             )
-            const fedAuthDropdown = screen.getByRole('group', {
+            const fedAuthQuestion = screen.getByRole('group', {
                 name: 'Active federal operating authority',
             })
-            expect(fedAuthDropdown).toBeInTheDocument()
+            expect(fedAuthQuestion).toBeInTheDocument()
             expect(
-                within(fedAuthDropdown).getAllByRole('checkbox')
+                within(fedAuthQuestion).getAllByRole('checkbox')
             ).toHaveLength(federalAuthorityKeys.length)
             expect(
-                within(fedAuthDropdown).getByRole('checkbox', {
+                within(fedAuthQuestion).getByRole('checkbox', {
                     name: '1915(b) Waiver Authority',
                 })
             ).toBeInTheDocument() // authority disallowed for chip is not included in list
         })
 
-        it('dislays correct fields in dropdown for CHIP only contract', async () => {
+        it('displays correct form fields for federal authorities with CHIP only contract', async () => {
             renderWithProviders(
                 <ContractDetails
                     draftSubmission={{
@@ -181,15 +181,15 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />
             )
-            const fedAuthDropdown = await screen.findByRole('group', {
+            const fedAuthQuestion = await screen.findByRole('group', {
                 name: 'Active federal operating authority',
             })
-            expect(fedAuthDropdown).toBeInTheDocument()
+            expect(fedAuthQuestion).toBeInTheDocument()
             expect(
-                within(fedAuthDropdown).getAllByRole('checkbox')
+                within(fedAuthQuestion).getAllByRole('checkbox')
             ).toHaveLength(federalAuthorityKeysForCHIP.length)
             expect(
-                within(fedAuthDropdown).queryByRole('checkbox', {
+                within(fedAuthQuestion).queryByRole('checkbox', {
                     name: '1915(b) Waiver Authority',
                 })
             ).not.toBeInTheDocument() // medicaid only authority should be in the list

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
@@ -144,786 +144,827 @@ describe('ContractDetails', () => {
         })
     })
 
-    describe('Federal authorities',  () => {
+    describe('Federal authorities', () => {
         it('dislays correct fields in dropdown for medicaid contract', () => {
-            renderWithProviders(<ContractDetails
-                draftSubmission={{...mockDraft(), populationCovered: 'MEDICAID'}}
-                updateDraft={jest.fn()}
-                previousDocuments={[]}
-            />,
+            renderWithProviders(
+                <ContractDetails
+                    draftSubmission={{
+                        ...mockDraft(),
+                        populationCovered: 'MEDICAID',
+                    }}
+                    updateDraft={jest.fn()}
+                    previousDocuments={[]}
+                />
             )
-            const fedAuthDropdown =  screen.getByRole('group', {name: 'Active federal operating authority'})
+            const fedAuthDropdown = screen.getByRole('group', {
+                name: 'Active federal operating authority',
+            })
             expect(fedAuthDropdown).toBeInTheDocument()
-            expect(within(fedAuthDropdown).getAllByRole('checkbox')).toHaveLength(federalAuthorityKeys.length)
-            expect(within(fedAuthDropdown).getByRole('checkbox', {name: '1115 Waiver Authority'})).toBeInTheDocument() // authority disallowed for chip is not included in list
+            expect(
+                within(fedAuthDropdown).getAllByRole('checkbox')
+            ).toHaveLength(federalAuthorityKeys.length)
+            expect(
+                within(fedAuthDropdown).getByRole('checkbox', {
+                    name: '1915(b) Waiver Authority',
+                })
+            ).toBeInTheDocument() // authority disallowed for chip is not included in list
         })
 
         it('dislays correct fields in dropdown for CHIP only contract', async () => {
-            renderWithProviders(<ContractDetails
-                draftSubmission={{...mockDraft(), populationCovered: 'CHIP'}}
-                updateDraft={jest.fn()}
-                previousDocuments={[]}
-            />,
+            renderWithProviders(
+                <ContractDetails
+                    draftSubmission={{
+                        ...mockDraft(),
+                        populationCovered: 'CHIP',
+                    }}
+                    updateDraft={jest.fn()}
+                    previousDocuments={[]}
+                />
             )
-            const fedAuthDropdown = await screen.findByRole('group', {name: 'Active federal operating authority'})
+            const fedAuthDropdown = await screen.findByRole('group', {
+                name: 'Active federal operating authority',
+            })
             expect(fedAuthDropdown).toBeInTheDocument()
-            expect(within(fedAuthDropdown).getAllByRole('checkbox')).toHaveLength(federalAuthorityKeysForCHIP.length)
-            expect(within(fedAuthDropdown).queryByRole('checkbox', {name: '1115 Waiver Authority'})).not.toBeInTheDocument()  // medicaid only authority should be in the list
-
-    })
-    describe('Modified provisions - yes/nos', () => {
-        it('allows setting all modified provisions for medicaid contract amendment', async () => {
-            const emptyDraft = mockDraft()
-            emptyDraft.contractType = 'AMENDMENT'
-            emptyDraft.populationCovered = 'MEDICAID'
-            const mockUpdateDraftFn = jest.fn()
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyDraft}
-                    updateDraft={mockUpdateDraftFn}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
-
-            // click "next"
-            const continueButton = screen.getByRole('button', {
-                name: 'Continue',
-            })
-
-            // risk and payment related provisions should be visible
             expect(
-                screen.queryByText(/Risk-sharing strategy/)
-            ).toBeInTheDocument()
+                within(fedAuthDropdown).getAllByRole('checkbox')
+            ).toHaveLength(federalAuthorityKeysForCHIP.length)
             expect(
-                screen.queryByText(/Withhold arrangements in accordance/)
-            ).toBeInTheDocument()
-            expect(
-                screen.queryByText(/Payments to MCOs and PIHPs/)
-            ).toBeInTheDocument()
-            expect(
-                screen.queryByText(/State directed payments/)
-            ).toBeInTheDocument()
-
-            await userEvent.click(continueButton)
-
-            // check for yes/no errors  - each field shows up twice, once in error summary, one as inline error next to label
-            await waitFor(() => {
-                expect(
-                    screen.getAllByText('You must select yes or no')
-                ).toHaveLength(modifiedProvisionKeys.length * 2)
-            })
-
-            const benefitsGroup = screen.getByText(
-                'Benefits provided by the managed care plans'
-            ).parentElement
-            const geoGroup = screen.getByText(
-                'Geographic areas served by the managed care plans'
-            ).parentElement
-            const lengthGroup = screen.getByText(
-                'Length of the contract period'
-            ).parentElement
-
-            if (
-                benefitsGroup === null ||
-                geoGroup === null ||
-                lengthGroup === null
-            ) {
-                throw new Error(
-                    'Benefits and Geo and Length must have parents.'
+                within(fedAuthDropdown).queryByRole('checkbox', {
+                    name: '1915(b) Waiver Authority',
+                })
+            ).not.toBeInTheDocument() // medicaid only authority should be in the list
+        })
+        describe('Modified provisions - yes/nos', () => {
+            it('allows setting all modified provisions for medicaid contract amendment', async () => {
+                const emptyDraft = mockDraft()
+                emptyDraft.contractType = 'AMENDMENT'
+                emptyDraft.populationCovered = 'MEDICAID'
+                const mockUpdateDraftFn = jest.fn()
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={emptyDraft}
+                        updateDraft={mockUpdateDraftFn}
+                        previousDocuments={[]}
+                    />,
+                    {
+                        apolloProvider: {
+                            mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        },
+                    }
                 )
-            }
 
-            // choose yes and no
-            const benefitsYes = within(benefitsGroup).getByLabelText('Yes') //
-            const geoNo = within(geoGroup).getByLabelText('No')
-            const lengthYes = within(lengthGroup).getByLabelText('Yes')
+                // click "next"
+                const continueButton = screen.getByRole('button', {
+                    name: 'Continue',
+                })
 
-            await userEvent.click(benefitsYes)
-            await userEvent.click(geoNo)
-            await userEvent.click(lengthYes)
-
-            await waitFor(() => {
+                // risk and payment related provisions should be visible
                 expect(
-                    screen.queryAllByText('You must select yes or no')
-                ).toHaveLength(modifiedProvisionKeys.length * 2 - 6)
-            })
-        })
-
-        it('shows correct validations for medicaid contract amendment', async () => {
-            const emptyDraft = mockDraft()
-            emptyDraft.contractType = 'AMENDMENT'
-            emptyDraft.populationCovered = 'MEDICAID'
-            const mockUpdateDraftFn = jest.fn()
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyDraft}
-                    updateDraft={mockUpdateDraftFn}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
-
-            // click "next"
-            const continueButton = screen.getByRole('button', {
-                name: 'Continue',
-            })
-            await userEvent.click(continueButton)
-
-            // check for yes/no errors  - each field shows up twice, once in error summary, one as inline error next to lab
-            await waitFor(() => {
-                expect(
-                    screen.getAllByText('You must select yes or no')
-                ).toHaveLength(modifiedProvisionKeys.length * 2)
-            })
-
-            const benefitsGroup = screen.getByText(
-                'Benefits provided by the managed care plans'
-            ).parentElement
-            const geoGroup = screen.getByText(
-                'Geographic areas served by the managed care plans'
-            ).parentElement
-            const lengthGroup = screen.getByText(
-                'Length of the contract period'
-            ).parentElement
-
-            if (
-                benefitsGroup === null ||
-                geoGroup === null ||
-                lengthGroup === null
-            ) {
-                throw new Error(
-                    'Benefits and Geo and Length must have parents.'
-                )
-            }
-
-            // choose yes and no
-            const benefitsYes = within(benefitsGroup).getByLabelText('Yes') //
-            const geoNo = within(geoGroup).getByLabelText('No')
-            const lengthYes = within(lengthGroup).getByLabelText('Yes')
-
-            await userEvent.click(benefitsYes)
-            await userEvent.click(geoNo)
-            await userEvent.click(lengthYes)
-
-            await waitFor(() => {
-                expect(
-                    screen.queryAllByText('You must select yes or no')
-                ).toHaveLength(modifiedProvisionKeys.length * 2 - 6)
-            })
-        })
-
-        it('does not allow setting risk related or payments provisions for CHIP only submissions', async () => {
-            const emptyDraft = mockDraft()
-            emptyDraft.contractType = 'AMENDMENT'
-            emptyDraft.populationCovered = 'CHIP'
-            const mockUpdateDraftFn = jest.fn()
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyDraft}
-                    updateDraft={mockUpdateDraftFn}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
-
-            // click "next"
-            const continueButton = screen.getByRole('button', {
-                name: 'Continue',
-            })
-            await userEvent.click(continueButton)
-
-            // check for yes/no errors - each field shows up twice, once in error summary, one as inline error next to lab
-            await waitFor(() => {
-                expect(
-                    screen.getAllByText('You must select yes or no')
-                ).toHaveLength(allowedProvisionKeysForCHIP.length * 2)
-            })
-
-            expect(screen.queryByText(/Risk-sharing strategy/)).toBeNull()
-            expect(
-                screen.queryByText(/Withhold arrangements in accordance/)
-            ).toBeNull()
-            expect(screen.queryByText(/Payments to MCOs and PIHPs/)).toBeNull()
-            expect(screen.queryByText(/State directed payments/)).toBeNull()
-        })
-
-        it('shows correct validations for CHIP only submissions', async () => {
-            const emptyDraft = mockDraft()
-            emptyDraft.contractType = 'AMENDMENT'
-            emptyDraft.populationCovered = 'CHIP'
-            const mockUpdateDraftFn = jest.fn()
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyDraft}
-                    updateDraft={mockUpdateDraftFn}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
-
-            // click "next"
-            const continueButton = screen.getByRole('button', {
-                name: 'Continue',
-            })
-            await userEvent.click(continueButton)
-
-            // check for yes/no errors - each field shows up twice, once in error summary, one as inline error next to lab
-            await waitFor(() => {
-                expect(
-                    screen.getAllByText('You must select yes or no')
-                ).toHaveLength(allowedProvisionKeysForCHIP.length * 2)
-            })
-
-            const benefitsGroup = screen.getByText(
-                'Benefits provided by the managed care plans'
-            ).parentElement
-            const geoGroup = screen.getByText(
-                'Geographic areas served by the managed care plans'
-            ).parentElement
-            const lengthGroup = screen.getByText(
-                'Length of the contract period'
-            ).parentElement
-
-            if (
-                benefitsGroup === null ||
-                geoGroup === null ||
-                lengthGroup === null
-            ) {
-                throw new Error(
-                    'Benefits and Geo and Length must have parents.'
-                )
-            }
-
-            // choose yes and no
-            const benefitsYes = within(benefitsGroup).getByLabelText('Yes') //
-            const geoNo = within(geoGroup).getByLabelText('No')
-            const lengthYes = within(lengthGroup).getByLabelText('Yes')
-
-            await userEvent.click(benefitsYes)
-            await userEvent.click(geoNo)
-            await userEvent.click(lengthYes)
-
-            await waitFor(() => {
-                expect(
-                    screen.queryAllByText('You must select yes or no')
-                ).toHaveLength(allowedProvisionKeysForCHIP.length * 2 - 6)
-            })
-        })
-    })
-
-    describe('Continue button', () => {
-        it('enabled when valid files are present', async () => {
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyContractDetailsDraft}
-                    updateDraft={jest.fn()}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
-
-            const continueButton = screen.getByRole('button', {
-                name: 'Continue',
-            })
-            const input = screen.getByLabelText('Upload contract')
-
-            await userEvent.upload(input, [TEST_DOC_FILE])
-
-            await waitFor(() => {
-                expect(continueButton).not.toHaveAttribute('aria-disabled')
-            })
-        })
-
-        it('enabled when invalid files have been dropped but valid files are present', async () => {
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyContractDetailsDraft}
-                    updateDraft={jest.fn()}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
-
-            const continueButton = screen.getByRole('button', {
-                name: 'Continue',
-            })
-            const input = screen.getByLabelText('Upload contract')
-            const targetEl = screen.getByTestId('file-input-droptarget')
-
-            await userEvent.upload(input, [TEST_DOC_FILE])
-            dragAndDrop(targetEl, [TEST_PNG_FILE])
-
-            await waitFor(() => {
-                expect(
-                    screen.getByText('This is not a valid file type.')
+                    screen.queryByText(/Risk-sharing strategy/)
                 ).toBeInTheDocument()
-                expect(continueButton).not.toHaveAttribute('aria-disabled')
+                expect(
+                    screen.queryByText(/Withhold arrangements in accordance/)
+                ).toBeInTheDocument()
+                expect(
+                    screen.queryByText(/Payments to MCOs and PIHPs/)
+                ).toBeInTheDocument()
+                expect(
+                    screen.queryByText(/State directed payments/)
+                ).toBeInTheDocument()
+
+                await userEvent.click(continueButton)
+
+                // check for yes/no errors  - each field shows up twice, once in error summary, one as inline error next to label
+                await waitFor(() => {
+                    expect(
+                        screen.getAllByText('You must select yes or no')
+                    ).toHaveLength(modifiedProvisionKeys.length * 2)
+                })
+
+                const benefitsGroup = screen.getByText(
+                    'Benefits provided by the managed care plans'
+                ).parentElement
+                const geoGroup = screen.getByText(
+                    'Geographic areas served by the managed care plans'
+                ).parentElement
+                const lengthGroup = screen.getByText(
+                    'Length of the contract period'
+                ).parentElement
+
+                if (
+                    benefitsGroup === null ||
+                    geoGroup === null ||
+                    lengthGroup === null
+                ) {
+                    throw new Error(
+                        'Benefits and Geo and Length must have parents.'
+                    )
+                }
+
+                // choose yes and no
+                const benefitsYes = within(benefitsGroup).getByLabelText('Yes') //
+                const geoNo = within(geoGroup).getByLabelText('No')
+                const lengthYes = within(lengthGroup).getByLabelText('Yes')
+
+                await userEvent.click(benefitsYes)
+                await userEvent.click(geoNo)
+                await userEvent.click(lengthYes)
+
+                await waitFor(() => {
+                    expect(
+                        screen.queryAllByText('You must select yes or no')
+                    ).toHaveLength(modifiedProvisionKeys.length * 2 - 6)
+                })
+            })
+
+            it('shows correct validations for medicaid contract amendment', async () => {
+                const emptyDraft = mockDraft()
+                emptyDraft.contractType = 'AMENDMENT'
+                emptyDraft.populationCovered = 'MEDICAID'
+                const mockUpdateDraftFn = jest.fn()
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={emptyDraft}
+                        updateDraft={mockUpdateDraftFn}
+                        previousDocuments={[]}
+                    />,
+                    {
+                        apolloProvider: {
+                            mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        },
+                    }
+                )
+
+                // click "next"
+                const continueButton = screen.getByRole('button', {
+                    name: 'Continue',
+                })
+                await userEvent.click(continueButton)
+
+                // check for yes/no errors  - each field shows up twice, once in error summary, one as inline error next to lab
+                await waitFor(() => {
+                    expect(
+                        screen.getAllByText('You must select yes or no')
+                    ).toHaveLength(modifiedProvisionKeys.length * 2)
+                })
+
+                const benefitsGroup = screen.getByText(
+                    'Benefits provided by the managed care plans'
+                ).parentElement
+                const geoGroup = screen.getByText(
+                    'Geographic areas served by the managed care plans'
+                ).parentElement
+                const lengthGroup = screen.getByText(
+                    'Length of the contract period'
+                ).parentElement
+
+                if (
+                    benefitsGroup === null ||
+                    geoGroup === null ||
+                    lengthGroup === null
+                ) {
+                    throw new Error(
+                        'Benefits and Geo and Length must have parents.'
+                    )
+                }
+
+                // choose yes and no
+                const benefitsYes = within(benefitsGroup).getByLabelText('Yes') //
+                const geoNo = within(geoGroup).getByLabelText('No')
+                const lengthYes = within(lengthGroup).getByLabelText('Yes')
+
+                await userEvent.click(benefitsYes)
+                await userEvent.click(geoNo)
+                await userEvent.click(lengthYes)
+
+                await waitFor(() => {
+                    expect(
+                        screen.queryAllByText('You must select yes or no')
+                    ).toHaveLength(modifiedProvisionKeys.length * 2 - 6)
+                })
+            })
+
+            it('does not allow setting risk related or payments provisions for CHIP only submissions', async () => {
+                const emptyDraft = mockDraft()
+                emptyDraft.contractType = 'AMENDMENT'
+                emptyDraft.populationCovered = 'CHIP'
+                const mockUpdateDraftFn = jest.fn()
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={emptyDraft}
+                        updateDraft={mockUpdateDraftFn}
+                        previousDocuments={[]}
+                    />,
+                    {
+                        apolloProvider: {
+                            mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        },
+                    }
+                )
+
+                // click "next"
+                const continueButton = screen.getByRole('button', {
+                    name: 'Continue',
+                })
+                await userEvent.click(continueButton)
+
+                // check for yes/no errors - each field shows up twice, once in error summary, one as inline error next to lab
+                await waitFor(() => {
+                    expect(
+                        screen.getAllByText('You must select yes or no')
+                    ).toHaveLength(allowedProvisionKeysForCHIP.length * 2)
+                })
+
+                expect(screen.queryByText(/Risk-sharing strategy/)).toBeNull()
+                expect(
+                    screen.queryByText(/Withhold arrangements in accordance/)
+                ).toBeNull()
+                expect(
+                    screen.queryByText(/Payments to MCOs and PIHPs/)
+                ).toBeNull()
+                expect(screen.queryByText(/State directed payments/)).toBeNull()
+            })
+
+            it('shows correct validations for CHIP only submissions', async () => {
+                const emptyDraft = mockDraft()
+                emptyDraft.contractType = 'AMENDMENT'
+                emptyDraft.populationCovered = 'CHIP'
+                const mockUpdateDraftFn = jest.fn()
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={emptyDraft}
+                        updateDraft={mockUpdateDraftFn}
+                        previousDocuments={[]}
+                    />,
+                    {
+                        apolloProvider: {
+                            mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        },
+                    }
+                )
+
+                // click "next"
+                const continueButton = screen.getByRole('button', {
+                    name: 'Continue',
+                })
+                await userEvent.click(continueButton)
+
+                // check for yes/no errors - each field shows up twice, once in error summary, one as inline error next to lab
+                await waitFor(() => {
+                    expect(
+                        screen.getAllByText('You must select yes or no')
+                    ).toHaveLength(allowedProvisionKeysForCHIP.length * 2)
+                })
+
+                const benefitsGroup = screen.getByText(
+                    'Benefits provided by the managed care plans'
+                ).parentElement
+                const geoGroup = screen.getByText(
+                    'Geographic areas served by the managed care plans'
+                ).parentElement
+                const lengthGroup = screen.getByText(
+                    'Length of the contract period'
+                ).parentElement
+
+                if (
+                    benefitsGroup === null ||
+                    geoGroup === null ||
+                    lengthGroup === null
+                ) {
+                    throw new Error(
+                        'Benefits and Geo and Length must have parents.'
+                    )
+                }
+
+                // choose yes and no
+                const benefitsYes = within(benefitsGroup).getByLabelText('Yes') //
+                const geoNo = within(geoGroup).getByLabelText('No')
+                const lengthYes = within(lengthGroup).getByLabelText('Yes')
+
+                await userEvent.click(benefitsYes)
+                await userEvent.click(geoNo)
+                await userEvent.click(lengthYes)
+
+                await waitFor(() => {
+                    expect(
+                        screen.queryAllByText('You must select yes or no')
+                    ).toHaveLength(allowedProvisionKeysForCHIP.length * 2 - 6)
+                })
             })
         })
 
-        it('disabled with alert after first attempt to continue with zero files', async () => {
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyContractDetailsDraft}
-                    updateDraft={jest.fn()}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
+        describe('Continue button', () => {
+            it('enabled when valid files are present', async () => {
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={emptyContractDetailsDraft}
+                        updateDraft={jest.fn()}
+                        previousDocuments={[]}
+                    />,
+                    {
+                        apolloProvider: {
+                            mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        },
+                    }
+                )
 
-            const continueButton = screen.getByRole('button', {
-                name: 'Continue',
+                const continueButton = screen.getByRole('button', {
+                    name: 'Continue',
+                })
+                const input = screen.getByLabelText('Upload contract')
+
+                await userEvent.upload(input, [TEST_DOC_FILE])
+
+                await waitFor(() => {
+                    expect(continueButton).not.toHaveAttribute('aria-disabled')
+                })
             })
-            expect(continueButton).not.toHaveAttribute('aria-disabled')
 
-            continueButton.click()
+            it('enabled when invalid files have been dropped but valid files are present', async () => {
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={emptyContractDetailsDraft}
+                        updateDraft={jest.fn()}
+                        previousDocuments={[]}
+                    />,
+                    {
+                        apolloProvider: {
+                            mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        },
+                    }
+                )
 
-            await waitFor(() => {
+                const continueButton = screen.getByRole('button', {
+                    name: 'Continue',
+                })
+                const input = screen.getByLabelText('Upload contract')
+                const targetEl = screen.getByTestId('file-input-droptarget')
+
+                await userEvent.upload(input, [TEST_DOC_FILE])
+                dragAndDrop(targetEl, [TEST_PNG_FILE])
+
+                await waitFor(() => {
+                    expect(
+                        screen.getByText('This is not a valid file type.')
+                    ).toBeInTheDocument()
+                    expect(continueButton).not.toHaveAttribute('aria-disabled')
+                })
+            })
+
+            it('disabled with alert after first attempt to continue with zero files', async () => {
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={emptyContractDetailsDraft}
+                        updateDraft={jest.fn()}
+                        previousDocuments={[]}
+                    />,
+                    {
+                        apolloProvider: {
+                            mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        },
+                    }
+                )
+
+                const continueButton = screen.getByRole('button', {
+                    name: 'Continue',
+                })
+                expect(continueButton).not.toHaveAttribute('aria-disabled')
+
+                continueButton.click()
+
+                await waitFor(() => {
+                    expect(
+                        screen.getAllByText(
+                            'You must upload at least one document'
+                        )
+                    ).toHaveLength(2)
+
+                    expect(continueButton).toHaveAttribute(
+                        'aria-disabled',
+                        'true'
+                    )
+                })
+            })
+
+            it('disabled with alert after first attempt to continue with invalid duplicate files', async () => {
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={emptyContractDetailsDraft}
+                        updateDraft={jest.fn()}
+                        previousDocuments={[]}
+                    />,
+                    {
+                        apolloProvider: {
+                            mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        },
+                    }
+                )
+
+                const input = screen.getByLabelText('Upload contract')
+                const continueButton = screen.getByRole('button', {
+                    name: 'Continue',
+                })
+
+                await userEvent.upload(input, [TEST_DOC_FILE])
+                await userEvent.upload(input, []) // clear input and ensure we add same file twice
+                await userEvent.upload(input, [TEST_DOC_FILE])
+                expect(continueButton).not.toHaveAttribute('aria-disabled')
+
+                continueButton.click()
+                await waitFor(() => {
+                    expect(
+                        screen.getAllByText(
+                            'You must remove all documents with error messages before continuing'
+                        )
+                    ).toHaveLength(2)
+
+                    expect(continueButton).toHaveAttribute(
+                        'aria-disabled',
+                        'true'
+                    )
+                })
+            })
+
+            it('disabled with alert after first attempt to continue with invalid files', async () => {
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={emptyContractDetailsDraft}
+                        updateDraft={jest.fn()}
+                        previousDocuments={[]}
+                    />,
+                    {
+                        apolloProvider: {
+                            mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        },
+                    }
+                )
+                const continueButton = screen.getByRole('button', {
+                    name: 'Continue',
+                })
+
+                const targetEl = screen.getByTestId('file-input-droptarget')
+                dragAndDrop(targetEl, [TEST_PNG_FILE])
+
                 expect(
-                    screen.getAllByText('You must upload at least one document')
+                    await screen.findByText('This is not a valid file type.')
+                ).toBeInTheDocument()
+
+                expect(continueButton).not.toHaveAttribute('aria-disabled')
+                continueButton.click()
+
+                expect(
+                    await screen.findAllByText(
+                        'You must upload at least one document'
+                    )
                 ).toHaveLength(2)
 
                 expect(continueButton).toHaveAttribute('aria-disabled', 'true')
             })
-        })
+            it('disabled with alert when trying to continue while a file is still uploading', async () => {
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={emptyContractDetailsDraft}
+                        updateDraft={jest.fn()}
+                        previousDocuments={[]}
+                    />,
+                    {
+                        apolloProvider: {
+                            mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        },
+                    }
+                )
+                const continueButton = screen.getByRole('button', {
+                    name: 'Continue',
+                })
+                const targetEl = screen.getByTestId('file-input-droptarget')
 
-        it('disabled with alert after first attempt to continue with invalid duplicate files', async () => {
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyContractDetailsDraft}
-                    updateDraft={jest.fn()}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
+                // upload one file
+                dragAndDrop(targetEl, [TEST_PDF_FILE])
+                const imageElFile1 = screen.getByTestId(
+                    'file-input-preview-image'
+                )
+                expect(imageElFile1).toHaveClass('is-loading')
+                await waitFor(() =>
+                    expect(imageElFile1).not.toHaveClass('is-loading')
+                )
 
-            const input = screen.getByLabelText('Upload contract')
-            const continueButton = screen.getByRole('button', {
-                name: 'Continue',
-            })
+                // upload second file
+                dragAndDrop(targetEl, [TEST_DOC_FILE])
 
-            await userEvent.upload(input, [TEST_DOC_FILE])
-            await userEvent.upload(input, []) // clear input and ensure we add same file twice
-            await userEvent.upload(input, [TEST_DOC_FILE])
-            expect(continueButton).not.toHaveAttribute('aria-disabled')
+                const imageElFile2 = screen.getAllByTestId(
+                    'file-input-preview-image'
+                )[1]
+                expect(imageElFile2).toHaveClass('is-loading')
+                fireEvent.click(continueButton)
+                expect(continueButton).toHaveAttribute('aria-disabled', 'true')
 
-            continueButton.click()
-            await waitFor(() => {
                 expect(
                     screen.getAllByText(
-                        'You must remove all documents with error messages before continuing'
+                        'You must wait for all documents to finish uploading before continuing'
                     )
                 ).toHaveLength(2)
-
-                expect(continueButton).toHaveAttribute('aria-disabled', 'true')
             })
         })
 
-        it('disabled with alert after first attempt to continue with invalid files', async () => {
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyContractDetailsDraft}
-                    updateDraft={jest.fn()}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
-            const continueButton = screen.getByRole('button', {
-                name: 'Continue',
-            })
-
-            const targetEl = screen.getByTestId('file-input-droptarget')
-            dragAndDrop(targetEl, [TEST_PNG_FILE])
-
-            expect(
-                await screen.findByText('This is not a valid file type.')
-            ).toBeInTheDocument()
-
-            expect(continueButton).not.toHaveAttribute('aria-disabled')
-            continueButton.click()
-
-            expect(
-                await screen.findAllByText(
-                    'You must upload at least one document'
-                )
-            ).toHaveLength(2)
-
-            expect(continueButton).toHaveAttribute('aria-disabled', 'true')
-        })
-        it('disabled with alert when trying to continue while a file is still uploading', async () => {
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyContractDetailsDraft}
-                    updateDraft={jest.fn()}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
-            const continueButton = screen.getByRole('button', {
-                name: 'Continue',
-            })
-            const targetEl = screen.getByTestId('file-input-droptarget')
-
-            // upload one file
-            dragAndDrop(targetEl, [TEST_PDF_FILE])
-            const imageElFile1 = screen.getByTestId('file-input-preview-image')
-            expect(imageElFile1).toHaveClass('is-loading')
-            await waitFor(() =>
-                expect(imageElFile1).not.toHaveClass('is-loading')
-            )
-
-            // upload second file
-            dragAndDrop(targetEl, [TEST_DOC_FILE])
-
-            const imageElFile2 = screen.getAllByTestId(
-                'file-input-preview-image'
-            )[1]
-            expect(imageElFile2).toHaveClass('is-loading')
-            fireEvent.click(continueButton)
-            expect(continueButton).toHaveAttribute('aria-disabled', 'true')
-
-            expect(
-                screen.getAllByText(
-                    'You must wait for all documents to finish uploading before continuing'
-                )
-            ).toHaveLength(2)
-        })
-    })
-
-    describe('Save as draft button', () => {
-        it('enabled when valid files are present', async () => {
-            const mockUpdateDraftFn = jest.fn()
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyContractDetailsDraft}
-                    updateDraft={mockUpdateDraftFn}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
-
-            const saveAsDraftButton = screen.getByRole('button', {
-                name: 'Save as draft',
-            })
-            const input = screen.getByLabelText('Upload contract')
-
-            await userEvent.upload(input, [TEST_DOC_FILE])
-
-            await waitFor(() => {
-                expect(saveAsDraftButton).not.toHaveAttribute('aria-disabled')
-            })
-        })
-
-        it('enabled when invalid files have been dropped but valid files are present', async () => {
-            const mockUpdateDraftFn = jest.fn()
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyContractDetailsDraft}
-                    updateDraft={mockUpdateDraftFn}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
-
-            const saveAsDraftButton = screen.getByRole('button', {
-                name: 'Save as draft',
-            })
-            const input = screen.getByLabelText('Upload contract')
-            const targetEl = screen.getByTestId('file-input-droptarget')
-
-            await userEvent.upload(input, [TEST_DOC_FILE])
-            dragAndDrop(targetEl, [TEST_PNG_FILE])
-
-            await waitFor(() => {
-                expect(saveAsDraftButton).not.toHaveAttribute('aria-disabled')
-            })
-        })
-
-        it('when zero files present, does not trigger missing documents alert on click but still saves the in progress draft', async () => {
-            const mockUpdateDraftFn = jest.fn()
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyContractDetailsDraft}
-                    updateDraft={mockUpdateDraftFn}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
-
-            const saveAsDraftButton = screen.getByRole('button', {
-                name: 'Save as draft',
-            })
-            expect(saveAsDraftButton).not.toHaveAttribute('aria-disabled')
-
-            await userEvent.click(saveAsDraftButton)
-            expect(mockUpdateDraftFn).toHaveBeenCalled()
-            expect(
-                screen.queryByText('You must upload at least one document')
-            ).toBeNull()
-        })
-
-        it('when existing file is removed, does not trigger missing documents alert on click but still saves the in progress draft', async () => {
-            const mockUpdateDraftFn = jest.fn()
-            const hasDocsDetailsDraft = {
-                ...mockDraft(),
-                contractDocuments: [
+        describe('Save as draft button', () => {
+            it('enabled when valid files are present', async () => {
+                const mockUpdateDraftFn = jest.fn()
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={emptyContractDetailsDraft}
+                        updateDraft={mockUpdateDraftFn}
+                        previousDocuments={[]}
+                    />,
                     {
-                        name: 'aasdf3423af',
-                        s3URL: 's3://bucketname/key/fileName',
-                        documentCategories: ['CONTRACT' as const],
-                    },
-                ],
-            }
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={hasDocsDetailsDraft}
-                    updateDraft={mockUpdateDraftFn}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
+                        apolloProvider: {
+                            mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        },
+                    }
+                )
 
-            const saveAsDraftButton = screen.getByRole('button', {
-                name: 'Save as draft',
-            })
-            expect(saveAsDraftButton).not.toHaveAttribute('aria-disabled')
+                const saveAsDraftButton = screen.getByRole('button', {
+                    name: 'Save as draft',
+                })
+                const input = screen.getByLabelText('Upload contract')
 
-            await userEvent.click(saveAsDraftButton)
-            expect(mockUpdateDraftFn).toHaveBeenCalled()
-            expect(
-                screen.queryByText('You must upload at least one document')
-            ).toBeNull()
-        })
+                await userEvent.upload(input, [TEST_DOC_FILE])
 
-        it('when duplicate files present, triggers error alert on click', async () => {
-            const mockUpdateDraftFn = jest.fn()
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyContractDetailsDraft}
-                    updateDraft={mockUpdateDraftFn}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
-            const input = screen.getByLabelText('Upload contract')
-            const saveAsDraftButton = screen.getByRole('button', {
-                name: 'Save as draft',
-            })
-
-            await userEvent.upload(input, [TEST_DOC_FILE])
-            await userEvent.upload(input, [TEST_PDF_FILE])
-            await userEvent.upload(input, [TEST_DOC_FILE])
-
-            await waitFor(() => {
-                expect(
-                    screen.queryAllByText('Duplicate file, please remove')
-                ).toHaveLength(1)
-            })
-            await userEvent.click(saveAsDraftButton)
-            await waitFor(() => {
-                expect(mockUpdateDraftFn).not.toHaveBeenCalled()
-                expect(
-                    screen.queryAllByText(
-                        'You must remove all documents with error messages before continuing'
+                await waitFor(() => {
+                    expect(saveAsDraftButton).not.toHaveAttribute(
+                        'aria-disabled'
                     )
-                ).toHaveLength(2)
-            })
-        })
-    })
-
-    describe('Back button', () => {
-        it('enabled when valid files are present', async () => {
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyContractDetailsDraft}
-                    updateDraft={jest.fn()}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
-
-            const backButton = screen.getByRole('button', {
-                name: 'Back',
-            })
-            const input = screen.getByLabelText('Upload contract')
-
-            await userEvent.upload(input, [TEST_DOC_FILE])
-
-            await waitFor(() => {
-                expect(backButton).not.toHaveAttribute('aria-disabled')
-            })
-        })
-
-        it('enabled when invalid files have been dropped but valid files are present', async () => {
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyContractDetailsDraft}
-                    updateDraft={jest.fn()}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
-
-            const backButton = screen.getByRole('button', {
-                name: 'Back',
-            })
-            const input = screen.getByLabelText('Upload contract')
-            const targetEl = screen.getByTestId('file-input-droptarget')
-
-            await userEvent.upload(input, [TEST_DOC_FILE])
-            dragAndDrop(targetEl, [TEST_PNG_FILE])
-
-            await waitFor(() => {
-                expect(backButton).not.toHaveAttribute('aria-disabled')
-            })
-        })
-
-        it('when zero files present, does not trigger missing documents alert on click', async () => {
-            const mockUpdateDraftFn = jest.fn()
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyContractDetailsDraft}
-                    updateDraft={mockUpdateDraftFn}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
-
-            const backButton = screen.getByRole('button', {
-                name: 'Back',
-            })
-            expect(backButton).not.toHaveAttribute('aria-disabled')
-
-            await userEvent.click(backButton)
-            expect(
-                screen.queryByText('You must upload at least one document')
-            ).toBeNull()
-            expect(mockUpdateDraftFn).not.toHaveBeenCalled()
-        })
-
-        it('when duplicate files present, does not trigger duplicate documents alert on click and silently updates submission without the duplicate', async () => {
-            const mockUpdateDraftFn = jest.fn()
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyContractDetailsDraft}
-                    updateDraft={mockUpdateDraftFn}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
-
-            const input = screen.getByLabelText('Upload contract')
-            const backButton = screen.getByRole('button', {
-                name: 'Back',
+                })
             })
 
-            await userEvent.upload(input, [TEST_DOC_FILE])
-            await userEvent.upload(input, [TEST_PDF_FILE])
-            await userEvent.upload(input, [TEST_DOC_FILE])
-            await waitFor(() => {
-                expect(backButton).not.toHaveAttribute('aria-disabled')
+            it('enabled when invalid files have been dropped but valid files are present', async () => {
+                const mockUpdateDraftFn = jest.fn()
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={emptyContractDetailsDraft}
+                        updateDraft={mockUpdateDraftFn}
+                        previousDocuments={[]}
+                    />,
+                    {
+                        apolloProvider: {
+                            mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        },
+                    }
+                )
+
+                const saveAsDraftButton = screen.getByRole('button', {
+                    name: 'Save as draft',
+                })
+                const input = screen.getByLabelText('Upload contract')
+                const targetEl = screen.getByTestId('file-input-droptarget')
+
+                await userEvent.upload(input, [TEST_DOC_FILE])
+                dragAndDrop(targetEl, [TEST_PNG_FILE])
+
+                await waitFor(() => {
+                    expect(saveAsDraftButton).not.toHaveAttribute(
+                        'aria-disabled'
+                    )
+                })
+            })
+
+            it('when zero files present, does not trigger missing documents alert on click but still saves the in progress draft', async () => {
+                const mockUpdateDraftFn = jest.fn()
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={emptyContractDetailsDraft}
+                        updateDraft={mockUpdateDraftFn}
+                        previousDocuments={[]}
+                    />,
+                    {
+                        apolloProvider: {
+                            mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        },
+                    }
+                )
+
+                const saveAsDraftButton = screen.getByRole('button', {
+                    name: 'Save as draft',
+                })
+                expect(saveAsDraftButton).not.toHaveAttribute('aria-disabled')
+
+                await userEvent.click(saveAsDraftButton)
+                expect(mockUpdateDraftFn).toHaveBeenCalled()
                 expect(
-                    screen.queryAllByText('Duplicate file, please remove')
-                ).toHaveLength(1)
+                    screen.queryByText('You must upload at least one document')
+                ).toBeNull()
             })
-            await userEvent.click(backButton)
-            expect(screen.queryByText('Remove files with errors')).toBeNull()
-            expect(mockUpdateDraftFn).toHaveBeenCalledWith(
-                expect.objectContaining({
+
+            it('when existing file is removed, does not trigger missing documents alert on click but still saves the in progress draft', async () => {
+                const mockUpdateDraftFn = jest.fn()
+                const hasDocsDetailsDraft = {
+                    ...mockDraft(),
                     contractDocuments: [
                         {
-                            name: 'testFile.doc',
-                            s3URL: expect.any(String),
-                            documentCategories: ['CONTRACT'],
-                            sha256: 'da7d22ce886b5ab262cd7ab28901212a027630a5edf8e88c8488087b03ffd833', // pragma: allowlist secret
-                        },
-                        {
-                            name: 'testFile.pdf',
-                            s3URL: expect.any(String),
-                            documentCategories: ['CONTRACT'],
-                            sha256: '6d50607f29187d5b185ffd9d46bc5ef75ce7abb53318690c73e55b6623e25ad5', // pragma: allowlist secret
+                            name: 'aasdf3423af',
+                            s3URL: 's3://bucketname/key/fileName',
+                            documentCategories: ['CONTRACT' as const],
                         },
                     ],
+                }
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={hasDocsDetailsDraft}
+                        updateDraft={mockUpdateDraftFn}
+                        previousDocuments={[]}
+                    />,
+                    {
+                        apolloProvider: {
+                            mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        },
+                    }
+                )
+
+                const saveAsDraftButton = screen.getByRole('button', {
+                    name: 'Save as draft',
                 })
-            )
+                expect(saveAsDraftButton).not.toHaveAttribute('aria-disabled')
+
+                await userEvent.click(saveAsDraftButton)
+                expect(mockUpdateDraftFn).toHaveBeenCalled()
+                expect(
+                    screen.queryByText('You must upload at least one document')
+                ).toBeNull()
+            })
+
+            it('when duplicate files present, triggers error alert on click', async () => {
+                const mockUpdateDraftFn = jest.fn()
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={emptyContractDetailsDraft}
+                        updateDraft={mockUpdateDraftFn}
+                        previousDocuments={[]}
+                    />,
+                    {
+                        apolloProvider: {
+                            mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        },
+                    }
+                )
+                const input = screen.getByLabelText('Upload contract')
+                const saveAsDraftButton = screen.getByRole('button', {
+                    name: 'Save as draft',
+                })
+
+                await userEvent.upload(input, [TEST_DOC_FILE])
+                await userEvent.upload(input, [TEST_PDF_FILE])
+                await userEvent.upload(input, [TEST_DOC_FILE])
+
+                await waitFor(() => {
+                    expect(
+                        screen.queryAllByText('Duplicate file, please remove')
+                    ).toHaveLength(1)
+                })
+                await userEvent.click(saveAsDraftButton)
+                await waitFor(() => {
+                    expect(mockUpdateDraftFn).not.toHaveBeenCalled()
+                    expect(
+                        screen.queryAllByText(
+                            'You must remove all documents with error messages before continuing'
+                        )
+                    ).toHaveLength(2)
+                })
+            })
+        })
+
+        describe('Back button', () => {
+            it('enabled when valid files are present', async () => {
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={emptyContractDetailsDraft}
+                        updateDraft={jest.fn()}
+                        previousDocuments={[]}
+                    />,
+                    {
+                        apolloProvider: {
+                            mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        },
+                    }
+                )
+
+                const backButton = screen.getByRole('button', {
+                    name: 'Back',
+                })
+                const input = screen.getByLabelText('Upload contract')
+
+                await userEvent.upload(input, [TEST_DOC_FILE])
+
+                await waitFor(() => {
+                    expect(backButton).not.toHaveAttribute('aria-disabled')
+                })
+            })
+
+            it('enabled when invalid files have been dropped but valid files are present', async () => {
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={emptyContractDetailsDraft}
+                        updateDraft={jest.fn()}
+                        previousDocuments={[]}
+                    />,
+                    {
+                        apolloProvider: {
+                            mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        },
+                    }
+                )
+
+                const backButton = screen.getByRole('button', {
+                    name: 'Back',
+                })
+                const input = screen.getByLabelText('Upload contract')
+                const targetEl = screen.getByTestId('file-input-droptarget')
+
+                await userEvent.upload(input, [TEST_DOC_FILE])
+                dragAndDrop(targetEl, [TEST_PNG_FILE])
+
+                await waitFor(() => {
+                    expect(backButton).not.toHaveAttribute('aria-disabled')
+                })
+            })
+
+            it('when zero files present, does not trigger missing documents alert on click', async () => {
+                const mockUpdateDraftFn = jest.fn()
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={emptyContractDetailsDraft}
+                        updateDraft={mockUpdateDraftFn}
+                        previousDocuments={[]}
+                    />,
+                    {
+                        apolloProvider: {
+                            mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        },
+                    }
+                )
+
+                const backButton = screen.getByRole('button', {
+                    name: 'Back',
+                })
+                expect(backButton).not.toHaveAttribute('aria-disabled')
+
+                await userEvent.click(backButton)
+                expect(
+                    screen.queryByText('You must upload at least one document')
+                ).toBeNull()
+                expect(mockUpdateDraftFn).not.toHaveBeenCalled()
+            })
+
+            it('when duplicate files present, does not trigger duplicate documents alert on click and silently updates submission without the duplicate', async () => {
+                const mockUpdateDraftFn = jest.fn()
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={emptyContractDetailsDraft}
+                        updateDraft={mockUpdateDraftFn}
+                        previousDocuments={[]}
+                    />,
+                    {
+                        apolloProvider: {
+                            mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        },
+                    }
+                )
+
+                const input = screen.getByLabelText('Upload contract')
+                const backButton = screen.getByRole('button', {
+                    name: 'Back',
+                })
+
+                await userEvent.upload(input, [TEST_DOC_FILE])
+                await userEvent.upload(input, [TEST_PDF_FILE])
+                await userEvent.upload(input, [TEST_DOC_FILE])
+                await waitFor(() => {
+                    expect(backButton).not.toHaveAttribute('aria-disabled')
+                    expect(
+                        screen.queryAllByText('Duplicate file, please remove')
+                    ).toHaveLength(1)
+                })
+                await userEvent.click(backButton)
+                expect(
+                    screen.queryByText('Remove files with errors')
+                ).toBeNull()
+                expect(mockUpdateDraftFn).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        contractDocuments: [
+                            {
+                                name: 'testFile.doc',
+                                s3URL: expect.any(String),
+                                documentCategories: ['CONTRACT'],
+                                sha256: 'da7d22ce886b5ab262cd7ab28901212a027630a5edf8e88c8488087b03ffd833', // pragma: allowlist secret
+                            },
+                            {
+                                name: 'testFile.pdf',
+                                s3URL: expect.any(String),
+                                documentCategories: ['CONTRACT'],
+                                sha256: '6d50607f29187d5b185ffd9d46bc5ef75ce7abb53318690c73e55b6623e25ad5', // pragma: allowlist secret
+                            },
+                        ],
+                    })
+                )
+            })
         })
     })
-})
 })

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
@@ -19,6 +19,7 @@ import { ContractDetails } from './'
 import {
     allowedProvisionKeysForCHIP,
     federalAuthorityKeys,
+    federalAuthorityKeysForCHIP,
     modifiedProvisionKeys,
 } from '../../../common-code/healthPlanFormDataType'
 
@@ -143,18 +144,18 @@ describe('ContractDetails', () => {
         })
     })
 
-    describe('Federal authorities', () => {
+    describe('Federal authorities',  () => {
         it('dislays correct fields in dropdown for medicaid contract', () => {
             renderWithProviders(<ContractDetails
-                draftSubmission={{...mockDraft(), populationCovered: 'CHIP'}}
+                draftSubmission={{...mockDraft(), populationCovered: 'MEDICAID'}}
                 updateDraft={jest.fn()}
                 previousDocuments={[]}
             />,
             )
-            const fedAuthDropdown = await screen.findByRole('select', {name: 'Active federal operating authority'})
+            const fedAuthDropdown =  screen.getByRole('group', {name: 'Active federal operating authority'})
             expect(fedAuthDropdown).toBeInTheDocument()
-            expect(within(fedAuthDropdown).getByRole('option')).toHaveLength(allowedProvisionKeysForCHIP.length)
-            expect(within(fedAuthDropdown).getByRole('option', {name: '1115 Waiver Authority'})).toBeInTheDocument() // authority disallowed for chip is not included in list
+            expect(within(fedAuthDropdown).getAllByRole('checkbox')).toHaveLength(federalAuthorityKeys.length)
+            expect(within(fedAuthDropdown).getByRole('checkbox', {name: '1115 Waiver Authority'})).toBeInTheDocument() // authority disallowed for chip is not included in list
         })
 
         it('dislays correct fields in dropdown for CHIP only contract', async () => {
@@ -164,10 +165,10 @@ describe('ContractDetails', () => {
                 previousDocuments={[]}
             />,
             )
-            const fedAuthDropdown = await screen.findByRole('select', {name: 'Active federal operating authority'})
+            const fedAuthDropdown = await screen.findByRole('group', {name: 'Active federal operating authority'})
             expect(fedAuthDropdown).toBeInTheDocument()
-            expect(within(fedAuthDropdown).getByRole('option')).toHaveLength(federalAuthorityKeys.length)
-            expect(within(fedAuthDropdown).getByRole('option', {name: '1115 Waiver Authority'})).toBeInTheDocument()  // medicaid only authority should be in the list
+            expect(within(fedAuthDropdown).getAllByRole('checkbox')).toHaveLength(federalAuthorityKeysForCHIP.length)
+            expect(within(fedAuthDropdown).queryByRole('checkbox', {name: '1115 Waiver Authority'})).not.toBeInTheDocument()  // medicaid only authority should be in the list
 
     })
     describe('Modified provisions - yes/nos', () => {
@@ -924,4 +925,5 @@ describe('ContractDetails', () => {
             )
         })
     })
+})
 })

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
@@ -18,6 +18,7 @@ import { ACCEPTED_SUBMISSION_FILE_TYPES } from '../../../components/FileUpload'
 import { ContractDetails } from './'
 import {
     allowedProvisionKeysForCHIP,
+    federalAuthorityKeys,
     modifiedProvisionKeys,
 } from '../../../common-code/healthPlanFormDataType'
 
@@ -26,16 +27,12 @@ HTMLElement.prototype.scrollIntoView = scrollIntoViewMock
 
 describe('ContractDetails', () => {
     afterEach(() => {
-        jest.resetAllMocks()
-    })
-    afterAll(() => {
         jest.clearAllMocks()
     })
 
     const emptyContractDetailsDraft = {
         ...mockDraft(),
     }
-    afterEach(() => jest.clearAllMocks())
 
     it('displays correct form guidance', async () => {
         renderWithProviders(
@@ -146,6 +143,33 @@ describe('ContractDetails', () => {
         })
     })
 
+    describe('Federal authorities', () => {
+        it('dislays correct fields in dropdown for medicaid contract', () => {
+            renderWithProviders(<ContractDetails
+                draftSubmission={{...mockDraft(), populationCovered: 'CHIP'}}
+                updateDraft={jest.fn()}
+                previousDocuments={[]}
+            />,
+            )
+            const fedAuthDropdown = await screen.findByRole('select', {name: 'Active federal operating authority'})
+            expect(fedAuthDropdown).toBeInTheDocument()
+            expect(within(fedAuthDropdown).getByRole('option')).toHaveLength(allowedProvisionKeysForCHIP.length)
+            expect(within(fedAuthDropdown).getByRole('option', {name: '1115 Waiver Authority'})).toBeInTheDocument() // authority disallowed for chip is not included in list
+        })
+
+        it('dislays correct fields in dropdown for CHIP only contract', async () => {
+            renderWithProviders(<ContractDetails
+                draftSubmission={{...mockDraft(), populationCovered: 'CHIP'}}
+                updateDraft={jest.fn()}
+                previousDocuments={[]}
+            />,
+            )
+            const fedAuthDropdown = await screen.findByRole('select', {name: 'Active federal operating authority'})
+            expect(fedAuthDropdown).toBeInTheDocument()
+            expect(within(fedAuthDropdown).getByRole('option')).toHaveLength(federalAuthorityKeys.length)
+            expect(within(fedAuthDropdown).getByRole('option', {name: '1115 Waiver Authority'})).toBeInTheDocument()  // medicaid only authority should be in the list
+
+    })
     describe('Modified provisions - yes/nos', () => {
         it('allows setting all modified provisions for medicaid contract amendment', async () => {
             const emptyDraft = mockDraft()

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -42,6 +42,7 @@ import {
     allowedProvisionKeysForCHIP,
     isCHIPProvision,
     federalAuthorityKeysForCHIP,
+    federalAuthorityKeys,
 } from '../../../common-code/healthPlanFormDataType'
 import {
     ManagedCareEntityRecord,
@@ -229,7 +230,7 @@ export const ContractDetails = ({
         ? allowedProvisionKeysForCHIP
         : modifiedProvisionKeys
     const applicableFederalAuthorities = isCHIPOnly? 
-    federalAuthorityKeysForCHIP : federalAuthorityKeysForCHIP;
+    federalAuthorityKeysForCHIP : federalAuthorityKeys;
 
     const contractDetailsInitialValues: ContractDetailsFormValues = {
         contractExecutionStatus:

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -41,6 +41,7 @@ import {
     FederalAuthority,
     allowedProvisionKeysForCHIP,
     isCHIPProvision,
+    federalAuthorityKeysForCHIP,
 } from '../../../common-code/healthPlanFormDataType'
 import {
     ManagedCareEntityRecord,
@@ -227,6 +228,8 @@ export const ContractDetails = ({
     const applicableProvisions = isCHIPOnly
         ? allowedProvisionKeysForCHIP
         : modifiedProvisionKeys
+    const applicableFederalAuthorities = isCHIPOnly? 
+    federalAuthorityKeysForCHIP : federalAuthorityKeysForCHIP;
 
     const contractDetailsInitialValues: ContractDetailsFormValues = {
         contractExecutionStatus:
@@ -769,54 +772,18 @@ export const ContractDetails = ({
                                                     {errors.federalAuthorities}
                                                 </PoliteErrorMessage>
                                             )}
-                                            <FieldCheckbox
-                                                id="1932aStatePlanAuthority"
-                                                name="federalAuthorities"
-                                                label={
-                                                    FederalAuthorityRecord.STATE_PLAN
-                                                }
-                                                value={'STATE_PLAN'}
-                                            />
-                                            <FieldCheckbox
-                                                id="1915bWaiverAuthority"
-                                                name="federalAuthorities"
-                                                label={
-                                                    FederalAuthorityRecord.WAIVER_1915B
-                                                }
-                                                value={'WAIVER_1915B'}
-                                            />
-                                            <FieldCheckbox
-                                                id="1115WaiverAuthority"
-                                                name="federalAuthorities"
-                                                label={
-                                                    FederalAuthorityRecord.WAIVER_1115
-                                                }
-                                                value={'WAIVER_1115'}
-                                            />
-                                            <FieldCheckbox
-                                                id="1915aVoluntaryAuthority"
-                                                name="federalAuthorities"
-                                                label={
-                                                    FederalAuthorityRecord.VOLUNTARY
-                                                }
-                                                value={'VOLUNTARY'}
-                                            />
-                                            <FieldCheckbox
-                                                id="1937BenchmarkAuthority"
-                                                name="federalAuthorities"
-                                                label={
-                                                    FederalAuthorityRecord.BENCHMARK
-                                                }
-                                                value={'BENCHMARK'}
-                                            />
-                                            <FieldCheckbox
-                                                id="titleXXISeparateChipStatePlanAuthority"
-                                                name="federalAuthorities"
-                                                label={
-                                                    FederalAuthorityRecord.TITLE_XXI
-                                                }
-                                                value={'TITLE_XXI'}
-                                            />
+                                            {applicableFederalAuthorities.map((federalAuthority) => (
+                                                    <FieldCheckbox
+                                                    id={federalAuthority.toLowerCase()}
+                                                    key={federalAuthority.toLowerCase()}
+                                                    name="federalAuthorities"
+                                                    label={
+                                                        FederalAuthorityRecord[federalAuthority]
+                                                    }
+                                                    value={federalAuthority}
+                                                />
+                                            ))}
+                                        
                                         </Fieldset>
                                     </FormGroup>
                                     {isContractAmendment && (

--- a/services/app-web/src/testHelpers/jestHelpers.tsx
+++ b/services/app-web/src/testHelpers/jestHelpers.tsx
@@ -26,13 +26,13 @@ import {
 /* Render */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const renderWithProviders = (
-    ui: React.ReactNode,
+    ui: React.ReactNode, // actual test UI - the JSX to render
     options?: {
-        routerProvider?: { route?: string }
-        apolloProvider?: MockedProviderProps
-        authProvider?: Partial<AuthProviderProps>
-        s3Provider?: S3ClientT
-        location?: (location: Location) => Location
+        routerProvider?: { route?: string } // used to pass react router related data
+        apolloProvider?: MockedProviderProps // used to pass GraphQL related data via apollo client
+        authProvider?: Partial<AuthProviderProps> // used to pass user authentication state via AuthContext
+        s3Provider?: S3ClientT // used to pass AWS S3 related state via  S3Context
+        location?: (location: Location) => Location // used to pass a location url for react-router
     }
 ) => {
     const {


### PR DESCRIPTION
## Summary
State cannot select an operating authority that is not relevant to CHIP-Only

#### Related issues
https://qmacbis.atlassian.net/browse/MR-3175
https://qmacbis.atlassian.net/browse/MR-3177 - last sprint work, just one additional CHIP copy change requested from stakeholders

#### Test cases covered
- `displays correct form fields for federal authorities with CHIP only contract`
- `displays correct form fields for federal authorities fields with Medicaid contract`
- `renders federal authorities for a medicaid contract`
- `renders federal authorities for a CHIP contract as expected, removing invalid authorities`
- `removes any invalid federal authorities from CHIP submission and submits successfully`

## QA guidance

-See ticket AC.
-  On submission type page you can toggle between CHIP and medicaid population covered - this will impacts federal authorities list on contract details (on 1115 Waiver and Title XXI are listed for CHIP). That will also be displayed options on submission summary. 
