### PR TITLE
MR-3578 Fix Date Added document date bug

### DIFF
--- a/services/app-web/src/components/FileUpload/FileUpload.stories.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.stories.tsx
@@ -26,7 +26,7 @@ export const DemoListUploadSuccess = (): React.ReactElement => {
                 await fakeRequest<S3FileData>(true, resolveData)
                 return
             }}
-            onFileItemsUpdate={() => console.log('Async load complete')}
+            onFileItemsUpdate={() => console.info('Async load complete')}
             isContractOnly={false}
         />
     )
@@ -50,7 +50,7 @@ export const DemoTableUploadSuccess = (): React.ReactElement => {
                 await fakeRequest<S3FileData>(true, resolveData)
                 return
             }}
-            onFileItemsUpdate={() => console.log('Async load complete')}
+            onFileItemsUpdate={() => console.info('Async load complete')}
             isContractOnly={false}
         />
     )
@@ -74,7 +74,7 @@ export const DemoListUploadFailure = (): React.ReactElement => {
                 await fakeRequest<S3FileData>(true, resolveData)
                 return
             }}
-            onFileItemsUpdate={() => console.log('Async load complete')}
+            onFileItemsUpdate={() => console.info('Async load complete')}
             isContractOnly={false}
         />
     )
@@ -98,7 +98,7 @@ export const DemoTableUploadFailure = (): React.ReactElement => {
                 await fakeRequest<S3FileData>(true, resolveData)
                 return
             }}
-            onFileItemsUpdate={() => console.log('Async load complete')}
+            onFileItemsUpdate={() => console.info('Async load complete')}
             isContractOnly={false}
         />
     )
@@ -122,7 +122,7 @@ export const DemoListScanFailure = (): React.ReactElement => {
                 await fakeRequest<S3FileData>(true, resolveData)
                 return
             }}
-            onFileItemsUpdate={() => console.log('Async load complete')}
+            onFileItemsUpdate={() => console.info('Async load complete')}
             isContractOnly={false}
         />
     )
@@ -146,7 +146,7 @@ export const DemoTableScanFailure = (): React.ReactElement => {
                 await fakeRequest<S3FileData>(true, resolveData)
                 return
             }}
-            onFileItemsUpdate={() => console.log('Async load complete')}
+            onFileItemsUpdate={() => console.info('Async load complete')}
             isContractOnly={false}
         />
     )

