### PR TITLE
MR-3452: Add a content security policy

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -13,6 +13,7 @@ export CT_AWS_ROLE='ct-ado-managedcare-developer-admin'
 export CT_IDMS='2'
 
 # values formerly in .env (required)
+export INLINE_RUNTIME_CHUNK=false
 export SASS_PATH='src:../../node_modules'
 export REACT_APP_AUTH_MODE='LOCAL'
 export REACT_APP_STAGE_NAME='local'

--- a/services/app-web/.eslintrc
+++ b/services/app-web/.eslintrc
@@ -2,7 +2,8 @@
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "project": ["./tsconfig.json"],
-        "sourceType": "module"
+        "sourceType": "module",
+        "extraFileExtensions": [".html"]
     },
     "plugins": ["@typescript-eslint", "jsx-a11y", "testing-library", "jest"],
     "extends": [

--- a/services/app-web/public/index.html
+++ b/services/app-web/public/index.html
@@ -6,6 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content="#000000" />
         <meta name="description" content="Managed Care Review" />
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn1.adoberesources.net; style-src 'self'; object-src 'none';">
         <!-- <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> -->
         <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
## Summary

Our content security policy included a deprecated directive (prefetch-src), which seemed to be blocking the analytics package from CMS.  I set a CSP explicitly that uses standard directives and should allow their script.  We can't really know until it's in prod and they try it.  But @haworku is there a way to see if Tealium and Google Analytics are unaffected before promoting to prod?

