### PR TITLE
MR-3452

### DIFF
--- a/services/app-web/src/contexts/TraceContext.tsx
+++ b/services/app-web/src/contexts/TraceContext.tsx
@@ -38,12 +38,18 @@ registerInstrumentations({
         getWebAutoInstrumentations({
             // load custom configuration for xml-http-request instrumentation
             '@opentelemetry/instrumentation-xml-http-request': {
-                ignoreUrls: [/(.*).launchdarkly\.(com|us)/g],
+                ignoreUrls: [
+                    /(.*).launchdarkly\.(com|us)/g,
+                    /adobe-ep\.cms\.gov/g,
+                ],
                 propagateTraceHeaderCorsUrls: [/.+/g],
             },
             // load custom configuration for fetch instrumentation
             '@opentelemetry/instrumentation-fetch': {
-                ignoreUrls: [/(.*).launchdarkly\.(com|us)/g],
+                ignoreUrls: [
+                    /(.*).launchdarkly\.(com|us)/g,
+                    /adobe-ep\.cms\.gov/g,
+                ],
                 propagateTraceHeaderCorsUrls: [/.+/g],
             },
         }),


### PR DESCRIPTION
## Summary

We're seeing a CORS error with the new analytics service hosted by adobe, and it seems to be coming from OpenTelemetry.  We're hoping that ignoring the adobe endpoint will get rid of the error.
