### PR TITLE
Refactor destroy action call order

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -24,13 +24,6 @@ jobs:
       - name: Setup env
         uses: ./.github/actions/setup_env
 
-      - name: Get AWS credentials
-        uses: ./.github/actions/get_aws_credentials
-        with:
-          region: ${{ vars.AWS_DEFAULT_REGION }}
-          account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
-          stage-name: main
-
       - name: build scripts
         shell: bash
         run: |
@@ -40,6 +33,13 @@ jobs:
         run: ./.github/github-lock.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get AWS credentials
+        uses: ./.github/actions/get_aws_credentials
+        with:
+          region: ${{ vars.AWS_DEFAULT_REGION }}
+          account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
+          stage-name: main
 
       - name: destroy all
         env:

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -130,7 +130,7 @@ resources:
           - postgresql
         ServerlessV2ScalingConfiguration:
           MinCapacity: ${self:custom.auroraMinCapacity.${opt:stage}, self:custom.auroraMinCapacity.other}
-          MaxCapacity: 32
+          MaxCapacity: 16
 
     PostgresAuroraV2Instance:
       Type: AWS::RDS::DBInstance


### PR DESCRIPTION
## Summary

Sometimes our destroy script will not complete because the AWS credentials it has have expired. This is due to the fact that the destroy script pauses for a promote to finish, but sometimes promotes can queue and take multiple hours to finish. This causes the requested AWS credentials to no longer work.

This changes the call order for the Destroy CI action to get credentials when they are going to be used.

#### Related issues
https://qmacbis.atlassian.net/browse/MR-3469
