### PR TITLE
make dev hybrid commands not rely on built in serverless

### DIFF
--- a/dev_tool/src/serverless.ts
+++ b/dev_tool/src/serverless.ts
@@ -10,7 +10,7 @@ type StageConnection =
 export function checkStageAccess(stage: string): StageConnection {
     // Test to see if we can read info from serverless. This is likely to trip folks up who haven't
     // configured their AWS keys correctly or if they have an invalid stage name.
-    const test = spawnSync('serverless', ['info', '--stage', stage], {
+    const test = spawnSync('npx', ['serverless', 'info', '--stage', stage], {
         cwd: 'services/ui-auth',
     })
     if (test.status != 0) {

--- a/services/output.sh
+++ b/services/output.sh
@@ -19,4 +19,4 @@ if [ "$output" == "url" ]; then
   output="CloudFrontEndpointUrl"
 fi
 
-cd "$service" && serverless info --verbose --stage "$stage" | sed -n -e "s/^.*$output: //p" && cd ..
+cd "$service" && npx serverless info --verbose --stage "$stage" | sed -n -e "s/^.*$output: //p" && cd ..


### PR DESCRIPTION
## Summary

`./dev hybrid` was failing for me because my built in serverless version is out of date. We've moved to invoking with `npx` elsewhere to address this problem
