### PR TITLE
Move reading schema to inside readGraphQLSchema task.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -248,7 +248,7 @@ jobs:
 
   deploy-infra:
     needs: [begin-deployment]
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@jl_mr-2482_populate_groups_of_submissions_in_cypress
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name}}
@@ -274,7 +274,7 @@ jobs:
       needs.api-unit-tests.result == 'success' &&
       needs.build-prisma-client-lambda-layer.result == 'success' &&
       needs.begin-deployment.result == 'success'
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@jl_mr-2482_populate_groups_of_submissions_in_cypress
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name }}

--- a/services/cypress/cypress.config.ts
+++ b/services/cypress/cypress.config.ts
@@ -23,7 +23,6 @@ module.exports = defineConfig({
             }))
             require('@cypress/code-coverage/task')(on, config)
 
-            const gqlSchema = fs.readFileSync(path.resolve(__dirname, './gen/schema.graphql'), 'utf-8')
             const newConfig = config
 
             newConfig.env.AUTH_MODE = process.env.REACT_APP_AUTH_MODE
@@ -44,6 +43,7 @@ module.exports = defineConfig({
             on('task', {
                 pa11y: pa11y(),
                 readGraphQLSchema() {
+                    const gqlSchema = fs.readFileSync(path.resolve(__dirname, './gen/schema.graphql'), 'utf-8')
                     return gql(`${gqlSchema}`)
                 }
             })


### PR DESCRIPTION
## Summary

Failed to promote in prod because in `promote.yml`, we are not copying over the `gen` folder, specifically the `schema.graphql` file. This file is needed for the `readGraphQLSchema` task in `cypress.config.ts`. 

Since promote only runs the `promote.spec.ts,` that task is never called. So the quickest solution was to read the schema when the task is called and not at startup.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
