### PR TITLE
MR-3569: Prod: User reported error in downloading zip files

### DIFF
--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -153,6 +153,7 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
         ): Promise<string> => {
             const result = await Storage.get(key, {
                 bucket: bucketConfig[bucket],
+                expires: 3600,
             })
             if (typeof result === 'string') {
                 return result
@@ -189,7 +190,7 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
                 return error
             }
 
-            return await Storage.get(filename)
+            return await Storage.get(filename, { expires: 3600 })
         },
     }
 }


### PR DESCRIPTION
## Summary
[MR-3569](https://qmacbis.atlassian.net/browse/MR-3569)

Changed the expiration for the document URLs to 1 hour. I was still able to download files past 15 minutes.

<img src="https://github.com/Enterprise-CMCS/managed-care-review/assets/98117700/99158984-4003-41b5-8406-a12dc1aeba54" width="400" />


This is the error after an hour (Using a different file)
<img src="https://github.com/Enterprise-CMCS/managed-care-review/assets/98117700/2dede73a-fb7a-4c00-9e6d-f65864e50b12" width="400" />



#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
If you keep opening the same file, it will work past 1 hour. Not sure why, maybe it's cached? But below are instructions on how to correctly test the expiration time.

For testing this issue:

1. Open a submission, but do not click on any file.
2. Wait 45 minutes or right before an hour.
3. Click on any file to download, and it should still work
4. Wait past 1 hour and click on **A DIFFERENT file** and it should open a new tab to an error.

<!---These are developer instructions on how to test or validate the work -->
