### PR TITLE
Move aws region into a var, remove from secrets

### DIFF
--- a/.github/workflows/deploy-app-to-env.yml
+++ b/.github/workflows/deploy-app-to-env.yml
@@ -15,9 +15,10 @@ on:
       changed_services:
         required: true
         type: string
-    secrets:
       aws_default_region:
         required: true
+        type: string
+    secrets:
       aws_account_id:
         required: true
       react_app_auth_mode:
@@ -43,7 +44,7 @@ jobs:
       - name: Get AWS credentials
         uses: ./.github/actions/get_aws_credentials
         with:
-          region: ${{ secrets.aws_default_region }}
+          region: ${{ inputs.aws_default_region }}
           account-id: ${{ secrets.aws_account_id }}
           stage-name: ${{ inputs.stage_name }}
           changed-services: ${{ inputs.changed_services }}
@@ -73,7 +74,7 @@ jobs:
       - name: Get AWS credentials
         uses: ./.github/actions/get_aws_credentials
         with:
-          region: ${{ secrets.aws_default_region }}
+          region: ${{ inputs.aws_default_region }}
           account-id: ${{ secrets.aws_account_id }}
           stage-name: ${{ inputs.stage_name }}
           changed-services: ${{ inputs.changed_services }}

--- a/.github/workflows/deploy-infra-to-env.yml
+++ b/.github/workflows/deploy-infra-to-env.yml
@@ -12,9 +12,10 @@ on:
       changed_services:
         required: true
         type: string
-    secrets:
       aws_default_region:
         required: true
+        type: string
+    secrets:
       aws_account_id:
         required: true
       nr_license_key:
@@ -61,7 +62,7 @@ jobs:
       - name: Get AWS credentials
         uses: ./.github/actions/get_aws_credentials
         with:
-          region: ${{ secrets.aws_default_region }}
+          region: ${{ inputs.aws_default_region }}
           account-id: ${{ secrets.aws_account_id }}
           # use the manually bootstrapped OIDC role to solve the chicken-and-egg problem of deploying the OIDC service via OIDC
           stage-name: ${{ steps.set-oidc-stage-name.outputs.stage-name }}
@@ -87,7 +88,7 @@ jobs:
       - name: Get AWS credentials
         uses: ./.github/actions/get_aws_credentials
         with:
-          region: ${{ secrets.aws_default_region }}
+          region: ${{ inputs.aws_default_region }}
           account-id: ${{ secrets.aws_account_id }}
           stage-name: ${{ inputs.stage_name }}
           changed-services: ${{ inputs.changed_services }}
@@ -112,7 +113,7 @@ jobs:
       - name: Get AWS credentials
         uses: ./.github/actions/get_aws_credentials
         with:
-          region: ${{ secrets.aws_default_region }}
+          region: ${{ inputs.aws_default_region }}
           account-id: ${{ secrets.aws_account_id }}
           stage-name: ${{ inputs.stage_name }}
           changed-services: ${{ inputs.changed_services }}
@@ -137,7 +138,7 @@ jobs:
       - name: Get AWS credentials
         uses: ./.github/actions/get_aws_credentials
         with:
-          region: ${{ secrets.aws_default_region }}
+          region: ${{ inputs.aws_default_region }}
           account-id: ${{ secrets.aws_account_id }}
           stage-name: ${{ inputs.stage_name }}
           changed-services: ${{ inputs.changed_services }}
@@ -162,7 +163,7 @@ jobs:
       - name: Get AWS credentials
         uses: ./.github/actions/get_aws_credentials
         with:
-          region: ${{ secrets.aws_default_region }}
+          region: ${{ inputs.aws_default_region }}
           account-id: ${{ secrets.aws_account_id }}
           stage-name: ${{ inputs.stage_name }}
           changed-services: ${{ inputs.changed_services }}
@@ -189,7 +190,7 @@ jobs:
       - name: Get AWS credentials
         uses: ./.github/actions/get_aws_credentials
         with:
-          region: ${{ secrets.aws_default_region }}
+          region: ${{ inputs.aws_default_region }}
           account-id: ${{ secrets.aws_account_id }}
           stage-name: ${{ inputs.stage_name }}
           changed-services: ${{ inputs.changed_services }}
@@ -214,7 +215,7 @@ jobs:
       - name: Get AWS credentials
         uses: ./.github/actions/get_aws_credentials
         with:
-          region: ${{ secrets.aws_default_region }}
+          region: ${{ inputs.aws_default_region }}
           account-id: ${{ secrets.aws_account_id }}
           stage-name: ${{ inputs.stage_name }}
           changed-services: ${{ inputs.changed_services }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -242,7 +242,7 @@ jobs:
       stage_name: ${{ needs.begin-deployment.outputs.stage-name}}
       changed_services: ${{ needs.begin-deployment.outputs.changed-services }}
     secrets:
-      aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+      aws_default_region: ${{ vars.AWS_DEFAULT_REGION }}
       aws_account_id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
 
@@ -269,7 +269,7 @@ jobs:
       app_version: ${{ needs.begin-deployment.outputs.app-version }}
       changed_services: ${{ needs.begin-deployment.outputs.changed-services }}
     secrets:
-      aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+      aws_default_region: ${{ vars.AWS_DEFAULT_REGION }}
       aws_account_id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
       react_app_auth_mode: AWS_COGNITO
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
@@ -297,7 +297,7 @@ jobs:
       - name: Get AWS credentials
         uses: ./.github/actions/get_aws_credentials
         with:
-          region: ${{ secrets.AWS_DEFAULT_REGION }}
+          region: ${{ vars.AWS_DEFAULT_REGION }}
           account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
           stage-name: ${{ needs.begin-deployment.outputs.stage-name }}
           changed-services: ${{ needs.begin-deployment.outputs.changed-services }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -236,13 +236,13 @@ jobs:
 
   deploy-infra:
     needs: [begin-deployment]
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@mt-move-region-from-secrets
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name}}
       changed_services: ${{ needs.begin-deployment.outputs.changed-services }}
