### PR TITLE
Refactor prisma further

### DIFF
--- a/services/app-api/prisma/migrations/20230825150259_remove_supporting_documents/migration.sql
+++ b/services/app-api/prisma/migrations/20230825150259_remove_supporting_documents/migration.sql
@@ -1,0 +1,54 @@
+BEGIN;
+/*
+  Warnings:
+
+  - You are about to drop the column `contractRevisionID` on the `ContractDocument` table. All the data in the column will be lost.
+  - You are about to drop the column `rateRevisionID` on the `RateDocument` table. All the data in the column will be lost.
+  - You are about to drop the `ContractSupportingDocument` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `RateSupportingDocument` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `contractDocumentRevisionID` to the `ContractDocument` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `supportingDocumentRevisionID` to the `ContractDocument` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `rateDocumentRevisionID` to the `RateDocument` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `supportingDocumentRevisionID` to the `RateDocument` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "ContractDocument" DROP CONSTRAINT "ContractDocument_contractRevisionID_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ContractSupportingDocument" DROP CONSTRAINT "ContractSupportingDocument_contractRevisionID_fkey";
+
+-- DropForeignKey
+ALTER TABLE "RateDocument" DROP CONSTRAINT "RateDocument_rateRevisionID_fkey";
+
+-- DropForeignKey
+ALTER TABLE "RateSupportingDocument" DROP CONSTRAINT "RateSupportingDocument_rateRevisionID_fkey";
+
+-- AlterTable
+ALTER TABLE "ContractDocument" DROP COLUMN "contractRevisionID",
+ADD COLUMN     "contractDocumentRevisionID" TEXT NOT NULL,
+ADD COLUMN     "supportingDocumentRevisionID" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "RateDocument" DROP COLUMN "rateRevisionID",
+ADD COLUMN     "rateDocumentRevisionID" TEXT NOT NULL,
+ADD COLUMN     "supportingDocumentRevisionID" TEXT NOT NULL;
+
+-- DropTable
+DROP TABLE "ContractSupportingDocument";
+
+-- DropTable
+DROP TABLE "RateSupportingDocument";
+
+-- AddForeignKey
+ALTER TABLE "ContractDocument" ADD CONSTRAINT "ContractDocument_contractDocumentRevisionID_fkey" FOREIGN KEY ("contractDocumentRevisionID") REFERENCES "ContractRevisionTable"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ContractDocument" ADD CONSTRAINT "ContractDocument_supportingDocumentRevisionID_fkey" FOREIGN KEY ("supportingDocumentRevisionID") REFERENCES "ContractRevisionTable"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RateDocument" ADD CONSTRAINT "RateDocument_rateDocumentRevisionID_fkey" FOREIGN KEY ("rateDocumentRevisionID") REFERENCES "RateRevisionTable"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RateDocument" ADD CONSTRAINT "RateDocument_supportingDocumentRevisionID_fkey" FOREIGN KEY ("supportingDocumentRevisionID") REFERENCES "RateRevisionTable"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+COMMIT;

--- a/services/app-api/prisma/migrations/20230825150840_add_display_seq/migration.sql
+++ b/services/app-api/prisma/migrations/20230825150840_add_display_seq/migration.sql
@@ -1,0 +1,13 @@
+BEGIN;
+-- AlterTable
+ALTER TABLE "ActuaryContact" ADD COLUMN     "display_seq" INTEGER;
+
+-- AlterTable
+ALTER TABLE "ContractDocument" ADD COLUMN     "display_seq" INTEGER;
+
+-- AlterTable
+ALTER TABLE "RateDocument" ADD COLUMN     "display_seq" INTEGER;
+
+-- AlterTable
+ALTER TABLE "StateContact" ADD COLUMN     "display_seq" INTEGER;
+COMMIT;

--- a/services/app-api/prisma/schema.prisma
+++ b/services/app-api/prisma/schema.prisma
@@ -187,6 +187,7 @@ model ActuaryContact {
   rateWithAddtlActuaryID      String?
   rateActuaryCertifying       RateRevisionTable? @relation(name: "CertifyingActuaryOnRateRevision", fields: [rateWithCertifyingActuaryID], references: [id])
   rateActuaryAddtl            RateRevisionTable? @relation(name: "AddtlActuaryOnRateRevision", fields: [rateWithAddtlActuaryID], references: [id])
+  display_seq                 Int?
 }
 
 model ContractDocument {
@@ -200,6 +201,7 @@ model ContractDocument {
   supportingDocumentRevisionID       String
   contractDocumentContractRevision   ContractRevisionTable? @relation(name: "ContractDocumentOnContractRevision", fields: [contractDocumentRevisionID], references: [id])
   supportingDocumentContractRevision ContractRevisionTable? @relation(name: "SupportingDocumentOnContractRevision", fields: [supportingDocumentRevisionID], references: [id])
+  display_seq                        Int?
 }
 
 model RateDocument {
@@ -213,6 +215,7 @@ model RateDocument {
   supportingDocumentRevisionID       String
   ratetDocumentContractRevision      RateRevisionTable? @relation(name: "RateDocumentOnRateRevision", fields: [rateDocumentRevisionID], references: [id])
   supportingDocumentContractRevision RateRevisionTable? @relation(name: "SupportingDocumentOnRateRevision", fields: [supportingDocumentRevisionID], references: [id])
+  display_seq                        Int?
 }
 
 model StateContact {
@@ -224,6 +227,7 @@ model StateContact {
   email              String?
   contractRevisionID String
   contractRevision   ContractRevisionTable @relation(fields: [contractRevisionID], references: [id])
+  display_seq        Int?
 }
 
 model State {

--- a/services/app-api/prisma/schema.prisma
+++ b/services/app-api/prisma/schema.prisma
@@ -35,47 +35,47 @@ model HealthPlanRevisionTable {
 }
 
 model ContractTable {
-  id                 String                  @id @default(uuid())
-  createdAt          DateTime                @default(now())
-  updatedAt          DateTime                @default(now()) @updatedAt
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
 
-  stateCode          String
-  state              State                   @relation(fields: [stateCode], references: [stateCode])
-  stateNumber        Int
+  stateCode   String
+  state       State  @relation(fields: [stateCode], references: [stateCode])
+  stateNumber Int
 
   revisions          ContractRevisionTable[]
   draftRateRevisions RateRevisionTable[]
 }
 
 model RateTable {
-  id                     String                  @id @default(uuid())
-  createdAt              DateTime                @default(now())
-  updatedAt              DateTime                @default(now()) @updatedAt
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
 
-  stateCode              String
-  state                  State                   @relation(fields: [stateCode], references: [stateCode])
-  stateNumber            Int
+  stateCode   String
+  state       State  @relation(fields: [stateCode], references: [stateCode])
+  stateNumber Int
 
   revisions              RateRevisionTable[]
   draftContractRevisions ContractRevisionTable[]
 }
 
 model ContractRevisionTable {
-  id                                           String                                  @id @default(uuid())
-  contractID                                   String
-  contract                                     ContractTable                           @relation(fields: [contractID], references: [id])
+  id         String        @id @default(uuid())
+  contractID String
+  contract   ContractTable @relation(fields: [contractID], references: [id])
 
-  rateRevisions                                RateRevisionsOnContractRevisionsTable[]
-  sharedRateRevisions                          SharedRateCertifications[]
-  draftRates                                   RateTable[]
+  rateRevisions       RateRevisionsOnContractRevisionsTable[]
+  sharedRateRevisions SharedRateCertifications[]
+  draftRates          RateTable[]
 
-  unlockInfoID                                 String?
-  unlockInfo                                   UpdateInfoTable?                        @relation("unlockContractInfo", fields: [unlockInfoID], references: [id])
-  submitInfoID                                 String?
-  submitInfo                                   UpdateInfoTable?                        @relation("submitContractInfo", fields: [submitInfoID], references: [id])
+  unlockInfoID String?
+  unlockInfo   UpdateInfoTable? @relation("unlockContractInfo", fields: [unlockInfoID], references: [id])
+  submitInfoID String?
+  submitInfo   UpdateInfoTable? @relation("submitContractInfo", fields: [submitInfoID], references: [id])
 
-  createdAt                                    DateTime                                @default(now())
-  updatedAt                                    DateTime                                @default(now()) @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
 
   submissionType                               SubmissionType
   submissionDescription                        String
@@ -83,12 +83,12 @@ model ContractRevisionTable {
   populationCovered                            PopulationCoverageType?
   riskBasedContract                            Boolean?
   stateContacts                                StateContact[]
-  supportingDocuments                          ContractSupportingDocument[]
   contractType                                 ContractType
   contractExecutionStatus                      ContractExecutionStatus?
-  contractDocuments                            ContractDocument[]
-  contractDateStart                            DateTime?                               @db.Date
-  contractDateEnd                              DateTime?                               @db.Date
+  contractDocuments                            ContractDocument[]       @relation(name: "ContractDocumentOnContractRevision")
+  supportingDocuments                          ContractDocument[]       @relation(name: "SupportingDocumentOnContractRevision")
+  contractDateStart                            DateTime?                @db.Date
+  contractDateEnd                              DateTime?                @db.Date
   managedCareEntities                          ManagedCareEntity[]
   federalAuthorities                           FederalAuthority[]
   modifiedBenefitsProvided                     Boolean?
@@ -111,32 +111,32 @@ model ContractRevisionTable {
 }
 
 model RateRevisionTable {
-  id                             String                                  @id @default(uuid())
-  rateID                         String
-  rate                           RateTable                               @relation(fields: [rateID], references: [id])
-  contractRevisions              RateRevisionsOnContractRevisionsTable[]
-  draftContracts                 ContractTable[]
+  id                String                                  @id @default(uuid())
+  rateID            String
+  rate              RateTable                               @relation(fields: [rateID], references: [id])
+  contractRevisions RateRevisionsOnContractRevisionsTable[]
+  draftContracts    ContractTable[]
 
-  createdAt                      DateTime                                @default(now())
-  updatedAt                      DateTime                                @default(now()) @updatedAt
-  unlockInfoID                   String?
-  unlockInfo                     UpdateInfoTable?                        @relation("unlockRateInfo", fields: [unlockInfoID], references: [id])
-  submitInfoID                   String?
-  submitInfo                     UpdateInfoTable?                        @relation("submitRateInfo", fields: [submitInfoID], references: [id])
+  createdAt    DateTime         @default(now())
+  updatedAt    DateTime         @default(now()) @updatedAt
+  unlockInfoID String?
+  unlockInfo   UpdateInfoTable? @relation("unlockRateInfo", fields: [unlockInfoID], references: [id])
+  submitInfoID String?
+  submitInfo   UpdateInfoTable? @relation("submitRateInfo", fields: [submitInfoID], references: [id])
 
   rateType                       RateType?
   rateCapitationType             RateCapitationType?
-  rateDocuments                  RateDocument[]
-  supportingDocuments            RateSupportingDocument[]
-  rateDateStart                  DateTime?                               @db.Date
-  rateDateEnd                    DateTime?                               @db.Date
-  rateDateCertified              DateTime?                               @db.Date
-  amendmentEffectiveDateStart    DateTime?                               @db.Date
-  amendmentEffectiveDateEnd      DateTime?                               @db.Date
+  rateDocuments                  RateDocument[]             @relation(name: "RateDocumentOnRateRevision")
+  supportingDocuments            RateDocument[]             @relation(name: "SupportingDocumentOnRateRevision")
+  rateDateStart                  DateTime?                  @db.Date
+  rateDateEnd                    DateTime?                  @db.Date
+  rateDateCertified              DateTime?                  @db.Date
+  amendmentEffectiveDateStart    DateTime?                  @db.Date
+  amendmentEffectiveDateEnd      DateTime?                  @db.Date
   rateProgramIDs                 String[]
   rateCertificationName          String?
-  certifyingActuaryContacts      ActuaryContact[] @relation(name: "CertifyingActuaryOnRateRevision")
-  addtlActuaryContacts           ActuaryContact[] @relation(name: "AddtlActuaryOnRateRevision")
+  certifyingActuaryContacts      ActuaryContact[]           @relation(name: "CertifyingActuaryOnRateRevision")
+  addtlActuaryContacts           ActuaryContact[]           @relation(name: "AddtlActuaryOnRateRevision")
   actuaryCommunicationPreference ActuaryCommunication?
   packagesWithSharedRateCerts    SharedRateCertifications[]
 }
@@ -155,15 +155,15 @@ model RateRevisionsOnContractRevisionsTable {
 }
 
 model UpdateInfoTable {
-  id                String                  @id @default(uuid())
-  updatedAt         DateTime
-  updatedByID       String
-  updatedBy         User                    @relation(fields: [updatedByID], references: [id])
-  updatedReason     String
-  unlockedContracts ContractRevisionTable[] @relation("unlockContractInfo")
+  id                 String                  @id @default(uuid())
+  updatedAt          DateTime
+  updatedByID        String
+  updatedBy          User                    @relation(fields: [updatedByID], references: [id])
+  updatedReason      String
+  unlockedContracts  ContractRevisionTable[] @relation("unlockContractInfo")
   submittedContracts ContractRevisionTable[] @relation("submitContractInfo")
-  unlockedRates     RateRevisionTable[]     @relation("unlockRateInfo")
-  submittedRates    RateRevisionTable[]     @relation("submitRateInfo")
+  unlockedRates      RateRevisionTable[]     @relation("unlockRateInfo")
+  submittedRates     RateRevisionTable[]     @relation("submitRateInfo")
 }
 
 model SharedRateCertifications {
@@ -175,62 +175,44 @@ model SharedRateCertifications {
 }
 
 model ActuaryContact {
-  id                 String                 @id @default(uuid())
-  createdAt          DateTime               @default(now())
-  updatedAt          DateTime               @default(now()) @updatedAt
-  name               String?
-  titleRole          String?
-  email              String?
-  actuarialFirm      ActuarialFirm?
-  actuarialFirmOther String?
-  rateWithCertifyingActuaryID    String?
-  rateWithAddtlActuaryID    String?
-  rateActuaryCertifying  RateRevisionTable?  @relation(name: "CertifyingActuaryOnRateRevision", fields: [  rateWithCertifyingActuaryID ], references: [id])
-  rateActuaryAddtl   RateRevisionTable?   @relation(name: "AddtlActuaryOnRateRevision", fields: [   rateWithAddtlActuaryID ], references: [id])
+  id                          String             @id @default(uuid())
+  createdAt                   DateTime           @default(now())
+  updatedAt                   DateTime           @default(now()) @updatedAt
+  name                        String?
+  titleRole                   String?
+  email                       String?
+  actuarialFirm               ActuarialFirm?
+  actuarialFirmOther          String?
+  rateWithCertifyingActuaryID String?
+  rateWithAddtlActuaryID      String?
+  rateActuaryCertifying       RateRevisionTable? @relation(name: "CertifyingActuaryOnRateRevision", fields: [rateWithCertifyingActuaryID], references: [id])
+  rateActuaryAddtl            RateRevisionTable? @relation(name: "AddtlActuaryOnRateRevision", fields: [rateWithAddtlActuaryID], references: [id])
 }
 
 model ContractDocument {
-  id                 String                @id @default(uuid())
-  createdAt          DateTime              @default(now())
-  updatedAt          DateTime              @default(now()) @updatedAt
-  name               String
-  s3URL              String
-  sha256             String
-  contractRevisionID String
-  contractRevision   ContractRevisionTable @relation(fields: [contractRevisionID], references: [id])
-}
-
-model ContractSupportingDocument {
-  id                 String                @id @default(uuid())
-  createdAt          DateTime              @default(now())
-  updatedAt          DateTime              @default(now()) @updatedAt
-  name               String
-  s3URL              String
-  sha256             String
-  contractRevisionID String
-  contractRevision   ContractRevisionTable @relation(fields: [contractRevisionID], references: [id])
+  id                                 String                 @id @default(uuid())
+  createdAt                          DateTime               @default(now())
+  updatedAt                          DateTime               @default(now()) @updatedAt
+  name                               String
+  s3URL                              String
+  sha256                             String
+  contractDocumentRevisionID         String
+  supportingDocumentRevisionID       String
+  contractDocumentContractRevision   ContractRevisionTable? @relation(name: "ContractDocumentOnContractRevision", fields: [contractDocumentRevisionID], references: [id])
+  supportingDocumentContractRevision ContractRevisionTable? @relation(name: "SupportingDocumentOnContractRevision", fields: [supportingDocumentRevisionID], references: [id])
 }
 
 model RateDocument {
-  id             String            @id @default(uuid())
-  createdAt      DateTime          @default(now())
-  updatedAt      DateTime          @default(now()) @updatedAt
-  name           String
-  s3URL          String
-  sha256         String
-  rateRevisionID String
-  rateRevision   RateRevisionTable @relation(fields: [rateRevisionID], references: [id])
-}
-
-model RateSupportingDocument {
-  id             String            @id @default(uuid())
-  createdAt      DateTime          @default(now())
-  updatedAt      DateTime          @default(now()) @updatedAt
-  name           String
-  s3URL          String
-  sha256         String
-  rateRevisionID String
-  rateRevision   RateRevisionTable @relation(fields: [rateRevisionID], references: [id])
+  id                                 String             @id @default(uuid())
+  createdAt                          DateTime           @default(now())
+  updatedAt                          DateTime           @default(now()) @updatedAt
+  name                               String
+  s3URL                              String
+  sha256                             String
+  rateDocumentRevisionID             String
+  supportingDocumentRevisionID       String
+  ratetDocumentContractRevision      RateRevisionTable? @relation(name: "RateDocumentOnRateRevision", fields: [rateDocumentRevisionID], references: [id])
+  supportingDocumentContractRevision RateRevisionTable? @relation(name: "SupportingDocumentOnRateRevision", fields: [supportingDocumentRevisionID], references: [id])
 }
 
 model StateContact {

--- a/services/app-api/src/testHelpers/contractAndRates/contractHelpers.ts
+++ b/services/app-api/src/testHelpers/contractAndRates/contractHelpers.ts
@@ -116,7 +116,8 @@ const createContractRevision = (
     supportingDocuments: [
         {
             id: uuidv4(),
-            contractRevisionID: 'contractRevisionID',
+            contractDocumentRevisionID: 'contractDocRevisionID',
+            supportingDocumentRevisionID: 'contractSupportingRevisionID',
             createdAt: new Date(),
             updatedAt: new Date(),
             name: 'contract supporting doc',
@@ -125,7 +126,8 @@ const createContractRevision = (
         },
         {
             id: uuidv4(),
-            contractRevisionID: 'contractRevisionID',
+            contractDocumentRevisionID: 'contractDocRevisionID',
+            supportingDocumentRevisionID: 'contractSupportingRevisionID',
             createdAt: new Date(),
             updatedAt: new Date(),
             name: 'contract supporting doc 2',
@@ -138,7 +140,8 @@ const createContractRevision = (
     contractDocuments: [
         {
             id: uuidv4(),
-            contractRevisionID: 'contractRevisionID',
+            contractDocumentRevisionID: 'contractDocRevisionID',
+            supportingDocumentRevisionID: 'contractSupportingRevisionID',
             createdAt: new Date(),
             updatedAt: new Date(),
             name: 'contract doc',

--- a/services/app-api/src/testHelpers/contractAndRates/contractHelpers.ts
+++ b/services/app-api/src/testHelpers/contractAndRates/contractHelpers.ts
@@ -123,6 +123,7 @@ const createContractRevision = (
             name: 'contract supporting doc',
             s3URL: 'fakeS3URL',
             sha256: '2342fwlkdmwvw',
+            display_seq: null,
         },
         {
             id: uuidv4(),
@@ -133,6 +134,7 @@ const createContractRevision = (
             name: 'contract supporting doc 2',
             s3URL: 'fakeS3URL',
             sha256: '45662342fwlkdmwvw',
+            display_seq: null,
         },
     ],
     contractType: 'BASE',
@@ -147,6 +149,7 @@ const createContractRevision = (
             name: 'contract doc',
             s3URL: 'fakeS3URL',
             sha256: '8984234fwlkdmwvw',
+            display_seq: null,
         },
     ],
     contractDateStart: new Date(Date.UTC(2025, 5, 1)),

--- a/services/app-api/src/testHelpers/contractAndRates/rateHelpers.ts
+++ b/services/app-api/src/testHelpers/contractAndRates/rateHelpers.ts
@@ -1,15 +1,17 @@
-
 import { must } from '../errorHelpers'
 import { v4 as uuidv4 } from 'uuid'
-import type { PrismaClient,State } from '@prisma/client'
+import type { PrismaClient, State } from '@prisma/client'
 import type { InsertRateArgsType } from '../../postgres/contractAndRates/insertRate'
-import type { RateTableFullPayload, RateRevisionTableWithContracts } from '../../postgres/contractAndRates/prismaSubmittedRateHelpers'
+import type {
+    RateTableFullPayload,
+    RateRevisionTableWithContracts,
+} from '../../postgres/contractAndRates/prismaSubmittedRateHelpers'
 const createInsertRateData = (
     rateArgs?: Partial<InsertRateArgsType>
 ): InsertRateArgsType => {
     return {
         stateCode: rateArgs?.stateCode ?? 'MN',
-        ...rateArgs
+        ...rateArgs,
     }
 }
 
@@ -34,7 +36,7 @@ const getStateRecord = async (
 
 const createDraftRateData = (
     rate?: Partial<RateTableFullPayload>
-): RateTableFullPayload=> ({
+): RateTableFullPayload => ({
     id: '24fb2a5f-6d0d-4e26-9906-4de28927c882',
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -66,11 +68,8 @@ const createRateData = (
 })
 
 const createRateRevision = (
-    revision?: Partial<
-    RateRevisionTableWithContracts
-    >
-):
-    RateRevisionTableWithContracts => ({
+    revision?: Partial<RateRevisionTableWithContracts>
+): RateRevisionTableWithContracts => ({
     id: uuidv4(),
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -95,7 +94,7 @@ const createRateRevision = (
     submitInfoID: null,
     unlockInfoID: null,
     rateType: 'NEW',
-    rateID:  'rateID',
+    rateID: 'rateID',
     rateCertificationName: 'testState-123',
     rateProgramIDs: ['Program'],
     rateCapitationType: 'RATE_CELL',
@@ -110,7 +109,8 @@ const createRateRevision = (
     supportingDocuments: [
         {
             id: uuidv4(),
-            rateRevisionID: 'rateRevisionID',
+            rateDocumentRevisionID: 'rateDocRevisionID',
+            supportingDocumentRevisionID: 'rateSupportingRevisionID',
             createdAt: new Date(),
             updatedAt: new Date(),
             name: 'rate supporting doc',
@@ -119,7 +119,8 @@ const createRateRevision = (
         },
         {
             id: uuidv4(),
-            rateRevisionID: 'rateRevisionID',
+            rateDocumentRevisionID: 'rateDocRevisionID',
+            supportingDocumentRevisionID: 'rateSupportingRevisionID',
             createdAt: new Date(),
             updatedAt: new Date(),
             name: 'rate supporting doc 2',
@@ -130,7 +131,8 @@ const createRateRevision = (
     rateDocuments: [
         {
             id: uuidv4(),
-            rateRevisionID: 'rateRevisionID',
+            rateDocumentRevisionID: 'rateDocRevisionID',
+            supportingDocumentRevisionID: 'rateSupportingRevisionID',
             createdAt: new Date(),
             updatedAt: new Date(),
             name: 'contract doc',

--- a/services/app-api/src/testHelpers/contractAndRates/rateHelpers.ts
+++ b/services/app-api/src/testHelpers/contractAndRates/rateHelpers.ts
@@ -116,6 +116,7 @@ const createRateRevision = (
             name: 'rate supporting doc',
             s3URL: 'fakeS3URL',
             sha256: '2342fwlkdmwvw',
+            display_seq: null,
         },
         {
             id: uuidv4(),
@@ -126,6 +127,7 @@ const createRateRevision = (
             name: 'rate supporting doc 2',
             s3URL: 'fakeS3URL',
             sha256: '45662342fwlkdmwvw',
+            display_seq: null,
         },
     ],
     rateDocuments: [
@@ -138,6 +140,7 @@ const createRateRevision = (
             name: 'contract doc',
             s3URL: 'fakeS3URL',
             sha256: '8984234fwlkdmwvw',
+            display_seq: null,
         },
     ],
     contractRevisions: [],


### PR DESCRIPTION
## Summary
Two proposed changes to new rates refactor db that have come up via Slack conversations and in person pairing. 

1. Supporting documents fields by using named relation, rather than standalone tables
2. Add optional `display_seq` field.
