### PR TITLE
MR-3541: Fix "Let us know" link goes to 404 page

### DIFF
--- a/services/app-web/src/components/Banner/GenericApiErrorBanner/GenericApiErrorBanner.tsx
+++ b/services/app-web/src/components/Banner/GenericApiErrorBanner/GenericApiErrorBanner.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styles from '../Banner.module.scss'
-import { Alert, Link } from '@trussworks/react-uswds'
+import { Alert } from '@trussworks/react-uswds'
 import { ERROR_MESSAGES } from '../../../constants/errors'
 import { useStringConstants } from '../../../hooks/useStringConstants'
 
@@ -39,7 +39,14 @@ export const GenericApiErrorBanner = ({
                                 Please refresh your browser and if you continue
                                 to experience an error,&nbsp;
                             </span>
-                            <Link href={MAIL_TO_SUPPORT}>let us know.</Link>
+                            <a
+                                href={`mailto: ${MAIL_TO_SUPPORT}, mc-review-team@truss.works`}
+                                className="usa-link"
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                let us know.
+                            </a>
                         </>
                     )}
                 </p>

--- a/services/app-web/src/pages/Errors/GenericErrorPage.tsx
+++ b/services/app-web/src/pages/Errors/GenericErrorPage.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
-
-import { Link } from '@trussworks/react-uswds'
+import { useStringConstants } from '../../hooks/useStringConstants'
 import styles from './Errors.module.scss'
 
 import { PageHeading } from '../../components/PageHeading'
 import { GridContainer } from '@trussworks/react-uswds'
 
 export const GenericErrorPage = (): React.ReactElement => {
+    const stringConstants = useStringConstants()
+    const MAIL_TO_SUPPORT = stringConstants.MAIL_TO_SUPPORT
     return (
         <section className={styles.errorsContainer}>
             <GridContainer>
@@ -14,11 +15,17 @@ export const GenericErrorPage = (): React.ReactElement => {
                 <p>
                     <span>
                         We're having trouble loading this page. Please refresh
-                        your browser and if you continue to experience an error,&nbsp;
+                        your browser and if you continue to experience an
+                        error,&nbsp;
                     </span>
-                    <Link href="mailto:mc-review-team@truss.works">
+                    <a
+                        href={`mailto: ${MAIL_TO_SUPPORT}, mc-review-team@truss.works`}
+                        className="usa-link"
+                        target="_blank"
+                        rel="noreferrer"
+                    >
                         let us know.
-                    </Link>
+                    </a>
                 </p>
             </GridContainer>
         </section>


### PR DESCRIPTION
## Summary
[MR-3541](https://qmacbis.atlassian.net/browse/MR-3541)

Fixed the `GenericErrorBanner` `href` link to open to email box correctly and unified `let us know` links to be consistent with how we display help desk links everywhere else.

Also updated the `GenericErrorPage` link to the help desk email.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