-    secrets:
       aws_default_region: ${{ vars.AWS_DEFAULT_REGION }}
+    secrets:
       aws_account_id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
 
@@ -262,14 +262,14 @@ jobs:
       needs.api-unit-tests.result == 'success' &&
       needs.build-prisma-client-lambda-layer.result == 'success' &&
       needs.begin-deployment.result == 'success'
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@mt-move-region-from-secrets
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name }}
       app_version: ${{ needs.begin-deployment.outputs.app-version }}
       changed_services: ${{ needs.begin-deployment.outputs.changed-services }}
-    secrets:
       aws_default_region: ${{ vars.AWS_DEFAULT_REGION }}
+    secrets:
       aws_account_id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
       react_app_auth_mode: AWS_COGNITO
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Get AWS credentials
         uses: ./.github/actions/get_aws_credentials
         with:
-          region: ${{ secrets.AWS_DEFAULT_REGION }}
+          region: ${{ vars.AWS_DEFAULT_REGION }}
           account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
           stage-name: main
 

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -125,7 +125,7 @@ jobs:
       stage_name: main
       changed_services: ${{ needs.unit-tests.outputs.changed-services}}
     secrets:
-      aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+      aws_default_region: ${{ vars.AWS_DEFAULT_REGION }}
       aws_account_id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
 
@@ -138,7 +138,7 @@ jobs:
       app_version: ${{ needs.unit-tests.outputs.app-version }}
       changed_services: ${{ needs.unit-tests.outputs.changed-services}}
     secrets:
-      aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+      aws_default_region: ${{ vars.AWS_DEFAULT_REGION }}
       aws_account_id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
       react_app_auth_mode: IDM
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
@@ -152,7 +152,7 @@ jobs:
       changed_services: ${{ needs.unit-tests.outputs.changed-services}}
     secrets:
       aws_account_id: ${{ secrets.VAL_AWS_ACCOUNT_ID }}
-      aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+      aws_default_region: ${{ vars.AWS_DEFAULT_REGION }}
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
 
   promote-app-val:
@@ -165,7 +165,7 @@ jobs:
       changed_services: ${{ needs.unit-tests.outputs.changed-services}}
     secrets:
       aws_account_id: ${{ secrets.VAL_AWS_ACCOUNT_ID }}
-      aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+      aws_default_region: ${{ vars.AWS_DEFAULT_REGION }}
       react_app_auth_mode: IDM
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
 
@@ -178,7 +178,7 @@ jobs:
       changed_services: ${{ needs.unit-tests.outputs.changed-services}}
     secrets:
       aws_account_id: ${{ secrets.PROD_AWS_ACCOUNT_ID }}
-      aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+      aws_default_region: ${{ vars.AWS_DEFAULT_REGION }}
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
 
   promote-app-prod:
@@ -191,7 +191,7 @@ jobs:
       changed_services: ${{ needs.unit-tests.outputs.changed-services}}
     secrets:
       aws_account_id: ${{ secrets.PROD_AWS_ACCOUNT_ID }}
-      aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+      aws_default_region: ${{ vars.AWS_DEFAULT_REGION }}
       react_app_auth_mode: IDM
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
 

--- a/.github/workflows/sechub-jira-sync.yml
+++ b/.github/workflows/sechub-jira-sync.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get AWS credentials
         uses: ./.github/actions/get_aws_credentials
         with:
-          region: ${{ secrets.AWS_DEFAULT_REGION }}
+          region: ${{ vars.AWS_DEFAULT_REGION }}
           account-id: ${{ secrets.PROD_AWS_ACCOUNT_ID }}
           stage-name: prod
 
@@ -48,5 +48,3 @@ jobs:
           SLACK_FOOTER: ''
           SLACK_MESSAGE: 'Failure syncing Security Hub findings and Jira issues'
           MSG_MINIMAL: actions url
-
-

--- a/services/github-oidc/README.md
+++ b/services/github-oidc/README.md
@@ -87,7 +87,7 @@ jobs:
       - name: Get AWS credentials
         uses: ./.github/actions/get_aws_credentials
         with:
-          region: ${{ secrets.AWS_DEFAULT_REGION }}
+          region: ${{ vars.AWS_DEFAULT_REGION }}
           account-id: ${{ secrets.{DEV,VAL,PROD}_AWS_ACCOUNT_ID }}
           stage-name: {your stage name}
      ...


### PR DESCRIPTION
## Summary

We hit an issue in a branch where Jason was attempting to output variables to use in our Cypress configuration, but because the value contains the string `us-east-1`, GitHub Actions masks that output value. There's no reason why `us-east-1` should be a secret, except I vaguely recall we had inherited that config from the quickstart.

This moves that variable to use `vars` instead of `secrets`.



