### PR TITLE
Fix typo in population coverage question.

### DIFF
--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.test.tsx
@@ -98,7 +98,7 @@ describe('SubmissionTypeSummarySection', () => {
         ).toBeInTheDocument()
         expect(
             screen.getByRole('definition', {
-                name: /Which populations does this contact action cover\?/,
+                name: /Which populations does this contract action cover\?/,
             })
         ).toBeInTheDocument()
     })
@@ -121,11 +121,11 @@ describe('SubmissionTypeSummarySection', () => {
 
         expect(
             screen.getByRole('definition', {
-                name: /Which populations does this contact action cover\?/,
+                name: /Which populations does this contract action cover\?/,
             })
         ).toBeInTheDocument()
         const riskBasedDefinitionParentDiv = screen.getByRole('definition', {
-            name: /Which populations does this contact action cover\?/,
+            name: /Which populations does this contract action cover\?/,
         })
         if (!riskBasedDefinitionParentDiv) throw Error('Testing error')
         expect(riskBasedDefinitionParentDiv).toHaveTextContent(

--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.tsx
@@ -108,7 +108,7 @@ export const SubmissionTypeSummarySection = ({
                     {showCHIPOnlyForm && (
                         <DataDetail
                             id="populationCoverage"
-                            label="Which populations does this contact action cover?"
+                            label="Which populations does this contract action cover?"
                             explainMissingData={!isSubmitted}
                             children={
                                 submission.populationCovered &&

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.test.tsx
@@ -121,7 +121,7 @@ describe('SubmissionType', () => {
 
             expect(
                 await screen.getByText(
-                    'Which populations does this contact action cover?'
+                    'Which populations does this contract action cover?'
                 )
             ).toBeInTheDocument()
             expect(
@@ -151,7 +151,7 @@ describe('SubmissionType', () => {
 
             expect(
                 await screen.getByText(
-                    'Which populations does this contact action cover?'
+                    'Which populations does this contract action cover?'
                 )
             ).toBeInTheDocument()
             const chipOnlyRadio = await screen.getByRole('radio', {
@@ -192,7 +192,7 @@ describe('SubmissionType', () => {
 
             expect(
                 await screen.getByText(
-                    'Which populations does this contact action cover?'
+                    'Which populations does this contract action cover?'
                 )
             ).toBeInTheDocument()
             const medicaidRadio = await screen.getByRole('radio', {
@@ -252,7 +252,7 @@ describe('SubmissionType', () => {
 
             expect(
                 await screen.getByText(
-                    'Which populations does this contact action cover?'
+                    'Which populations does this contract action cover?'
                 )
             ).toBeInTheDocument()
             const medicaidRadio = await screen.getByRole('radio', {
@@ -311,7 +311,7 @@ describe('SubmissionType', () => {
 
             expect(
                 await screen.getByText(
-                    'Which populations does this contact action cover?'
+                    'Which populations does this contract action cover?'
                 )
             ).toBeInTheDocument()
             const medicaidRadio = await screen.getByRole('radio', {
@@ -358,7 +358,7 @@ describe('SubmissionType', () => {
             // Expect population coverage question and radios
             expect(
                 await screen.getByText(
-                    'Which populations does this contact action cover?'
+                    'Which populations does this contract action cover?'
                 )
             ).toBeInTheDocument()
             expect(

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
@@ -340,7 +340,7 @@ export const SubmissionType = ({
                                         className={styles.radioGroup}
                                         role="radiogroup"
                                         aria-required
-                                        legend="Which populations does this contact action cover?"
+                                        legend="Which populations does this contract action cover?"
                                     >
                                         {showFieldErrors(
                                             errors.populationCovered


### PR DESCRIPTION
## Summary
Fixing a typo in the population coverage question.

"which populations does this **_contact_** action cover" -> "which populations does this **_contract_** action cover"

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
