### PR TITLE
Fix: Supporting docs migration - address type error, guard against similar issues

### DIFF
--- a/services/app-api/src/handlers/migrate_rate_documents.test.ts
+++ b/services/app-api/src/handlers/migrate_rate_documents.test.ts
@@ -300,6 +300,46 @@ describe('migrate_rate_documents', () => {
             })
         )
     })
+    it('should skip submissions with no rate infos', async () => {
+        // Create a revision with a rate related document
+        const revisions: HealthPlanRevisionTable[] = [
+            {
+                id: 'mockId',
+                createdAt: new Date(),
+                pkgID: 'mockPkgID',
+                formDataProto: Buffer.from(
+                    toProtoBuffer({
+                        ...unlockedWithALittleBitOfEverything(),
+                        rateInfos: [],
+                    })
+                ),
+                submittedAt: new Date(),
+                unlockedAt: new Date(),
+                unlockedBy: 'mockUnlockedBy',
+                unlockedReason: 'mockUnlockedReason',
+                submittedBy: 'mockSubmittedBy',
+                submittedReason: 'mockSubmittedReason',
+            },
+        ]
+
+        const storeFindAllRevisionsSpy = jest.spyOn(
+            mockStore,
+            'findAllRevisions'
+        )
+        storeFindAllRevisionsSpy.mockResolvedValue(revisions)
+
+        const updateHealthPlanRevisionSpy = jest.spyOn(
+            mockStore,
+            'updateHealthPlanRevision'
+        )
+
+        await main({} as Event, {} as Context, () => {
+            /*empty callback*/
+        })
+
+        // the document should be moved to rateInfos
+        expect(updateHealthPlanRevisionSpy).not.toHaveBeenCalled()
+    })
 
     it('should move specific documents to specific places in rateInfos', async () => {
         // Create a revision with two specific documents

--- a/services/app-api/src/handlers/migrate_rate_documents.test.ts
+++ b/services/app-api/src/handlers/migrate_rate_documents.test.ts
@@ -301,7 +301,6 @@ describe('migrate_rate_documents', () => {
         )
     })
     it('should skip submissions with no rate infos', async () => {
-        // Create a revision with a rate related document
         const revisions: HealthPlanRevisionTable[] = [
             {
                 id: 'mockId',
@@ -337,7 +336,6 @@ describe('migrate_rate_documents', () => {
             /*empty callback*/
         })
 
-        // the document should be moved to rateInfos
         expect(updateHealthPlanRevisionSpy).not.toHaveBeenCalled()
     })
 

--- a/services/app-api/src/handlers/migrate_rate_documents.ts
+++ b/services/app-api/src/handlers/migrate_rate_documents.ts
@@ -46,7 +46,7 @@ export const processRevisions = async (
             if (formData.id !== 'ddd5dde1-0082-4398-90fe-89fc1bc148df') {
                 if (formData.rateInfos.length > 1 && formData.documents) {
                     console.info(
-                        `There is an additional submission on this environment with rate supporting docs to be migrated. ID: ${formData.id}`
+                        `UNEXPECTED: There is an additional submission on this environment with rate supporting docs to be migrated. ID: ${formData.id}`
                     )
                 }
 
@@ -66,11 +66,33 @@ export const processRevisions = async (
                         doc.name ===
                         'Report12 - SFY 2022 Preliminary MississippiCAN Capitation Rates - Exhibits.xlsx'
                 )
+
                 const secondRateRelatedDocument = formData.documents.filter(
                     (doc) =>
                         doc.name ===
                         'Report13 - SFY 2023 Preliminary MississippiCAN Capitation Rates - Exhibits.xlsx'
                 )
+
+                if (
+                    firstRateRelatedDocument.length === 0 ||
+                    secondRateRelatedDocument.length === 0
+                ) {
+                    console.info(
+                        'UNEXPECTED: Rate related documents for odd duck submission are incorrect',
+                        firstRateRelatedDocument,
+                        secondRateRelatedDocument
+                    )
+                }
+                if (
+                    !formData.rateInfos[0] ||
+                    !formData.rateInfos[1].supportingDocuments
+                ) {
+                    console.info(
+                        'UNEXPECTED: Rate infos for odd duck submission are incorrect',
+                        formData.rateInfos
+                    )
+                }
+
                 formData.rateInfos[0].supportingDocuments =
                     firstRateRelatedDocument
                 formData.rateInfos[1].supportingDocuments =

--- a/services/app-api/src/handlers/migrate_rate_documents.ts
+++ b/services/app-api/src/handlers/migrate_rate_documents.ts
@@ -36,18 +36,31 @@ export const processRevisions = async (
         const decodedFormDataProto = toDomain(revision.formDataProto)
         if (!(decodedFormDataProto instanceof Error)) {
             const formData = decodedFormDataProto as HealthPlanFormDataType
+            if (
+                formData.submissionType === 'CONTRACT_ONLY' ||
+                !formData.rateInfos[0]
+            )
+                return // no need to migrate these
+
             // skip the submission with two rates
             if (formData.id !== 'ddd5dde1-0082-4398-90fe-89fc1bc148df') {
-                // we know the other submissions have only a single rate document
+                if (formData.rateInfos.length > 1 && formData.documents) {
+                    console.info(
+                        `There is an additional submission on this environment with rate supporting docs to be migrated. ID: ${formData.id}`
+                    )
+                }
+
+                // we know the other submissions have only a single rate to handle
                 const ratesRelatedDocument = formData.documents.filter((doc) =>
                     doc.documentCategories.includes('RATES_RELATED')
                 )
+
                 formData.rateInfos[0].supportingDocuments = ratesRelatedDocument
                 formData.documents = formData.documents.filter(
                     (doc) => !ratesRelatedDocument.includes(doc)
                 )
             } else {
-                // now handle the submisson with two rates
+                // now handle the submission with two rates
                 const firstRateRelatedDocument = formData.documents.filter(
                     (doc) =>
                         doc.name ===


### PR DESCRIPTION
## Summary
This addresses a failed migration in DEV due to `rateInfos` being undefined.

#### Related issues
#1763 