### PR TITLE
Fix document download warning banner margin for Q&A flag off UI

### DIFF
--- a/services/app-web/src/components/Banner/DocumentWarningBanner/DocumentWarningBanner.tsx
+++ b/services/app-web/src/components/Banner/DocumentWarningBanner/DocumentWarningBanner.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
-import styles from '../Banner.module.scss'
 import { Alert } from '@trussworks/react-uswds'
 import { useStringConstants } from '../../../hooks/useStringConstants'
 import classnames from 'classnames'
 
-export const DocumentWarningBanner = (): React.ReactElement => {
+export const DocumentWarningBanner = ({
+    className,
+}: React.HTMLAttributes<HTMLDivElement>): React.ReactElement => {
     const stringConstants = useStringConstants()
     const MAIL_TO_SUPPORT = stringConstants.MAIL_TO_SUPPORT
     return (
@@ -14,7 +15,7 @@ export const DocumentWarningBanner = (): React.ReactElement => {
             heading={`Document download unavailable`}
             headingLevel="h4"
             data-testid="warning-alert"
-            className={classnames(styles.bannerBodyText, 'usa-alert__text')}
+            className={classnames(className, 'usa-alert__text')}
         >
             <span>
                 Some documents aren’t available right now. Refresh the page to

--- a/services/app-web/src/components/DownloadButton/DownloadButton.tsx
+++ b/services/app-web/src/components/DownloadButton/DownloadButton.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentProps } from 'react'
 import { Link } from '@trussworks/react-uswds'
 import { Spinner } from '../Spinner'
-import styles from '../ActionButton/ActionButton.module.scss'
+import styles from './DownloadButton.module.scss'
 import classnames from 'classnames'
 
 type DownloadButtonProps = {

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -127,7 +127,9 @@ export const SubmissionSummary = (): React.ReactElement => {
                     />
                 )}
 
-                {documentError && <DocumentWarningBanner />}
+                {!documentError && (
+                    <DocumentWarningBanner className={styles.banner} />
+                )}
 
                 {!showQuestionResponse && (
                     <Link

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -127,7 +127,7 @@ export const SubmissionSummary = (): React.ReactElement => {
                     />
                 )}
 
-                {!documentError && (
+                {documentError && (
                     <DocumentWarningBanner className={styles.banner} />
                 )}
 


### PR DESCRIPTION
## Summary
Fixed margins for warning banner when the Q&A UI is toggled off.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