--- a/services/app-web/src/components/Form/FieldCheckbox/FieldCheckbox.stories.tsx
+++ b/services/app-web/src/components/Form/FieldCheckbox/FieldCheckbox.stories.tsx
@@ -10,7 +10,7 @@ export default {
 const Template: Story<FieldCheckboxProps> = (args) => (
     <Formik
         initialValues={{ input1: '' }}
-        onSubmit={(e) => console.log('submitted')}
+        onSubmit={(e) => console.info('submitted')}
     >
         <FieldCheckbox {...args} />
     </Formik>

--- a/services/app-web/src/components/Form/FieldDropdown/FieldDropdown.stories.tsx
+++ b/services/app-web/src/components/Form/FieldDropdown/FieldDropdown.stories.tsx
@@ -16,7 +16,7 @@ const Template: Story<FieldDropdownProps> = (args) => (
         initialValues={{ program: '' }}
         validationSchema={schema}
         validateOnMount={true}
-        onSubmit={(e) => console.log('submitted')}
+        onSubmit={(e) => console.info('submitted')}
     >
         <FieldDropdown {...args} />
     </Formik>

--- a/services/app-web/src/components/Form/FieldRadio/FieldRadio.stories.tsx
+++ b/services/app-web/src/components/Form/FieldRadio/FieldRadio.stories.tsx
@@ -10,7 +10,7 @@ export default {
 const Template: Story<FieldRadioProps> = (args) => (
     <Formik
         initialValues={{ input1: '' }}
-        onSubmit={(e) => console.log('submitted')}
+        onSubmit={(e) => console.info('submitted')}
     >
         <FieldRadio {...args} />
     </Formik>

--- a/services/app-web/src/components/Form/FieldTextInput/FieldTextInput.stories.tsx
+++ b/services/app-web/src/components/Form/FieldTextInput/FieldTextInput.stories.tsx
@@ -18,7 +18,7 @@ const Template: Story<TextInputProps> = (args) => (
         initialValues={{ submissionDescription: '' }}
         validationSchema={schema}
         validateOnMount={true}
-        onSubmit={(e) => console.log('submitted')}
+        onSubmit={(e) => console.info('submitted')}
     >
         <FieldTextInput {...args} />
     </Formik>

--- a/services/app-web/src/components/Form/FieldTextarea/FieldTextarea.stories.tsx
+++ b/services/app-web/src/components/Form/FieldTextarea/FieldTextarea.stories.tsx
@@ -19,7 +19,7 @@ const Template: Story<TextAreaProps> = (args) => (
         initialValues={{ submissionDescription: '' }}
         validationSchema={schema}
         validateOnMount={true}
-        onSubmit={(e) => console.log('submitted')}
+        onSubmit={(e) => console.info('submitted')}
     >
         <FieldTextarea {...args} />
     </Formik>

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
@@ -31,6 +31,7 @@ describe('ContractDetailsSummarySection', () => {
 
         renderWithProviders(
             <ContractDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={testSubmission}
                 navigateTo="contract-details"
                 submissionName="MN-PMAP-0001"
@@ -66,6 +67,7 @@ describe('ContractDetailsSummarySection', () => {
     it('can render state submission on summary page without errors (submission summary behavior)', () => {
         renderWithProviders(
             <ContractDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={{
                     ...mockStateSubmission(),
                     status: 'SUBMITTED',
@@ -91,6 +93,7 @@ describe('ContractDetailsSummarySection', () => {
     it('can render all contract details fields', () => {
         renderWithProviders(
             <ContractDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={mockContractAndRatesDraft()}
                 navigateTo="contract-details"
                 submissionName="MN-PMAP-0001"
@@ -127,6 +130,7 @@ describe('ContractDetailsSummarySection', () => {
     it('displays correct effective dates text for base contract', () => {
         renderWithProviders(
             <ContractDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={mockStateSubmission()}
                 submissionName="MN-PMAP-0001"
             />
@@ -137,6 +141,7 @@ describe('ContractDetailsSummarySection', () => {
     it('displays correct effective dates text for contract amendment', () => {
         renderWithProviders(
             <ContractDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={mockContractAndRatesDraft()}
                 submissionName="MN-PMAP-0001"
             />
@@ -179,6 +184,7 @@ describe('ContractDetailsSummarySection', () => {
         }
         renderWithProviders(
             <ContractDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={testSubmission}
                 submissionName="MN-PMAP-0001"
             />
@@ -220,6 +226,7 @@ describe('ContractDetailsSummarySection', () => {
     it('does not render supporting contract documents table when no documents exist', () => {
         renderWithProviders(
             <ContractDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={mockContractAndRatesDraft()}
                 submissionName="MN-PMAP-0001"
             />
@@ -235,6 +242,7 @@ describe('ContractDetailsSummarySection', () => {
     it('does not render download all button when on previous submission', () => {
         renderWithProviders(
             <ContractDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={mockContractAndRatesDraft()}
                 submissionName="MN-PMAP-0001"
             />
@@ -249,6 +257,7 @@ describe('ContractDetailsSummarySection', () => {
     it('renders federal authorities for a medicaid contract', async () => {
         renderWithProviders(
             <ContractDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={{
                     ...mockContractAndRatesDraft(),
                     // Add all medicaid federal authorities, as if medicaid contract being unlocked
@@ -289,6 +298,7 @@ describe('ContractDetailsSummarySection', () => {
     it('renders federal authorities for a CHIP contract as expected, removing invalid authorities', async () => {
         renderWithProviders(
             <ContractDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={{
                     ...mockContractAndRatesDraft(),
                     populationCovered: 'CHIP',
@@ -330,6 +340,9 @@ describe('ContractDetailsSummarySection', () => {
         it('renders provisions and MLR references for a medicaid amendment', () => {
             renderWithProviders(
                 <ContractDetailsSummarySection
+                    documentDateLookupTable={{
+                        previousSubmissionDate: '01/01/01',
+                    }}
                     submission={mockContractAndRatesDraft()}
                     submissionName="MN-PMAP-0001"
                 />
@@ -354,9 +367,7 @@ describe('ContractDetailsSummarySection', () => {
             ).toBeInTheDocument()
 
             expect(
-                within(modifiedProvisions).getByText(
-                    /Risk-sharing strategy/
-                )
+                within(modifiedProvisions).getByText(/Risk-sharing strategy/)
             ).toBeInTheDocument()
             expect(
                 within(modifiedProvisions).getByText(
@@ -425,6 +436,9 @@ describe('ContractDetailsSummarySection', () => {
         it('renders provisions and MLR references for a medicaid base contract', () => {
             renderWithProviders(
                 <ContractDetailsSummarySection
+                    documentDateLookupTable={{
+                        previousSubmissionDate: '01/01/01',
+                    }}
                     submission={mockContractAndRatesDraft({
                         contractType: 'BASE',
                     })}
@@ -447,9 +461,7 @@ describe('ContractDetailsSummarySection', () => {
             ).toBeInTheDocument()
 
             expect(
-                within(modifiedProvisions).getByText(
-                    /Risk-sharing strategy/
-                )
+                within(modifiedProvisions).getByText(/Risk-sharing strategy/)
             ).toBeInTheDocument()
             expect(
                 within(modifiedProvisions).getByText(
@@ -475,6 +487,9 @@ describe('ContractDetailsSummarySection', () => {
         it('renders provisions with correct MLR references for CHIP amendment', () => {
             renderWithProviders(
                 <ContractDetailsSummarySection
+                    documentDateLookupTable={{
+                        previousSubmissionDate: '01/01/01',
+                    }}
                     submission={{
                         ...mockContractAndRatesDraft(),
                         populationCovered: 'CHIP',
@@ -554,6 +569,9 @@ describe('ContractDetailsSummarySection', () => {
                 }
             renderWithProviders(
                 <ContractDetailsSummarySection
+                    documentDateLookupTable={{
+                        previousSubmissionDate: '01/01/01',
+                    }}
                     submission={contractWithUnansweredProvisions}
                     submissionName="MN-PMAP-0001"
                     navigateTo="contract-details"
@@ -602,6 +620,9 @@ describe('ContractDetailsSummarySection', () => {
                 }
             renderWithProviders(
                 <ContractDetailsSummarySection
+                    documentDateLookupTable={{
+                        previousSubmissionDate: '01/01/01',
+                    }}
                     submission={contractWithUnansweredProvisions}
                     submissionName="MN-PMAP-0001"
                     navigateTo="contract-details"
@@ -650,6 +671,9 @@ describe('ContractDetailsSummarySection', () => {
                 }
             renderWithProviders(
                 <ContractDetailsSummarySection
+                    documentDateLookupTable={{
+                        previousSubmissionDate: '01/01/01',
+                    }}
                     submission={contractWithUnansweredProvisions}
                     submissionName="MN-PMAP-0001"
                 />,
@@ -701,6 +725,9 @@ describe('ContractDetailsSummarySection', () => {
                 }
             renderWithProviders(
                 <ContractDetailsSummarySection
+                    documentDateLookupTable={{
+                        previousSubmissionDate: '01/01/01',
+                    }}
                     submission={contractWithAllUnmodifiedProvisions}
                     submissionName="MN-PMAP-0001"
                     navigateTo="contract-details"
@@ -760,6 +787,9 @@ describe('ContractDetailsSummarySection', () => {
                 }
             renderWithProviders(
                 <ContractDetailsSummarySection
+                    documentDateLookupTable={{
+                        previousSubmissionDate: '01/01/01',
+                    }}
                     submission={contractWithAllUnmodifiedProvisions}
                     submissionName="MN-PMAP-0001"
                 />,

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -29,12 +29,12 @@ import {
     HealthPlanFormDataType,
     federalAuthorityKeysForCHIP,
 } from '../../../common-code/healthPlanFormDataType'
-import { useOutletContext } from 'react-router-dom'
-import { SideNavOutletContextType } from '../../../pages/SubmissionSideNav/SubmissionSideNav'
+import { DocumentDateLookupTableType } from '../../../documentHelpers/makeDocumentDateLookupTable'
 
 export type ContractDetailsSummarySectionProps = {
     submission: HealthPlanFormDataType
     navigateTo?: string
+    documentDateLookupTable: DocumentDateLookupTableType
     isCMSUser?: boolean
     submissionName: string
 }
@@ -42,6 +42,7 @@ export type ContractDetailsSummarySectionProps = {
 export const ContractDetailsSummarySection = ({
     submission,
     navigateTo, // this is the edit link for the section. When this prop exists, summary section is loaded in edit mode
+    documentDateLookupTable,
     isCMSUser,
     submissionName,
 }: ContractDetailsSummarySectionProps): React.ReactElement => {
@@ -62,8 +63,7 @@ export const ContractDetailsSummarySection = ({
     const [modifiedProvisions, unmodifiedProvisions] =
         sortModifiedProvisions(submission)
     const provisionsAreInvalid = isMissingProvisions(submission) && isEditing
-    const { documentDates } =
-    useOutletContext<SideNavOutletContextType>()
+
     useEffect(() => {
         // get all the keys for the documents we want to zip
         async function fetchZipUrl() {
@@ -168,7 +168,11 @@ export const ContractDetailsSummarySection = ({
                     <DoubleColumnGrid>
                         <DataDetail
                             id="modifiedProvisions"
-                            label={isBaseContract(submission)? "This contract action includes provisions related to the following" : "This contract action includes new or modified provisions related to the following"}
+                            label={
+                                isBaseContract(submission)
+                                    ? 'This contract action includes provisions related to the following'
+                                    : 'This contract action includes new or modified provisions related to the following'
+                            }
                             explainMissingData={
                                 provisionsAreInvalid && !isSubmitted(submission)
                             }
@@ -176,7 +180,7 @@ export const ContractDetailsSummarySection = ({
                             {provisionsAreInvalid ? null : (
                                 <DataDetailCheckboxList
                                     list={modifiedProvisions}
-                                    dict={getProvisionDictionary(submission) }
+                                    dict={getProvisionDictionary(submission)}
                                     displayEmptyList
                                 />
                             )}
@@ -184,7 +188,11 @@ export const ContractDetailsSummarySection = ({
 
                         <DataDetail
                             id="unmodifiedProvisions"
-                            label={isBaseContract(submission)? "This contract action does NOT include provisions related to the following": "This contract action does NOT include new or modified provisions related to the following"}
+                            label={
+                                isBaseContract(submission)
+                                    ? 'This contract action does NOT include provisions related to the following'
+                                    : 'This contract action does NOT include new or modified provisions related to the following'
+                            }
                             explainMissingData={
                                 provisionsAreInvalid && !isSubmitted(submission)
                             }
@@ -202,14 +210,14 @@ export const ContractDetailsSummarySection = ({
             </dl>
             <UploadedDocumentsTable
                 documents={submission.contractDocuments}
-                documentDateLookupTable={documentDates}
+                documentDateLookupTable={documentDateLookupTable}
                 isCMSUser={isCMSUser}
                 caption="Contract"
                 documentCategory="Contract"
             />
             <UploadedDocumentsTable
                 documents={contractSupportingDocuments}
-                documentDateLookupTable={documentDates}
+                documentDateLookupTable={documentDateLookupTable}
                 isCMSUser={isCMSUser}
                 caption="Contract supporting documents"
                 documentCategory="Contract-supporting"

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react'
 import { DataDetail } from '../../../components/DataDetail'
 import { SectionHeader } from '../../../components/SectionHeader'
 import { UploadedDocumentsTable } from '../../../components/SubmissionSummarySection'
-import { DocumentDateLookupTable } from '../../../pages/SubmissionSummary/SubmissionSummary'
 import {
     ContractExecutionStatusRecord,
     FederalAuthorityRecord,
@@ -30,11 +29,12 @@ import {
     HealthPlanFormDataType,
     federalAuthorityKeysForCHIP,
 } from '../../../common-code/healthPlanFormDataType'
+import { useOutletContext } from 'react-router-dom'
+import { SideNavOutletContextType } from '../../../pages/SubmissionSideNav/SubmissionSideNav'
 
 export type ContractDetailsSummarySectionProps = {
     submission: HealthPlanFormDataType
     navigateTo?: string
-    documentDateLookupTable?: DocumentDateLookupTable
     isCMSUser?: boolean
     submissionName: string
 }
@@ -42,7 +42,6 @@ export type ContractDetailsSummarySectionProps = {
 export const ContractDetailsSummarySection = ({
     submission,
     navigateTo, // this is the edit link for the section. When this prop exists, summary section is loaded in edit mode
-    documentDateLookupTable,
     isCMSUser,
     submissionName,
 }: ContractDetailsSummarySectionProps): React.ReactElement => {
@@ -63,7 +62,8 @@ export const ContractDetailsSummarySection = ({
     const [modifiedProvisions, unmodifiedProvisions] =
         sortModifiedProvisions(submission)
     const provisionsAreInvalid = isMissingProvisions(submission) && isEditing
-
+    const { documentDates } =
+    useOutletContext<SideNavOutletContextType>()
     useEffect(() => {
         // get all the keys for the documents we want to zip
         async function fetchZipUrl() {
@@ -202,14 +202,14 @@ export const ContractDetailsSummarySection = ({
             </dl>
             <UploadedDocumentsTable
                 documents={submission.contractDocuments}
-                documentDateLookupTable={documentDateLookupTable}
+                documentDateLookupTable={documentDates}
                 isCMSUser={isCMSUser}
                 caption="Contract"
                 documentCategory="Contract"
             />
             <UploadedDocumentsTable
                 documents={contractSupportingDocuments}
-                documentDateLookupTable={documentDateLookupTable}
+                documentDateLookupTable={documentDates}
                 isCMSUser={isCMSUser}
                 caption="Contract supporting documents"
                 documentCategory="Contract-supporting"

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -211,14 +211,13 @@ export const ContractDetailsSummarySection = ({
             <UploadedDocumentsTable
                 documents={submission.contractDocuments}
                 documentDateLookupTable={documentDateLookupTable}
-                isCMSUser={isCMSUser}
                 caption="Contract"
                 documentCategory="Contract"
+                isEditing={isEditing}
             />
             <UploadedDocumentsTable
                 documents={contractSupportingDocuments}
                 documentDateLookupTable={documentDateLookupTable}
-                isCMSUser={isCMSUser}
                 caption="Contract supporting documents"
                 documentCategory="Contract-supporting"
                 isSupportingDocuments

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.test.tsx
@@ -79,6 +79,7 @@ describe('RateDetailsSummarySection', () => {
     it('can render draft submission without errors', () => {
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
                 navigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
@@ -100,6 +101,7 @@ describe('RateDetailsSummarySection', () => {
     it('can render state submission without errors', () => {
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={stateSubmission}
                 submissionName="MN-MSHO-0003"
                 statePrograms={statePrograms}
@@ -119,6 +121,7 @@ describe('RateDetailsSummarySection', () => {
     it('can render all rate details fields for amendment to prior rate certification submission', () => {
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
                 navigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
@@ -158,6 +161,7 @@ describe('RateDetailsSummarySection', () => {
         const statePrograms = mockMNState().programs
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={submission}
                 navigateTo="rate-details"
                 submissionName="MN-MSHO-0003"
@@ -188,6 +192,7 @@ describe('RateDetailsSummarySection', () => {
 
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={submission}
                 navigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
@@ -207,6 +212,7 @@ describe('RateDetailsSummarySection', () => {
             'MCR-MN-0005-SNBC-RATE-20221014-20221014-CERTIFICATION-20221014'
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={stateSubmission}
                 submissionName="MN-MSHO-0003"
                 statePrograms={statePrograms}
@@ -266,6 +272,7 @@ describe('RateDetailsSummarySection', () => {
         }
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={testSubmission}
                 navigateTo="/rate-details'"
                 submissionName="MN-PMAP-0001"
@@ -316,6 +323,7 @@ describe('RateDetailsSummarySection', () => {
     it('does not render supporting rate documents when they do not exist', () => {
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
@@ -332,6 +340,7 @@ describe('RateDetailsSummarySection', () => {
     it('does not render download all button when on previous submission', () => {
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={stateSubmission}
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
@@ -347,6 +356,7 @@ describe('RateDetailsSummarySection', () => {
     it('renders rate cell capitation type', () => {
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
                 navigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
@@ -370,6 +380,7 @@ describe('RateDetailsSummarySection', () => {
         draftSubmission.rateInfos[0].rateCapitationType = 'RATE_RANGE'
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
                 navigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
@@ -396,6 +407,7 @@ describe('RateDetailsSummarySection', () => {
         ]
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
                 navigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
@@ -419,6 +431,7 @@ describe('RateDetailsSummarySection', () => {
         ]
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
                 navigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
@@ -438,6 +451,7 @@ describe('RateDetailsSummarySection', () => {
         draftSubmission.rateInfos = mockRateInfos
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
                 navigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
@@ -457,6 +471,7 @@ describe('RateDetailsSummarySection', () => {
 
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
                 navigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
@@ -476,6 +491,7 @@ describe('RateDetailsSummarySection', () => {
         draftSubmission.rateInfos = mockRateInfos
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
                 navigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
@@ -505,6 +521,7 @@ describe('RateDetailsSummarySection', () => {
         draftSubmission.rateInfos = mockRateInfos
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
                 navigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
@@ -576,6 +593,7 @@ describe('RateDetailsSummarySection', () => {
         ]
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={testSubmission}
                 navigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
@@ -672,6 +690,7 @@ describe('RateDetailsSummarySection', () => {
         ]
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={testSubmission}
                 navigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
@@ -734,6 +753,7 @@ describe('RateDetailsSummarySection', () => {
         }
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={testSubmission}
                 navigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
@@ -756,6 +776,7 @@ describe('RateDetailsSummarySection', () => {
     it('renders submitted package without errors', () => {
         renderWithProviders(
             <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
                 navigateTo="rate-details"
                 submissionName="MN-PMAP-0001"

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -341,9 +341,9 @@ export const RateDetailsSummarySection = ({
                                         documentDateLookupTable={
                                             documentDateLookupTable
                                         }
-                                        isCMSUser={isCMSUser}
                                         caption="Rate certification"
                                         documentCategory="Rate certification"
+                                        isEditing={isEditing}
                                     />
                                 ) : (
                                     <span className="srOnly">'LOADING...'</span>
@@ -357,7 +357,6 @@ export const RateDetailsSummarySection = ({
                                         documentDateLookupTable={
                                             documentDateLookupTable
                                         }
-                                        isCMSUser={isCMSUser}
                                         caption="Rate supporting documents"
                                         isSupportingDocuments
                                         documentCategory="Rate-supporting"
@@ -378,7 +377,6 @@ export const RateDetailsSummarySection = ({
                     <UploadedDocumentsTable
                         documents={submissionLevelRateSupportingDocuments}
                         documentDateLookupTable={documentDateLookupTable}
-                        isCMSUser={isCMSUser}
                         caption="Rate supporting documents"
                         documentCategory="Rate-supporting"
                         isSupportingDocuments

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react'
 import { DataDetail } from '../../../components/DataDetail'
 import { SectionHeader } from '../../../components/SectionHeader'
 import { UploadedDocumentsTable } from '../../../components/SubmissionSummarySection'
-import { DocumentDateLookupTable } from '../../../pages/SubmissionSummary/SubmissionSummary'
 import { useS3 } from '../../../contexts/S3Context'
 import { formatCalendarDate } from '../../../common-code/dateHelpers'
 import { DoubleColumnGrid } from '../../DoubleColumnGrid'
@@ -24,6 +23,8 @@ import { DataDetailContactField } from '../../DataDetail/DataDetailContactField/
 import { v4 as uuidv4 } from 'uuid'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { featureFlags } from '../../../common-code/featureFlags'
+import { SideNavOutletContextType } from '../../../pages/SubmissionSideNav/SubmissionSideNav'
+import { useOutletContext } from 'react-router-dom'
 
 // Used for refreshed packages names keyed by their package id
 // package name includes (Draft) for draft packages.
@@ -38,7 +39,6 @@ type PackageNamesLookupType = {
 export type RateDetailsSummarySectionProps = {
     submission: HealthPlanFormDataType
     navigateTo?: string
-    documentDateLookupTable?: DocumentDateLookupTable
     isCMSUser?: boolean
     submissionName: string
     statePrograms: Program[]
@@ -47,7 +47,6 @@ export type RateDetailsSummarySectionProps = {
 export const RateDetailsSummarySection = ({
     submission,
     navigateTo,
-    documentDateLookupTable,
     isCMSUser,
     submissionName,
     statePrograms,
@@ -58,6 +57,8 @@ export const RateDetailsSummarySection = ({
         featureFlags.SUPPORTING_DOCS_BY_RATE.flag,
         featureFlags.SUPPORTING_DOCS_BY_RATE.defaultValue
     )
+    const { documentDates } =
+    useOutletContext<SideNavOutletContextType>()
 
     const [packageNamesLookup, setPackageNamesLookup] =
         React.useState<PackageNamesLookupType | null>(null)
@@ -339,7 +340,7 @@ export const RateDetailsSummarySection = ({
                                             rateInfo
                                         )}
                                         documentDateLookupTable={
-                                            documentDateLookupTable
+                                            documentDates
                                         }
                                         isCMSUser={isCMSUser}
                                         caption="Rate certification"
@@ -355,7 +356,7 @@ export const RateDetailsSummarySection = ({
                                             rateInfo
                                         )}
                                         documentDateLookupTable={
-                                            documentDateLookupTable
+                                            documentDates
                                         }
                                         isCMSUser={isCMSUser}
                                         caption="Rate supporting documents"
@@ -377,7 +378,7 @@ export const RateDetailsSummarySection = ({
                 !supportingDocsByRate && (
                     <UploadedDocumentsTable
                         documents={submissionLevelRateSupportingDocuments}
-                        documentDateLookupTable={documentDateLookupTable}
+                        documentDateLookupTable={documentDates}
                         isCMSUser={isCMSUser}
                         caption="Rate supporting documents"
                         documentCategory="Rate-supporting"

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -23,8 +23,7 @@ import { DataDetailContactField } from '../../DataDetail/DataDetailContactField/
 import { v4 as uuidv4 } from 'uuid'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { featureFlags } from '../../../common-code/featureFlags'
-import { SideNavOutletContextType } from '../../../pages/SubmissionSideNav/SubmissionSideNav'
-import { useOutletContext } from 'react-router-dom'
+import { DocumentDateLookupTableType } from '../../../documentHelpers/makeDocumentDateLookupTable'
 
 // Used for refreshed packages names keyed by their package id
 // package name includes (Draft) for draft packages.
@@ -39,6 +38,7 @@ type PackageNamesLookupType = {
 export type RateDetailsSummarySectionProps = {
     submission: HealthPlanFormDataType
     navigateTo?: string
+    documentDateLookupTable: DocumentDateLookupTableType
     isCMSUser?: boolean
     submissionName: string
     statePrograms: Program[]
@@ -47,6 +47,7 @@ export type RateDetailsSummarySectionProps = {
 export const RateDetailsSummarySection = ({
     submission,
     navigateTo,
+    documentDateLookupTable,
     isCMSUser,
     submissionName,
     statePrograms,
@@ -57,8 +58,6 @@ export const RateDetailsSummarySection = ({
         featureFlags.SUPPORTING_DOCS_BY_RATE.flag,
         featureFlags.SUPPORTING_DOCS_BY_RATE.defaultValue
     )
-    const { documentDates } =
-    useOutletContext<SideNavOutletContextType>()
 
     const [packageNamesLookup, setPackageNamesLookup] =
         React.useState<PackageNamesLookupType | null>(null)
@@ -340,7 +339,7 @@ export const RateDetailsSummarySection = ({
                                             rateInfo
                                         )}
                                         documentDateLookupTable={
-                                            documentDates
+                                            documentDateLookupTable
                                         }
                                         isCMSUser={isCMSUser}
                                         caption="Rate certification"
@@ -356,7 +355,7 @@ export const RateDetailsSummarySection = ({
                                             rateInfo
                                         )}
                                         documentDateLookupTable={
-                                            documentDates
+                                            documentDateLookupTable
                                         }
                                         isCMSUser={isCMSUser}
                                         caption="Rate supporting documents"
@@ -378,7 +377,7 @@ export const RateDetailsSummarySection = ({
                 !supportingDocsByRate && (
                     <UploadedDocumentsTable
                         documents={submissionLevelRateSupportingDocuments}
-                        documentDateLookupTable={documentDates}
+                        documentDateLookupTable={documentDateLookupTable}
                         isCMSUser={isCMSUser}
                         caption="Rate supporting documents"
                         documentCategory="Rate-supporting"

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../../testHelpers/apolloMocks'
 
 describe('UploadedDocumentsTable', () => {
+    const emptyDocumentsTable = () => {return {}}
     it('renders documents without errors', async () => {
         const testDocuments = [
             {
@@ -17,6 +18,7 @@ describe('UploadedDocumentsTable', () => {
         ]
         renderWithProviders(
             <UploadedDocumentsTable
+                documentDateLookupTable={emptyDocumentsTable()}
                 documents={testDocuments}
                 caption="Contract"
                 documentCategory="Contract"
@@ -59,6 +61,7 @@ describe('UploadedDocumentsTable', () => {
 
         renderWithProviders(
             <UploadedDocumentsTable
+            documentDateLookupTable={emptyDocumentsTable()}
                 documents={testDocuments}
                 caption="Contract supporting"
                 documentCategory="Contract-supporting"
@@ -121,6 +124,7 @@ describe('UploadedDocumentsTable', () => {
         )
         renderWithProviders(
             <UploadedDocumentsTable
+            documentDateLookupTable={emptyDocumentsTable()}
                 documents={testDocuments}
                 caption="Contract supporting"
                 documentCategory="Contract-supporting"

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
@@ -5,6 +5,8 @@ import {
     fetchCurrentUserMock,
     mockValidCMSUser,
 } from '../../../testHelpers/apolloMocks'
+import { DocumentDateLookupTableType } from '../../../documentHelpers/makeDocumentDateLookupTable'
+import { SubmissionDocument } from '../../../common-code/healthPlanFormDataType'
 
 describe('UploadedDocumentsTable', () => {
     const emptyDocumentsTable = () => {
@@ -153,7 +155,7 @@ describe('UploadedDocumentsTable', () => {
         })
     })
     it('renders date added when supplied with a date lookup table', async () => {
-        const testDocuments = [
+        const testDocuments: SubmissionDocument[] = [
             {
                 s3URL: 's3://foo/bar/test-1',
                 name: 'supporting docs test 1',
@@ -173,7 +175,7 @@ describe('UploadedDocumentsTable', () => {
                 ],
             },
         ]
-        const dateLookupTable = {
+        const dateLookupTable: DocumentDateLookupTableType = {
             's3://foo/bar/test-1':
                 'Fri Mar 25 2022 16:13:20 GMT-0500 (Central Daylight Time)',
             's3://foo/bar/test-2':
@@ -213,7 +215,7 @@ describe('UploadedDocumentsTable', () => {
         })
     })
     it('shows the NEW tag when a document is submitted after the last submission', async () => {
-        const testDocuments = [
+        const testDocuments: SubmissionDocument[] = [
             {
                 s3URL: 's3://foo/bar/test-1',
                 name: 'supporting docs test 1',
@@ -233,7 +235,7 @@ describe('UploadedDocumentsTable', () => {
                 ],
             },
         ]
-        const dateLookupTable = {
+        const dateLookupTable: DocumentDateLookupTableType = {
             's3://foo/bar/test-1':
                 'Fri Mar 25 2022 16:13:20 GMT-0500 (Central Daylight Time)',
             's3://foo/bar/test-2':

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, within } from '@testing-library/react'
 import { renderWithProviders } from '../../../testHelpers/jestHelpers'
 import { UploadedDocumentsTable } from './UploadedDocumentsTable'
 import {
@@ -154,7 +154,7 @@ describe('UploadedDocumentsTable', () => {
             ).toBeNull()
         })
     })
-    it('renders date added when supplied with a date lookup table', async () => {
+    it('renders date added when supplied with a date lookup table and is CMS user viewing submission', async () => {
         const testDocuments: SubmissionDocument[] = [
             {
                 s3URL: 's3://foo/bar/test-1',
@@ -192,7 +192,6 @@ describe('UploadedDocumentsTable', () => {
                 documentCategory="Contract-supporting"
                 isSupportingDocuments
                 documentDateLookupTable={dateLookupTable}
-                isCMSUser={true}
             />,
             {
                 apolloProvider: {
@@ -212,6 +211,127 @@ describe('UploadedDocumentsTable', () => {
             expect(rows[1]).toHaveTextContent('3/25/22')
             expect(rows[2]).toHaveTextContent('3/26/22')
             expect(rows[3]).toHaveTextContent('3/27/22')
+        })
+    })
+
+    it('renders date added when supplied with a date lookup table and is State user', async () => {
+        const testDocuments: SubmissionDocument[] = [
+            {
+                s3URL: 's3://foo/bar/test-1',
+                name: 'supporting docs test 1',
+                documentCategories: ['CONTRACT_RELATED' as const],
+            },
+            {
+                s3URL: 's3://foo/bar/test-2',
+                name: 'supporting docs test 2',
+                documentCategories: ['RATES_RELATED' as const],
+            },
+            {
+                s3URL: 's3://foo/bar/test-3',
+                name: 'supporting docs test 3',
+                documentCategories: [
+                    'CONTRACT_RELATED' as const,
+                    'RATES_RELATED' as const,
+                ],
+            },
+        ]
+        const dateLookupTable: DocumentDateLookupTableType = {
+            's3://foo/bar/test-1':
+                'Fri Mar 25 2022 16:13:20 GMT-0500 (Central Daylight Time)',
+            's3://foo/bar/test-2':
+                'Sat Mar 26 2022 16:13:20 GMT-0500 (Central Daylight Time)',
+            's3://foo/bar/test-3':
+                'Sun Mar 27 2022 16:13:20 GMT-0500 (Central Daylight Time)',
+            previousSubmissionDate:
+                'Sun Mar 26 2022 16:13:20 GMT-0500 (Central Daylight Time)',
+        }
+        renderWithProviders(
+            <UploadedDocumentsTable
+                documents={testDocuments}
+                caption="Contract supporting"
+                documentCategory="Contract-supporting"
+                isSupportingDocuments
+                documentDateLookupTable={dateLookupTable}
+            />,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                    ],
+                },
+            }
+        )
+        await waitFor(() => {
+            const rows = screen.getAllByRole('row')
+            expect(rows).toHaveLength(4)
+            expect(rows[0]).toHaveTextContent('Date added')
+            expect(rows[1]).toHaveTextContent('3/25/22')
+            expect(rows[2]).toHaveTextContent('3/26/22')
+            expect(rows[3]).toHaveTextContent('3/27/22')
+        })
+    })
+
+    it('does not render a date added when supplied with empty date lookup table (this happens with new draft submissions)', async () => {
+        const testDocuments: SubmissionDocument[] = [
+            {
+                s3URL: 's3://foo/bar/test-1',
+                name: 'supporting docs test 1',
+                documentCategories: ['CONTRACT_RELATED' as const],
+            },
+            {
+                s3URL: 's3://foo/bar/test-2',
+                name: 'supporting docs test 2',
+                documentCategories: ['RATES_RELATED' as const],
+            },
+            {
+                s3URL: 's3://foo/bar/test-3',
+                name: 'supporting docs test 3',
+                documentCategories: [
+                    'CONTRACT_RELATED' as const,
+                    'RATES_RELATED' as const,
+                ],
+            },
+        ]
+        const dateLookupTable: DocumentDateLookupTableType = {
+            previousSubmissionDate: null,
+        }
+        renderWithProviders(
+            <UploadedDocumentsTable
+                documents={testDocuments}
+                caption="Contract supporting"
+                documentCategory="Contract-supporting"
+                isSupportingDocuments
+                documentDateLookupTable={dateLookupTable}
+            />,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                    ],
+                },
+            }
+        )
+        await waitFor(() => {
+            expect(screen.getByRole('table')).toBeInTheDocument()
+            // we have a table with rows for each document
+            const rows = screen.getAllByRole('row')
+            rows.shift() // get ride of column header row
+            expect(rows).toHaveLength(testDocuments.length)
+
+            // There is a screenreader only "N/A" for each row
+            rows.forEach((row) => {
+                expect(within(row).getByText('N/A')).toBeInTheDocument()
+                expect(within(row).getByText('N/A')).toHaveAttribute(
+                    'class',
+                    'srOnly'
+                )
+            })
         })
     })
     it('shows the NEW tag when a document is submitted after the last submission', async () => {
@@ -252,7 +372,6 @@ describe('UploadedDocumentsTable', () => {
                 documentCategory="Contract-supporting"
                 isSupportingDocuments
                 documentDateLookupTable={dateLookupTable}
-                isCMSUser={true}
             />,
             {
                 apolloProvider: {
@@ -307,7 +426,6 @@ describe('UploadedDocumentsTable', () => {
                 documentCategory="Contract-supporting"
                 isSupportingDocuments
                 documentDateLookupTable={dateLookupTable}
-                isCMSUser={false}
             />,
             {
                 apolloProvider: {

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
@@ -7,7 +7,9 @@ import {
 } from '../../../testHelpers/apolloMocks'
 
 describe('UploadedDocumentsTable', () => {
-    const emptyDocumentsTable = () => {return {}}
+    const emptyDocumentsTable = () => {
+        return { previousSubmissionDate: '01/01/01' }
+    }
     it('renders documents without errors', async () => {
         const testDocuments = [
             {
@@ -61,7 +63,7 @@ describe('UploadedDocumentsTable', () => {
 
         renderWithProviders(
             <UploadedDocumentsTable
-            documentDateLookupTable={emptyDocumentsTable()}
+                documentDateLookupTable={emptyDocumentsTable()}
                 documents={testDocuments}
                 caption="Contract supporting"
                 documentCategory="Contract-supporting"
@@ -124,7 +126,7 @@ describe('UploadedDocumentsTable', () => {
         )
         renderWithProviders(
             <UploadedDocumentsTable
-            documentDateLookupTable={emptyDocumentsTable()}
+                documentDateLookupTable={emptyDocumentsTable()}
                 documents={testDocuments}
                 caption="Contract supporting"
                 documentCategory="Contract-supporting"

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
@@ -93,11 +93,12 @@ export const UploadedDocumentsTable = ({
 
     // this is util needed to guard against passing in null or undefined to dayjs  - we  would get back today's date
     const canDisplayDateAddedForDocument = (doc: DocumentWithS3Data) => {
-        const documentKey = getDocumentKey(doc)
-        return documentKey && documentDateLookupTable[documentKey]
+        const documentLookupKey = getDocumentKey(doc)
+        return documentLookupKey && documentDateLookupTable[documentLookupKey]
     }
 
     const shouldHaveNewTag = (doc: DocumentWithS3Data) => {
+        const documentLookupKey = getDocumentKey(doc)
         if (!isCMSUser) {
             return false // design requirement, don't show new tag to state users  on review submit
         }
@@ -105,7 +106,7 @@ export const UploadedDocumentsTable = ({
         if (!documentDateLookupTable || !doc || !doc.s3Key) {
             return false // this is a document with bad s3 data
         }
-        const documentDate = documentDateLookupTable?.[doc.s3Key]
+        const documentDate = documentDateLookupTable?.[documentLookupKey]
         const previousSubmissionDate =
             documentDateLookupTable.previousSubmissionDate
 
@@ -227,9 +228,7 @@ export const UploadedDocumentsTable = ({
                                 !isEditing
                                     ? dayjs(
                                           documentDateLookupTable[
-                                              // can disable non-null here because we check in canDisplayDateAddedForDocument
-                                              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                                              doc.s3Key!
+                                              getDocumentKey(doc)
                                           ]
                                       ).format('M/D/YY')
                                     : ''}

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
@@ -3,17 +3,17 @@ import { Link } from '@trussworks/react-uswds'
 import { NavLink } from 'react-router-dom'
 import dayjs from 'dayjs'
 import { SubmissionDocument } from '../../../common-code/healthPlanFormDataType'
-import { DocumentDateLookupTable } from '../../../pages/SubmissionSummary/SubmissionSummary'
 import styles from './UploadedDocumentsTable.module.scss'
 import { usePreviousSubmission } from '../../../hooks'
 import { SharedRateCertDisplay } from '../../../common-code/healthPlanFormDataType/UnlockedHealthPlanFormDataType'
 import { DocumentTag } from './DocumentTag'
 import { useDocument } from '../../../hooks/useDocument'
 import { getDocumentKey } from '../../../documentHelpers/getDocumentKey'
+import { DocumentDateLookupTableType } from '../../../documentHelpers/makeDocumentDateLookupTable'
 export type UploadedDocumentsTableProps = {
     documents: SubmissionDocument[]
     caption: string | null
-    documentDateLookupTable?: DocumentDateLookupTable
+    documentDateLookupTable: DocumentDateLookupTableType,
     packagesWithSharedRateCerts?: SharedRateCertDisplay[]
     isSupportingDocuments?: boolean
     documentCategory?: string // if this prop is not included, do not show category column
@@ -87,11 +87,13 @@ export const UploadedDocumentsTable = ({
     )
     const shouldHaveNewTag = (doc: SubmissionDocument) => {
         const documentKey = getDocumentKey(doc)
+        if ( documentDateLookupTable[documentKey] === undefined  ||   documentDateLookupTable.previousSubmissionDate === undefined){
+            return false // this is a document on a draft submission
+        }
         return (
-            isCMSUser &&
-            documentDateLookupTable &&
-            documentDateLookupTable[documentKey] >
-                documentDateLookupTable.previousSubmissionDate
+        isCMSUser &&
+         documentDateLookupTable['documentKey'] >
+        documentDateLookupTable.previousSubmissionDate
         )
     }
 

--- a/services/app-web/src/documentHelpers/getAllDocuments.ts
+++ b/services/app-web/src/documentHelpers/getAllDocuments.ts
@@ -1,0 +1,14 @@
+import { HealthPlanFormDataType } from '../common-code/healthPlanFormDataType'
+
+const getAllDocuments = (pkg: HealthPlanFormDataType) => {
+    let allDocuments = [...pkg.contractDocuments, ...pkg.documents]
+    if (pkg.rateInfos.length > 0) {
+        pkg.rateInfos.forEach((rateInfo) => {
+            allDocuments = allDocuments.concat(rateInfo.rateDocuments)
+            allDocuments = allDocuments.concat(rateInfo.supportingDocuments)
+        })
+    }
+    return allDocuments
+}
+
+export { getAllDocuments }

--- a/services/app-web/src/documentHelpers/getDocumentKey.ts
+++ b/services/app-web/src/documentHelpers/getDocumentKey.ts
@@ -1,5 +1,9 @@
 import { SubmissionDocument } from '../common-code/healthPlanFormDataType'
 
-export const getDocumentKey = (doc: SubmissionDocument): string => {
+// getDocumentKey - Returns a unique identifier for the document. This should be the document sha.
+// Not to be confused with "s3Key" which is a different field / use case
+const getDocumentKey = (doc: SubmissionDocument): string => {
     return doc.sha256 ? doc.sha256 : doc.s3URL
 }
+
+export { getDocumentKey }

--- a/services/app-web/src/documentHelpers/index.ts
+++ b/services/app-web/src/documentHelpers/index.ts
@@ -1,0 +1,3 @@
+export { makeDocumentDateTable } from './makeDocumentDateLookupTable'
+export { makeDocumentS3KeyLookup } from './makeDocumentKeyLookupList'
+export { getDocumentKey } from './getDocumentKey'

--- a/services/app-web/src/documentHelpers/makeDocumentDateLookupTable.test.ts
+++ b/services/app-web/src/documentHelpers/makeDocumentDateLookupTable.test.ts
@@ -1,56 +1,73 @@
-import { makeDateTable } from './makeDocumentDateLookupTable'
-import { mockSubmittedHealthPlanPackageWithRevision } from '../testHelpers/apolloMocks'
+import { makeDocumentDateTable } from './makeDocumentDateLookupTable'
+import {
+    mockDraftHealthPlanPackage,
+    mockSubmittedHealthPlanPackageWithRevision,
+} from '../testHelpers/apolloMocks'
 import { UnlockedHealthPlanFormDataType } from '../common-code/healthPlanFormDataType'
 import { TextEncoder, TextDecoder } from 'util'
+import { buildRevisionsLookup } from '../gqlHelpers/fetchHealthPlanPackageWrapper'
 
 Object.assign(global, { TextDecoder, TextEncoder })
 
-describe('makeDateTable', () => {
+describe('makeDocumentDateTable', () => {
     it('should make a proper lookup table', () => {
-        const submissions = mockSubmittedHealthPlanPackageWithRevision({
-            currentSubmissionData: {
+        const submission = mockSubmittedHealthPlanPackageWithRevision({
+            currentSubmitInfo: {
                 updatedAt: new Date('2022-03-28T17:56:32.953Z'),
             },
-            previousSubmissionData: {
+            previousSubmitInfo: {
                 updatedAt: new Date('2022-03-25T21:14:43.057Z'),
             },
-            initialSubmissionData: {
+            initialSubmitInfo: {
                 updatedAt: new Date('2022-03-25T21:13:20.420Z'),
             },
         })
-        const lookupTable = makeDateTable(submissions)
-
-        expect(JSON.stringify(lookupTable)).toEqual(
-            JSON.stringify({
-                's3://bucketname/1648242632157-Amerigroup Texas, Inc.pdf/Amerigroup Texas, Inc.pdf':
-                    '2022-03-25T21:13:20.420Z',
-                's3://bucketname/1648490162641-lifeofgalileo.pdf/lifeofgalileo.pdf':
-                    '2022-03-28T17:56:32.953Z',
-                's3://bucketname/1648242665634-Amerigroup Texas, Inc.pdf/Amerigroup Texas, Inc.pdf':
-                    '2022-03-25T21:13:20.420Z',
-                's3://bucketname/1648242711421-Amerigroup Texas Inc copy.pdf/Amerigroup Texas Inc copy.pdf':
-                    '2022-03-25T21:13:20.420Z',
-                's3://bucketname/1648242711421-529-10-0020-00003_Superior_Health Plan, Inc.pdf/529-10-0020-00003_Superior_Health Plan, Inc.pdf':
-                    '2022-03-25T21:13:20.420Z',
-                's3://bucketname/1648242873229-covid-ifc-2-flu-rsv-codes 5-5-2021.pdf/covid-ifc-2-flu-rsv-codes 5-5-2021.pdf':
-                    '2022-03-25T21:13:20.420Z',
-                previousSubmissionDate: '2022-03-25T21:14:43.057Z',
-            })
-        )
+        const revisionsLookup = buildRevisionsLookup(submission)
+        if (revisionsLookup instanceof Error) {
+            throw revisionsLookup
+        }
+        const lookupTable = makeDocumentDateTable(revisionsLookup)
+        expect(lookupTable).toEqual({
+            's3://bucketname/1648242632157-Amerigroup Texas, Inc.pdf/Amerigroup Texas, Inc.pdf':
+                new Date('2022-03-25T21:13:20.420Z'),
+            's3://bucketname/1648490162641-lifeofgalileo.pdf/lifeofgalileo.pdf':
+                new Date('2022-03-28T17:56:32.953Z'),
+            's3://bucketname/1648242665634-Amerigroup Texas, Inc.pdf/Amerigroup Texas, Inc.pdf':
+                new Date('2022-03-25T21:13:20.420Z'),
+            's3://bucketname/1648242711421-Amerigroup Texas Inc copy.pdf/Amerigroup Texas Inc copy.pdf':
+                new Date('2022-03-25T21:13:20.420Z'),
+            's3://bucketname/1648242711421-529-10-0020-00003_Superior_Health Plan, Inc.pdf/529-10-0020-00003_Superior_Health Plan, Inc.pdf':
+                new Date('2022-03-25T21:13:20.420Z'),
+            's3://bucketname/1648242873229-covid-ifc-2-flu-rsv-codes 5-5-2021.pdf/covid-ifc-2-flu-rsv-codes 5-5-2021.pdf':
+                new Date('2022-03-25T21:13:20.420Z'),
+            previousSubmissionDate: new Date('2022-03-25T21:14:43.057Z'),
+        })
     })
-    it('should use earliest document added date', () => {
+
+    it('should return no document dates for submission still in initial draft', () => {
+        const submission = mockDraftHealthPlanPackage()
+        const revisionsLookup = buildRevisionsLookup(submission)
+        if (revisionsLookup instanceof Error) {
+            throw revisionsLookup
+        }
+        const lookupTable = makeDocumentDateTable(revisionsLookup)
+
+        expect(lookupTable).toEqual({})
+    })
+
+    it('should use earliest document added date based that revisions submit date', () => {
         const docs: Partial<UnlockedHealthPlanFormDataType> = {
             documents: [
                 {
-                    s3URL: 's3://bucketname/testDateDoc/testDateDoc.png',
+                    s3URL: 's3://bucketname/testDateDoc/testDateDoc.pdf',
                     name: 'Test Date Doc',
                     documentCategories: ['CONTRACT_RELATED'],
                 },
             ],
             contractDocuments: [
                 {
-                    s3URL: 's3://bucketname/key/foo.png',
-                    name: 'contract doc',
+                    s3URL: 's3://bucketname/key/replaced-contract.pdf',
+                    name: 'replaced contract',
                     documentCategories: ['CONTRACT'],
                 },
             ],
@@ -63,27 +80,49 @@ describe('makeDateTable', () => {
                 },
             ],
         }
-        const submissions = mockSubmittedHealthPlanPackageWithRevision({
+        const submission = mockSubmittedHealthPlanPackageWithRevision({
             currentSubmissionData: {
                 ...docs,
+            },
+            currentSubmitInfo: {
                 updatedAt: new Date('2022-03-10T00:00:00.000Z'),
             },
             previousSubmissionData: {
                 ...docs,
+            },
+            previousSubmitInfo: {
                 updatedAt: new Date('2022-02-10T00:00:00.000Z'),
             },
             initialSubmissionData: {
                 ...docs,
+                contractDocuments: [
+                    {
+                        s3URL: 's3://bucketname/key/original-contract.pdf',
+                        name: 'original contract',
+                        documentCategories: ['CONTRACT'],
+                    },
+                ],
+            },
+            initialSubmitInfo: {
                 updatedAt: new Date('2022-01-10T00:00:00.000Z'),
             },
         })
 
-        const lookupTable = makeDateTable(submissions)
+        const revisionsLookup = buildRevisionsLookup(submission)
+        if (revisionsLookup instanceof Error) {
+            throw revisionsLookup
+        }
+        const lookupTable = makeDocumentDateTable(revisionsLookup)
 
         expect(lookupTable).toEqual({
-            's3://bucketname/key/foo.png': new Date('2022-01-10T00:00:00.000Z'),
-            's3://bucketname/testDateDoc/testDateDoc.png': new Date(
+            's3://bucketname/key/original-contract.pdf': new Date(
                 '2022-01-10T00:00:00.000Z'
+            ),
+            's3://bucketname/key/replaced-contract.pdf': new Date(
+                '2022-02-10T00:00:00.000Z'
+            ),
+            's3://bucketname/testDateDoc/testDateDoc.pdf': new Date(
+                '2022-01-10T00:00:00.00'
             ),
             previousSubmissionDate: new Date('2022-02-10T00:00:00.000Z'),
         })

--- a/services/app-web/src/documentHelpers/makeDocumentDateLookupTable.test.ts
+++ b/services/app-web/src/documentHelpers/makeDocumentDateLookupTable.test.ts
@@ -52,7 +52,9 @@ describe('makeDocumentDateTable', () => {
         }
         const lookupTable = makeDocumentDateTable(revisionsLookup)
 
-        expect(lookupTable).toEqual({})
+        expect(lookupTable).toEqual({
+            previousSubmissionDate: null,
+        })
     })
 
     it('should use earliest document added date based that revisions submit date', () => {

--- a/services/app-web/src/documentHelpers/makeDocumentDateLookupTable.ts
+++ b/services/app-web/src/documentHelpers/makeDocumentDateLookupTable.ts
@@ -6,7 +6,6 @@ import { getAllDocuments } from './getAllDocuments'
 import { getDocumentKey } from './getDocumentKey'
 
 // DocumentDateLookupTableType -  { document lookup key string : date string for "date added" }
-// see logic in getDocumentKey for how document lookup key string is calculated. This can be simplified once we have doc.sha everywhere
 type DocumentDateLookupTableType = {
     previousSubmissionDate: string | null
     [key: string]: string | null
@@ -19,9 +18,10 @@ const getDateAdded = (
 ): string | undefined => {
     return revisionData.submitInfo?.updatedAt
 }
-// makeDateTable - generates document S3 keys and their "date added"
+// makeDateTable - generates unique document keys and their "date added"
 // used for date added column on UploadedDocumentsTable displayed in SubmissionSummary and ReviewSubmit
-// documents without a date added all together are excluded
+// documents without a submitted date are excluded from list
+// logic for unique document keys comes from getDocumentKey -  This can be simplified once we have doc.sha everywhere
 function makeDocumentDateTable(
     revisionsLookup: RevisionsLookupType
 ): DocumentDateLookupTableType {

--- a/services/app-web/src/documentHelpers/makeDocumentDateLookupTable.ts
+++ b/services/app-web/src/documentHelpers/makeDocumentDateLookupTable.ts
@@ -7,7 +7,7 @@ import { getDocumentKey } from './getDocumentKey'
 
 // DocumentDateLookupTableType -  { S3 key string : date string for "date added" }
 type DocumentDateLookupTableType = {
-    [key: string]: string | undefined
+    [key: string]: string
 }
 
 // getDateAdded - picks out the submit info updatedAt date for a revision
@@ -19,6 +19,7 @@ const getDateAdded = (
 }
 // makeDateTable - generates document S3 keys and their "date added"
 // used for date added column on UploadedDocumentsTable displayed in SubmissionSummary and ReviewSubmit
+// documents without a date added all together are excluded
 function makeDocumentDateTable(
     revisionsLookup: RevisionsLookupType
 ): DocumentDateLookupTableType {
@@ -28,13 +29,15 @@ function makeDocumentDateTable(
             const revision = revisionsLookup[revisionId]
             if (index === 1) {
                 // second most recent revision
-                lookupTable['previousSubmissionDate'] = getDateAdded(revision) // used in UploadedDocumentsTable to determine if we should show NEW tag
+                const previousSubmission = getDateAdded(revision) // used in UploadedDocumentsTable to determine if we should show NEW tag
+                if (previousSubmission) lookupTable['previousSubmissionDate'] = previousSubmission
             }
 
             const allDocuments = getAllDocuments(revision.formData)
             allDocuments.forEach((doc) => {
                 const documentKey = getDocumentKey(doc)
-                lookupTable[documentKey] = getDateAdded(revision)
+                const dateAdded = getDateAdded(revision)
+                if (dateAdded) lookupTable[documentKey] = dateAdded
             })
         }
     )

--- a/services/app-web/src/documentHelpers/makeDocumentDateLookupTable.ts
+++ b/services/app-web/src/documentHelpers/makeDocumentDateLookupTable.ts
@@ -8,7 +8,7 @@ import { getDocumentKey } from './getDocumentKey'
 // DocumentDateLookupTableType -  { document key string : date string for "date added" }
 // see logic in getDocumentKey for how document key string is calculated
 type DocumentDateLookupTableType = {
-    previousSubmissionDate: string | null,
+    previousSubmissionDate: string | null
     [key: string]: string | null
 }
 
@@ -25,14 +25,17 @@ const getDateAdded = (
 function makeDocumentDateTable(
     revisionsLookup: RevisionsLookupType
 ): DocumentDateLookupTableType {
-    const lookupTable: DocumentDateLookupTableType = { previousSubmissionDate: null}
+    const lookupTable: DocumentDateLookupTableType = {
+        previousSubmissionDate: null,
+    }
     Object.keys(revisionsLookup).forEach(
         (revisionId: string, index: number) => {
             const revision = revisionsLookup[revisionId]
             if (index === 1) {
                 // second most recent revision
                 const previousSubmission = getDateAdded(revision) // used in UploadedDocumentsTable to determine if we should show NEW tag
-                if (previousSubmission) lookupTable['previousSubmissionDate'] = previousSubmission
+                if (previousSubmission)
+                    lookupTable['previousSubmissionDate'] = previousSubmission
             }
 
             const allDocuments = getAllDocuments(revision.formData)
@@ -43,7 +46,6 @@ function makeDocumentDateTable(
             })
         }
     )
-
     return lookupTable
 }
 

--- a/services/app-web/src/documentHelpers/makeDocumentDateLookupTable.ts
+++ b/services/app-web/src/documentHelpers/makeDocumentDateLookupTable.ts
@@ -5,9 +5,11 @@ import {
 import { getAllDocuments } from './getAllDocuments'
 import { getDocumentKey } from './getDocumentKey'
 
-// DocumentDateLookupTableType -  { S3 key string : date string for "date added" }
+// DocumentDateLookupTableType -  { document key string : date string for "date added" }
+// see logic in getDocumentKey for how document key string is calculated
 type DocumentDateLookupTableType = {
-    [key: string]: string
+    previousSubmissionDate: string | null,
+    [key: string]: string | null
 }
 
 // getDateAdded - picks out the submit info updatedAt date for a revision
@@ -23,7 +25,7 @@ const getDateAdded = (
 function makeDocumentDateTable(
     revisionsLookup: RevisionsLookupType
 ): DocumentDateLookupTableType {
-    const lookupTable: DocumentDateLookupTableType = {}
+    const lookupTable: DocumentDateLookupTableType = { previousSubmissionDate: null}
     Object.keys(revisionsLookup).forEach(
         (revisionId: string, index: number) => {
             const revision = revisionsLookup[revisionId]

--- a/services/app-web/src/documentHelpers/makeDocumentDateLookupTable.ts
+++ b/services/app-web/src/documentHelpers/makeDocumentDateLookupTable.ts
@@ -5,8 +5,8 @@ import {
 import { getAllDocuments } from './getAllDocuments'
 import { getDocumentKey } from './getDocumentKey'
 
-// DocumentDateLookupTableType -  { document key string : date string for "date added" }
-// see logic in getDocumentKey for how document key string is calculated
+// DocumentDateLookupTableType -  { document lookup key string : date string for "date added" }
+// see logic in getDocumentKey for how document lookup key string is calculated. This can be simplified once we have doc.sha everywhere
 type DocumentDateLookupTableType = {
     previousSubmissionDate: string | null
     [key: string]: string | null

--- a/services/app-web/src/documentHelpers/makeDocumentKeyLookupList.test.ts
+++ b/services/app-web/src/documentHelpers/makeDocumentKeyLookupList.test.ts
@@ -1,8 +1,9 @@
-import { makeDocumentList } from './makeDocumentKeyLookupList'
+import { makeDocumentS3KeyLookup } from './makeDocumentKeyLookupList'
 import { mockSubmittedHealthPlanPackageWithRevision } from '../testHelpers/apolloMocks'
 import { UnlockedHealthPlanFormDataType } from '../common-code/healthPlanFormDataType'
+import { buildRevisionsLookup } from '../gqlHelpers/fetchHealthPlanPackageWrapper'
 
-describe('makeDocumentList', () => {
+describe('makeDocumentS3KeyLookup', () => {
     const noSubmissionDocuments: Partial<UnlockedHealthPlanFormDataType> = {
         contractDocuments: [],
         rateInfos: [
@@ -17,47 +18,45 @@ describe('makeDocumentList', () => {
     }
 
     it('should make two lists with document s3 keys', () => {
-        const submissions = mockSubmittedHealthPlanPackageWithRevision({})
-        const lookupTable = makeDocumentList(submissions)
-
-        expect(lookupTable).toEqual({
-            currentDocuments: [
+        const submission = mockSubmittedHealthPlanPackageWithRevision({})
+        const revisionsLookup = buildRevisionsLookup(submission)
+        if (revisionsLookup instanceof Error) {
+            throw revisionsLookup
+        }
+        const lookupTable = makeDocumentS3KeyLookup(revisionsLookup)
+        expect(lookupTable.currentDocuments.sort()).toEqual(
+            [
                 '1648242632157-Amerigroup Texas, Inc.pdf',
                 '1648490162641-lifeofgalileo.pdf',
                 '1648242665634-Amerigroup Texas, Inc.pdf',
                 '1648242711421-Amerigroup Texas Inc copy.pdf',
                 '1648242711421-529-10-0020-00003_Superior_Health Plan, Inc.pdf',
                 '1648242873229-covid-ifc-2-flu-rsv-codes 5-5-2021.pdf',
-            ],
-            previousDocuments: [
-                '1648242632157-Amerigroup Texas, Inc.pdf',
-                '1648242665634-Amerigroup Texas, Inc.pdf',
-                '1648242711421-Amerigroup Texas Inc copy.pdf',
-                '1648242711421-529-10-0020-00003_Superior_Health Plan, Inc.pdf',
+            ].sort()
+        )
+
+        expect(lookupTable.previousDocuments.sort()).toEqual(
+            [
                 '1648242873229-covid-ifc-2-flu-rsv-codes 5-5-2021.pdf',
                 '1648242632157-Amerigroup Texas, Inc.pdf',
                 '1648242665634-Amerigroup Texas, Inc.pdf',
                 '1648242711421-Amerigroup Texas Inc copy.pdf',
                 '1648242711421-529-10-0020-00003_Superior_Health Plan, Inc.pdf',
-                '1648242632157-Amerigroup Texas, Inc.pdf',
-                '1648242665634-Amerigroup Texas, Inc.pdf',
-                '1648242711421-Amerigroup Texas Inc copy.pdf',
-                '1648242711421-529-10-0020-00003_Superior_Health Plan, Inc.pdf',
-                '1648242873229-covid-ifc-2-flu-rsv-codes 5-5-2021.pdf',
-                '1648242632157-Amerigroup Texas, Inc.pdf',
-                '1648242665634-Amerigroup Texas, Inc.pdf',
-                '1648242711421-Amerigroup Texas Inc copy.pdf',
-                '1648242711421-529-10-0020-00003_Superior_Health Plan, Inc.pdf',
-            ],
-        })
+            ].sort()
+        )
     })
+
     it('should return empty arrays for no documents in submission', () => {
-        const submissions = mockSubmittedHealthPlanPackageWithRevision({
+        const submission = mockSubmittedHealthPlanPackageWithRevision({
             currentSubmissionData: noSubmissionDocuments,
             previousSubmissionData: noSubmissionDocuments,
             initialSubmissionData: noSubmissionDocuments,
         })
-        const lookupTable = makeDocumentList(submissions)
+        const revisionsLookup = buildRevisionsLookup(submission)
+        if (revisionsLookup instanceof Error) {
+            throw revisionsLookup
+        }
+        const lookupTable = makeDocumentS3KeyLookup(revisionsLookup)
 
         expect(lookupTable).toEqual({
             currentDocuments: [],
@@ -65,66 +64,50 @@ describe('makeDocumentList', () => {
         })
     })
 
-    it('should return empty array for currentDocuments', () => {
-        const submissions = mockSubmittedHealthPlanPackageWithRevision({
+    it('should return empty array for currentDocuments when none exist', () => {
+        const submission = mockSubmittedHealthPlanPackageWithRevision({
             currentSubmissionData: noSubmissionDocuments,
         })
-        const lookupTable = makeDocumentList(submissions)
+        const revisionsLookup = buildRevisionsLookup(submission)
+        if (revisionsLookup instanceof Error) {
+            throw revisionsLookup
+        }
+        const lookupTable = makeDocumentS3KeyLookup(revisionsLookup)
 
-        expect(lookupTable).toEqual({
-            currentDocuments: [],
-            previousDocuments: [
-                '1648242632157-Amerigroup Texas, Inc.pdf',
-                '1648242665634-Amerigroup Texas, Inc.pdf',
-                '1648242711421-Amerigroup Texas Inc copy.pdf',
-                '1648242711421-529-10-0020-00003_Superior_Health Plan, Inc.pdf',
+        expect(lookupTable.currentDocuments).toEqual([])
+        expect(lookupTable.previousDocuments.sort()).toEqual(
+            [
                 '1648242873229-covid-ifc-2-flu-rsv-codes 5-5-2021.pdf',
                 '1648242632157-Amerigroup Texas, Inc.pdf',
                 '1648242665634-Amerigroup Texas, Inc.pdf',
                 '1648242711421-Amerigroup Texas Inc copy.pdf',
                 '1648242711421-529-10-0020-00003_Superior_Health Plan, Inc.pdf',
-                '1648242632157-Amerigroup Texas, Inc.pdf',
-                '1648242665634-Amerigroup Texas, Inc.pdf',
-                '1648242711421-Amerigroup Texas Inc copy.pdf',
-                '1648242711421-529-10-0020-00003_Superior_Health Plan, Inc.pdf',
-                '1648242873229-covid-ifc-2-flu-rsv-codes 5-5-2021.pdf',
-                '1648242632157-Amerigroup Texas, Inc.pdf',
-                '1648242665634-Amerigroup Texas, Inc.pdf',
-                '1648242711421-Amerigroup Texas Inc copy.pdf',
-                '1648242711421-529-10-0020-00003_Superior_Health Plan, Inc.pdf',
-            ],
-        })
+            ].sort()
+        )
     })
 
-    it('should return empty array for previousDocuments', () => {
-        const submissions = mockSubmittedHealthPlanPackageWithRevision({
+    it('should return empty array for previousDocuments when none exist', () => {
+        const submission = mockSubmittedHealthPlanPackageWithRevision({
             previousSubmissionData: noSubmissionDocuments,
             initialSubmissionData: noSubmissionDocuments,
         })
-        const lookupTable = makeDocumentList(submissions)
 
-        expect(lookupTable).toEqual({
-            currentDocuments: [
+        const revisionsLookup = buildRevisionsLookup(submission)
+        if (revisionsLookup instanceof Error) {
+            throw revisionsLookup
+        }
+        const lookupTable = makeDocumentS3KeyLookup(revisionsLookup)
+
+        expect(lookupTable.previousDocuments).toEqual([])
+        expect(lookupTable.currentDocuments.sort()).toEqual(
+            [
                 '1648242632157-Amerigroup Texas, Inc.pdf',
                 '1648490162641-lifeofgalileo.pdf',
                 '1648242665634-Amerigroup Texas, Inc.pdf',
                 '1648242711421-Amerigroup Texas Inc copy.pdf',
                 '1648242711421-529-10-0020-00003_Superior_Health Plan, Inc.pdf',
                 '1648242873229-covid-ifc-2-flu-rsv-codes 5-5-2021.pdf',
-            ],
-            previousDocuments: [],
-        })
-    })
-
-    it('should return error if any revisions does not decode', () => {
-        const submissions = mockSubmittedHealthPlanPackageWithRevision({})
-        submissions.revisions[1].node.formDataProto = 'Should return an error'
-        const lookupTable = makeDocumentList(submissions)
-
-        expect(lookupTable).toEqual(
-            new Error(
-                'Failed to read submission data; unable to display documents'
-            )
+            ].sort()
         )
     })
 })

--- a/services/app-web/src/documentHelpers/makeDocumentKeyLookupList.ts
+++ b/services/app-web/src/documentHelpers/makeDocumentKeyLookupList.ts
@@ -1,9 +1,10 @@
-import { base64ToDomain } from '../common-code/proto/healthPlanFormDataProto'
-import { HealthPlanPackage } from '../gen/gqlClient'
 import { parseKey } from '../common-code/s3URLEncoding'
-import { HealthPlanFormDataType } from '../common-code/healthPlanFormDataType'
+import { RevisionsLookupType } from '../gqlHelpers/fetchHealthPlanPackageWrapper'
+import { getAllDocuments } from './getAllDocuments'
 
-export type LookupListType = {
+// CurrentPreviousDocsLookup - array of document keys for currentDocuments and previousDocuments
+
+type LookupListType = {
     currentDocuments: string[]
     previousDocuments: string[]
 }
@@ -13,64 +14,50 @@ const getKey = (s3URL: string) => {
     return key instanceof Error ? null : key
 }
 
-export function makeDocumentListFromFormDatas(
-    formDatas: HealthPlanFormDataType[]
-): LookupListType {
-    const docBuckets = [
-        'contractDocuments',
-        'rateDocuments',
-        'documents',
-    ] as const
-    const lookupList: LookupListType = {
-        currentDocuments: [],
-        previousDocuments: [],
-    }
+// makeDocumentS3KeyLookup - generates list of currentDocuments and previousDocuments by s3Key
+// this is used to to determine if can delete a document from s3 after it removed from the FileUpload UI on the  documents pages - ContractDetails, RateDetails, Documents
 
-    for (let index = 0; index < formDatas.length; index++) {
-        const revisionData = formDatas[index]
-        docBuckets.forEach((bucket) => {
-            if (bucket === 'rateDocuments') {
-                revisionData.rateInfos.forEach((rateInfo) => {
-                    rateInfo[bucket].forEach((doc) => {
-                        const key = getKey(doc.s3URL)
-                        if (key && index === 0) {
-                            lookupList.currentDocuments.push(key)
-                        } else if (key && index > 0) {
-                            lookupList.previousDocuments.push(key)
-                        }
-                    })
+function makeDocumentS3KeyLookup(
+    revisionsLookup: RevisionsLookupType
+): LookupListType {
+    const currentDocumentsSet = new Set<string>()
+    const previousDocumentsSet = new Set<string>()
+
+    Object.keys(revisionsLookup).forEach(
+        (revisionId: string, index: number) => {
+            const revisionData = revisionsLookup[revisionId].formData
+            const allDocuments = getAllDocuments(revisionData)
+            if (index === 0) {
+                allDocuments.forEach((doc) => {
+                    const s3Key = getKey(doc.s3URL)
+                    if (!s3Key) {
+                        console.error(
+                            `makeDocumentS3KeyLookup- Failed to read S3 key for $${doc.name} - ${doc.s3URL}`
+                        )
+                        // fail silently, just return good documents
+                    } else {
+                        currentDocumentsSet.add(s3Key)
+                    }
                 })
             } else {
-                revisionData[bucket].forEach((doc) => {
-                    const key = getKey(doc.s3URL)
-                    if (key && index === 0) {
-                        lookupList.currentDocuments.push(key)
-                    } else if (key && index > 0) {
-                        lookupList.previousDocuments.push(key)
+                allDocuments.forEach((doc) => {
+                    const s3Key = getKey(doc.s3URL)
+                    if (!s3Key) {
+                        console.error(
+                            `makeDocumentS3KeyLookup - Failed to read S3 key for $${doc.name} - ${doc.s3URL}`
+                        )
+                        // fail silently, just return good documents
+                    } else {
+                        previousDocumentsSet.add(s3Key)
                     }
                 })
             }
-        })
-    }
-
-    return lookupList
-}
-
-export const makeDocumentList = (
-    submissions: HealthPlanPackage
-): LookupListType | Error => {
-    const revisions = submissions.revisions
-
-    const formDatas: HealthPlanFormDataType[] = []
-    for (let index = 0; index < revisions.length; index++) {
-        const revisionData = base64ToDomain(revisions[index].node.formDataProto)
-        if (revisionData instanceof Error) {
-            return new Error(
-                'Failed to read submission data; unable to display documents'
-            )
         }
-        formDatas.push(revisionData)
+    )
+    return {
+        currentDocuments: [...currentDocumentsSet],
+        previousDocuments: [...previousDocumentsSet],
     }
-
-    return makeDocumentListFromFormDatas(formDatas)
 }
+
+export { makeDocumentS3KeyLookup }

--- a/services/app-web/src/documentHelpers/makeDocumentKeyLookupList.ts
+++ b/services/app-web/src/documentHelpers/makeDocumentKeyLookupList.ts
@@ -4,7 +4,7 @@ import { getAllDocuments } from './getAllDocuments'
 
 // CurrentPreviousDocsLookup - array of document keys for currentDocuments and previousDocuments
 
-type LookupListType = {
+type DocumentKeyLookupType = {
     currentDocuments: string[]
     previousDocuments: string[]
 }
@@ -19,7 +19,7 @@ const getKey = (s3URL: string) => {
 
 function makeDocumentS3KeyLookup(
     revisionsLookup: RevisionsLookupType
-): LookupListType {
+): DocumentKeyLookupType {
     const currentDocumentsSet = new Set<string>()
     const previousDocumentsSet = new Set<string>()
 
@@ -61,3 +61,4 @@ function makeDocumentS3KeyLookup(
 }
 
 export { makeDocumentS3KeyLookup }
+export type {DocumentKeyLookupType}

--- a/services/app-web/src/gqlHelpers/fetchHealthPlanPackageWrapper.ts
+++ b/services/app-web/src/gqlHelpers/fetchHealthPlanPackageWrapper.ts
@@ -15,6 +15,10 @@ import {
 } from './apolloQueryWrapper'
 import { QueryFunctionOptions } from '@apollo/client'
 import { recordJSException } from '../otelHelpers'
+import {
+    DocumentDateLookupTableType,
+    makeDocumentDateTable,
+} from '../documentHelpers/makeDocumentDateLookupTable'
 
 // ExpandedRevisionsType - HPP revision plus an additional formData field containing values of formDataProto decoded into typescript
 type ExpandedRevisionsType = HealthPlanRevision & {
@@ -26,6 +30,7 @@ type RevisionsLookupType = { [revisionID: string]: ExpandedRevisionsType }
 // all of these fields will be added to the SUCCESS type
 type AdditionalParsedDataType = {
     revisionsLookup: RevisionsLookupType
+    documentDates: DocumentDateLookupTableType
 }
 
 type ParsedFetchResultType = ApolloResultType<
@@ -79,6 +84,7 @@ function parseProtos(
         return {
             ...result,
             revisionsLookup: {},
+            documentDates: { previousSubmissionDate: null },
         }
     }
 
@@ -92,6 +98,7 @@ function parseProtos(
             error: err,
         }
     }
+
     const revisionsLookup = buildRevisionsLookup(pkg)
     if (revisionsLookup instanceof Error) {
         return {
@@ -99,9 +106,12 @@ function parseProtos(
             error: revisionsLookup,
         }
     } else {
+        const documentDates = makeDocumentDateTable(revisionsLookup)
+
         return {
             ...result,
             revisionsLookup,
+            documentDates,
         }
     }
 }

--- a/services/app-web/src/hooks/useDocument.tsx
+++ b/services/app-web/src/hooks/useDocument.tsx
@@ -11,24 +11,26 @@ type ParsedDocumentWithLinkType =
 
 const useDocument = () => {
     const { getKey, getURL } = useS3()
-
-    const getDocumentsUrl = useCallback(
+    const getDocumentsWithS3KeyAndUrl= useCallback(
         async <T = Record<string, unknown>,>(
             documents: Array<T & UnionDocumentType>,
             bucket: BucketShortName
         ): Promise<Array<T & ParsedDocumentWithLinkType>> => {
+
             return await Promise.all(
                 documents.map(async (doc) => {
                     const key = getKey(doc.s3URL)
                     if (!key)
                         return {
                             ...doc,
+                            s3Key: null,
                             url: null,
                         }
 
                     const documentLink = await getURL(key, bucket)
                     return {
                         ...doc,
+                        s3Key: key,
                         url: documentLink,
                     }
                 })
@@ -40,7 +42,8 @@ const useDocument = () => {
         [getURL, getKey]
     )
 
-    return { getDocumentsUrl }
+
+    return { getDocumentsWithS3KeyAndUrl }
 }
 
 export { useDocument }

--- a/services/app-web/src/pages/QuestionResponse/QATable/QATable.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/QATable.tsx
@@ -45,7 +45,7 @@ export const QATable = ({
     round: number
     user: User
 }) => {
-    const { getDocumentsUrl } = useDocument()
+    const { getDocumentsWithS3KeyAndUrl } = useDocument()
     const tableDocuments = [
         ...question.documents.map((doc) => ({
             ...doc,
@@ -84,7 +84,7 @@ export const QATable = ({
 
     useDeepCompareEffect(() => {
         const refreshDocuments = async () => {
-            const newDocuments = await getDocumentsUrl(
+            const newDocuments = await getDocumentsWithS3KeyAndUrl(
                 tableDocuments,
                 'QUESTION_ANSWER_DOCS'
             )
@@ -94,7 +94,7 @@ export const QATable = ({
         }
 
         void refreshDocuments()
-    }, [tableDocuments, getDocumentsUrl, setRefreshedDocs])
+    }, [tableDocuments, getDocumentsWithS3KeyAndUrl, setRefreshedDocs])
 
     return (
         <>

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.test.tsx
@@ -10,6 +10,7 @@ describe('ReviewSubmit', () => {
     it('renders without errors', async () => {
         renderWithProviders(
             <ReviewSubmit
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 draftSubmission={mockBaseContract()}
                 unlocked={false}
                 submissionName="MN-PMAP-0001"
@@ -28,6 +29,7 @@ describe('ReviewSubmit', () => {
     it('displays edit buttons for every section', async () => {
         renderWithProviders(
             <ReviewSubmit
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 draftSubmission={mockBaseContract()}
                 unlocked={false}
                 submissionName="MN-PMAP-0001"
@@ -55,6 +57,7 @@ describe('ReviewSubmit', () => {
     it('does not display zip download buttons', async () => {
         renderWithProviders(
             <ReviewSubmit
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 draftSubmission={mockBaseContract()}
                 unlocked={false}
                 submissionName="MN-PMAP-0001"
@@ -77,6 +80,7 @@ describe('ReviewSubmit', () => {
     it('renders info from a DraftSubmission', async () => {
         renderWithProviders(
             <ReviewSubmit
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 draftSubmission={mockBaseContract()}
                 unlocked={false}
                 submissionName="MN-PMAP-0001"
@@ -116,6 +120,7 @@ describe('ReviewSubmit', () => {
     it('displays back and save as draft buttons', async () => {
         renderWithProviders(
             <ReviewSubmit
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 draftSubmission={mockBaseContract()}
                 unlocked={false}
                 submissionName="MN-PMAP-0001"
@@ -146,6 +151,7 @@ describe('ReviewSubmit', () => {
     it('displays submit button', async () => {
         renderWithProviders(
             <ReviewSubmit
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 draftSubmission={mockBaseContract()}
                 unlocked={false}
                 submissionName="MN-PMAP-0001"

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
@@ -16,18 +16,16 @@ import { PageActionsContainer } from '../PageActions'
 import styles from './ReviewSubmit.module.scss'
 import { UnlockedHealthPlanFormDataType } from '../../../common-code/healthPlanFormDataType'
 import { ActionButton } from '../../../components/ActionButton'
-import { DocumentDateLookupTable } from '../../SubmissionSummary/SubmissionSummary'
 import { UnlockSubmitModal } from '../../../components/Modal/UnlockSubmitModal'
 import { useStatePrograms } from '../../../hooks/useStatePrograms'
+import { DocumentDateLookupTableType } from '../../../documentHelpers/makeDocumentDateLookupTable'
 
 export const ReviewSubmit = ({
     draftSubmission,
-    documentDateLookupTable,
     unlocked,
     submissionName,
 }: {
     draftSubmission: UnlockedHealthPlanFormDataType
-    documentDateLookupTable?: DocumentDateLookupTable
     unlocked: boolean
     submissionName: string
 }): React.ReactElement => {
@@ -54,7 +52,6 @@ export const ReviewSubmit = ({
                 submission={draftSubmission}
                 navigateTo="../contract-details"
                 submissionName={submissionName}
-                documentDateLookupTable={documentDateLookupTable}
             />
 
             {isContractActionAndRateCertification && (
@@ -62,7 +59,6 @@ export const ReviewSubmit = ({
                     submission={draftSubmission}
                     navigateTo="../rate-details"
                     submissionName={submissionName}
-                    documentDateLookupTable={documentDateLookupTable}
                     statePrograms={statePrograms}
                 />
             )}

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
@@ -22,10 +22,12 @@ import { DocumentDateLookupTableType } from '../../../documentHelpers/makeDocume
 
 export const ReviewSubmit = ({
     draftSubmission,
+    documentDateLookupTable,
     unlocked,
     submissionName,
 }: {
     draftSubmission: UnlockedHealthPlanFormDataType
+    documentDateLookupTable: DocumentDateLookupTableType
     unlocked: boolean
     submissionName: string
 }): React.ReactElement => {
@@ -52,6 +54,7 @@ export const ReviewSubmit = ({
                 submission={draftSubmission}
                 navigateTo="../contract-details"
                 submissionName={submissionName}
+                documentDateLookupTable={documentDateLookupTable}
             />
 
             {isContractActionAndRateCertification && (
@@ -59,6 +62,7 @@ export const ReviewSubmit = ({
                     submission={draftSubmission}
                     navigateTo="../rate-details"
                     submissionName={submissionName}
+                    documentDateLookupTable={documentDateLookupTable}
                     statePrograms={statePrograms}
                 />
             )}

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
@@ -320,7 +320,6 @@ export const StateSubmissionForm = (): React.ReactElement => {
                                 draftSubmission={formDataFromLatestRevision}
                                 unlocked={!!unlockedInfo}
                                 submissionName={computedSubmissionName}
-                                documentDateLookupTable={documentDates}
                             />
                         }
                     />

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
@@ -318,6 +318,7 @@ export const StateSubmissionForm = (): React.ReactElement => {
                         element={
                             <ReviewSubmit
                                 draftSubmission={formDataFromLatestRevision}
+                                documentDateLookupTable={documentDates}
                                 unlocked={!!unlockedInfo}
                                 submissionName={computedSubmissionName}
                             />

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.test.tsx
@@ -84,7 +84,12 @@ describe('SubmissionRevisionSummary', () => {
             expect(rows).toHaveLength(2)
             expect(within(rows[0]).getByText('Date added')).toBeInTheDocument()
             expect(
-                within(rows[1]).getByText(dayjs(new Date()).format('M/D/YY'))
+                within(rows[1]).getByText(
+                    dayjs(
+                        mockSubmittedHealthPlanPackageWithRevisions()
+                            .revisions[2]?.node?.submitInfo?.updatedAt
+                    ).format('M/D/YY')
+                )
             ).toBeInTheDocument()
         })
     })

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.tsx
@@ -121,14 +121,13 @@ export const SubmissionRevisionSummary = (): React.ReactElement => {
 
                 <ContractDetailsSummarySection
                     submission={packageData}
-                    documentDateLookupTable={documentDates}
                     submissionName={packageName(packageData, statePrograms)}
                 />
 
                 {isContractActionAndRateCertification && (
                     <RateDetailsSummarySection
                         submission={packageData}
-                        documentDateLookupTable={documentDates}
+
                         submissionName={packageName(packageData, statePrograms)}
                         statePrograms={statePrograms}
                     />

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.tsx
@@ -20,7 +20,6 @@ import { recordJSException } from '../../otelHelpers/tracingHelper'
 import { useFetchHealthPlanPackageWrapper } from '../../gqlHelpers'
 import { ApolloError } from '@apollo/client'
 import { handleApolloError } from '../../gqlHelpers/apolloErrors'
-import { makeDocumentDateTable } from '../../documentHelpers/makeDocumentDateLookupTable'
 
 export const SubmissionRevisionSummary = (): React.ReactElement => {
     // Page level state
@@ -61,7 +60,7 @@ export const SubmissionRevisionSummary = (): React.ReactElement => {
         return <GenericErrorPage /> // api failure or protobuf decode failure
     }
 
-    const { data, revisionsLookup } = fetchResult
+    const { data, revisionsLookup, documentDates } = fetchResult
     const pkg = data.fetchHealthPlanPackage.pkg
 
     // fetchHPP returns null if no package is found with the given ID
@@ -79,7 +78,6 @@ export const SubmissionRevisionSummary = (): React.ReactElement => {
         return <Error404 />
     }
     const packageData = revisionsLookup[revision.id].formData
-    const documentDates = makeDocumentDateTable(revisionsLookup)
 
     const statePrograms = pkg.state.programs
     const name = packageName(packageData, statePrograms)
@@ -121,13 +119,14 @@ export const SubmissionRevisionSummary = (): React.ReactElement => {
 
                 <ContractDetailsSummarySection
                     submission={packageData}
+                    documentDateLookupTable={documentDates}
                     submissionName={packageName(packageData, statePrograms)}
                 />
 
                 {isContractActionAndRateCertification && (
                     <RateDetailsSummarySection
                         submission={packageData}
-
+                        documentDateLookupTable={documentDates}
                         submissionName={packageName(packageData, statePrograms)}
                         statePrograms={statePrograms}
                     />

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.tsx
@@ -20,6 +20,7 @@ import { recordJSException } from '../../otelHelpers/tracingHelper'
 import { useFetchHealthPlanPackageWrapper } from '../../gqlHelpers'
 import { ApolloError } from '@apollo/client'
 import { handleApolloError } from '../../gqlHelpers/apolloErrors'
+import { makeDocumentDateTable } from '../../documentHelpers/makeDocumentDateLookupTable'
 
 export const SubmissionRevisionSummary = (): React.ReactElement => {
     // Page level state
@@ -60,7 +61,7 @@ export const SubmissionRevisionSummary = (): React.ReactElement => {
         return <GenericErrorPage /> // api failure or protobuf decode failure
     }
 
-    const { data, formDatas, documentDates } = fetchResult
+    const { data, revisionsLookup } = fetchResult
     const pkg = data.fetchHealthPlanPackage.pkg
 
     // fetchHPP returns null if no package is found with the given ID
@@ -77,7 +78,8 @@ export const SubmissionRevisionSummary = (): React.ReactElement => {
         console.info('no revision found at index', revisionIndex)
         return <Error404 />
     }
-    const packageData = formDatas[revision.id]
+    const packageData = revisionsLookup[revision.id].formData
+    const documentDates = makeDocumentDateTable(revisionsLookup)
 
     const statePrograms = pkg.state.programs
     const name = packageName(packageData, statePrograms)

--- a/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
@@ -28,7 +28,7 @@ import {
 } from '../../common-code/healthPlanFormDataType'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { featureFlags } from '../../common-code/featureFlags'
-import { DocumentDateLookupTableType } from '../../documentHelpers/makeDocumentDateLookupTable'
+import { DocumentDateLookupTableType, makeDocumentDateTable } from '../../documentHelpers/makeDocumentDateLookupTable'
 
 export type SideNavOutletContextType = {
     pkg: HealthPlanPackage
@@ -131,7 +131,7 @@ export const SubmissionSideNav = () => {
     const currentRevision = edge.node
     const packageData = revisionsLookup[currentRevision.id].formData
     const pkgName = packageName(packageData, pkg.state.programs)
-
+    const documentDates = makeDocumentDateTable(revisionsLookup)
     const outletContext: SideNavOutletContextType = {
         pkg,
         packageName: pkgName,

--- a/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
@@ -28,7 +28,10 @@ import {
 } from '../../common-code/healthPlanFormDataType'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { featureFlags } from '../../common-code/featureFlags'
-import { DocumentDateLookupTableType, makeDocumentDateTable } from '../../documentHelpers/makeDocumentDateLookupTable'
+import {
+    DocumentDateLookupTableType,
+    makeDocumentDateTable,
+} from '../../documentHelpers/makeDocumentDateLookupTable'
 
 export type SideNavOutletContextType = {
     pkg: HealthPlanPackage

--- a/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
@@ -28,14 +28,14 @@ import {
 } from '../../common-code/healthPlanFormDataType'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { featureFlags } from '../../common-code/featureFlags'
-import { DocumentDateLookupTable } from '../SubmissionSummary/SubmissionSummary'
+import { DocumentDateLookupTableType } from '../../documentHelpers/makeDocumentDateLookupTable'
 
 export type SideNavOutletContextType = {
     pkg: HealthPlanPackage
     packageName: string
     currentRevision: HealthPlanRevision
     packageData: HealthPlanFormDataType
-    documentDates: DocumentDateLookupTable
+    documentDates: DocumentDateLookupTableType
     user: User
 }
 
@@ -86,7 +86,7 @@ export const SubmissionSideNav = () => {
         )
     }
 
-    const { data, formDatas, documentDates } = fetchResult
+    const { data, revisionsLookup } = fetchResult
     const pkg = data.fetchHealthPlanPackage.pkg
 
     // Display generic error page if getting logged in user returns undefined.
@@ -98,7 +98,6 @@ export const SubmissionSideNav = () => {
     if (!pkg) {
         return <Error404 />
     }
-
     const submissionStatus = pkg.status
 
     const isCMSUser = loggedInUser?.role === 'CMS_USER'
@@ -130,7 +129,7 @@ export const SubmissionSideNav = () => {
         return <GenericErrorPage />
     }
     const currentRevision = edge.node
-    const packageData = formDatas[currentRevision.id]
+    const packageData = revisionsLookup[currentRevision.id].formData
     const pkgName = packageName(packageData, pkg.state.programs)
 
     const outletContext: SideNavOutletContextType = {

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -367,13 +367,13 @@ describe('SubmissionSummary', () => {
 
         it('extracts the correct dates from the submission and displays them in tables', async () => {
             const submission = mockSubmittedHealthPlanPackageWithRevision({
-                currentSubmissionData: {
+                currentSubmitInfo: {
                     updatedAt: new Date('2022-05-12T21:13:20.420Z'),
                 },
-                previousSubmissionData: {
+                previousSubmitInfo: {
                     updatedAt: new Date('2022-04-12T21:13:20.420Z'),
                 },
-                initialSubmissionData: {
+                initialSubmitInfo: {
                     updatedAt: new Date('2022-03-12T21:13:20.420Z'),
                 },
             })
@@ -408,7 +408,7 @@ describe('SubmissionSummary', () => {
             )
             await waitFor(() => {
                 const rows = screen.getAllByRole('row')
-                expect(rows).toHaveLength(10)
+                expect(rows).toHaveLength(8)
                 expect(
                     within(rows[0]).getByText('Date added')
                 ).toBeInTheDocument()
@@ -523,7 +523,7 @@ describe('SubmissionSummary', () => {
                 'src/common-code/proto/healthPlanFormDataProto/testData/'
             )
             .filter((f) => f.endsWith('.proto'))
-        /* as much as we'd like to loop over all the proto files here, looping and async tests, 
+        /* as much as we'd like to loop over all the proto files here, looping and async tests,
         which this one is (document loading) produces inconsistent results.  We have to copy/paste
         the test for each proto file. */
         it('loads outdated health plan packages with old protos as expected - 0', async () => {
@@ -582,10 +582,10 @@ describe('SubmissionSummary', () => {
                 expect(rows[0]).toHaveTextContent('Document name')
                 expect(rows[0]).toHaveTextContent('Document category')
                 expect(rows[1]).toHaveTextContent('contract doc')
-                expect(rows[1]).toHaveTextContent('8/19/22')
+                expect(rows[1]).toHaveTextContent('1/2/21')
                 expect(rows[1]).toHaveTextContent('Contract-supporting')
                 expect(rows[3]).toHaveTextContent('rates cert 1')
-                expect(rows[3]).toHaveTextContent('8/19/22')
+                expect(rows[3]).toHaveTextContent('11/2/21')
                 expect(rows[3]).toHaveTextContent('Rate certification')
                 expect(rows[4]).toHaveTextContent('rates cert 2')
                 expect(document.body).toHaveTextContent(/Submission type/)
@@ -714,9 +714,7 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        /Risk-sharing strategy/
-                    )
+                    screen.getByText(/Risk-sharing strategy/)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText(
@@ -742,9 +740,7 @@ describe('SubmissionSummary', () => {
                     screen.getByText('Network adequacy standards')
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        /Non-risk payment arrangements/
-                    )
+                    screen.getByText(/Non-risk payment arrangements/)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByRole('definition', {
@@ -955,10 +951,10 @@ describe('SubmissionSummary', () => {
                 expect(rows[0]).toHaveTextContent('Document name')
                 expect(rows[0]).toHaveTextContent('Document category')
                 expect(rows[1]).toHaveTextContent('contract doc')
-                expect(rows[1]).toHaveTextContent('5/13/21')
+                expect(rows[1]).toHaveTextContent('1/2/21')
                 expect(rows[1]).toHaveTextContent('Contract')
                 expect(rows[3]).toHaveTextContent('contract doc')
-                expect(rows[3]).toHaveTextContent('5/13/21')
+                expect(rows[3]).toHaveTextContent('1/2/21')
                 expect(rows[3]).toHaveTextContent('Contract-supporting')
                 expect(rows[4]).toHaveTextContent('Document')
                 expect(document.body).toHaveTextContent(/Submission type/)
@@ -1086,9 +1082,7 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        /Risk-sharing strategy/
-                    )
+                    screen.getByText(/Risk-sharing strategy/)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText(
@@ -1114,9 +1108,7 @@ describe('SubmissionSummary', () => {
                     screen.getByText('Network adequacy standards')
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        /Non-risk payment arrangements/
-                    )
+                    screen.getByText(/Non-risk payment arrangements/)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByRole('definition', {
@@ -1322,17 +1314,17 @@ describe('SubmissionSummary', () => {
                 expect(rows[0]).toHaveTextContent('Document name')
                 expect(rows[0]).toHaveTextContent('Document category')
                 expect(rows[1]).toHaveTextContent('contract doc')
-                expect(rows[1]).toHaveTextContent('5/13/21')
+                expect(rows[1]).toHaveTextContent('1/2/21')
                 expect(rows[1]).toHaveTextContent('Contract')
                 expect(rows[2]).toHaveTextContent('Document')
                 expect(rows[3]).toHaveTextContent('contract doc')
-                expect(rows[3]).toHaveTextContent('5/13/21')
+                expect(rows[3]).toHaveTextContent('1/2/21')
                 expect(rows[3]).toHaveTextContent('Contract-supporting')
                 expect(rows[4]).toHaveTextContent('Document')
                 expect(rows[5]).toHaveTextContent('rates cert 1')
-                expect(rows[5]).toHaveTextContent('5/13/21')
+                expect(rows[5]).toHaveTextContent('1/2/21')
                 expect(rows[5]).toHaveTextContent('Rate certification')
-                expect(rows[6]).toHaveTextContent('5/13/21')
+                expect(rows[6]).toHaveTextContent('1/2/21')
                 expect(document.body).toHaveTextContent(/Submission type/)
                 expect(
                     screen.getByRole('heading', {
@@ -1458,9 +1450,7 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        /Risk-sharing strategy/
-                    )
+                    screen.getByText(/Risk-sharing strategy/)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText(
@@ -1486,9 +1476,7 @@ describe('SubmissionSummary', () => {
                     screen.getByText('Network adequacy standards')
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        /Non-risk payment arrangements/
-                    )
+                    screen.getByText(/Non-risk payment arrangements/)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByRole('definition', {
@@ -1693,17 +1681,17 @@ describe('SubmissionSummary', () => {
                 expect(rows[0]).toHaveTextContent('Document name')
                 expect(rows[0]).toHaveTextContent('Document category')
                 expect(rows[1]).toHaveTextContent('contract doc')
-                expect(rows[1]).toHaveTextContent('5/13/21')
+                expect(rows[1]).toHaveTextContent('1/2/21')
                 expect(rows[1]).toHaveTextContent('Contract')
                 expect(rows[2]).toHaveTextContent('Document')
                 expect(rows[3]).toHaveTextContent('contract doc')
-                expect(rows[3]).toHaveTextContent('5/13/21')
+                expect(rows[3]).toHaveTextContent('1/2/21')
                 expect(rows[3]).toHaveTextContent('Contract-supporting')
                 expect(rows[4]).toHaveTextContent('Document')
                 expect(rows[5]).toHaveTextContent('rates cert 1')
-                expect(rows[5]).toHaveTextContent('5/13/21')
+                expect(rows[5]).toHaveTextContent('1/2/21')
                 expect(rows[5]).toHaveTextContent('Rate certification')
-                expect(rows[6]).toHaveTextContent('5/13/21')
+                expect(rows[6]).toHaveTextContent('1/2/21')
                 expect(document.body).toHaveTextContent(/Submission type/)
                 expect(
                     screen.getByRole('heading', {
@@ -1829,9 +1817,7 @@ describe('SubmissionSummary', () => {
                     )
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        /Risk-sharing strategy/
-                    )
+                    screen.getByText(/Risk-sharing strategy/)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByText(
@@ -1857,9 +1843,7 @@ describe('SubmissionSummary', () => {
                     screen.getByText('Network adequacy standards')
                 ).toBeInTheDocument()
                 expect(
-                    screen.getByText(
-                        /Non-risk payment arrangements/
-                    )
+                    screen.getByText(/Non-risk payment arrangements/)
                 ).toBeInTheDocument()
                 expect(
                     screen.getByRole('definition', {

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -65,7 +65,7 @@ export const SubmissionSummary = (): React.ReactElement => {
         featureFlags.CMS_QUESTIONS.defaultValue
     )
 
-    const { pkg, currentRevision, packageData, user, documentDates } =
+    const { pkg, currentRevision, packageData, user} =
         useOutletContext<SideNavOutletContextType>()
 
     const isCMSUser = user?.role === 'CMS_USER'
@@ -161,7 +161,6 @@ export const SubmissionSummary = (): React.ReactElement => {
                 />
                 <ContractDetailsSummarySection
                     submission={packageData}
-                    documentDateLookupTable={documentDates}
                     isCMSUser={isCMSUser}
                     submissionName={packageName(packageData, statePrograms)}
                 />
@@ -170,7 +169,6 @@ export const SubmissionSummary = (): React.ReactElement => {
                     <RateDetailsSummarySection
                         submission={packageData}
                         submissionName={packageName(packageData, statePrograms)}
-                        documentDateLookupTable={documentDates}
                         isCMSUser={isCMSUser}
                         statePrograms={statePrograms}
                     />

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -65,7 +65,7 @@ export const SubmissionSummary = (): React.ReactElement => {
         featureFlags.CMS_QUESTIONS.defaultValue
     )
 
-    const { pkg, currentRevision, packageData, user} =
+    const { pkg, currentRevision, packageData, user, documentDates } =
         useOutletContext<SideNavOutletContextType>()
 
     const isCMSUser = user?.role === 'CMS_USER'
@@ -160,6 +160,7 @@ export const SubmissionSummary = (): React.ReactElement => {
                     initiallySubmittedAt={pkg.initiallySubmittedAt}
                 />
                 <ContractDetailsSummarySection
+                    documentDateLookupTable={documentDates}
                     submission={packageData}
                     isCMSUser={isCMSUser}
                     submissionName={packageName(packageData, statePrograms)}
@@ -167,6 +168,7 @@ export const SubmissionSummary = (): React.ReactElement => {
 
                 {isContractActionAndRateCertification && (
                     <RateDetailsSummarySection
+                        documentDateLookupTable={documentDates}
                         submission={packageData}
                         submissionName={packageName(packageData, statePrograms)}
                         isCMSUser={isCMSUser}

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -28,10 +28,6 @@ import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { featureFlags } from '../../common-code/featureFlags'
 import { SideNavOutletContextType } from '../SubmissionSideNav/SubmissionSideNav'
 
-export type DocumentDateLookupTable = {
-    [key: string]: string
-}
-
 function UnlockModalButton({
     disabled,
     modalRef,

--- a/services/app-web/src/testHelpers/apolloMocks/healthPlanPackageGQLMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/healthPlanPackageGQLMock.ts
@@ -18,6 +18,7 @@ import {
     UpdateHealthPlanFormDataMutation,
     CreateHealthPlanPackageDocument,
     CreateHealthPlanPackageMutation,
+    HealthPlanRevision,
 } from '../../gen/gqlClient'
 import {
     mockContractAndRatesDraft,
@@ -125,12 +126,18 @@ const fetchStateHealthPlanPackageMockSuccess = ({
 
 const mockSubmittedHealthPlanPackageWithRevision = ({
     currentSubmissionData,
+    currentSubmitInfo,
     previousSubmissionData,
+    previousSubmitInfo,
     initialSubmissionData,
+    initialSubmitInfo,
 }: {
     currentSubmissionData?: Partial<UnlockedHealthPlanFormDataType>
+    currentSubmitInfo?: Partial<HealthPlanRevision['submitInfo']>
     previousSubmissionData?: Partial<UnlockedHealthPlanFormDataType>
+    previousSubmitInfo?: Partial<HealthPlanRevision['submitInfo']>
     initialSubmissionData?: Partial<UnlockedHealthPlanFormDataType>
+    initialSubmitInfo?: Partial<HealthPlanRevision['submitInfo']>
 }): HealthPlanPackage => {
     const currentFiles: Partial<UnlockedHealthPlanFormDataType> = {
         contractDocuments: [
@@ -151,15 +158,21 @@ const mockSubmittedHealthPlanPackageWithRevision = ({
                     {
                         s3URL: 's3://bucketname/1648242665634-Amerigroup Texas, Inc.pdf/Amerigroup Texas, Inc.pdf',
                         name: 'Amerigroup Texas, Inc.pdf',
-                        documentCategories: ['RATES_RELATED'],
+                        documentCategories: ['RATES'],
                     },
                     {
                         s3URL: 's3://bucketname/1648242711421-Amerigroup Texas Inc copy.pdf/Amerigroup Texas Inc copy.pdf',
                         name: 'Amerigroup Texas Inc copy.pdf',
+                        documentCategories: ['RATES'],
+                    },
+                ],
+                supportingDocuments: [
+                    {
+                        s3URL: 's3://bucketname/1648242873229-covid-ifc-2-flu-rsv-codes 5-5-2021.pdf/covid-ifc-2-flu-rsv-codes 5-5-2021.pdf',
+                        name: 'covid-ifc-2-flu-rsv-codes 5-5-2021.pdf',
                         documentCategories: ['RATES_RELATED'],
                     },
                 ],
-                supportingDocuments: [],
                 actuaryContacts: [],
                 packagesWithSharedRateCerts: [],
             },
@@ -169,11 +182,6 @@ const mockSubmittedHealthPlanPackageWithRevision = ({
                 s3URL: 's3://bucketname/1648242711421-529-10-0020-00003_Superior_Health Plan, Inc.pdf/529-10-0020-00003_Superior_Health Plan, Inc.pdf',
                 name: '529-10-0020-00003_Superior_Health Plan, Inc.pdf',
                 documentCategories: ['CONTRACT_RELATED'],
-            },
-            {
-                s3URL: 's3://bucketname/1648242873229-covid-ifc-2-flu-rsv-codes 5-5-2021.pdf/covid-ifc-2-flu-rsv-codes 5-5-2021.pdf',
-                name: 'covid-ifc-2-flu-rsv-codes 5-5-2021.pdf',
-                documentCategories: ['RATES_RELATED'],
             },
         ],
     }
@@ -214,7 +222,13 @@ const mockSubmittedHealthPlanPackageWithRevision = ({
                         documentCategories: ['RATES'],
                     },
                 ],
-                supportingDocuments: [],
+                supportingDocuments: [
+                    {
+                        s3URL: 's3://bucketname/1648242711421-529-10-0020-00003_Superior_Health Plan, Inc.pdf/529-10-0020-00003_Superior_Health Plan, Inc.pdf',
+                        name: '529-10-0020-00003_Superior_Health Plan, Inc.pdf',
+                        documentCategories: ['RATES_RELATED'],
+                    },
+                ],
                 actuaryContacts: [],
                 packagesWithSharedRateCerts: [],
             },
@@ -230,11 +244,6 @@ const mockSubmittedHealthPlanPackageWithRevision = ({
                 name: 'Amerigroup Texas Inc copy.pdf',
                 documentCategories: ['CONTRACT_RELATED'],
             },
-            {
-                s3URL: 's3://bucketname/1648242711421-529-10-0020-00003_Superior_Health Plan, Inc.pdf/529-10-0020-00003_Superior_Health Plan, Inc.pdf',
-                name: '529-10-0020-00003_Superior_Health Plan, Inc.pdf',
-                documentCategories: ['RATES_RELATED'],
-            },
         ],
     }
 
@@ -243,16 +252,36 @@ const mockSubmittedHealthPlanPackageWithRevision = ({
         ...currentFiles,
         ...currentSubmissionData,
     })
+    const currentSubmit = {
+        updatedAt: '2022-03-28T17:56:32.952Z',
+        updatedBy: 'aang@example.com',
+        updatedReason: 'Placeholder resubmission reason',
+        ...currentSubmitInfo,
+    }
     const previousProto = domainToBase64({
         ...unlockedWithALittleBitOfEverything(),
         ...previousFiles,
         ...previousSubmissionData,
     })
+
+    const previousSubmit = {
+        updatedAt: '2022-03-25T21:14:43.057Z',
+        updatedBy: 'aang@example.com',
+        updatedReason: 'Placeholder resubmission reason',
+        ...previousSubmitInfo,
+    }
     const initialProto = domainToBase64({
         ...mockContractAndRatesDraft(),
         ...previousFiles,
         ...initialSubmissionData,
     })
+
+    const initialSubmit = {
+        updatedAt: '2022-03-25T21:13:20.419Z',
+        updatedBy: 'aang@example.com',
+        updatedReason: 'Initial submission',
+        ...initialSubmitInfo,
+    }
     return {
         __typename: 'HealthPlanPackage',
         id: '07f9efbf-d4d1-44ae-8674-56d9d6b75ce6',
@@ -278,9 +307,7 @@ const mockSubmittedHealthPlanPackageWithRevision = ({
                     },
                     submitInfo: {
                         __typename: 'UpdateInformation',
-                        updatedAt: '2022-03-28T17:56:32.952Z',
-                        updatedBy: 'aang@example.com',
-                        updatedReason: 'Placeholder resubmission reason',
+                        ...currentSubmit,
                     },
                     createdAt: '2022-03-28T17:54:39.175Z',
                     formDataProto: currentProto,
@@ -299,9 +326,7 @@ const mockSubmittedHealthPlanPackageWithRevision = ({
                     },
                     submitInfo: {
                         __typename: 'UpdateInformation',
-                        updatedAt: '2022-03-25T21:14:43.057Z',
-                        updatedBy: 'aang@example.com',
-                        updatedReason: 'Placeholder resubmission reason',
+                        ...previousSubmit,
                     },
                     createdAt: '2022-03-25T21:13:56.176Z',
                     formDataProto: previousProto,
@@ -315,9 +340,7 @@ const mockSubmittedHealthPlanPackageWithRevision = ({
                     unlockInfo: null,
                     submitInfo: {
                         __typename: 'UpdateInformation',
-                        updatedAt: '2022-03-25T21:13:20.419Z',
-                        updatedBy: 'aang@example.com',
-                        updatedReason: 'Initial submission',
+                        ...initialSubmit,
                     },
                     createdAt: '2022-03-25T03:28:56.244Z',
                     formDataProto: initialProto,


### PR DESCRIPTION
## Summary
Use the `submitInfo.updatedAt` instead of the proto `updatedAt` to determine the date added for documents.

#### Related issues
https://qmacbis.atlassian.net/browse/MR-3578

#### Screenshots

#### Test cases covered
`UploadedDocumentsTable` has some new tests to reflect the new behavior on review and submit with new submissions (don't show any date/empty string)

## QA guidance
I ended up separating off the refactor so this change is pretty contained to uploaded documents behavior i would test that across submissions 