### PR TITLE
Skip ahead to re-run only Cypress

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -405,10 +405,6 @@ jobs:
           echo $endpoint
           echo "storybook-endpoint=$endpoint" >> "$GITHUB_OUTPUT"
 
-      - name: Generate unique ID for Cypress
-        id: uuid
-        run: echo "value=sha-$GITHUB_SHA-time-$(date +"%s")" >> "$GITHUB_OUTPUT"
-
   end-deployment:
     needs: [begin-deployment, deploy-app, finishing-prep]
     if: always() && needs.begin-deployment.result == 'success'
@@ -491,7 +487,7 @@ jobs:
           parallel: true
           browser: chrome
           group: 'Chrome'
-          ci-build-id: ${{ needs.finishing-prep.outputs.cypress-uuid }}
+          ci-build-id: ${{ github.run_id }}-${{ github.run_attempt }}
           # Point to the cypress config file from root
           config-file: services/cypress/cypress.config.ts
         env:

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ If you are going to need to modify the migration that prisma generates you can u
 
 Whenever you run `./dev postgres` we start a new postgres docker container and run `prisma migrate reset --force` to clean it out and run all of our checked in migrations there. After that you should be ready to develop.
 
-## Build & Deploy
+## Build & Deploy in CI
 
 See main build/deploy [here](https://github.com/Enterprise-CMCS/managed-care-review/actions/workflows/promote.yml?query=branch%3Amain)
 
@@ -184,7 +184,9 @@ This application is deployed into three different AWS accounts: Dev, Val, and Pr
 
 In the Dev account, in addition to deploying the main branch, we deploy a full version of the app on every branch that is pushed that is not the main branch. We call these deployments "review apps" since they host all the changes for a PR in a full deployment. These review apps are differentiated by their Serverless "stack" name. This is set to the branch name and all infra ends up being prefixed with it to keep from there being any overlapping.
 
-We have a script (`getChangedServices`) that runs in CI to check if a service needs to be re-deployed due to your most recent commit or if a service can be skipped in order to save CI deploy time. For example, if you're just making changes to `app-web`, it's likely that you won't need to re-deploy any infra services, such as postgres, after an initial branch deploy. However, if you do need your branch to be fully re-deployed, you can add the string `force-ci-run` to your commit message and the entire deploy workflow will be run.
+#### CI stage skipping script
+
+We have a script (`getChangedServices`) that runs in CI to check if a service needs to be re-deployed due to your most recent commit or if a service can be skipped in order to save CI deploy time. For example, if you're just making changes to `app-web`, it's likely that you won't need to re-deploy any infra services, such as postgres, after an initial branch deploy. However, if you do need your branch to be fully re-deployed, you can add the string `force-ci-run` to your commit message and the entire deploy workflow will be run. If you have a failing Cypress container and want to skip over deploying infra and the application, use the string `cypress re-run` in a commit message and the `getChangedServices` script will skip you to the Cypress run (unit tests will still run, but it still saves time).
 
 You can see the deploys for review apps [here](https://github.com/Enterprise-CMCS/managed-care-review/actions/workflows/deploy.yml)
 

--- a/scripts/get-changed-services/index.ts
+++ b/scripts/get-changed-services/index.ts
@@ -33,6 +33,12 @@ async function main() {
         return
     }
 
+    // force just a cypress re-run
+    if (commitMessage.includes('cypress re-run')) {
+        core.setOutput('changed-services', [])
+        return
+    }
+
     // if we haven't had a run on this branch, we need to deploy everything
     if (allWorkflowRuns.data.total_count === 0) {
         core.setOutput('changed-services', deployAllServices)

--- a/scripts/get-changed-services/index.ts
+++ b/scripts/get-changed-services/index.ts
@@ -28,6 +28,8 @@ async function main() {
     // get the latest commit in the branch to see if we are forcing a run
     const latestCommit = await getLatestCommitSHA()
     const commitMessage = await getLatestCommitMessage(latestCommit)
+
+    // force a complete CI run
     if (commitMessage.includes('ci-force-run')) {
         core.setOutput('changed-services', deployAllServices)
         return


### PR DESCRIPTION
## Summary

There is a bug -- or really, a lack of functionality -- with cypress re-runs when using the GHA `re-run failed jobs` option, which is a [known issue](https://github.com/cypress-io/github-action/issues/531#issuecomment-1608902697). If you're using a parallelized container build in GHA CI (as we do) and a container or two has a failed spec, choosing to use the GHA `re-run failed jobs` feature will load _all_ of the Cypress tests onto that container that has failed and try to re-run everything there. This is unexpected, as I think people assume only the failed specs and other tests that were allocated to the failed container will re-run. Since we have a 25 minute timeout on Cypress runs, and we're running the entire test suite on a fraction of the containers in this scenario, we'll always hit that timeout and get a failed run.

I've added a bit of a hack-y workaround here until a re-run feature is taken on by the Cypress team. Basically, if the CI skipping script sees a commit message with `cypress re-run` in it, it'll skip past all the infra and app deploy stages and bring us right to the Cypress run stage. It's not as good as re-running only the failed test specs, but I guess it's better than having to wait for an entire CI deploy due to a flaky test.

This also changes the ID for cypress runs to help us correlate the run in Cypress dashboard to the GHA run a little easier.

#### Related issues
https://qmacbis.atlassian.net/browse/MR-3225
