### PR TITLE
Update GitHub AWS OIDC thumbprints

### DIFF
--- a/services/github-oidc/serverless.yml
+++ b/services/github-oidc/serverless.yml
@@ -24,7 +24,11 @@ params:
 
     # list of valid server thumbprints for tokens sent by the GitHub OIDC provider
     # value comes from https://github.blog/changelog/2022-01-13-github-actions-update-on-oidc-based-deployments-to-aws/
-    githubActionsThumbprint: [6938fd4d98bab03faadb97b34396831e3780aea1]
+    githubActionsThumbprint:
+      [
+        6938fd4d98bab03faadb97b34396831e3780aea1,
+        1c58a3a8518e8759bf075b76b750d4f2df264fcd,
+      ]
 
     # list of allowed audiences for tokens sent by the GitHub OIDC provider
     # value is the audience for the official AWS credentials action: https://github.com/aws-actions/configure-aws-credentials


### PR DESCRIPTION
## Summary

We started hitting an issue where github oidc connect setup for AWS credentials started failing. Jason found this [blog post](https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/) from GitHub yesterday that tells users to make sure both OIDC intermediary thumbprints are added in AWS. 

We only had the first one, so this adds the second one to the list of known thumbprints.

#### Related issues
https://qmacbis.atlassian.net/browse/MR-3529