### PR TITLE
Upload Many Documents Bug

### DIFF
--- a/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
+++ b/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
@@ -254,7 +254,7 @@ export const Documents = ({
                 const updatedSubmission = await updateDraft(draftSubmission)
                 if (updatedSubmission instanceof Error) {
                     console.info(
-                        'Error updating draft submission',
+                        'Error updating draft submission on docs page',
                         updatedSubmission
                     )
                     onUpdateDraftSubmissionError()

--- a/services/infra-api/serverless.yml
+++ b/services/infra-api/serverless.yml
@@ -12,6 +12,9 @@ plugins:
 
 custom:
   stage: ${opt:stage, self:provider.stage}
+  wafExcludeRules:
+    awsCommon:
+      - "SizeRestrictions_BODY"
   nrLicenseKey: ${ssm:/configuration/nr_license_key}
   nrMetricStreamName: 'NewRelic-Metric-Stream'
   nrFirehoseStreamName: 'NewRelic-Delivery-Stream'


### PR DESCRIPTION
## Summary

https://qmacbis.atlassian.net/browse/MR-3540

updateHPFormData is erroring when NJ adds 35 files to supporting documents. 

Best guess so far is that this is hitting a default WAF rule for body length at 2^13 bytes.