### PR TITLE
MR-3480: Update Cypress to 12.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "@bahmutov/cypress-esbuild-preprocessor": "^2.2.0",
         "@cypress-audit/pa11y": "^1.3.0",
         "chromedriver": "^106.0.1",
-        "cypress": "12.16.0",
+        "cypress": "^12.16.0",
         "cypress-pipe": "^2.0.0",
         "danger": "^11.2.6",
         "esbuild": "^0.17.19",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "@bahmutov/cypress-esbuild-preprocessor": "^2.2.0",
         "@cypress-audit/pa11y": "^1.3.0",
         "chromedriver": "^106.0.1",
-        "cypress": "12.14.0",
+        "cypress": "12.16.0",
         "cypress-pipe": "^2.0.0",
         "danger": "^11.2.6",
         "esbuild": "^0.17.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18941,10 +18941,10 @@ cypress-pipe@^2.0.0:
   resolved "https://registry.yarnpkg.com/cypress-pipe/-/cypress-pipe-2.0.0.tgz#577df7a70a8603d89a96dfe4092a605962181af8"
   integrity sha512-KW9s+bz4tFLucH3rBGfjW+Q12n7S4QpUSSyxiGrgPOfoHlbYWzAGB3H26MO0VTojqf9NVvfd5Kt0MH5XMgbfyg==
 
-cypress@12.14.0:
-  version "12.14.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.14.0.tgz#37a19b85f5e9d881995e9fee1ddf41b3d3a623dd"
-  integrity sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==
+cypress@12.16.0:
+  version "12.16.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.16.0.tgz#d0dcd0725a96497f4c60cf54742242259847924c"
+  integrity sha512-mwv1YNe48hm0LVaPgofEhGCtLwNIQEjmj2dJXnAkY1b4n/NE9OtgPph4TyS+tOtYp5CKtRmDvBzWseUXQTjbTg==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18941,7 +18941,7 @@ cypress-pipe@^2.0.0:
   resolved "https://registry.yarnpkg.com/cypress-pipe/-/cypress-pipe-2.0.0.tgz#577df7a70a8603d89a96dfe4092a605962181af8"
   integrity sha512-KW9s+bz4tFLucH3rBGfjW+Q12n7S4QpUSSyxiGrgPOfoHlbYWzAGB3H26MO0VTojqf9NVvfd5Kt0MH5XMgbfyg==
 
-cypress@12.16.0:
+cypress@^12.16.0:
   version "12.16.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.16.0.tgz#d0dcd0725a96497f4c60cf54742242259847924c"
   integrity sha512-mwv1YNe48hm0LVaPgofEhGCtLwNIQEjmj2dJXnAkY1b4n/NE9OtgPph4TyS+tOtYp5CKtRmDvBzWseUXQTjbTg==


### PR DESCRIPTION
## Summary
[MR-3480](https://qmacbis.atlassian.net/browse/MR-3480)

Cypress 12.16.0 fixed the code coverage bug.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
