### PR TITLE
Update sechub/jira sync action to use new repo name

### DIFF
--- a/.github/workflows/sechub-jira-sync.yml
+++ b/.github/workflows/sechub-jira-sync.yml
@@ -25,7 +25,7 @@ jobs:
           stage-name: prod
 
       - name: Sync Security Hub and Jira
-        uses: Enterprise-CMCS/security-hub-visibility@v1.0.1
+        uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v1.0.1
         with:
           jira-token: ${{ secrets.JIRA_TOKEN }}
           jira-username: ${{ secrets.JIRA_USERNAME }}


### PR DESCRIPTION
## Summary
The SecHub/Jira sync action is hosted in a repo MAC-FC recently renamed. GitHub does the right thing and resolves the new repo, but the best practice is to update the reference in that workflow to the new repo name, which is [Enterprise-CMCS/mac-fc-security-hub-visibility.](https://github.com/Enterprise-CMCS/mac-fc-security-hub-visibility) 
#### Related issues
N/A
#### Screenshots
N/A
#### Test cases covered
N/A
<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
I can't test it directly because I don't have repo access to workflows anymore.  Someone with that access could try this on a branch if they want to
<!---These are developer instructions on how to test or validate the work -->
