### PR TITLE
MR-3281: handle missing files and revisions in add_sha and reports

### DIFF
--- a/services/app-api/src/handlers/reports.ts
+++ b/services/app-api/src/handlers/reports.ts
@@ -60,12 +60,6 @@ const decodeRevisions = (
     revisions.forEach((revision) => {
         let decodedRevision = {} as RevisionWithDecodedProtobuf
         const decodedFormDataProto = toDomain(revision.formDataProto)
-        console.info(
-            'decodedFormDataProto',
-            JSON.stringify(decodedFormDataProto)
-        )
-        console.info('id', revision.id)
-        console.info('submittedAt', revision.submittedAt)
         decodedRevision.formDataProto = decodedFormDataProto
         const names = programList
             .filter(

--- a/services/app-api/src/handlers/reports.ts
+++ b/services/app-api/src/handlers/reports.ts
@@ -17,6 +17,11 @@ import {
     userFromCognitoAuthProvider,
     userFromLocalAuthProvider,
 } from '../authn'
+import {
+    initTracer,
+    initMeter,
+    recordException,
+} from '../../../uploads/src/lib/otel'
 
 type RequiredRevisionWithDecodedProtobufProperties = {
     formDataProto: HealthPlanFormDataType | Error
@@ -55,6 +60,12 @@ const decodeRevisions = (
     revisions.forEach((revision) => {
         let decodedRevision = {} as RevisionWithDecodedProtobuf
         const decodedFormDataProto = toDomain(revision.formDataProto)
+        console.info(
+            'decodedFormDataProto',
+            JSON.stringify(decodedFormDataProto)
+        )
+        console.info('id', revision.id)
+        console.info('submittedAt', revision.submittedAt)
         decodedRevision.formDataProto = decodedFormDataProto
         const names = programList
             .filter(
@@ -128,12 +139,29 @@ export const main: APIGatewayProxyHandler = async (event, context) => {
         result,
         programList
     )
-
+    const stageName = process.env.stage
+    if (!stageName || stageName === '') {
+        throw new Error('Configuration Error: stage env var must be set')
+    }
+    const otelCollectorURL = process.env.REACT_APP_OTEL_COLLECTOR_URL
+    if (!otelCollectorURL || otelCollectorURL === '') {
+        throw new Error(
+            'Configuration Error: REACT_APP_OTEL_COLLECTOR_URL must be set'
+        )
+    }
+    const serviceName = `reports_endpoint-${stageName}`
+    initTracer(serviceName, otelCollectorURL)
+    initMeter(serviceName)
     const bucket = [] as RevisionWithDecodedProtobuf[]
-    allDecodedRevisions.forEach((revision) => {
+    for (const revision of allDecodedRevisions) {
         if (revision.formDataProto instanceof Error) {
-            console.error('Error decoding revision')
-            throw new Error(`Error generating reports array`)
+            console.error('Error decoding revision', revision.id)
+            recordException(
+                revision.formDataProto,
+                serviceName,
+                'decode_revision'
+            )
+            continue
         } else {
             // add the package name to the revision
             revision.packageName = packageName(
@@ -154,7 +182,7 @@ export const main: APIGatewayProxyHandler = async (event, context) => {
                 bucket.push(revision)
             }
         }
-    })
+    }
     const parser = new Parser({
         transforms: [
             transforms.flatten({


### PR DESCRIPTION
## Summary

This is a follow-up to [previous work](https://github.com/Enterprise-CMCS/managed-care-review/pull/1656).  We didn't anticipate that some document records would be missing a corresponding file in S3, but we ran into that in Val, so here we skip those records rather than blowing up the whole migration.  

In addition, a record with missing formData was breaking the reports endpoint, so I put in a similar fix there.

In both places, we've added a `recordException` call to otel to track when these errors occur.
