### PR TITLE
Fix statusCode return value in migrate lambdas

### DIFF
--- a/.github/workflows/deploy-app-to-env.yml
+++ b/.github/workflows/deploy-app-to-env.yml
@@ -140,6 +140,7 @@ jobs:
       - name: invoke proto_to_db lambda
         id: invoke-proto_to_db
         working-directory: services/app-api
+        continue-on-error: true
         env:
           STAGE_NAME: ${{ inputs.stage_name }}
         run: |

--- a/.github/workflows/deploy-app-to-env.yml
+++ b/.github/workflows/deploy-app-to-env.yml
@@ -137,7 +137,7 @@ jobs:
         run: |
           ./scripts/invoke-migrate-lambda.sh app-api-$STAGE_NAME-migrate \$LATEST "Migration of the database failed."
 
-      - name: invoke proto_to_db lambda
+      - name: invoke proto_to_db lambda -- (rates refactor migrate)
         id: invoke-proto_to_db
         working-directory: services/app-api
         continue-on-error: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -277,7 +277,7 @@ jobs:
       needs.api-unit-tests.result == 'success' &&
       needs.build-prisma-client-lambda-layer.result == 'success' &&
       needs.begin-deployment.result == 'success'
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@ma_3212_migration_lambda
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -277,7 +277,7 @@ jobs:
       needs.api-unit-tests.result == 'success' &&
       needs.build-prisma-client-lambda-layer.result == 'success' &&
       needs.begin-deployment.result == 'success'
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@mt-sha-to-main
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name }}

--- a/services/app-api/scripts/invoke-migrate-lambda.sh
+++ b/services/app-api/scripts/invoke-migrate-lambda.sh
@@ -8,7 +8,7 @@ error_message="${3:-}"
 cli_read_timeout=240
 
 if (set -x ; aws lambda invoke --qualifier "$lambda_version" --cli-read-timeout "$cli_read_timeout" --function "$function_name" lambda_response.json) ; then
-  exitCode="$(jq '.statusCode' < lambda_response.json)"
+  exitCode="$(jq '.StatusCode' < lambda_response.json)"
   if [[ "$exitCode" != 200 ]] ; then
     cat lambda_response.json
     echo "$error_message" 1>&2

--- a/services/app-api/scripts/invoke-migrate-lambda.sh
+++ b/services/app-api/scripts/invoke-migrate-lambda.sh
@@ -8,7 +8,7 @@ error_message="${3:-}"
 cli_read_timeout=240
 
 if (set -x ; aws lambda invoke --qualifier "$lambda_version" --cli-read-timeout "$cli_read_timeout" --function "$function_name" lambda_response.json) ; then
-  exitCode="$(jq '.StatusCode' < lambda_response.json)"
+  exitCode="$(jq '.statusCode' < lambda_response.json)"
   if [[ "$exitCode" != 200 ]] ; then
     cat lambda_response.json
     echo "$error_message" 1>&2

--- a/services/app-api/src/handlers/proto_to_db.ts
+++ b/services/app-api/src/handlers/proto_to_db.ts
@@ -1,4 +1,4 @@
-import { Handler } from 'aws-lambda'
+import { Handler, APIGatewayProxyResultV2 } from 'aws-lambda'
 import { initTracer, initMeter } from '../../../uploads/src/lib/otel'
 import { configurePostgres } from './configuration'
 import { NewPostgresStore } from '../postgres/postgresStore'
@@ -47,7 +47,10 @@ export const getRevisions = async (
     return result
 }
 
-export const main: Handler = async (event, context) => {
+export const main: Handler = async (
+    event,
+    context
+): Promise<APIGatewayProxyResultV2> => {
     // Check on the values for our required config
     const stageName = process.env.stage ?? 'stageNotSet'
     const serviceName = `proto_to_db_lambda-${stageName}`
@@ -78,5 +81,5 @@ export const main: Handler = async (event, context) => {
             message: 'Lambda function executed successfully',
             packageId: pkgID,
         }),
-    }
+    } as APIGatewayProxyResultV2
 }


### PR DESCRIPTION
## Summary
We were seeing a failure in `app-api` deploy at the step that the called the `proto_to_db` handler. It turns out that the case of `statusCode` returned from that handler was slightly different than the other migration handler (`StatusCode` vs `statusCode`). This caused the error check to fail in the invoke script.

This fixes it by using the same TypeScript return type in the handler.


#### Related issues
https://qmacbis.atlassian.net/browse/MR-3585
