### PR TITLE
Increase timeout for updateHealthPlanFormDataMutation.

### DIFF
--- a/services/cypress/integration/stateWorkflow/stateSubmissionForm/newSubmission.spec.ts
+++ b/services/cypress/integration/stateWorkflow/stateSubmissionForm/newSubmission.spec.ts
@@ -11,7 +11,7 @@ describe('new submission', () => {
 
         // Navigate to dashboard page by clicking cancel
         cy.findByRole('button', { name: /Cancel/ }).click()
-        cy.wait('@indexHealthPlanPackagesQuery', { timeout: 50000 })
+        cy.wait('@indexHealthPlanPackagesQuery', { timeout: 50_000 })
         cy.findByRole('heading', { level: 1, name: /Dashboard/ })
 
         // Navigate to new page

--- a/services/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
+++ b/services/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
@@ -95,7 +95,7 @@ describe('submission type', () => {
 
             // Navigate to dashboard page by clicking cancel
             cy.findByRole('button', { name: /Cancel/ }).click()
-            cy.wait('@indexHealthPlanPackagesQuery', { timeout: 50000 })
+            cy.wait('@indexHealthPlanPackagesQuery', { timeout: 50_000 })
             cy.findByRole('heading', { level: 1, name: /Dashboard/ })
 
             // Navigate to type page

--- a/services/cypress/support/navigateCommands.ts
+++ b/services/cypress/support/navigateCommands.ts
@@ -26,7 +26,7 @@ Cypress.Commands.add(
 
         if (buttonKey === 'SAVE_DRAFT') {
             if(waitForLoad) {
-                cy.wait('@updateHealthPlanFormDataMutation')
+                cy.wait('@updateHealthPlanFormDataMutation', { timeout: 50_000})
              }
             cy.findByTestId('dashboard-page').should('exist')
             cy.findByRole('heading',{name:'Submissions'}).should('exist')
@@ -39,7 +39,7 @@ Cypress.Commands.add(
         } else if (buttonKey === 'CONTINUE') {
             if (waitForLoad) {
                 cy.findAllByTestId('errorMessage').should('have.length', 0)
-                cy.wait('@updateHealthPlanFormDataMutation')
+                cy.wait('@updateHealthPlanFormDataMutation', { timeout: 50_000})
             }
             cy.findByTestId('state-submission-form-page').should('exist')
         } else {
@@ -53,6 +53,6 @@ Cypress.Commands.add(
     (url: string, waitForLoad = true) => {
         cy.visit(url)
         if (waitForLoad)
-            cy.wait('@fetchHealthPlanPackageQuery', { timeout: 20_000 })
+            cy.wait('@fetchHealthPlanPackageQuery', { timeout: 50_000 })
     }
 )

--- a/services/cypress/support/questionResponseCommands.ts
+++ b/services/cypress/support/questionResponseCommands.ts
@@ -22,7 +22,7 @@ Cypress.Commands.add(
             .click()
 
         // Wait for re-fetching of health plan package.
-        cy.wait(['@createQuestionMutation', '@fetchHealthPlanPackageWithQuestionsQuery'], { timeout: 20000 })
+        cy.wait(['@createQuestionMutation', '@fetchHealthPlanPackageWithQuestionsQuery'], { timeout: 50_000 })
     }
 )
 
@@ -51,6 +51,6 @@ Cypress.Commands.add(
             .click()
 
         // Wait for re-fetching of health plan package.
-        cy.wait(['@createQuestionResponseMutation', '@fetchHealthPlanPackageWithQuestionsQuery'], { timeout: 20000 })
+        cy.wait(['@createQuestionResponseMutation', '@fetchHealthPlanPackageWithQuestionsQuery'], { timeout: 50_000 })
     }
 )


### PR DESCRIPTION
## Summary

Looking at the [cypress failures](https://cloud.cypress.io/projects/tt5hbz/runs/bae7be7b-918e-4ec5-b88f-f5ee7b28a879/test-results/226d784d-8eb8-4d47-bd44-2f407e61e05b) for the dependabot [PR#1735](https://github.com/Enterprise-CMCS/managed-care-review/pull/1735). 

Increasing the timeout for uploading files may have let servers go to sleep. Then hitting `Continue`, the wait for `updateHealthPlanFormDataMutation` times out. Increasing the default timeout for `cy.wait('@updateHealthPlanFormDataMutation')` should allow the tests to wait longer for server response.

Also, increasing the timeout for the `wait` in `questionResponseCommands.ts` since they also wait on graphql request right after document upload.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
