### PR TITLE
Fix SecurityHub CloudFront.5 logging

### DIFF
--- a/services/infra-api/serverless.yml
+++ b/services/infra-api/serverless.yml
@@ -14,7 +14,7 @@ custom:
   stage: ${opt:stage, self:provider.stage}
   wafExcludeRules:
     awsCommon:
-      - "SizeRestrictions_BODY"
+      - 'SizeRestrictions_BODY'
   nrLicenseKey: ${ssm:/configuration/nr_license_key}
   nrMetricStreamName: 'NewRelic-Metric-Stream'
   nrFirehoseStreamName: 'NewRelic-Delivery-Stream'

--- a/services/storybook/serverless.yml
+++ b/services/storybook/serverless.yml
@@ -156,6 +156,9 @@ resources:
             Fn::GetAtt:
               - CloudFrontWebAcl
               - Arn
+          Logging:
+            Bucket: !Ref S3Bucket
+            Prefix: ${sls:stage}-${self:service}-cloudfront-logs/
 
   Outputs:
     S3BucketName:

--- a/services/storybook/serverless.yml
+++ b/services/storybook/serverless.yml
@@ -46,6 +46,10 @@ resources:
           ServerSideEncryptionConfiguration:
             - ServerSideEncryptionByDefault:
                 SSEAlgorithm: AES256
+        OwnershipControls:
+          Rules:
+            - ObjectOwnership: ObjectWriter
+
     BucketPolicy:
       Type: AWS::S3::BucketPolicy
       Properties:
@@ -71,6 +75,7 @@ resources:
                 - !Sub ${S3Bucket.Arn}/*
               Sid: DenyUnencryptedConnections
         Bucket: !Ref S3Bucket
+
     CloudFrontWebAcl:
       Type: AWS::WAFv2::WebACL
       Properties:
@@ -99,6 +104,7 @@ resources:
           CloudWatchMetricsEnabled: true
           SampledRequestsEnabled: true
           MetricName: ${sls:stage}-webacl
+
     CloudFrontOriginAccessIdentity:
       Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
       Properties:
@@ -157,7 +163,7 @@ resources:
               - CloudFrontWebAcl
               - Arn
           Logging:
-            Bucket: !Ref S3Bucket
+            Bucket: !Sub ${S3Bucket.DomainName}
             Prefix: ${sls:stage}-${self:service}-cloudfront-logs/
 
   Outputs:

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -45,6 +45,10 @@ resources:
           ServerSideEncryptionConfiguration:
             - ServerSideEncryptionByDefault:
                 SSEAlgorithm: AES256
+        OwnershipControls:
+          Rules:
+            - ObjectOwnership: ObjectWriter
+
     BucketPolicy:
       Type: AWS::S3::BucketPolicy
       Properties:
@@ -67,6 +71,7 @@ resources:
                 - !Sub ${S3Bucket.Arn}/*
               Sid: DenyUnencryptedConnections
         Bucket: !Ref S3Bucket
+
     CloudFrontWebAcl:
       Type: AWS::WAFv2::WebACL
       Properties:
@@ -95,6 +100,7 @@ resources:
           CloudWatchMetricsEnabled: true
           SampledRequestsEnabled: true
           MetricName: ${sls:stage}-webacl
+
     CloudFrontOriginAccessIdentity:
       Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
       Properties:
@@ -146,7 +152,7 @@ resources:
               ResponsePagePath: /index.html
           WebACLId: !GetAtt CloudFrontWebAcl.Arn
           Logging:
-            Bucket: !Ref S3Bucket
+            Bucket: !Sub ${S3Bucket.DomainName}
             Prefix: ${sls:stage}-${self:service}-cloudfront-logs/
 
     HstsCloudfrontFunction:

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -145,6 +145,9 @@ resources:
               ResponseCode: 200
               ResponsePagePath: /index.html
           WebACLId: !GetAtt CloudFrontWebAcl.Arn
+          Logging:
+            Bucket: !Ref S3Bucket
+            Prefix: ${sls:stage}-${self:service}-cloudfront-logs/
 
     HstsCloudfrontFunction:
       Type: AWS::CloudFront::Function


### PR DESCRIPTION
## Summary

This resolves the security hub notice `CloudFront.5 CloudFront distributions should have logging enabled`. It adds logging to the CloudFront bucket under a prefix path of `$stage-$service-cloudfront-logs`.

#### Related issues
https://qmacbis.atlassian.net/browse/MR-3105

