### PR TITLE
MR-3639: Modify update hpp mutation

### DIFF
--- a/services/app-api/src/domain-models/contractAndRates/contractTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/contractTypes.ts
@@ -11,6 +11,13 @@ import {
 import { rateRevisionSchema } from './rateTypes'
 import { updateInfoSchema } from './updateInfoType'
 
+const managedCareEntitiesSchema = z.union([
+    z.literal('MCO'),
+    z.literal('PIHP'),
+    z.literal('PAHP'),
+    z.literal('PCCM'),
+])
+
 const contractFormDataSchema = z.object({
     programIDs: z.array(z.string()),
     populationCovered: populationCoveredSchema.optional(),
@@ -24,7 +31,7 @@ const contractFormDataSchema = z.object({
     contractDocuments: z.array(submissionDocumentSchema),
     contractDateStart: z.date().optional(),
     contractDateEnd: z.date().optional(),
-    managedCareEntities: z.array(z.string()),
+    managedCareEntities: z.array(managedCareEntitiesSchema),
     federalAuthorities: z.array(federalAuthoritySchema),
     inLieuServicesAndSettings: z.boolean().optional(),
     modifiedBenefitsProvided: z.boolean().optional(),

--- a/services/app-api/src/domain-models/contractAndRates/contractTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/contractTypes.ts
@@ -1,15 +1,20 @@
 import { z } from 'zod'
+import { rateRevisionSchema } from './rateTypes'
+import { updateInfoSchema } from './updateInfoType'
 import {
     contractExecutionStatusSchema,
     contractTypeSchema,
     federalAuthoritySchema,
     populationCoveredSchema,
     stateContactSchema,
-    submissionDocumentSchema,
     submissionTypeSchema,
 } from '../../../../app-web/src/common-code/proto/healthPlanFormDataProto/zodSchemas'
-import { rateRevisionSchema } from './rateTypes'
-import { updateInfoSchema } from './updateInfoType'
+
+const documentSchema = z.object({
+    name: z.string(),
+    s3URL: z.string(),
+    sha256: z.string().optional(),
+})
 
 const managedCareEntitiesSchema = z.union([
     z.literal('MCO'),
@@ -25,10 +30,10 @@ const contractFormDataSchema = z.object({
     riskBasedContract: z.boolean().optional(),
     submissionDescription: z.string(),
     stateContacts: z.array(stateContactSchema),
-    supportingDocuments: z.array(submissionDocumentSchema),
+    supportingDocuments: z.array(documentSchema),
     contractType: contractTypeSchema,
     contractExecutionStatus: contractExecutionStatusSchema.optional(),
-    contractDocuments: z.array(submissionDocumentSchema),
+    contractDocuments: z.array(documentSchema),
     contractDateStart: z.date().optional(),
     contractDateEnd: z.date().optional(),
     managedCareEntities: z.array(managedCareEntitiesSchema),

--- a/services/app-api/src/domain-models/contractAndRates/contractTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/contractTypes.ts
@@ -1,78 +1,5 @@
 import { z } from 'zod'
-import { rateRevisionSchema } from './rateTypes'
-import { updateInfoSchema } from './updateInfoType'
-import {
-    contractExecutionStatusSchema,
-    contractTypeSchema,
-    federalAuthoritySchema,
-    populationCoveredSchema,
-    stateContactSchema,
-    submissionTypeSchema,
-} from '../../../../app-web/src/common-code/proto/healthPlanFormDataProto/zodSchemas'
-
-const documentSchema = z.object({
-    name: z.string(),
-    s3URL: z.string(),
-    sha256: z.string().optional(),
-})
-
-const managedCareEntitiesSchema = z.union([
-    z.literal('MCO'),
-    z.literal('PIHP'),
-    z.literal('PAHP'),
-    z.literal('PCCM'),
-])
-
-const contractFormDataSchema = z.object({
-    programIDs: z.array(z.string()),
-    populationCovered: populationCoveredSchema.optional(),
-    submissionType: submissionTypeSchema,
-    riskBasedContract: z.boolean().optional(),
-    submissionDescription: z.string(),
-    stateContacts: z.array(stateContactSchema),
-    supportingDocuments: z.array(documentSchema),
-    contractType: contractTypeSchema,
-    contractExecutionStatus: contractExecutionStatusSchema.optional(),
-    contractDocuments: z.array(documentSchema),
-    contractDateStart: z.date().optional(),
-    contractDateEnd: z.date().optional(),
-    managedCareEntities: z.array(managedCareEntitiesSchema),
-    federalAuthorities: z.array(federalAuthoritySchema),
-    inLieuServicesAndSettings: z.boolean().optional(),
-    modifiedBenefitsProvided: z.boolean().optional(),
-    modifiedGeoAreaServed: z.boolean().optional(),
-    modifiedMedicaidBeneficiaries: z.boolean().optional(),
-    modifiedRiskSharingStrategy: z.boolean().optional(),
-    modifiedIncentiveArrangements: z.boolean().optional(),
-    modifiedWitholdAgreements: z.boolean().optional(),
-    modifiedStateDirectedPayments: z.boolean().optional(),
-    modifiedPassThroughPayments: z.boolean().optional(),
-    modifiedPaymentsForMentalDiseaseInstitutions: z.boolean().optional(),
-    modifiedMedicalLossRatioStandards: z.boolean().optional(),
-    modifiedOtherFinancialPaymentIncentive: z.boolean().optional(),
-    modifiedEnrollmentProcess: z.boolean().optional(),
-    modifiedGrevienceAndAppeal: z.boolean().optional(),
-    modifiedNetworkAdequacyStandards: z.boolean().optional(),
-    modifiedLengthOfContract: z.boolean().optional(),
-    modifiedNonRiskPaymentArrangements: z.boolean().optional(),
-})
-
-const contractRevisionSchema = z.object({
-    id: z.string().uuid(),
-    submitInfo: updateInfoSchema.optional(),
-    unlockInfo: updateInfoSchema.optional(),
-    createdAt: z.date(),
-    updatedAt: z.date(),
-    formData: contractFormDataSchema,
-})
-
-// ContractRevision has all the information in a single submission of this contract.
-// If a revision has been submitted it will have submitInfo (otherwise it will be a draft)
-// if a revision was unlocked, it will have unlock info, otherwise it was an initial submission
-// The set of rateRevisions hold exactly what rate data was present at the time this contract was submitted.
-const contractRevisionWithRatesSchema = contractRevisionSchema.extend({
-    rateRevisions: z.array(rateRevisionSchema),
-})
+import { contractRevisionWithRatesSchema } from './revisionTypes'
 
 // Contract represents the contract specific information in a submission package
 // All that data is contained in revisions, each revision represents the data in a single submission
@@ -94,22 +21,7 @@ const draftContractSchema = contractSchema.extend({
 })
 
 type ContractType = z.infer<typeof contractSchema>
-type ContractRevisionType = z.infer<typeof contractRevisionSchema>
-type ContractRevisionWithRatesType = z.infer<
-    typeof contractRevisionWithRatesSchema
->
-type ContractFormDataType = z.infer<typeof contractFormDataSchema>
 
-export {
-    contractRevisionSchema,
-    contractRevisionWithRatesSchema,
-    draftContractSchema,
-    contractSchema,
-}
+export { contractRevisionWithRatesSchema, draftContractSchema, contractSchema }
 
-export type {
-    ContractType,
-    ContractRevisionType,
-    ContractRevisionWithRatesType,
-    ContractFormDataType,
-}
+export type { ContractType }

--- a/services/app-api/src/domain-models/contractAndRates/formDataTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/formDataTypes.ts
@@ -1,0 +1,88 @@
+import { z } from 'zod'
+import {
+    actuaryCommunicationTypeSchema,
+    actuaryContactSchema,
+    contractExecutionStatusSchema,
+    contractTypeSchema,
+    federalAuthoritySchema,
+    populationCoveredSchema,
+    rateCapitationTypeSchema,
+    rateTypeSchema,
+    sharedRateCertDisplay,
+    stateContactSchema,
+    submissionDocumentSchema,
+    submissionTypeSchema,
+} from '../../../../app-web/src/common-code/proto/healthPlanFormDataProto/zodSchemas'
+
+const documentSchema = z.object({
+    name: z.string(),
+    s3URL: z.string(),
+    sha256: z.string().optional(),
+})
+
+const managedCareEntitiesSchema = z.union([
+    z.literal('MCO'),
+    z.literal('PIHP'),
+    z.literal('PAHP'),
+    z.literal('PCCM'),
+])
+
+const contractFormDataSchema = z.object({
+    programIDs: z.array(z.string()),
+    populationCovered: populationCoveredSchema.optional(),
+    submissionType: submissionTypeSchema,
+    riskBasedContract: z.boolean().optional(),
+    submissionDescription: z.string(),
+    stateContacts: z.array(stateContactSchema),
+    supportingDocuments: z.array(documentSchema),
+    contractType: contractTypeSchema,
+    contractExecutionStatus: contractExecutionStatusSchema.optional(),
+    contractDocuments: z.array(documentSchema),
+    contractDateStart: z.date().optional(),
+    contractDateEnd: z.date().optional(),
+    managedCareEntities: z.array(managedCareEntitiesSchema),
+    federalAuthorities: z.array(federalAuthoritySchema),
+    inLieuServicesAndSettings: z.boolean().optional(),
+    modifiedBenefitsProvided: z.boolean().optional(),
+    modifiedGeoAreaServed: z.boolean().optional(),
+    modifiedMedicaidBeneficiaries: z.boolean().optional(),
+    modifiedRiskSharingStrategy: z.boolean().optional(),
+    modifiedIncentiveArrangements: z.boolean().optional(),
+    modifiedWitholdAgreements: z.boolean().optional(),
+    modifiedStateDirectedPayments: z.boolean().optional(),
+    modifiedPassThroughPayments: z.boolean().optional(),
+    modifiedPaymentsForMentalDiseaseInstitutions: z.boolean().optional(),
+    modifiedMedicalLossRatioStandards: z.boolean().optional(),
+    modifiedOtherFinancialPaymentIncentive: z.boolean().optional(),
+    modifiedEnrollmentProcess: z.boolean().optional(),
+    modifiedGrevienceAndAppeal: z.boolean().optional(),
+    modifiedNetworkAdequacyStandards: z.boolean().optional(),
+    modifiedLengthOfContract: z.boolean().optional(),
+    modifiedNonRiskPaymentArrangements: z.boolean().optional(),
+})
+
+const rateFormDataSchema = z.object({
+    id: z.string().optional(),
+    rateType: rateTypeSchema.optional(),
+    rateCapitationType: rateCapitationTypeSchema.optional(),
+    rateDocuments: z.array(submissionDocumentSchema).optional(),
+    supportingDocuments: z.array(submissionDocumentSchema).optional(),
+    rateDateStart: z.date().optional(),
+    rateDateEnd: z.date().optional(),
+    rateDateCertified: z.date().optional(),
+    amendmentEffectiveDateStart: z.date().optional(),
+    amendmentEffectiveDateEnd: z.date().optional(),
+    rateProgramIDs: z.array(z.string()).optional(),
+    rateCertificationName: z.string().optional(),
+    certifyingActuaryContacts: z.array(actuaryContactSchema).optional(),
+    addtlActuaryContacts: z.array(actuaryContactSchema).optional(),
+    actuaryCommunicationPreference: actuaryCommunicationTypeSchema.optional(),
+    packagesWithSharedRateCerts: z.array(sharedRateCertDisplay).optional(),
+})
+
+type ContractFormDataType = z.infer<typeof contractFormDataSchema>
+type RateFormDataType = z.infer<typeof rateFormDataSchema>
+
+export { contractFormDataSchema, rateFormDataSchema }
+
+export type { ContractFormDataType, RateFormDataType }

--- a/services/app-api/src/domain-models/contractAndRates/index.ts
+++ b/services/app-api/src/domain-models/contractAndRates/index.ts
@@ -1,10 +1,9 @@
 export {
-   rateSchema,
-   rateRevisionSchema,
-   rateRevisionWithContractsSchema,
+    rateSchema,
+    rateRevisionSchema,
+    rateRevisionWithContractsSchema,
     draftRateSchema,
 } from './rateTypes'
-
 
 export type {
     RateType,

--- a/services/app-api/src/domain-models/contractAndRates/index.ts
+++ b/services/app-api/src/domain-models/contractAndRates/index.ts
@@ -1,29 +1,27 @@
+export { rateSchema, draftRateSchema } from './rateTypes'
+
+export type { RateType } from './rateTypes'
+
+export { contractSchema, draftContractSchema } from './contractTypes'
+
+export { contractFormDataSchema, rateFormDataSchema } from './formDataTypes'
+
 export {
-    rateSchema,
-    rateRevisionSchema,
     rateRevisionWithContractsSchema,
-    draftRateSchema,
-} from './rateTypes'
-
-export type {
-    RateType,
-    RateRevisionType,
-    RateRevisionWithContractsType,
-    RateFormDataType,
-} from './rateTypes'
-
-export {
-    contractSchema,
-    contractRevisionSchema,
     contractRevisionWithRatesSchema,
-    draftContractSchema,
-} from './contractTypes'
+    contractRevisionSchema,
+    rateRevisionSchema,
+} from './revisionTypes'
 
-export type {
-    ContractType,
-    ContractRevisionType,
-    ContractRevisionWithRatesType,
-    ContractFormDataType,
-} from './contractTypes'
+export type { ContractType } from './contractTypes'
 
 export type { ContractStatusType, UpdateInfoType } from './updateInfoType'
+
+export type { ContractFormDataType, RateFormDataType } from './formDataTypes'
+
+export type {
+    ContractRevisionType,
+    RateRevisionType,
+    RateRevisionWithContractsType,
+    ContractRevisionWithRatesType,
+} from './revisionTypes'

--- a/services/app-api/src/domain-models/contractAndRates/rateTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/rateTypes.ts
@@ -2,18 +2,31 @@ import { z } from 'zod'
 import {
     actuaryCommunicationTypeSchema,
     actuaryContactSchema,
+    rateCapitationTypeSchema,
+    rateTypeSchema,
+    sharedRateCertDisplay,
+    submissionDocumentSchema,
     contractExecutionStatusSchema,
     contractTypeSchema,
     federalAuthoritySchema,
     populationCoveredSchema,
-    rateCapitationTypeSchema,
-    rateTypeSchema,
-    sharedRateCertDisplay,
     stateContactSchema,
-    submissionDocumentSchema,
     submissionTypeSchema,
 } from '../../../../app-web/src/common-code/proto/healthPlanFormDataProto/zodSchemas'
 import { updateInfoSchema } from './updateInfoType'
+
+const documentSchema = z.object({
+    name: z.string(),
+    s3URL: z.string(),
+    sha256: z.string().optional(),
+})
+
+const managedCareEntitiesSchema = z.union([
+    z.literal('MCO'),
+    z.literal('PIHP'),
+    z.literal('PAHP'),
+    z.literal('PCCM'),
+])
 
 // hacky workaround - importing from contract types is causing circular imports and this error
 // https://github.com/colinhacks/zod/issues/643#issuecomment-1015277287
@@ -26,13 +39,13 @@ const _contractFormDataSchema = z.object({
     riskBasedContract: z.boolean().optional(),
     submissionDescription: z.string(),
     stateContacts: z.array(stateContactSchema),
-    supportingDocuments: z.array(submissionDocumentSchema),
+    supportingDocuments: z.array(documentSchema),
     contractType: contractTypeSchema,
     contractExecutionStatus: contractExecutionStatusSchema.optional(),
-    contractDocuments: z.array(submissionDocumentSchema),
+    contractDocuments: z.array(documentSchema),
     contractDateStart: z.date().optional(),
     contractDateEnd: z.date().optional(),
-    managedCareEntities: z.array(z.string()),
+    managedCareEntities: z.array(managedCareEntitiesSchema),
     federalAuthorities: z.array(federalAuthoritySchema),
     inLieuServicesAndSettings: z.boolean().optional(),
     modifiedBenefitsProvided: z.boolean().optional(),
@@ -61,7 +74,6 @@ const _contractRevisionSchema = z.object({
     updatedAt: z.date(),
     formData: _contractFormDataSchema,
 })
-//
 
 // The rate form data  is the form filled out by state users submitting rates for review
 const rateFormDataSchema = z.object({

--- a/services/app-api/src/domain-models/contractAndRates/rateTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/rateTypes.ts
@@ -1,115 +1,8 @@
 import { z } from 'zod'
 import {
-    actuaryCommunicationTypeSchema,
-    actuaryContactSchema,
-    rateCapitationTypeSchema,
-    rateTypeSchema,
-    sharedRateCertDisplay,
-    submissionDocumentSchema,
-    contractExecutionStatusSchema,
-    contractTypeSchema,
-    federalAuthoritySchema,
-    populationCoveredSchema,
-    stateContactSchema,
-    submissionTypeSchema,
-} from '../../../../app-web/src/common-code/proto/healthPlanFormDataProto/zodSchemas'
-import { updateInfoSchema } from './updateInfoType'
-
-const documentSchema = z.object({
-    name: z.string(),
-    s3URL: z.string(),
-    sha256: z.string().optional(),
-})
-
-const managedCareEntitiesSchema = z.union([
-    z.literal('MCO'),
-    z.literal('PIHP'),
-    z.literal('PAHP'),
-    z.literal('PCCM'),
-])
-
-// hacky workaround - importing from contract types is causing circular imports and this error
-// https://github.com/colinhacks/zod/issues/643#issuecomment-1015277287
-// we should resolve this issue to avoid duplicating efforts but hardcoding it for now to make progress
-
-const _contractFormDataSchema = z.object({
-    programIDs: z.array(z.string()),
-    populationCovered: populationCoveredSchema.optional(),
-    submissionType: submissionTypeSchema,
-    riskBasedContract: z.boolean().optional(),
-    submissionDescription: z.string(),
-    stateContacts: z.array(stateContactSchema),
-    supportingDocuments: z.array(documentSchema),
-    contractType: contractTypeSchema,
-    contractExecutionStatus: contractExecutionStatusSchema.optional(),
-    contractDocuments: z.array(documentSchema),
-    contractDateStart: z.date().optional(),
-    contractDateEnd: z.date().optional(),
-    managedCareEntities: z.array(managedCareEntitiesSchema),
-    federalAuthorities: z.array(federalAuthoritySchema),
-    inLieuServicesAndSettings: z.boolean().optional(),
-    modifiedBenefitsProvided: z.boolean().optional(),
-    modifiedGeoAreaServed: z.boolean().optional(),
-    modifiedMedicaidBeneficiaries: z.boolean().optional(),
-    modifiedRiskSharingStrategy: z.boolean().optional(),
-    modifiedIncentiveArrangements: z.boolean().optional(),
-    modifiedWitholdAgreements: z.boolean().optional(),
-    modifiedStateDirectedPayments: z.boolean().optional(),
-    modifiedPassThroughPayments: z.boolean().optional(),
-    modifiedPaymentsForMentalDiseaseInstitutions: z.boolean().optional(),
-    modifiedMedicalLossRatioStandards: z.boolean().optional(),
-    modifiedOtherFinancialPaymentIncentive: z.boolean().optional(),
-    modifiedEnrollmentProcess: z.boolean().optional(),
-    modifiedGrevienceAndAppeal: z.boolean().optional(),
-    modifiedNetworkAdequacyStandards: z.boolean().optional(),
-    modifiedLengthOfContract: z.boolean().optional(),
-    modifiedNonRiskPaymentArrangements: z.boolean().optional(),
-})
-// importing here bc of circular imports error
-const _contractRevisionSchema = z.object({
-    id: z.string().uuid(),
-    submitInfo: updateInfoSchema.optional(),
-    unlockInfo: updateInfoSchema.optional(),
-    createdAt: z.date(),
-    updatedAt: z.date(),
-    formData: _contractFormDataSchema,
-})
-
-// The rate form data  is the form filled out by state users submitting rates for review
-const rateFormDataSchema = z.object({
-    id: z.string().optional(),
-    rateType: rateTypeSchema.optional(),
-    rateCapitationType: rateCapitationTypeSchema.optional(),
-    rateDocuments: z.array(submissionDocumentSchema).optional(),
-    supportingDocuments: z.array(submissionDocumentSchema).optional(),
-    rateDateStart: z.date().optional(),
-    rateDateEnd: z.date().optional(),
-    rateDateCertified: z.date().optional(),
-    amendmentEffectiveDateStart: z.date().optional(),
-    amendmentEffectiveDateEnd: z.date().optional(),
-    rateProgramIDs: z.array(z.string()).optional(),
-    rateCertificationName: z.string().optional(),
-    certifyingActuaryContacts: z.array(actuaryContactSchema).optional(),
-    addtlActuaryContacts: z.array(actuaryContactSchema).optional(),
-    actuaryCommunicationPreference: actuaryCommunicationTypeSchema.optional(),
-    packagesWithSharedRateCerts: z.array(sharedRateCertDisplay).optional(),
-})
-
-// A Rate represents all the data associated with a single rate certification over time.
-// The rate's revisions field hold the array of rate revisions that show change history of specific rate data
-// The first revision (array index 0) is the current revision
-const rateRevisionSchema = z.object({
-    id: z.string().uuid(),
-    submitInfo: updateInfoSchema.optional(),
-    unlockInfo: updateInfoSchema.optional(),
-    createdAt: z.date(),
-    updatedAt: z.date(),
-    formData: rateFormDataSchema,
-})
-
-const rateRevisionWithContractsSchema = rateRevisionSchema.extend({
-    contractRevisions: z.array(_contractRevisionSchema),
-})
+    rateRevisionWithContractsSchema,
+    rateRevisionSchema,
+} from './revisionTypes'
 
 const rateSchema = z.object({
     id: z.string().uuid(),
@@ -127,11 +20,6 @@ const draftRateSchema = rateSchema.extend({
     revisions: z.array(rateRevisionWithContractsSchema).min(1),
 })
 type RateType = z.infer<typeof rateSchema>
-type RateRevisionType = z.infer<typeof rateRevisionSchema>
-type RateRevisionWithContractsType = z.infer<
-    typeof rateRevisionWithContractsSchema
->
-type RateFormDataType = z.infer<typeof rateFormDataSchema>
 
 export {
     rateRevisionSchema,
@@ -140,9 +28,4 @@ export {
     rateSchema,
 }
 
-export type {
-    RateType,
-    RateRevisionType,
-    RateRevisionWithContractsType,
-    RateFormDataType,
-}
+export type { RateType }

--- a/services/app-api/src/domain-models/contractAndRates/revisionTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/revisionTypes.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod'
+import { updateInfoSchema } from './updateInfoType'
+import { contractFormDataSchema, rateFormDataSchema } from './formDataTypes'
+
+const contractRevisionSchema = z.object({
+    id: z.string().uuid(),
+    submitInfo: updateInfoSchema.optional(),
+    unlockInfo: updateInfoSchema.optional(),
+    createdAt: z.date(),
+    updatedAt: z.date(),
+    formData: contractFormDataSchema,
+})
+
+const rateRevisionSchema = z.object({
+    id: z.string().uuid(),
+    submitInfo: updateInfoSchema.optional(),
+    unlockInfo: updateInfoSchema.optional(),
+    createdAt: z.date(),
+    updatedAt: z.date(),
+    formData: rateFormDataSchema,
+})
+
+const rateRevisionWithContractsSchema = rateRevisionSchema.extend({
+    contractRevisions: z.array(contractRevisionSchema),
+})
+
+const contractRevisionWithRatesSchema = contractRevisionSchema.extend({
+    rateRevisions: z.array(rateRevisionSchema),
+})
+
+type ContractRevisionType = z.infer<typeof contractRevisionSchema>
+type RateRevisionType = z.infer<typeof rateRevisionSchema>
+type RateRevisionWithContractsType = z.infer<
+    typeof rateRevisionWithContractsSchema
+>
+type ContractRevisionWithRatesType = z.infer<
+    typeof contractRevisionWithRatesSchema
+>
+
+export {
+    rateRevisionWithContractsSchema,
+    contractRevisionWithRatesSchema,
+    contractRevisionSchema,
+    rateRevisionSchema,
+}
+
+export type {
+    ContractRevisionType,
+    RateRevisionType,
+    RateRevisionWithContractsType,
+    ContractRevisionWithRatesType,
+}

--- a/services/app-api/src/domain-models/healthPlanPackage.ts
+++ b/services/app-api/src/domain-models/healthPlanPackage.ts
@@ -121,9 +121,7 @@ function convertContractRevisionToHealthPlanRevision(
             addtlActuaryContacts: [],
             documents: contractRev.formData.supportingDocuments.map((doc) => ({
                 ...doc,
-                documentCategories: doc.documentCategories.filter(
-                    (category) => category !== undefined
-                ),
+                documentCategories: ['CONTRACT_RELATED'],
             })) as SubmissionDocument[],
             contractType: contractRev.formData.contractType,
             contractExecutionStatus:
@@ -131,9 +129,7 @@ function convertContractRevisionToHealthPlanRevision(
             contractDocuments: contractRev.formData.contractDocuments.map(
                 (doc) => ({
                     ...doc,
-                    documentCategories: doc.documentCategories.filter(
-                        (category) => category !== undefined
-                    ),
+                    documentCategories: ['CONTRACT'],
                 })
             ) as SubmissionDocument[],
             contractDateStart: contractRev.formData.contractDateStart,

--- a/services/app-api/src/postgres/contractAndRates/findContractWithHistory.ts
+++ b/services/app-api/src/postgres/contractAndRates/findContractWithHistory.ts
@@ -18,7 +18,7 @@ async function findContractWithHistory(
                 id: contractID,
             },
             include: includeFullContract,
-    })
+        })
 
         if (!contract) {
             const err = `PRISMA ERROR: Cannot find contract with id: ${contractID}`

--- a/services/app-api/src/postgres/contractAndRates/index.ts
+++ b/services/app-api/src/postgres/contractAndRates/index.ts
@@ -1,7 +1,5 @@
-import type { InsertContractArgsType } from './insertContract'
-import { insertDraftContract } from './insertContract'
-import { findContractWithHistory } from './findContractWithHistory'
-
-export { insertDraftContract, findContractWithHistory }
-
-export type { InsertContractArgsType }
+export type { InsertContractArgsType } from './insertContract'
+export type { UpdateContractArgsType } from './updateDraftContract'
+export { insertDraftContract } from './insertContract'
+export { findContractWithHistory } from './findContractWithHistory'
+export { updateDraftContract } from './updateDraftContract'

--- a/services/app-api/src/postgres/contractAndRates/insertContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/insertContract.ts
@@ -3,13 +3,14 @@ import type {
     SubmissionType,
     ContractType as PrismaContractType,
 } from '@prisma/client'
-import type { ContractType } from '../../domain-models/contractAndRates'
+import type {
+    ContractType,
+    ContractFormDataType,
+} from '../../domain-models/contractAndRates'
 import { parseContractWithHistory } from './parseContractWithHistory'
 import { includeFullContract } from './prismaSubmittedContractHelpers'
-import type { ContractFormEditable } from './updateDraftContract'
 
-
-type InsertContractArgsType = ContractFormEditable & {
+type InsertContractArgsType = Partial<ContractFormDataType> & {
     // Certain fields are required on insert contract only
     stateCode: string
     programIDs: string[]

--- a/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
@@ -182,9 +182,6 @@ function contractFormDataToDomainModel(
                   name: doc.name,
                   s3URL: doc.s3URL,
                   sha256: doc.sha256 ?? undefined,
-                  documentCategories: [
-                      'CONTRACT_RELATED',
-                  ] as DocumentCategoryType[],
               }))
             : [],
         contractExecutionStatus:
@@ -194,7 +191,6 @@ function contractFormDataToDomainModel(
                   name: doc.name,
                   s3URL: doc.s3URL,
                   sha256: doc.sha256 ?? undefined,
-                  documentCategories: ['CONTRACT'] as DocumentCategoryType[],
               }))
             : [],
         contractDateStart: contractRevision.contractDateStart ?? undefined,

--- a/services/app-api/src/postgres/contractAndRates/prismaToDomainModel.test.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaToDomainModel.test.ts
@@ -21,17 +21,11 @@ describe('prismaToDomainModel', () => {
                             name: 'contract supporting doc',
                             s3URL: 'fakeS3URL',
                             sha256: '2342fwlkdmwvw',
-                            documentCategories: expect.arrayContaining([
-                                'CONTRACT_RELATED',
-                            ]),
                         }),
                         expect.objectContaining({
                             name: 'contract supporting doc 2',
                             s3URL: 'fakeS3URL',
                             sha256: '45662342fwlkdmwvw',
-                            documentCategories: expect.arrayContaining([
-                                'CONTRACT_RELATED',
-                            ]),
                         }),
                     ]),
                     contractDocuments: expect.arrayContaining([
@@ -39,9 +33,6 @@ describe('prismaToDomainModel', () => {
                             name: 'contract doc',
                             s3URL: 'fakeS3URL',
                             sha256: '8984234fwlkdmwvw',
-                            documentCategories: expect.arrayContaining([
-                                'CONTRACT',
-                            ]),
                         }),
                     ]),
                 })

--- a/services/app-api/src/postgres/contractAndRates/updateDraftContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/updateDraftContract.ts
@@ -167,4 +167,4 @@ async function updateDraftContract(
 }
 
 export { updateDraftContract }
-export type { ContractFormEditable }
+export type { ContractFormEditable, UpdateContractArgsType }

--- a/services/app-api/src/postgres/contractAndRates/updateDraftContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/updateDraftContract.ts
@@ -1,55 +1,12 @@
 import { findContractWithHistory } from './findContractWithHistory'
 import { NotFoundError } from '../storeError'
 import type { ContractType } from '../../domain-models/contractAndRates'
-import type {
-    ContractType as DomainContractType,
-    PopulationCoveredType,
-    SubmissionType,
-    ContractExecutionStatus,
-    StateContact,
-    ManagedCareEntity,
-    FederalAuthority,
-    SubmissionDocument,
-} from 'app-web/src/common-code/healthPlanFormDataType'
 import type { PrismaClient } from '@prisma/client'
-
-type ContractFormEditable = {
-    submissionType?: SubmissionType
-    submissionDescription?: string
-    programIDs?: string[]
-    populationCovered?: PopulationCoveredType
-    riskBasedContract?: boolean
-    stateContacts?: StateContact[]
-    supportingDocuments?: SubmissionDocument[]
-    contractType?: DomainContractType
-    contractExecutionStatus?: ContractExecutionStatus
-    contractDocuments?: SubmissionDocument[]
-    contractDateStart?: Date
-    contractDateEnd?: Date
-    managedCareEntities?: ManagedCareEntity[]
-    federalAuthorities?: FederalAuthority[]
-    modifiedBenefitsProvided?: boolean
-    modifiedGeoAreaServed?: boolean
-    modifiedMedicaidBeneficiaries?: boolean
-    modifiedRiskSharingStrategy?: boolean
-    modifiedIncentiveArrangements?: boolean
-    modifiedWitholdAgreements?: boolean
-    modifiedStateDirectedPayments?: boolean
-    modifiedPassThroughPayments?: boolean
-    modifiedPaymentsForMentalDiseaseInstitutions?: boolean
-    modifiedMedicalLossRatioStandards?: boolean
-    modifiedOtherFinancialPaymentIncentive?: boolean
-    modifiedEnrollmentProcess?: boolean
-    modifiedGrevienceAndAppeal?: boolean
-    modifiedNetworkAdequacyStandards?: boolean
-    modifiedLengthOfContract?: boolean
-    modifiedNonRiskPaymentArrangements?: boolean
-    inLieuServicesAndSettings?: boolean
-}
+import type { ContractFormDataType } from '../../domain-models/contractAndRates'
 
 type UpdateContractArgsType = {
     contractID: string
-    formData: ContractFormEditable
+    formData: Partial<ContractFormDataType>
     rateIDs: string[]
 }
 // Update the given draft
@@ -167,4 +124,4 @@ async function updateDraftContract(
 }
 
 export { updateDraftContract }
-export type { ContractFormEditable, UpdateContractArgsType }
+export type { UpdateContractArgsType }

--- a/services/app-api/src/postgres/postgresStore.ts
+++ b/services/app-api/src/postgres/postgresStore.ts
@@ -51,8 +51,12 @@ import type { ContractType } from '../domain-models/contractAndRates'
 import {
     insertDraftContract,
     findContractWithHistory,
+    updateDraftContract,
 } from './contractAndRates'
-import type { InsertContractArgsType } from './contractAndRates'
+import type {
+    InsertContractArgsType,
+    UpdateContractArgsType,
+} from './contractAndRates'
 
 type Store = {
     findPrograms: (
@@ -137,6 +141,10 @@ type Store = {
     findContractWithHistory: (
         contractID: string
     ) => Promise<ContractType | Error>
+
+    updateDraftContract: (
+        args: UpdateContractArgsType
+    ) => Promise<ContractType | Error>
 }
 
 function NewPostgresStore(client: PrismaClient): Store {
@@ -197,6 +205,7 @@ function NewPostgresStore(client: PrismaClient): Store {
         insertDraftContract: (args) => insertDraftContract(client, args),
         findContractWithHistory: (args) =>
             findContractWithHistory(client, args),
+        updateDraftContract: (args) => updateDraftContract(client, args),
     }
 }
 

--- a/services/app-api/src/resolvers/configureResolvers.ts
+++ b/services/app-api/src/resolvers/configureResolvers.ts
@@ -56,7 +56,10 @@ export function configureResolvers(
                 store,
                 launchDarkly
             ),
-            updateHealthPlanFormData: updateHealthPlanFormDataResolver(store),
+            updateHealthPlanFormData: updateHealthPlanFormDataResolver(
+                store,
+                launchDarkly
+            ),
             submitHealthPlanPackage: submitHealthPlanPackageResolver(
                 store,
                 emailer,

--- a/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.test.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.test.ts
@@ -373,7 +373,7 @@ describe.each(flagValueTestParameters)(
             )
 
             const expectedErrorMsg = flagValue
-                ? 'Transient server error: Concurrent editing occurred. Please refresh the page to continue.'
+                ? 'Concurrent update error: The data you are trying to modify has changed since you last retrieved it. Please refresh the page to continue.'
                 : 'Transient server error: attempted to modify un-modifiable field(s): updatedAt.  Please refresh the page to continue.'
 
             expect(updateResult.errors[0].message).toBe(expectedErrorMsg)
@@ -414,7 +414,7 @@ describe.each(flagValueTestParameters)(
             )
 
             const expectedErrorMsg = flagValue
-                ? 'Transient server error: Concurrent editing occurred. Please refresh the page to continue.'
+                ? 'Concurrent update error: The data you are trying to modify has changed since you last retrieved it. Please refresh the page to continue.'
                 : 'Transient server error: attempted to modify un-modifiable field(s): stateCode,stateNumber,createdAt,updatedAt.  Please refresh the page to continue.'
 
             expect(updateResult.errors[0].message).toBe(expectedErrorMsg)

--- a/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.test.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.test.ts
@@ -55,10 +55,45 @@ describe.each(flagValueTestParameters)(
 
             const createdDraft = await createTestHealthPlanPackage(server)
 
-            const formData = latestFormData(createdDraft)
-
             // update that draft.
-            formData.submissionDescription = 'UPDATED BY REVISION'
+            const formData = Object.assign(latestFormData(createdDraft), {
+                programIDs: [],
+                populationCovered: 'MEDICAID',
+                submissionType: 'CONTRACT_ONLY',
+                riskBasedContract: true,
+                submissionDescription: 'Updated submission',
+                stateContacts: [],
+                documents: [],
+                contractType: 'BASE',
+                contractExecutionStatus: 'EXECUTED',
+                contractDocuments: [],
+                contractDateStart: new Date(Date.UTC(2025, 5, 1)),
+                contractDateEnd: new Date(Date.UTC(2026, 5, 1)),
+                managedCareEntities: ['MCO'],
+                federalAuthorities: [],
+                contractAmendmentInfo: {
+                    modifiedProvisions: {
+                        inLieuServicesAndSettings: true,
+                        modifiedBenefitsProvided: true,
+                        modifiedGeoAreaServed: true,
+                        modifiedMedicaidBeneficiaries: true,
+                        modifiedRiskSharingStrategy: true,
+                        modifiedIncentiveArrangements: true,
+                        modifiedWitholdAgreements: true,
+                        modifiedStateDirectedPayments: true,
+                        modifiedPassThroughPayments: false,
+                        modifiedPaymentsForMentalDiseaseInstitutions: false,
+                        modifiedMedicalLossRatioStandards: false,
+                        modifiedOtherFinancialPaymentIncentive: false,
+                        modifiedEnrollmentProcess: false,
+                        modifiedGrevienceAndAppeal: false,
+                        modifiedNetworkAdequacyStandards: undefined,
+                        modifiedLengthOfContract: undefined,
+                        modifiedNonRiskPaymentArrangements: undefined,
+                    },
+                },
+                rateInfos: [],
+            })
 
             // convert to base64 proto
             const updatedB64 = domainToBase64(formData)
@@ -79,10 +114,17 @@ describe.each(flagValueTestParameters)(
                 updateResult.data?.updateHealthPlanFormData.pkg
 
             const updatedFormData = latestFormData(healthPlanPackage)
-            expect(updatedFormData.submissionDescription).toBe(
-                'UPDATED BY REVISION'
+            expect(updatedFormData).toEqual(
+                expect.objectContaining({
+                    ...formData,
+                    updatedAt: expect.any(Date),
+                })
             )
         })
+
+        it.todo(
+            'updates documents and state contacts. Complete after documents and state contacts have uuids in proto'
+        )
 
         it('errors if a CMS user calls it', async () => {
             const server = await constructTestPostgresServer({
@@ -241,7 +283,8 @@ describe.each(flagValueTestParameters)(
             })
             const createdDraft = await createTestHealthPlanPackage(server)
             const submitPackage = async () => {
-                // Manually submit package when flag is on
+                // Manually submit package when flag is on.
+                // TODO: remove the conditional after submit resolver has been modified.
                 if (flagValue) {
                     const client = await sharedTestPrismaClient()
                     const stateUser = await client.user.create({

--- a/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.test.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.test.ts
@@ -1,14 +1,10 @@
 import {
     constructTestPostgresServer,
     createAndSubmitTestHealthPlanPackage,
-    createAndUpdateTestHealthPlanPackage,
     createTestHealthPlanPackage,
 } from '../../testHelpers/gqlHelpers'
 import UPDATE_HEALTH_PLAN_FORM_DATA from '../../../../app-graphql/src/mutations/updateHealthPlanFormData.graphql'
-import {
-    base64ToDomain,
-    domainToBase64,
-} from '../../../../app-web/src/common-code/proto/healthPlanFormDataProto'
+import { domainToBase64 } from '../../../../app-web/src/common-code/proto/healthPlanFormDataProto'
 import { latestFormData } from '../../testHelpers/healthPlanPackageHelpers'
 import {
     basicLockedHealthPlanFormData,
@@ -21,376 +17,415 @@ import {
 } from '../../testHelpers/storeHelpers'
 import { NewPostgresStore } from '../../postgres'
 import { testCMSUser, testStateUser } from '../../testHelpers/userHelpers'
-
-describe('updateHealthPlanFormData', () => {
-    const cmsUser = testCMSUser()
-
-    it('updates valid fields in the formData', async () => {
-        const server = await constructTestPostgresServer()
-
-        const createdDraft = await createTestHealthPlanPackage(server)
-
-        const formData = latestFormData(createdDraft)
-
-        // update that draft.
-        formData.submissionDescription = 'UPDATED BY REVISION'
-
-        // convert to base64 proto
-        const updatedB64 = domainToBase64(formData)
-
-        const updateResult = await server.executeOperation({
-            query: UPDATE_HEALTH_PLAN_FORM_DATA,
-            variables: {
-                input: {
-                    pkgID: createdDraft.id,
-                    healthPlanFormData: updatedB64,
-                },
-            },
-        })
-
-        expect(updateResult.errors).toBeUndefined()
-
-        const healthPlanPackage =
-            updateResult.data?.updateHealthPlanFormData.pkg
-
-        const updatedFormData = latestFormData(healthPlanPackage)
-        expect(updatedFormData.submissionDescription).toBe(
-            'UPDATED BY REVISION'
-        )
-    })
-
-    it('errors if a CMS user calls it', async () => {
-        const server = await constructTestPostgresServer()
-
-        const createdDraft = await createTestHealthPlanPackage(server)
-
-        const formData = latestFormData(createdDraft)
-
-        // update that draft.
-        formData.submissionDescription = 'UPDATED BY REVISION'
-
-        // convert to base64 proto
-        const updatedB64 = domainToBase64(formData)
-
-        const cmsUserServer = await constructTestPostgresServer({
-            context: {
-                user: cmsUser,
-            },
-        })
-
-        const updateResult = await cmsUserServer.executeOperation({
-            query: UPDATE_HEALTH_PLAN_FORM_DATA,
-            variables: {
-                input: {
-                    pkgID: createdDraft.id,
-                    healthPlanFormData: updatedB64,
-                },
-            },
-        })
-
-        expect(updateResult.errors).toBeDefined()
-        if (updateResult.errors === undefined) {
-            throw new Error('type narrow')
-        }
-
-        expect(updateResult.errors[0].extensions?.code).toBe('FORBIDDEN')
-        expect(updateResult.errors[0].message).toBe(
-            'user not authorized to modify state data'
-        )
-    })
-
-    it('errors if a state user from a different state calls it', async () => {
-        const server = await constructTestPostgresServer()
-        const createdDraft = await createTestHealthPlanPackage(server)
-        const formData = latestFormData(createdDraft)
-
-        // update that draft.
-        formData.submissionDescription = 'UPDATED BY REVISION'
-
-        // convert to base64 proto
-        const updatedB64 = domainToBase64(formData)
-
-        // setup a server with a different user
-        const otherUserServer = await constructTestPostgresServer({
-            context: {
-                user: testStateUser({ stateCode: 'VA' }),
-            },
-        })
-
-        const updateResult = await otherUserServer.executeOperation({
-            query: UPDATE_HEALTH_PLAN_FORM_DATA,
-            variables: {
-                input: {
-                    pkgID: createdDraft.id,
-                    healthPlanFormData: updatedB64,
-                },
-            },
-        })
-
-        expect(updateResult.errors).toBeDefined()
-        if (updateResult.errors === undefined) {
-            throw new Error('type narrow')
-        }
-
-        expect(updateResult.errors[0].extensions?.code).toBe('FORBIDDEN')
-        expect(updateResult.errors[0].message).toBe(
-            'user not authorized to fetch data from a different state'
-        )
-    })
-
-    it('errors if the payload isnt valid', async () => {
-        const server = await constructTestPostgresServer()
-
-        const createdDraft = await createTestHealthPlanPackage(server)
-
-        const formData = 'not-valid-proto'
-
-        const updateResult = await server.executeOperation({
-            query: UPDATE_HEALTH_PLAN_FORM_DATA,
-            variables: {
-                input: {
-                    pkgID: createdDraft.id,
-                    healthPlanFormData: formData,
-                },
-            },
-        })
-
-        expect(updateResult.errors).toBeDefined()
-        if (updateResult.errors === undefined) {
-            throw new Error('type narrow')
-        }
-
-        expect(updateResult.errors[0].extensions?.code).toBe('BAD_USER_INPUT')
-        expect(updateResult.errors[0].message).toContain(
-            'Failed to parse out form data in request'
-        )
-    })
-
-    it('errors if the payload is submitted', async () => {
-        const server = await constructTestPostgresServer()
-
-        const createdDraft = await createTestHealthPlanPackage(server)
-
-        const stateSubmission = basicLockedHealthPlanFormData()
-
-        const formData = domainToBase64(stateSubmission)
-
-        const updateResult = await server.executeOperation({
-            query: UPDATE_HEALTH_PLAN_FORM_DATA,
-            variables: {
-                input: {
-                    pkgID: createdDraft.id,
-                    healthPlanFormData: formData,
-                },
-            },
-        })
-
-        expect(updateResult.errors).toBeDefined()
-        if (updateResult.errors === undefined) {
-            throw new Error('type narrow')
-        }
-
-        expect(updateResult.errors[0].extensions?.code).toBe('BAD_USER_INPUT')
-        expect(updateResult.errors[0].message).toContain(
-            'Attempted to update with a StateSubmission'
-        )
-    })
-
-    it('errors if the Package is already submitted', async () => {
-        const server = await constructTestPostgresServer()
-        const createdSubmitted = await createAndSubmitTestHealthPlanPackage(
-            server
-        )
-
-        const draft = basicHealthPlanFormData()
-        const b64 = domainToBase64(draft)
-
-        const updateResult = await server.executeOperation({
-            query: UPDATE_HEALTH_PLAN_FORM_DATA,
-            variables: {
-                input: {
-                    pkgID: createdSubmitted.id,
-                    healthPlanFormData: b64,
-                },
-            },
-        })
-
-        expect(updateResult.errors).toBeDefined()
-        if (updateResult.errors === undefined) {
-            throw new Error('type narrow')
-        }
-
-        expect(updateResult.errors[0].extensions?.code).toBe('BAD_USER_INPUT')
-        expect(updateResult.errors[0].message).toContain(
-            'Package is not in editable state:'
-        )
-        expect(updateResult.errors[0].message).toContain('status: SUBMITTED')
-    })
-
-    it('errors if the id doesnt match the db', async () => {
-        // id is wrong
-        // createdAt is wrong? or just overwrite
-        //
-
-        const server = await constructTestPostgresServer()
-        const createdDraft = await createTestHealthPlanPackage(server)
-
-        const formData = latestFormData(createdDraft)
-
-        formData.id = uuidv4()
-
-        const b64 = domainToBase64(formData)
-
-        const updateResult = await server.executeOperation({
-            query: UPDATE_HEALTH_PLAN_FORM_DATA,
-            variables: {
-                input: {
-                    pkgID: createdDraft.id,
-                    healthPlanFormData: b64,
-                },
-            },
-        })
-
-        expect(updateResult.errors).toBeDefined()
-        if (updateResult.errors === undefined) {
-            throw new Error('type narrow')
-        }
-
-        expect(updateResult.errors[0].extensions?.code).toBe('BAD_USER_INPUT')
-        expect(updateResult.errors[0].message).toBe(
-            'Transient server error: attempted to modify un-modifiable field(s): id.  Please refresh the page to continue.'
-        )
-    })
-
-    it('errors if the other payload values dont match the db', async () => {
-        const server = await constructTestPostgresServer()
-        const createdDraft = await createTestHealthPlanPackage(server)
-
-        const formData = latestFormData(createdDraft)
-
-        formData.stateCode = 'CA'
-        formData.stateNumber = 9999999
-        formData.createdAt = new Date(2021)
-        formData.updatedAt = new Date(2021)
-
-        const b64 = domainToBase64(formData)
-
-        const updateResult = await server.executeOperation({
-            query: UPDATE_HEALTH_PLAN_FORM_DATA,
-            variables: {
-                input: {
-                    pkgID: createdDraft.id,
-                    healthPlanFormData: b64,
-                },
-            },
-        })
-
-        expect(updateResult.errors).toBeDefined()
-        if (updateResult.errors === undefined) {
-            throw new Error('type narrow')
-        }
-
-        expect(updateResult.errors[0].extensions?.code).toBe('BAD_USER_INPUT')
-        expect(updateResult.errors[0].message).toBe(
-            'Transient server error: attempted to modify un-modifiable field(s): stateCode,stateNumber,createdAt,updatedAt.  Please refresh the page to continue.'
-        )
-    })
-
-    it('errors if the update call to the db fails', async () => {
-        const prismaClient = await sharedTestPrismaClient()
-        const postgresStore = NewPostgresStore(prismaClient)
-        const failStore = mockStoreThatErrors()
-
-        // set our store to error on the updateFormData call, only
-        postgresStore.updateHealthPlanRevision =
-            failStore.updateHealthPlanRevision
-
-        const server = await constructTestPostgresServer({
-            store: postgresStore,
-        })
-
-        const createdDraft = await createTestHealthPlanPackage(server)
-
-        const formData = latestFormData(createdDraft)
-
-        // update that draft.
-        formData.submissionDescription = 'UPDATED BY REVISION'
-
-        // convert to base64 proto
-        const updatedB64 = domainToBase64(formData)
-
-        const updateResult = await server.executeOperation({
-            query: UPDATE_HEALTH_PLAN_FORM_DATA,
-            variables: {
-                input: {
-                    pkgID: createdDraft.id,
-                    healthPlanFormData: updatedB64,
-                },
-            },
-        })
-
-        expect(updateResult.errors).toBeDefined()
-        if (updateResult.errors === undefined) {
-            throw new Error('type narrow')
-        }
-
-        expect(updateResult.errors[0].extensions?.code).toBe(
-            'INTERNAL_SERVER_ERROR'
-        )
-        expect(updateResult.errors[0].message).toContain('UNEXPECTED_EXCEPTION')
-        expect(updateResult.errors[0].message).toContain(
-            'Error updating form data'
-        )
-    })
-
-    it('converts RATES_RELATED documents to CONTRACT_RELATED on contract only submissions', async () => {
-        const server = await constructTestPostgresServer()
-
-        const updatedPackage = await createAndUpdateTestHealthPlanPackage(
-            server,
-            {
-                submissionType: 'CONTRACT_ONLY',
-                documents: [
-                    {
-                        name: 'contract_supporting_that_applies_to_a_rate_also.pdf',
-                        s3URL: 'fakeS3URL',
-                        documentCategories: [
-                            'CONTRACT_RELATED' as const,
-                            'RATES_RELATED' as const,
-                        ],
-                    },
-                    {
-                        name: 'rate_only_supporting_doc.pdf',
-                        s3URL: 'fakeS3URL',
-                        documentCategories: ['RATES_RELATED' as const],
-                    },
-                ],
-            }
-        )
-
-        const currentRevision = updatedPackage.revisions[0].node
-
-        const packageData = base64ToDomain(currentRevision.formDataProto)
-
-        if (packageData instanceof Error) {
-            throw new Error(packageData.message)
-        }
-
-        expect(packageData).toEqual(
-            expect.objectContaining({
-                documents: [
-                    {
-                        name: 'contract_supporting_that_applies_to_a_rate_also.pdf',
-                        s3URL: 'fakeS3URL',
-                        documentCategories: ['CONTRACT_RELATED'],
-                    },
-                    {
-                        name: 'rate_only_supporting_doc.pdf',
-                        s3URL: 'fakeS3URL',
-                        documentCategories: ['CONTRACT_RELATED'],
-                    },
-                ],
+import type {
+    FeatureFlagLDConstant,
+    FlagValue,
+} from 'app-web/src/common-code/featureFlags'
+import { testLDService } from '../../testHelpers/launchDarklyHelpers'
+import { must } from '../../testHelpers'
+import { submitContract } from '../../postgres/contractAndRates/submitContract'
+
+const flagValueTestParameters: {
+    flagName: FeatureFlagLDConstant
+    flagValue: FlagValue
+    testName: string
+}[] = [
+    {
+        flagName: 'rates-db-refactor',
+        flagValue: false,
+        testName: 'updateHealthPlanFormData with all feature flags off',
+    },
+    {
+        flagName: 'rates-db-refactor',
+        flagValue: true,
+        testName: 'updateHealthPlanFormData with rates-db-refactor on',
+    },
+]
+
+describe.each(flagValueTestParameters)(
+    `Tests $testName`,
+    ({ flagName, flagValue }) => {
+        const cmsUser = testCMSUser()
+        const mockLDService = testLDService({ [flagName]: flagValue })
+
+        it('updates valid fields in the formData', async () => {
+            const server = await constructTestPostgresServer({
+                ldService: mockLDService,
             })
-        )
-    })
-})
+
+            const createdDraft = await createTestHealthPlanPackage(server)
+
+            const formData = latestFormData(createdDraft)
+
+            // update that draft.
+            formData.submissionDescription = 'UPDATED BY REVISION'
+
+            // convert to base64 proto
+            const updatedB64 = domainToBase64(formData)
+
+            const updateResult = await server.executeOperation({
+                query: UPDATE_HEALTH_PLAN_FORM_DATA,
+                variables: {
+                    input: {
+                        pkgID: createdDraft.id,
+                        healthPlanFormData: updatedB64,
+                    },
+                },
+            })
+
+            expect(updateResult.errors).toBeUndefined()
+
+            const healthPlanPackage =
+                updateResult.data?.updateHealthPlanFormData.pkg
+
+            const updatedFormData = latestFormData(healthPlanPackage)
+            expect(updatedFormData.submissionDescription).toBe(
+                'UPDATED BY REVISION'
+            )
+        })
+
+        it('errors if a CMS user calls it', async () => {
+            const server = await constructTestPostgresServer({
+                ldService: mockLDService,
+            })
+
+            const createdDraft = await createTestHealthPlanPackage(server)
+
+            const formData = latestFormData(createdDraft)
+
+            // update that draft.
+            formData.submissionDescription = 'UPDATED BY REVISION'
+
+            // convert to base64 proto
+            const updatedB64 = domainToBase64(formData)
+
+            const cmsUserServer = await constructTestPostgresServer({
+                context: {
+                    user: cmsUser,
+                },
+                ldService: mockLDService,
+            })
+
+            const updateResult = await cmsUserServer.executeOperation({
+                query: UPDATE_HEALTH_PLAN_FORM_DATA,
+                variables: {
+                    input: {
+                        pkgID: createdDraft.id,
+                        healthPlanFormData: updatedB64,
+                    },
+                },
+            })
+
+            expect(updateResult.errors).toBeDefined()
+            if (updateResult.errors === undefined) {
+                throw new Error('type narrow')
+            }
+
+            expect(updateResult.errors[0].extensions?.code).toBe('FORBIDDEN')
+            expect(updateResult.errors[0].message).toBe(
+                'user not authorized to modify state data'
+            )
+        })
+
+        it('errors if a state user from a different state calls it', async () => {
+            const server = await constructTestPostgresServer({
+                ldService: mockLDService,
+            })
+            const createdDraft = await createTestHealthPlanPackage(server)
+            const formData = latestFormData(createdDraft)
+
+            // update that draft.
+            formData.submissionDescription = 'UPDATED BY REVISION'
+
+            // convert to base64 proto
+            const updatedB64 = domainToBase64(formData)
+
+            // setup a server with a different user
+            const otherUserServer = await constructTestPostgresServer({
+                context: {
+                    user: testStateUser({ stateCode: 'VA' }),
+                },
+                ldService: mockLDService,
+            })
+
+            const updateResult = await otherUserServer.executeOperation({
+                query: UPDATE_HEALTH_PLAN_FORM_DATA,
+                variables: {
+                    input: {
+                        pkgID: createdDraft.id,
+                        healthPlanFormData: updatedB64,
+                    },
+                },
+            })
+
+            expect(updateResult.errors).toBeDefined()
+            if (updateResult.errors === undefined) {
+                throw new Error('type narrow')
+            }
+
+            expect(updateResult.errors[0].extensions?.code).toBe('FORBIDDEN')
+            expect(updateResult.errors[0].message).toBe(
+                'user not authorized to fetch data from a different state'
+            )
+        })
+
+        it('errors if the payload isnt valid', async () => {
+            const server = await constructTestPostgresServer({
+                ldService: mockLDService,
+            })
+
+            const createdDraft = await createTestHealthPlanPackage(server)
+
+            const formData = 'not-valid-proto'
+
+            const updateResult = await server.executeOperation({
+                query: UPDATE_HEALTH_PLAN_FORM_DATA,
+                variables: {
+                    input: {
+                        pkgID: createdDraft.id,
+                        healthPlanFormData: formData,
+                    },
+                },
+            })
+
+            expect(updateResult.errors).toBeDefined()
+            if (updateResult.errors === undefined) {
+                throw new Error('type narrow')
+            }
+
+            expect(updateResult.errors[0].extensions?.code).toBe(
+                'BAD_USER_INPUT'
+            )
+            expect(updateResult.errors[0].message).toContain(
+                'Failed to parse out form data in request'
+            )
+        })
+
+        it('errors if the payload is submitted', async () => {
+            const server = await constructTestPostgresServer({
+                ldService: mockLDService,
+            })
+
+            const createdDraft = await createTestHealthPlanPackage(server)
+
+            const stateSubmission = basicLockedHealthPlanFormData()
+
+            const formData = domainToBase64(stateSubmission)
+
+            const updateResult = await server.executeOperation({
+                query: UPDATE_HEALTH_PLAN_FORM_DATA,
+                variables: {
+                    input: {
+                        pkgID: createdDraft.id,
+                        healthPlanFormData: formData,
+                    },
+                },
+            })
+
+            expect(updateResult.errors).toBeDefined()
+            if (updateResult.errors === undefined) {
+                throw new Error('type narrow')
+            }
+
+            expect(updateResult.errors[0].extensions?.code).toBe(
+                'BAD_USER_INPUT'
+            )
+            expect(updateResult.errors[0].message).toContain(
+                'Attempted to update with a StateSubmission'
+            )
+        })
+
+        it('errors if the Package is already submitted', async () => {
+            const server = await constructTestPostgresServer({
+                ldService: mockLDService,
+            })
+            const createdDraft = await createTestHealthPlanPackage(server)
+            const submitPackage = async () => {
+                // Manually submit package when flag is on
+                if (flagValue) {
+                    const client = await sharedTestPrismaClient()
+                    const stateUser = await client.user.create({
+                        data: {
+                            id: uuidv4(),
+                            givenName: 'Aang',
+                            familyName: 'Avatar',
+                            email: 'aang@example.com',
+                            role: 'STATE_USER',
+                            stateCode: 'NM',
+                        },
+                    })
+                    return must(
+                        await submitContract(
+                            client,
+                            createdDraft.id,
+                            stateUser.id,
+                            'Submission'
+                        )
+                    )
+                } else {
+                    return await createAndSubmitTestHealthPlanPackage(server)
+                }
+            }
+
+            const createdSubmitted = await submitPackage()
+
+            const draft = basicHealthPlanFormData()
+            const b64 = domainToBase64(draft)
+
+            const updateResult = await server.executeOperation({
+                query: UPDATE_HEALTH_PLAN_FORM_DATA,
+                variables: {
+                    input: {
+                        pkgID: createdSubmitted.id,
+                        healthPlanFormData: b64,
+                    },
+                },
+            })
+
+            expect(updateResult.errors).toBeDefined()
+            if (updateResult.errors === undefined) {
+                throw new Error('type narrow')
+            }
+
+            expect(updateResult.errors[0].extensions?.code).toBe(
+                'BAD_USER_INPUT'
+            )
+            expect(updateResult.errors[0].message).toContain(
+                'Package is not in editable state:'
+            )
+            expect(updateResult.errors[0].message).toContain(
+                'status: SUBMITTED'
+            )
+        })
+
+        it('errors if the id doesnt match the db', async () => {
+            // id is wrong
+            // createdAt is wrong? or just overwrite
+            //
+
+            const server = await constructTestPostgresServer({
+                ldService: mockLDService,
+            })
+            const createdDraft = await createTestHealthPlanPackage(server)
+
+            const formData = latestFormData(createdDraft)
+
+            formData.id = uuidv4()
+
+            const b64 = domainToBase64(formData)
+
+            const updateResult = await server.executeOperation({
+                query: UPDATE_HEALTH_PLAN_FORM_DATA,
+                variables: {
+                    input: {
+                        pkgID: createdDraft.id,
+                        healthPlanFormData: b64,
+                    },
+                },
+            })
+
+            expect(updateResult.errors).toBeDefined()
+            if (updateResult.errors === undefined) {
+                throw new Error('type narrow')
+            }
+
+            expect(updateResult.errors[0].extensions?.code).toBe(
+                'BAD_USER_INPUT'
+            )
+            expect(updateResult.errors[0].message).toBe(
+                'Transient server error: attempted to modify un-modifiable field(s): id.  Please refresh the page to continue.'
+            )
+        })
+
+        it('errors if the other payload values dont match the db', async () => {
+            const server = await constructTestPostgresServer({
+                ldService: mockLDService,
+            })
+            const createdDraft = await createTestHealthPlanPackage(server)
+
+            const formData = latestFormData(createdDraft)
+
+            formData.stateCode = 'CA'
+            formData.stateNumber = 9999999
+            formData.createdAt = new Date(2021)
+            formData.updatedAt = new Date(2021)
+
+            const b64 = domainToBase64(formData)
+
+            const updateResult = await server.executeOperation({
+                query: UPDATE_HEALTH_PLAN_FORM_DATA,
+                variables: {
+                    input: {
+                        pkgID: createdDraft.id,
+                        healthPlanFormData: b64,
+                    },
+                },
+            })
+
+            expect(updateResult.errors).toBeDefined()
+            if (updateResult.errors === undefined) {
+                throw new Error('type narrow')
+            }
+
+            expect(updateResult.errors[0].extensions?.code).toBe(
+                'BAD_USER_INPUT'
+            )
+            expect(updateResult.errors[0].message).toBe(
+                'Transient server error: attempted to modify un-modifiable field(s): stateCode,stateNumber,createdAt,updatedAt.  Please refresh the page to continue.'
+            )
+        })
+
+        it('errors if the update call to the db fails', async () => {
+            const prismaClient = await sharedTestPrismaClient()
+            const postgresStore = NewPostgresStore(prismaClient)
+            const failStore = mockStoreThatErrors()
+
+            // set our store to error on the updateFormData call, only
+            postgresStore.updateHealthPlanRevision =
+                failStore.updateHealthPlanRevision
+
+            // set store error for flag on.
+            postgresStore.updateDraftContract = failStore.updateDraftContract
+
+            const server = await constructTestPostgresServer({
+                store: postgresStore,
+                ldService: mockLDService,
+            })
+
+            const createdDraft = await createTestHealthPlanPackage(server)
+
+            const formData = latestFormData(createdDraft)
+
+            // update that draft.
+            formData.submissionDescription = 'UPDATED BY REVISION'
+
+            // convert to base64 proto
+            const updatedB64 = domainToBase64(formData)
+
+            const updateResult = await server.executeOperation({
+                query: UPDATE_HEALTH_PLAN_FORM_DATA,
+                variables: {
+                    input: {
+                        pkgID: createdDraft.id,
+                        healthPlanFormData: updatedB64,
+                    },
+                },
+            })
+
+            expect(updateResult.errors).toBeDefined()
+            if (updateResult.errors === undefined) {
+                throw new Error('type narrow')
+            }
+
+            expect(updateResult.errors[0].extensions?.code).toBe(
+                'INTERNAL_SERVER_ERROR'
+            )
+            expect(updateResult.errors[0].message).toContain(
+                'UNEXPECTED_EXCEPTION'
+            )
+            expect(updateResult.errors[0].message).toContain(
+                'Error updating form data'
+            )
+        })
+    }
+)

--- a/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.test.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.test.ts
@@ -342,10 +342,6 @@ describe.each(flagValueTestParameters)(
         })
 
         it('errors if the id doesnt match the db', async () => {
-            // id is wrong
-            // createdAt is wrong? or just overwrite
-            //
-
             const server = await constructTestPostgresServer({
                 ldService: mockLDService,
             })
@@ -353,7 +349,7 @@ describe.each(flagValueTestParameters)(
 
             const formData = latestFormData(createdDraft)
 
-            formData.id = uuidv4()
+            formData.updatedAt = new Date(Date.UTC(2025, 5, 1))
 
             const b64 = domainToBase64(formData)
 
@@ -375,9 +371,12 @@ describe.each(flagValueTestParameters)(
             expect(updateResult.errors[0].extensions?.code).toBe(
                 'BAD_USER_INPUT'
             )
-            expect(updateResult.errors[0].message).toBe(
-                'Transient server error: attempted to modify un-modifiable field(s): id.  Please refresh the page to continue.'
-            )
+
+            const expectedErrorMsg = flagValue
+                ? 'Transient server error: Concurrent editing occurred. Please refresh the page to continue.'
+                : 'Transient server error: attempted to modify un-modifiable field(s): updatedAt.  Please refresh the page to continue.'
+
+            expect(updateResult.errors[0].message).toBe(expectedErrorMsg)
         })
 
         it('errors if the other payload values dont match the db', async () => {
@@ -413,9 +412,12 @@ describe.each(flagValueTestParameters)(
             expect(updateResult.errors[0].extensions?.code).toBe(
                 'BAD_USER_INPUT'
             )
-            expect(updateResult.errors[0].message).toBe(
-                'Transient server error: attempted to modify un-modifiable field(s): stateCode,stateNumber,createdAt,updatedAt.  Please refresh the page to continue.'
-            )
+
+            const expectedErrorMsg = flagValue
+                ? 'Transient server error: Concurrent editing occurred. Please refresh the page to continue.'
+                : 'Transient server error: attempted to modify un-modifiable field(s): stateCode,stateNumber,createdAt,updatedAt.  Please refresh the page to continue.'
+
+            expect(updateResult.errors[0].message).toBe(expectedErrorMsg)
         })
 
         it('errors if the update call to the db fails', async () => {

--- a/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.ts
@@ -220,7 +220,15 @@ export function updateHealthPlanFormDataResolver(
                 contractID: input.pkgID,
                 formData: {
                     ...unlockedFormData,
+                    ...unlockedFormData.contractAmendmentInfo
+                        ?.modifiedProvisions,
                     managedCareEntities: unlockedFormData.managedCareEntities,
+                    // Store function is not ready for updating documents and state. We can complete this after these
+                    // three fields in the proto include a UUID and we can reliably CRUD records. Make sure to complete
+                    // the todo test after this is implemented.
+                    stateContacts: [],
+                    supportingDocuments: [],
+                    contractDocuments: [],
                 },
                 rateIDs: [],
             })

--- a/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.ts
@@ -1,28 +1,82 @@
 import { ForbiddenError, UserInputError } from 'apollo-server-lambda'
 import type { UnlockedHealthPlanFormDataType } from '../../../../app-web/src/common-code/healthPlanFormDataType'
-import { convertRateSupportingDocs } from '../../../../app-web/src/common-code/healthPlanFormDataType'
 import {
     base64ToDomain,
     toDomain,
 } from '../../../../app-web/src/common-code/proto/healthPlanFormDataProto'
 import type { HealthPlanPackageType } from '../../domain-models'
-import { isStateUser, packageStatus } from '../../domain-models'
+import {
+    convertContractToUnlockedHealthPlanPackage,
+    isStateUser,
+    packageStatus,
+} from '../../domain-models'
 import type { MutationResolvers } from '../../gen/gqlServer'
 import { logError, logSuccess } from '../../logger'
 import type { Store } from '../../postgres'
-import { isStoreError } from '../../postgres'
+import { isStoreError, NotFoundError } from '../../postgres'
 import {
     setErrorAttributesOnActiveSpan,
     setResolverDetailsOnActiveSpan,
     setSuccessAttributesOnActiveSpan,
 } from '../attributeHelper'
+import type { LDService } from '../../launchDarkly/launchDarkly'
+import { GraphQLError } from 'graphql/index'
+
+type ProtectedFieldType = Pick<
+    UnlockedHealthPlanFormDataType,
+    'id' | 'stateCode' | 'stateNumber' | 'createdAt' | 'updatedAt'
+>
+
+// Validate that none of these protected fields have been modified.
+// These fields should only be modified by the server, never by an update.
+function validateProtectedFields(
+    previousFormData: ProtectedFieldType,
+    unlockedFormData: ProtectedFieldType
+): string[] {
+    const fixedFields: (keyof ProtectedFieldType)[] = [
+        'id',
+        'stateCode',
+        'stateNumber',
+        'createdAt',
+        'updatedAt',
+    ]
+    const unfixedFields = []
+    for (const fixedField of fixedFields) {
+        const prevVal = previousFormData[fixedField]
+        const newVal = unlockedFormData[fixedField]
+
+        if (prevVal instanceof Date && newVal instanceof Date) {
+            if (prevVal.getTime() !== newVal.getTime()) {
+                console.info(
+                    `ERRMOD ${fixedField}: old: ${previousFormData[fixedField]} new: ${unlockedFormData[fixedField]}`
+                )
+                unfixedFields.push(fixedField)
+            }
+        } else {
+            if (previousFormData[fixedField] !== unlockedFormData[fixedField]) {
+                console.info(
+                    `ERRMOD ${fixedField}: old: ${previousFormData[fixedField]} new: ${unlockedFormData[fixedField]}`
+                )
+                unfixedFields.push(fixedField)
+            }
+        }
+    }
+
+    return unfixedFields
+}
 
 export function updateHealthPlanFormDataResolver(
-    store: Store
+    store: Store,
+    launchDarkly: LDService
 ): MutationResolvers['updateHealthPlanFormData'] {
     return async (_parent, { input }, context) => {
         const { user, span } = context
         setResolverDetailsOnActiveSpan('updateHealthPlanFormData', user, span)
+
+        const ratesDatabaseRefactor = await launchDarkly.getFeatureFlag(
+            context,
+            'rates-db-refactor'
+        )
 
         // This resolver is only callable by state users
         if (!isStateUser(context.user)) {
@@ -48,6 +102,7 @@ export function updateHealthPlanFormDataResolver(
                 argumentName: 'healthPlanFormData',
             })
         }
+
         // don't send a LockedFormData to the update endpoint
         if (formDataResult.status === 'SUBMITTED') {
             const errMessage = `Attempted to update with a StateSubmission: ${input.pkgID}`
@@ -59,168 +114,269 @@ export function updateHealthPlanFormDataResolver(
         }
 
         const unlockedFormData: UnlockedHealthPlanFormDataType = formDataResult
-        const result = await store.findHealthPlanPackage(input.pkgID)
 
-        if (isStoreError(result)) {
-            console.info('Error finding a package', result)
-            const errMessage = `Issue finding a package of type ${result.code}. Message: ${result.message}`
-            logError('updateHealthPlanFormData', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-            throw new Error(errMessage)
-        }
-
-        if (result === undefined) {
-            const errMessage = `No package found to update with that ID: ${input.pkgID}`
-            logError('updateHealthPlanFormData', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-            throw new UserInputError(errMessage, {
-                argumentName: 'pgkID',
-            })
-        }
-
-        const planPackage: HealthPlanPackageType = result
-
-        // Authorize the update
-        const stateFromCurrentUser = context.user.stateCode
-        if (planPackage.stateCode !== stateFromCurrentUser) {
-            logError(
-                'updateHealthPlanFormData',
-                'user not authorized to fetch data from a different state'
+        // Uses new DB if flag is on
+        if (ratesDatabaseRefactor) {
+            // Find contract from DB
+            const contractWithHistory = await store.findContractWithHistory(
+                input.pkgID
             )
-            setErrorAttributesOnActiveSpan(
-                'user not authorized to fetch data from a different state',
-                span
-            )
-            throw new ForbiddenError(
-                'user not authorized to fetch data from a different state'
-            )
-        }
 
-        // Check the package is in an update-able state
-        const planPackageStatus = packageStatus(planPackage)
-        if (planPackageStatus instanceof Error) {
-            const errMessage = `No revisions found on package: ${input.pkgID}`
-            logError('updateHealthPlanFormData', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-            throw new Error(errMessage)
-        }
+            if (contractWithHistory instanceof Error) {
+                const errMessage = `Issue finding a contract with history with id ${input.pkgID}. Message: ${contractWithHistory.message}`
+                logError('fetchHealthPlanPackage', errMessage)
+                setErrorAttributesOnActiveSpan(errMessage, span)
 
-        // Can't update a submission that is locked or resubmitted
-        if (!['DRAFT', 'UNLOCKED'].includes(planPackageStatus)) {
-            const errMessage = `Package is not in editable state: ${input.pkgID} status: ${planPackageStatus}`
-            logError('updateHealthPlanFormData', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-            throw new UserInputError(errMessage, {
-                argumentName: 'pkg',
-            })
-        }
-
-        // Validate input against the db.
-        // Having to crack this open to check on this is probably an indication that some of this info
-        // really belongs on the HealthPlanPackage itself instead of being inside form data, but this is where we are now.
-
-        const previousFormDataResult = toDomain(
-            planPackage.revisions[0].formDataProto
-        )
-        if (previousFormDataResult instanceof Error) {
-            const errMessage = `Issue deserializing old formData ${previousFormDataResult.message}`
-            logError('updateHealthPlanFormData', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-            throw new Error(errMessage)
-        }
-
-        // Sanity check, Can't update a package that is locked or resubmitted in the form data either
-        if (previousFormDataResult.status === 'SUBMITTED') {
-            const errMessage = `Package form data is not in editable state: ${input.pkgID}`
-            logError('updateHealthPlanFormData', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-            throw new UserInputError(errMessage, {
-                argumentName: 'pgkID',
-            })
-        }
-
-        const previousFormData: UnlockedHealthPlanFormDataType =
-            previousFormDataResult
-
-        // Validate that none of these protected fields have been modified.
-        // These fields should only be modified by the server, never by an update.
-        const fixedFields: (keyof UnlockedHealthPlanFormDataType)[] = [
-            'id',
-            'stateCode',
-            'stateNumber',
-            'createdAt',
-            'updatedAt',
-        ]
-        const unfixedFields = []
-        for (const fixedField of fixedFields) {
-            const prevVal = previousFormData[fixedField]
-            const newVal = unlockedFormData[fixedField]
-
-            if (prevVal instanceof Date && newVal instanceof Date) {
-                if (prevVal.getTime() !== newVal.getTime()) {
-                    console.info(
-                        `ERRMOD ${fixedField}: old: ${previousFormData[fixedField]} new: ${unlockedFormData[fixedField]}`
-                    )
-                    unfixedFields.push(fixedField)
+                if (contractWithHistory instanceof NotFoundError) {
+                    throw new GraphQLError(errMessage, {
+                        extensions: {
+                            code: 'NOT_FOUND',
+                            cause: 'DB_ERROR',
+                        },
+                    })
                 }
-            } else {
-                if (
-                    previousFormData[fixedField] !==
-                    unlockedFormData[fixedField]
-                ) {
-                    console.info(
-                        `ERRMOD ${fixedField}: old: ${previousFormData[fixedField]} new: ${unlockedFormData[fixedField]}`
-                    )
-                    unfixedFields.push(fixedField)
-                }
+
+                throw new GraphQLError(errMessage, {
+                    extensions: {
+                        code: 'INTERNAL_SERVER_ERROR',
+                        cause: 'DB_ERROR',
+                    },
+                })
             }
-        }
 
-        if (unfixedFields.length !== 0) {
-            const errMessage = `Transient server error: attempted to modify un-modifiable field(s): ${unfixedFields.join(
-                ','
-            )}.  Please refresh the page to continue.`
-            logError('updateHealthPlanFormData', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-            throw new UserInputError(errMessage, {
-                argumentName: unfixedFields.join(','),
+            // Authorize the update
+            const stateFromCurrentUser = context.user.stateCode
+            if (contractWithHistory.stateCode !== stateFromCurrentUser) {
+                logError(
+                    'updateHealthPlanFormData',
+                    'user not authorized to fetch data from a different state'
+                )
+                setErrorAttributesOnActiveSpan(
+                    'user not authorized to fetch data from a different state',
+                    span
+                )
+                throw new ForbiddenError(
+                    'user not authorized to fetch data from a different state'
+                )
+            }
+
+            // Can't update a submission that is locked or resubmitted
+            if (!['DRAFT', 'UNLOCKED'].includes(contractWithHistory.status)) {
+                const errMessage = `Package is not in editable state: ${input.pkgID} status: ${contractWithHistory.status}`
+                logError('updateHealthPlanFormData', errMessage)
+                setErrorAttributesOnActiveSpan(errMessage, span)
+                throw new UserInputError(errMessage, {
+                    argumentName: 'pkg',
+                })
+            }
+
+            // Check if draft revision exist, if not then return error
+            if (!contractWithHistory.draftRevision) {
+                const errMessage = `Issue finding a draft revision for contract id ${input.pkgID}. Message: Draft revision not found}`
+                throw new GraphQLError(errMessage, {
+                    extensions: {
+                        code: 'NOT_FOUND',
+                        cause: 'DB_ERROR',
+                    },
+                })
+            }
+
+            //check for fields
+            // Validate that none of these protected fields have been modified.
+            // These fields should only be modified by the server, never by an update.
+            const previousFormData = {
+                id: contractWithHistory.draftRevision.id,
+                stateCode: contractWithHistory.stateCode,
+                stateNumber: contractWithHistory.stateNumber,
+                // Matches the format of the created at date that comes out of the proto.
+                createdAt: new Date(
+                    Date.UTC(
+                        contractWithHistory.draftRevision.updatedAt.getUTCFullYear(),
+                        contractWithHistory.draftRevision.updatedAt.getUTCMonth(),
+                        contractWithHistory.draftRevision.updatedAt.getUTCDate()
+                    )
+                ),
+                updatedAt: contractWithHistory.draftRevision.updatedAt,
+            }
+
+            const unfixedFields = validateProtectedFields(
+                previousFormData,
+                unlockedFormData
+            )
+
+            if (unfixedFields.length !== 0) {
+                const errMessage = `Transient server error: attempted to modify un-modifiable field(s): ${unfixedFields.join(
+                    ','
+                )}.  Please refresh the page to continue.`
+                logError('updateHealthPlanFormData', errMessage)
+                setErrorAttributesOnActiveSpan(errMessage, span)
+                throw new UserInputError(errMessage, {
+                    argumentName: unfixedFields.join(','),
+                })
+            }
+
+            // Update contract draft revision
+            const updateResult = await store.updateDraftContract({
+                contractID: input.pkgID,
+                formData: {
+                    ...unlockedFormData,
+                    managedCareEntities: unlockedFormData.managedCareEntities,
+                },
+                rateIDs: [],
             })
-        }
 
-        const editableRevision = planPackage.revisions[0]
+            if (updateResult instanceof Error) {
+                const errMessage = `Error updating form data: ${input.pkgID}:: ${updateResult.message}`
+                logError('updateHealthPlanFormData', errMessage)
+                setErrorAttributesOnActiveSpan(errMessage, span)
+                throw new GraphQLError(errMessage, {
+                    extensions: {
+                        code: 'INTERNAL_SERVER_ERROR',
+                        cause: 'DB_ERROR',
+                    },
+                })
+            }
 
-        // This logic is no longer needed once SUPPORTING_DOCS_BY_RATE flag is on in production - it was used to remove rate supporting docs form contract only submisisons
-        if (
-            unlockedFormData.submissionType === 'CONTRACT_ONLY' &&
-            unlockedFormData.documents.some((document) =>
-                document.documentCategories.includes('RATES_RELATED')
+            // Convert back to health plan package
+            const pkg = convertContractToUnlockedHealthPlanPackage(updateResult)
+
+            if (pkg instanceof Error) {
+                const errMessage = `Error converting draft contract. Message: ${pkg.message}`
+                logError('createHealthPlanPackage', errMessage)
+                setErrorAttributesOnActiveSpan(errMessage, span)
+                throw new GraphQLError(errMessage, {
+                    extensions: {
+                        code: 'INTERNAL_SERVER_ERROR',
+                        cause: 'PROTO_DECODE_ERROR',
+                    },
+                })
+            }
+
+            return { pkg }
+        } else {
+            const result = await store.findHealthPlanPackage(input.pkgID)
+
+            if (isStoreError(result)) {
+                console.info('Error finding a package', result)
+                const errMessage = `Issue finding a package of type ${result.code}. Message: ${result.message}`
+                logError('updateHealthPlanFormData', errMessage)
+                setErrorAttributesOnActiveSpan(errMessage, span)
+                throw new Error(errMessage)
+            }
+
+            if (result === undefined) {
+                const errMessage = `No package found to update with that ID: ${input.pkgID}`
+                logError('updateHealthPlanFormData', errMessage)
+                setErrorAttributesOnActiveSpan(errMessage, span)
+                throw new UserInputError(errMessage, {
+                    argumentName: 'pgkID',
+                })
+            }
+
+            const planPackage: HealthPlanPackageType = result
+
+            // Authorize the update
+            const stateFromCurrentUser = context.user.stateCode
+            if (planPackage.stateCode !== stateFromCurrentUser) {
+                logError(
+                    'updateHealthPlanFormData',
+                    'user not authorized to fetch data from a different state'
+                )
+                setErrorAttributesOnActiveSpan(
+                    'user not authorized to fetch data from a different state',
+                    span
+                )
+                throw new ForbiddenError(
+                    'user not authorized to fetch data from a different state'
+                )
+            }
+
+            // Check the package is in an update-able state
+            const planPackageStatus = packageStatus(planPackage)
+            if (planPackageStatus instanceof Error) {
+                const errMessage = `No revisions found on package: ${input.pkgID}`
+                logError('updateHealthPlanFormData', errMessage)
+                setErrorAttributesOnActiveSpan(errMessage, span)
+                throw new Error(errMessage)
+            }
+
+            // Can't update a submission that is locked or resubmitted
+            if (!['DRAFT', 'UNLOCKED'].includes(planPackageStatus)) {
+                const errMessage = `Package is not in editable state: ${input.pkgID} status: ${planPackageStatus}`
+                logError('updateHealthPlanFormData', errMessage)
+                setErrorAttributesOnActiveSpan(errMessage, span)
+                throw new UserInputError(errMessage, {
+                    argumentName: 'pkg',
+                })
+            }
+
+            // Validate input against the db.
+            // Having to crack this open to check on this is probably an indication that some of this info
+            // really belongs on the HealthPlanPackage itself instead of being inside form data, but this is where we are now.
+
+            const previousFormDataResult = toDomain(
+                planPackage.revisions[0].formDataProto
             )
-        ) {
-            const convertedDocs = convertRateSupportingDocs(
-                unlockedFormData.documents
+            if (previousFormDataResult instanceof Error) {
+                const errMessage = `Issue deserializing old formData ${previousFormDataResult.message}`
+                logError('updateHealthPlanFormData', errMessage)
+                setErrorAttributesOnActiveSpan(errMessage, span)
+                throw new Error(errMessage)
+            }
+
+            // Sanity check, Can't update a package that is locked or resubmitted in the form data either
+            if (previousFormDataResult.status === 'SUBMITTED') {
+                const errMessage = `Package form data is not in editable state: ${input.pkgID}`
+                logError('updateHealthPlanFormData', errMessage)
+                setErrorAttributesOnActiveSpan(errMessage, span)
+                throw new UserInputError(errMessage, {
+                    argumentName: 'pgkID',
+                })
+            }
+
+            const previousFormData: UnlockedHealthPlanFormDataType =
+                previousFormDataResult
+
+            // Validate that none of these protected fields have been modified.
+            // These fields should only be modified by the server, never by an update.
+            const unfixedFields = validateProtectedFields(
+                previousFormData,
+                unlockedFormData
             )
-            unlockedFormData.documents = convertedDocs
-        }
 
-        // save the new form data to the db
-        const updateResult = await store.updateHealthPlanRevision(
-            planPackage.id,
-            editableRevision.id,
-            unlockedFormData
-        )
+            if (unfixedFields.length !== 0) {
+                const errMessage = `Transient server error: attempted to modify un-modifiable field(s): ${unfixedFields.join(
+                    ','
+                )}.  Please refresh the page to continue.`
+                logError('updateHealthPlanFormData', errMessage)
+                setErrorAttributesOnActiveSpan(errMessage, span)
+                throw new UserInputError(errMessage, {
+                    argumentName: unfixedFields.join(','),
+                })
+            }
 
-        if (isStoreError(updateResult)) {
-            const errMessage = `Error updating form data: ${input.pkgID}:: ${updateResult.code}: ${updateResult.message}`
-            logError('updateHealthPlanFormData', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-            throw new Error(errMessage)
-        }
+            const editableRevision = planPackage.revisions[0]
 
-        logSuccess('updateHealthPlanFormData')
-        setSuccessAttributesOnActiveSpan(span)
+            // save the new form data to the db
+            const updateResult = await store.updateHealthPlanRevision(
+                planPackage.id,
+                editableRevision.id,
+                unlockedFormData
+            )
 
-        return {
-            pkg: updateResult,
+            if (isStoreError(updateResult)) {
+                const errMessage = `Error updating form data: ${input.pkgID}:: ${updateResult.code}: ${updateResult.message}`
+                logError('updateHealthPlanFormData', errMessage)
+                setErrorAttributesOnActiveSpan(errMessage, span)
+                throw new Error(errMessage)
+            }
+
+            logSuccess('updateHealthPlanFormData')
+            setSuccessAttributesOnActiveSpan(span)
+
+            return {
+                pkg: updateResult,
+            }
         }
     }
 }

--- a/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.ts
@@ -185,8 +185,8 @@ export function updateHealthPlanFormDataResolver(
 
             // If updatedAt does not match concurrent editing occurred.
             if (
-                contractWithHistory.draftRevision.updatedAt !==
-                unlockedFormData.updatedAt
+                contractWithHistory.draftRevision.updatedAt.getTime() !==
+                unlockedFormData.updatedAt.getTime()
             ) {
                 const errMessage = `Transient server error: Concurrent editing occurred. Please refresh the page to continue.`
                 logError('updateHealthPlanFormData', errMessage)

--- a/services/app-api/src/testHelpers/contractAndRates/contractHelpers.ts
+++ b/services/app-api/src/testHelpers/contractAndRates/contractHelpers.ts
@@ -8,14 +8,14 @@ import type {
     ContractTableFullPayload,
 } from '../../postgres/contractAndRates/prismaSubmittedContractHelpers'
 import type { StateCodeType } from 'app-web/src/common-code/healthPlanFormDataType'
-import type { ContractFormEditable } from '../../postgres/contractAndRates/updateDraftContract'
+import type { ContractFormDataType } from '../../domain-models/contractAndRates'
 
 const createInsertContractData = ({
     stateCode,
     ...formData
 }: {
     stateCode?: StateCodeType
-} & Partial<ContractFormEditable>): InsertContractArgsType => {
+} & Partial<ContractFormDataType>): InsertContractArgsType => {
     return {
         stateCode: stateCode ?? 'MN',
         submissionType: formData?.submissionType ?? 'CONTRACT_AND_RATES',

--- a/services/app-api/src/testHelpers/emailerHelpers.ts
+++ b/services/app-api/src/testHelpers/emailerHelpers.ts
@@ -287,7 +287,7 @@ const mockContractAndRatesFormData = (
         ],
         contractDateStart: new Date('01/01/2021'),
         contractDateEnd: new Date('01/01/2022'),
-        managedCareEntities: ['ENROLLMENT_PROCESS'],
+        managedCareEntities: ['PCCM'],
         federalAuthorities: ['VOLUNTARY', 'BENCHMARK'],
         rateInfos: [
             {
@@ -369,7 +369,7 @@ const mockUnlockedContractAndRatesFormData = (
         ],
         contractDateStart: new Date('01/01/2021'),
         contractDateEnd: new Date('01/01/2022'),
-        managedCareEntities: ['ENROLLMENT_PROCESS'],
+        managedCareEntities: ['PCCM'],
         federalAuthorities: ['VOLUNTARY', 'BENCHMARK'],
         rateInfos: [
             {
@@ -451,7 +451,7 @@ const mockUnlockedContractOnlyFormData = (
         ],
         contractDateStart: new Date('01/01/2021'),
         contractDateEnd: new Date('01/01/2022'),
-        managedCareEntities: ['ENROLLMENT_PROCESS'],
+        managedCareEntities: ['PCCM'],
         federalAuthorities: ['VOLUNTARY', 'BENCHMARK'],
         rateInfos: [],
         stateContacts: [
@@ -499,7 +499,7 @@ const mockContractOnlyFormData = (
         ],
         contractDateStart: new Date('01/01/2021'),
         contractDateEnd: new Date('01/01/2022'),
-        managedCareEntities: ['ENROLLMENT_PROCESS'],
+        managedCareEntities: ['PCCM'],
         federalAuthorities: ['VOLUNTARY', 'BENCHMARK'],
         rateInfos: [],
         stateContacts: [
@@ -547,7 +547,7 @@ const mockContractAmendmentFormData = (
         ],
         contractDateStart: new Date('01/01/2021'),
         contractDateEnd: new Date('01/01/2022'),
-        managedCareEntities: ['ENROLLMENT_PROCESS'],
+        managedCareEntities: ['PCCM'],
         federalAuthorities: ['VOLUNTARY', 'BENCHMARK'],
         rateInfos: [
             {

--- a/services/app-api/src/testHelpers/storeHelpers.ts
+++ b/services/app-api/src/testHelpers/storeHelpers.ts
@@ -107,6 +107,12 @@ function mockStoreThatErrors(): Store {
                 'UNEXPECTED_EXCEPTION: This error came from the generic store with errors mock'
             )
         },
+
+        updateDraftContract: async (_ID) => {
+            return new Error(
+                'UNEXPECTED_EXCEPTION: This error came from the generic store with errors mock'
+            )
+        },
     }
 }
 

--- a/services/app-web/src/common-code/healthPlanFormDataType/LockedHealthPlanFormDataType.d.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/LockedHealthPlanFormDataType.d.ts
@@ -11,6 +11,7 @@ import type {
     ContractExecutionStatus,
     RateInfoType,
     PopulationCoveredType,
+    ManagedCareEntity,
 } from './UnlockedHealthPlanFormDataType'
 
 // future refactor- locked health data could have its own version of StateContact and ActuaryContact with stricter types
@@ -33,7 +34,7 @@ export type LockedHealthPlanFormDataType = {
     contractDocuments: SubmissionDocument[]
     contractDateStart: Date
     contractDateEnd: Date
-    managedCareEntities: string[]
+    managedCareEntities: ManagedCareEntity[]
     federalAuthorities: FederalAuthority[]
     contractAmendmentInfo?: ContractAmendmentInfo
     rateInfos: RateInfoType[]

--- a/services/app-web/src/common-code/healthPlanFormDataType/UnlockedHealthPlanFormDataType.d.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/UnlockedHealthPlanFormDataType.d.ts
@@ -107,7 +107,7 @@ type UnlockedHealthPlanFormDataType = {
     contractDocuments: SubmissionDocument[]
     contractDateStart?: Date
     contractDateEnd?: Date
-    managedCareEntities: string[]
+    managedCareEntities: ManagedCareEntity[]
     federalAuthorities: FederalAuthority[]
     contractAmendmentInfo?: ContractAmendmentInfo
     rateInfos: RateInfoType[]

--- a/services/app-web/src/common-code/proto/healthPlanFormDataProto/toDomain.ts
+++ b/services/app-web/src/common-code/proto/healthPlanFormDataProto/toDomain.ts
@@ -9,6 +9,7 @@ import {
     DocumentCategoryType,
     ActuarialFirmType,
     FederalAuthority,
+    ManagedCareEntity,
     isLockedHealthPlanFormData,
     RateInfoType,
     generateRateName,
@@ -353,7 +354,9 @@ function parseRateInfos(
                     rateInfo?.rateCapitationType
                 ),
                 rateDocuments: parseProtoDocuments(rateInfo?.rateDocuments),
-                supportingDocuments: parseProtoDocuments(rateInfo?.supportingDocuments),
+                supportingDocuments: parseProtoDocuments(
+                    rateInfo?.supportingDocuments
+                ),
                 rateDateStart: protoDateToDomain(rateInfo?.rateDateStart),
                 rateDateEnd: protoDateToDomain(rateInfo?.rateDateEnd),
                 rateDateCertified: protoDateToDomain(
@@ -467,7 +470,7 @@ const toDomain = (
         managedCareEntities: protoEnumArrayToDomain(
             mcreviewproto.ManagedCareEntity,
             formDataMessage?.contractInfo?.managedCareEntities
-        ),
+        ) as Partial<ManagedCareEntity[]>,
         federalAuthorities: protoEnumArrayToDomain(
             mcreviewproto.FederalAuthority,
             formDataMessage?.contractInfo?.federalAuthorities

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
@@ -154,7 +154,7 @@ export const StateSubmissionForm = (): React.ReactElement => {
             const updateResult = await updateFormData({
                 variables: {
                     input: {
-                        pkgID: input.id,
+                        pkgID: pkg.id,
                         healthPlanFormData: base64Draft,
                     },
                 },

--- a/services/app-web/src/testHelpers/apolloMocks/healthPlanFormDataMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/healthPlanFormDataMock.ts
@@ -258,7 +258,7 @@ function mockStateSubmission(): LockedHealthPlanFormDataType {
                 modifiedNonRiskPaymentArrangements: true,
             },
         },
-        managedCareEntities: ['ENROLLMENT_PROCESS'],
+        managedCareEntities: ['PAHP'],
         federalAuthorities: ['VOLUNTARY', 'BENCHMARK'],
         rateInfos: [
             {
@@ -360,7 +360,7 @@ function mockStateSubmissionContractAmendment(): LockedHealthPlanFormDataType {
                 modifiedNonRiskPaymentArrangements: true,
             },
         },
-        managedCareEntities: ['ENROLLMENT_PROCESS'],
+        managedCareEntities: ['PCCM'],
         federalAuthorities: ['VOLUNTARY', 'BENCHMARK'],
         rateInfos: [
             {


### PR DESCRIPTION
## Summary
[MR-3639](https://qmacbis.atlassian.net/browse/MR-3639)

- Modified updateHHP to update contract only submissions with the new DB.
- Updated `managedCareEntities` type to be string literals of the entities instead of a string array.
- Removed `documentCategories` from the `contractFormDataSchema`. Adding document categories in `convertContractRevisionToHealthPlanRevision`.
- Updating `stateContacts`, `supportingDocuments`, and `contractDocuments` is not implemented in this PR. We will need a reliable way to CRUD these relationships using a `UUID` or something. This work of adding a unique ID will be done in a different ticket.
- Just heads up, looks like our frontend doesn't let state contacts be partially filled out when `Save as draft`
<img src="https://github.com/Enterprise-CMCS/managed-care-review/assets/98117700/4ddf4a21-53f1-40fc-b6ce-c3ca27e4461c" width="300"/>


#### Related issues

#### Screenshots

#### Test cases covered

- `updateHealthPlanFormData.test.ts`
   - Used `describe.each` to test flag on and off for existing tests.
   - `'updates valid fields in the formData'`
      - Updated to test several form data fields.
   - `'updates documents and state contacts. Complete after documents and state contacts have uuids in proto'`
      - Added this `todo` so we don't forget to test these fields.

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
