### PR TITLE
[MR-3339] ensure that logged in and non logged in users can access the help page

### DIFF
--- a/services/app-web/src/components/Header/Header.tsx
+++ b/services/app-web/src/components/Header/Header.tsx
@@ -70,6 +70,7 @@ export const Header = ({
             </div>
             <PageHeadingRow
                 heading={route !== 'UNKNOWN_ROUTE' ? heading : undefined}
+                route={route}
                 isLoading={loginStatus === 'LOADING'}
                 loggedInUser={loggedInUser}
             />

--- a/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.test.tsx
+++ b/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.test.tsx
@@ -45,10 +45,7 @@ describe('Page Heading Row', () => {
 
     it('renders without errors and without the managed care header on the help page page', () => {
         renderWithProviders(<PageHeadingRow route="HELP" />)
-        expect(screen.getByRole('heading')).toBeInTheDocument()
-        expect(screen.getByRole('heading')).not.toHaveTextContent(
-            'Medicaid and CHIP Managed Care Reporting and Review System'
-        )
+        expect(screen.getByRole('heading')).not.toBeInTheDocument()
     })
 
     it('does not display heading text when isLoading', async () => {

--- a/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.test.tsx
+++ b/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.test.tsx
@@ -45,7 +45,10 @@ describe('Page Heading Row', () => {
 
     it('renders without errors and without the managed care header on the help page page', () => {
         renderWithProviders(<PageHeadingRow route="ROOT" />)
-        expect(screen.getByRole('heading')).not.toBeInTheDocument()
+        expect(screen.getByRole('heading')).toBeInTheDocument()
+        expect(screen.getByRole('heading')).not.toHaveTextContent(
+            'Medicaid and CHIP Managed Care Reporting and Review System'
+        )
     })
 
     it('does not display heading text when isLoading', async () => {

--- a/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.test.tsx
+++ b/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.test.tsx
@@ -45,7 +45,7 @@ describe('Page Heading Row', () => {
 
     it('renders without errors and without the managed care header on the help page page', () => {
         renderWithProviders(<PageHeadingRow route="HELP" />)
-        expect(screen.getByRole('heading')).not.toBeInTheDocument()
+        expect(screen.queryByRole('heading')).not.toBeInTheDocument()
     })
 
     it('does not display heading text when isLoading', async () => {

--- a/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.test.tsx
+++ b/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.test.tsx
@@ -44,7 +44,7 @@ describe('Page Heading Row', () => {
     })
 
     it('renders without errors and without the managed care header on the help page page', () => {
-        renderWithProviders(<PageHeadingRow route="ROOT" />)
+        renderWithProviders(<PageHeadingRow route="HELP" />)
         expect(screen.getByRole('heading')).toBeInTheDocument()
         expect(screen.getByRole('heading')).not.toHaveTextContent(
             'Medicaid and CHIP Managed Care Reporting and Review System'

--- a/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.test.tsx
+++ b/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.test.tsx
@@ -61,7 +61,9 @@ describe('Page Heading Row', () => {
     })
 
     it('displays Medicaid and CHIP Managed Care Reporting heading when logged out', () => {
-        renderWithProviders(<PageHeadingRow heading="Custom page heading" />)
+        renderWithProviders(
+            <PageHeadingRow heading="Custom page heading" route="ROOT" />
+        )
         expect(screen.getByRole('heading')).toHaveTextContent(
             'Medicaid and CHIP Managed Care Reporting and Review System'
         )
@@ -72,6 +74,7 @@ describe('Page Heading Row', () => {
             <PageHeadingRow
                 heading="Custom page heading"
                 loggedInUser={loggedInUser}
+                route="ROOT"
             />
         )
         expect(screen.getByRole('heading')).not.toHaveTextContent(

--- a/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.test.tsx
+++ b/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.test.tsx
@@ -38,13 +38,18 @@ describe('Page Heading Row', () => {
         role: 'State User',
         email: 'bob@dmas.mn.gov',
     }
-    it('renders without errors', () => {
-        renderWithProviders(<PageHeadingRow />)
+    it('renders without errors and with the managed care header on the landing page', () => {
+        renderWithProviders(<PageHeadingRow route="ROOT" />)
         expect(screen.getByRole('heading')).toBeInTheDocument()
     })
 
+    it('renders without errors and without the managed care header on the help page page', () => {
+        renderWithProviders(<PageHeadingRow route="ROOT" />)
+        expect(screen.getByRole('heading')).not.toBeInTheDocument()
+    })
+
     it('does not display heading text when isLoading', async () => {
-        renderWithProviders(<PageHeadingRow isLoading />)
+        renderWithProviders(<PageHeadingRow isLoading route="ROOT" />)
 
         expect(screen.getByRole('heading')).toBeInTheDocument()
         expect(screen.getByRole('heading')).not.toHaveTextContent(

--- a/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.tsx
+++ b/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.tsx
@@ -100,15 +100,21 @@ type PageHeadingProps = {
     isLoading?: boolean
     loggedInUser?: User
     heading?: string
+    route?: string
 }
 
 export const PageHeadingRow = ({
     isLoading = false,
     heading,
+    route,
     loggedInUser,
 }: PageHeadingProps): React.ReactElement | null => {
     if (!loggedInUser) {
-        return <LandingRow isLoading={isLoading} />
+        if (route === 'ROOT') {
+            return <LandingRow isLoading={isLoading} />
+        } else {
+            return null
+        }
     }
 
     if (

--- a/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.tsx
+++ b/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.tsx
@@ -110,7 +110,7 @@ export const PageHeadingRow = ({
     loggedInUser,
 }: PageHeadingProps): React.ReactElement | null => {
     if (!loggedInUser) {
-        if (route === 'ROOT') {
+        if (route === 'ROOT' || route === 'AUTH') {
             return <LandingRow isLoading={isLoading} />
         } else {
             return null

--- a/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.tsx
+++ b/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.tsx
@@ -110,10 +110,10 @@ export const PageHeadingRow = ({
     loggedInUser,
 }: PageHeadingProps): React.ReactElement | null => {
     if (!loggedInUser) {
-        if (route === 'ROOT' || route === 'AUTH') {
-            return <LandingRow isLoading={isLoading} />
-        } else {
+        if (route === 'HELP') {
             return null
+        } else {
+            return <LandingRow isLoading={isLoading} />
         }
     }
 

--- a/services/app-web/src/pages/App/AppRoutes.test.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.test.tsx
@@ -1,0 +1,184 @@
+import { screen, waitFor } from '@testing-library/react'
+
+import {
+    ldUseClientSpy,
+    renderWithProviders,
+} from '../../testHelpers/jestHelpers'
+import { AppRoutes } from './AppRoutes'
+import {
+    fetchCurrentUserMock,
+    mockValidCMSUser,
+    indexHealthPlanPackagesMockSuccess,
+} from '../../testHelpers/apolloMocks'
+import { AppBody } from './AppBody'
+
+// Routing and routes configuration
+describe('AppRoutes', () => {
+    window.scrollTo = jest.fn()
+    afterEach(() => {
+        jest.resetAllMocks()
+    })
+    afterAll(() => {
+        jest.clearAllMocks()
+    })
+    describe('/[root]', () => {
+        it('dashboard when state user logged in', async () => {
+            ldUseClientSpy({ 'session-expiring-modal': false })
+            renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({ statusCode: 200 }),
+                        indexHealthPlanPackagesMockSuccess(),
+                    ],
+                },
+            })
+
+            await waitFor(() => {
+                expect(screen.getByTestId('dashboard-page')).toBeInTheDocument()
+                expect(
+                    screen.queryByRole('heading', {
+                        level: 2,
+                        name: /Submissions/,
+                    })
+                ).toBeInTheDocument()
+            })
+        })
+
+        it('landing page when logged out', async () => {
+            ldUseClientSpy({ 'session-expiring-modal': false })
+            renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />)
+            await waitFor(() => {
+                expect(
+                    screen.getByRole('heading', {
+                        name: /How it works/i,
+                        level: 2,
+                    })
+                ).toBeInTheDocument()
+            })
+            expect(
+                screen.getByRole('heading', {
+                    name: /Submit your managed care health plans to CMS for review/i,
+                    level: 2,
+                })
+            ).toBeInTheDocument()
+        })
+    })
+
+    describe('/auth', () => {
+        it('auth header is displayed', async () => {
+            ldUseClientSpy({ 'session-expiring-modal': false })
+            renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
+                routerProvider: { route: '/auth' },
+            })
+
+            await waitFor(() => {
+                expect(
+                    screen.getByRole('heading', {
+                        name: /Auth Page/i,
+                        level: 2,
+                    })
+                ).toBeInTheDocument()
+            })
+            expect(
+                screen.queryByRole('heading', {
+                    name: /How it works/i,
+                    level: 2,
+                })
+            ).toBeNull()
+        })
+    })
+
+    describe('/help', () => {
+        it('can be accessed by state user', async () => {
+            renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
+                routerProvider: { route: '/help' },
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            })
+
+            await waitFor(() => {
+                expect(
+                    screen.getByRole('heading', {
+                        name: /Help documentation/i,
+                        level: 2,
+                    })
+                ).toBeInTheDocument()
+            })
+        })
+
+        it('can be accessed by CMS user', async () => {
+            renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
+                routerProvider: { route: '/help' },
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            statusCode: 200,
+                            user: mockValidCMSUser(),
+                        }),
+                    ],
+                },
+            })
+
+            await waitFor(() => {
+                expect(
+                    screen.getByRole('heading', {
+                        name: /Help documentation/i,
+                        level: 2,
+                    })
+                ).toBeInTheDocument()
+            })
+        })
+
+        it('can be accessed by unauthenticated users', async () => {
+            renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
+                routerProvider: { route: '/help' },
+            })
+
+            await waitFor(() => {
+                expect(
+                    screen.getByRole('heading', {
+                        name: /Help documentation/i,
+                        level: 2,
+                    })
+                ).toBeInTheDocument()
+            })
+        })
+    })
+
+    describe('invalid routes', () => {
+        it('redirect to landing page when logged out', async () => {
+            ldUseClientSpy({ 'session-expiring-modal': false })
+            renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
+                routerProvider: { route: '/not-a-real-place' },
+            })
+            await waitFor(() => {
+                expect(
+                    screen.getByRole('heading', {
+                        name: /How it works/i,
+                        level: 2,
+                    })
+                ).toBeInTheDocument()
+            })
+        })
+
+        it('redirects to 404 error page when logged in', async () => {
+            ldUseClientSpy({ 'session-expiring-modal': false })
+            renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+                routerProvider: { route: '/not-a-real-place' },
+            })
+
+            await waitFor(() =>
+                expect(
+                    screen.getByRole('heading', {
+                        name: /Page not found/i,
+                        level: 1,
+                    })
+                ).toBeInTheDocument()
+            )
+        })
+    })
+})

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { Fragment, useEffect, useState } from 'react'
 import { useNavigate, useLocation } from 'react-router'
 import { Route, Routes } from 'react-router-dom'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
@@ -48,6 +48,14 @@ function componentForAuthMode(
             assertNever(authMode)
     }
 }
+
+// Routes that are agnostic to user login and authentication
+// Should be available on all defined routes lists
+const UniversalRoutes = (
+    <Fragment>
+        <Route path={RoutesRecord.HELP} element={<Help />} />
+    </Fragment>
+)
 
 const StateUserRoutes = ({
     authMode,
@@ -104,7 +112,7 @@ const StateUserRoutes = ({
                     path={RoutesRecord.SUBMISSIONS_FORM}
                     element={<StateSubmissionForm />}
                 />
-                <Route path={RoutesRecord.HELP} element={<Help />} />
+                {UniversalRoutes}
                 {stageName !== 'prod' && (
                     <Route
                         path={RoutesRecord.GRAPHQL_EXPLORER}
@@ -169,7 +177,7 @@ const CMSUserRoutes = ({
                 )}
                 <Route path={RoutesRecord.REPORTS} element={<Reports />} />
                 <Route path={RoutesRecord.SETTINGS} element={<Settings />} />
-                <Route path={RoutesRecord.HELP} element={<Help />} />
+                {UniversalRoutes}
                 <Route path="*" element={<Error404 />} />
             </Routes>
         </AuthenticatedRouteWrapper>
@@ -186,7 +194,7 @@ const UnauthenticatedRoutes = ({
     return (
         <Routes>
             <Route path={RoutesRecord.ROOT} element={<Landing />} />
-            <Route path={RoutesRecord.HELP} element={<Help />} />
+            {UniversalRoutes}
             {/* no /auth page for IDM auth, we just have the login redirect link */}
             {authComponent && (
                 <Route path={RoutesRecord.AUTH} element={authComponent} />

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -69,6 +69,8 @@ const StateUserRoutes = ({
                     element={<StateDashboard />}
                 />
 
+                <Route path={RoutesRecord.HELP} element={<Help />} />
+
                 <Route
                     path={RoutesRecord.SUBMISSIONS}
                     element={<StateDashboard />}

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -68,9 +68,6 @@ const StateUserRoutes = ({
                     path={RoutesRecord.DASHBOARD}
                     element={<StateDashboard />}
                 />
-
-                <Route path={RoutesRecord.HELP} element={<Help />} />
-
                 <Route
                     path={RoutesRecord.SUBMISSIONS}
                     element={<StateDashboard />}
@@ -107,6 +104,7 @@ const StateUserRoutes = ({
                     path={RoutesRecord.SUBMISSIONS_FORM}
                     element={<StateSubmissionForm />}
                 />
+                <Route path={RoutesRecord.HELP} element={<Help />} />
                 {stageName !== 'prod' && (
                     <Route
                         path={RoutesRecord.GRAPHQL_EXPLORER}
@@ -171,6 +169,7 @@ const CMSUserRoutes = ({
                 )}
                 <Route path={RoutesRecord.REPORTS} element={<Reports />} />
                 <Route path={RoutesRecord.SETTINGS} element={<Settings />} />
+                <Route path={RoutesRecord.HELP} element={<Help />} />
                 <Route path="*" element={<Error404 />} />
             </Routes>
         </AuthenticatedRouteWrapper>

--- a/services/app-web/src/pages/CMSDashboard/CMSDashboard.tsx
+++ b/services/app-web/src/pages/CMSDashboard/CMSDashboard.tsx
@@ -24,7 +24,7 @@ import {
  * We only pull a subset of data out of the submission and revisions for display in Dashboard
  * Depending on submission status, CMS users look at data from current or previous revision
  */
-
+const DASHBOARD_ATTRIBUTE = 'cms-dashboard-page'
 export const CMSDashboard = (): React.ReactElement => {
     const { loginStatus, loggedInUser } = useAuth()
     const { loading, data, error } = useIndexHealthPlanPackagesQuery({
@@ -36,22 +36,22 @@ export const CMSDashboard = (): React.ReactElement => {
         handleApolloError(error, isAuthenticated)
         if (isLikelyUserAuthError(error, isAuthenticated)) {
             return (
-                <div id="cms-dashboard-page" className={styles.wrapper}>
-                    <GridContainer
-                        data-testid="cms-dashboard-page"
-                        className={styles.container}
-                    >
+                <div
+                    data-testid={DASHBOARD_ATTRIBUTE}
+                    className={styles.wrapper}
+                >
+                    <GridContainer className={styles.container}>
                         <ErrorAlertSignIn />
                     </GridContainer>
                 </div>
             )
         } else {
             return (
-                <div id="cms-dashboard-page" className={styles.wrapper}>
-                    <GridContainer
-                        data-testid="cms-dashboard-page"
-                        className={styles.container}
-                    >
+                <div
+                    data-testid={DASHBOARD_ATTRIBUTE}
+                    className={styles.wrapper}
+                >
+                    <GridContainer className={styles.container}>
                         <ErrorAlertFailedRequest />
                     </GridContainer>
                 </div>
@@ -161,11 +161,8 @@ export const CMSDashboard = (): React.ReactElement => {
 
     return (
         <>
-            <div id="cms-dashboard-page" className={styles.wrapper}>
-                <GridContainer
-                    className={styles.container}
-                    data-testid="cms-dashboard-page"
-                >
+            <div data-testid={DASHBOARD_ATTRIBUTE} className={styles.wrapper}>
+                <GridContainer className={styles.container}>
                     <section className={styles.panel}>
                         <div className={styles.panelHeader}>
                             <h2>Submissions</h2>

--- a/services/app-web/src/pages/Help/Help.tsx
+++ b/services/app-web/src/pages/Help/Help.tsx
@@ -2,9 +2,11 @@ import React, { useEffect } from 'react'
 import { useLocation } from 'react-router'
 import { GridContainer, Table } from '@trussworks/react-uswds'
 import styles from './Help.module.scss'
+import { useAuth } from '../../contexts/AuthContext'
 
 export const Help = (): React.ReactElement => {
     const location = useLocation()
+    const { loggedInUser } = useAuth()
 
     useEffect(() => {
         if (location.hash) {
@@ -15,7 +17,11 @@ export const Help = (): React.ReactElement => {
     }, [location])
 
     return (
-        <GridContainer>
+        <GridContainer
+            data-testid={
+                loggedInUser ? 'help-authenticated' : 'help-unauthenticated'
+            }
+        >
             <h2>Help documentation</h2>
             <section className={styles.helpSection}>
                 <h3 id="submission-description">

--- a/services/app-web/src/pages/Landing/Landing.module.scss
+++ b/services/app-web/src/pages/Landing/Landing.module.scss
@@ -1,6 +1,8 @@
 @import '../../styles/uswdsImports.scss';
 @import '../../styles/custom.scss';
 
+$details-text-line-height: 1.5;
+
 .detailsSection {
     background-color: $cms-color-background;
     flex: 1;
@@ -29,7 +31,7 @@
                 border-left: 3px solid $theme-color-base-lighter;
                 padding-left: units(4);
                 position: relative;
-                line-height: line-height('body', 3);
+                line-height: $details-text-line-height;
 
                 &:last-child {
                     padding-bottom: 0;
@@ -62,7 +64,7 @@
         .detailsList {
             > li {
                 padding: units(1);
-                font-size: size('body', 'md');
+                line-height: $details-text-line-height;
             }
         }
     }

--- a/services/app-web/src/pages/Landing/Landing.tsx
+++ b/services/app-web/src/pages/Landing/Landing.tsx
@@ -81,7 +81,7 @@ export const Landing = (): React.ReactElement => {
                                 Submit your managed care health plans to CMS for
                                 review
                             </h2>
-                            <p>
+                            <p className="line-height-sans-4 measure-6">
                                 You can use MC-Review to submit Medicaid and
                                 CHIP managed care health plan contracts and
                                 rates to CMS. This portal accepts:
@@ -118,8 +118,6 @@ export const Landing = (): React.ReactElement => {
                                     Eligible Special Needs Plans (D-SNP),
                                     Programs of All-Inclusive Care for the
                                     Elderly (PACE), dual demonstration contracts
-                                    Non health plan submissions (EBRK, EQRO,
-                                    dual demonstration contracts)
                                 </li>
                             </ul>
                         </Grid>

--- a/services/app-web/src/pages/StateDashboard/StateDashboard.test.tsx
+++ b/services/app-web/src/pages/StateDashboard/StateDashboard.test.tsx
@@ -135,7 +135,9 @@ describe('StateDashboard', () => {
         })
 
         await waitFor(() => {
-            expect(screen.queryByTestId('dashboard-page')).toBeInTheDocument()
+            expect(
+                screen.queryByTestId('state-dashboard-page')
+            ).toBeInTheDocument()
             expect(screen.queryByTestId('accordion')).not.toBeInTheDocument()
         })
     })

--- a/services/app-web/src/pages/StateDashboard/StateDashboard.tsx
+++ b/services/app-web/src/pages/StateDashboard/StateDashboard.tsx
@@ -23,6 +23,7 @@ import { getCurrentRevisionFromHealthPlanPackage } from '../../gqlHelpers'
  * We only pull a subset of data out of the submission and revisions for display in Dashboard
  */
 
+const DASHBOARD_ATTRIBUTE = 'state-dashboard-page'
 export const StateDashboard = (): React.ReactElement => {
     const { loginStatus, loggedInUser } = useAuth()
     const location = useLocation()
@@ -32,7 +33,7 @@ export const StateDashboard = (): React.ReactElement => {
     if (error) {
         handleApolloError(error, true)
         return (
-            <div id="dashboard-page" className={styles.wrapper}>
+            <div id={DASHBOARD_ATTRIBUTE} className={styles.wrapper}>
                 <GridContainer className={styles.container}>
                     {isLikelyUserAuthError(error, true) ? (
                         <ErrorAlertSignIn />
@@ -50,8 +51,8 @@ export const StateDashboard = (): React.ReactElement => {
 
     if (loggedInUser.__typename !== 'StateUser') {
         return (
-            <div id="dashboard-page" className={styles.wrapper}>
-                <div>CMS Users not supported yet.</div>{' '}
+            <div id={DASHBOARD_ATTRIBUTE} className={styles.wrapper}>
+                <div>State dashboard only visible for state users.</div>{' '}
             </div>
         )
     }
@@ -88,11 +89,8 @@ export const StateDashboard = (): React.ReactElement => {
 
     return (
         <>
-            <div id="dashboard-page" className={styles.wrapper}>
-                <GridContainer
-                    className={styles.container}
-                    data-testid="dashboard-page"
-                >
+            <div data-testid={DASHBOARD_ATTRIBUTE} className={styles.wrapper}>
+                <GridContainer className={styles.container}>
                     {programs.length ? (
                         <section className={styles.panel}>
                             {justSubmittedSubmissionName && (

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.module.scss
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.module.scss
@@ -133,7 +133,7 @@
 
 .legendSubHeader {
     font-weight: normal;
-}
+} 
 
 .guidanceTextBlock{
     padding-top: 0;

--- a/services/app-web/src/testHelpers/apolloMocks/userGQLMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/userGQLMock.ts
@@ -1,4 +1,5 @@
 import { MockedResponse } from '@apollo/client/testing'
+import { ServerError } from '@apollo/client'
 import {
     CmsUser,
     FetchCurrentUserDocument,
@@ -58,6 +59,12 @@ const fetchCurrentUserMock = ({
     statusCode,
 }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
 fetchCurrentUserMockProps): MockedResponse<Record<string, any>> => {
+    const mockError = (message: string, statusCode?: number) => {
+        const error = new Error(message) as ServerError
+        error.statusCode = statusCode || 400
+        error.name = 'ServerError'
+        return error
+    }
     switch (statusCode) {
         case 200:
             return {
@@ -71,12 +78,12 @@ fetchCurrentUserMockProps): MockedResponse<Record<string, any>> => {
         case 403:
             return {
                 request: { query: FetchCurrentUserDocument },
-                error: new Error('You are not logged in'),
+                error: mockError('You are not logged in', 403),
             }
         default:
             return {
                 request: { query: FetchCurrentUserDocument },
-                error: new Error('A network error occurred'),
+                error: mockError('A network error occurred', 500),
             }
     }
 }

--- a/services/app-web/src/testHelpers/apolloMocks/userGQLMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/userGQLMock.ts
@@ -54,7 +54,7 @@ type fetchCurrentUserMockProps = {
     statusCode: 200 | 403 | 500
 }
 const fetchCurrentUserMock = ({
-    user = mockValidUser(),
+    user = mockValidUser(), // defaults to logged in state user, we can override though from test
     statusCode,
 }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
 fetchCurrentUserMockProps): MockedResponse<Record<string, any>> => {

--- a/services/cypress/integration/smokeTest/smokeTest.spec.ts
+++ b/services/cypress/integration/smokeTest/smokeTest.spec.ts
@@ -17,5 +17,5 @@ describe('smoke test', () => {
     it('can contact the API and connect to the database', () => {
         cy.logInAsStateUser()
         cy.startNewContractOnlySubmissionWithBaseContract()
-    })
+    }) 
 })

--- a/services/cypress/support/loginCommands.ts
+++ b/services/cypress/support/loginCommands.ts
@@ -27,7 +27,7 @@ Cypress.Commands.add('logInAsStateUser', () => {
     cy.wait(['@fetchCurrentUserQuery', '@indexHealthPlanPackagesQuery'], {
         timeout: 80_000,
     })
-    cy.findByTestId('dashboard-page', {timeout: 10_000 }).should('exist')
+    cy.findByTestId('state-dashboard-page', {timeout: 10_000 }).should('exist')
     cy.findByText('Start new submission').should('exist')
 })
 

--- a/services/cypress/support/navigateCommands.ts
+++ b/services/cypress/support/navigateCommands.ts
@@ -28,7 +28,7 @@ Cypress.Commands.add(
             if(waitForLoad) {
                 cy.wait('@updateHealthPlanFormDataMutation', { timeout: 50_000})
              }
-            cy.findByTestId('dashboard-page').should('exist')
+            cy.findByTestId('state-dashboard-page').should('exist')
             cy.findByRole('heading',{name:'Submissions'}).should('exist')
         } else if (buttonKey === 'CONTINUE_FROM_START_NEW') {
             if (waitForLoad) {

--- a/services/cypress/support/stateSubmissionFormCommands.ts
+++ b/services/cypress/support/stateSubmissionFormCommands.ts
@@ -1,6 +1,6 @@
 Cypress.Commands.add('startNewContractOnlySubmissionWithBaseContract', () => {
     // Must be on '/submissions/new'
-    cy.findByTestId('dashboard-page').should('exist')
+    cy.findByTestId('state-dashboard-page').should('exist')
     cy.findByRole('link', { name: 'Start new submission' }).click()
     cy.findByRole('heading', { level: 1, name: /New submission/ })
 
@@ -12,7 +12,7 @@ Cypress.Commands.add('startNewContractOnlySubmissionWithBaseContract', () => {
 
 Cypress.Commands.add('startNewContractOnlySubmissionWithAmendment', () => {
     // Must be on '/submissions/new'
-    cy.findByTestId('dashboard-page').should('exist')
+    cy.findByTestId('state-dashboard-page').should('exist')
     cy.findByRole('link', { name: 'Start new submission' , timeout: 5000}).click()
     cy.findByRole('heading', { level: 1, name: /New submission/ })
 
@@ -24,7 +24,7 @@ Cypress.Commands.add('startNewContractOnlySubmissionWithAmendment', () => {
 
 Cypress.Commands.add('startNewContractAndRatesSubmission', () => {
     // Must be on '/submissions/new'
-    cy.findByTestId('dashboard-page').should('exist')
+    cy.findByTestId('state-dashboard-page').should('exist')
     cy.findByRole('link', { name: 'Start new submission', timeout: 5000 }).click()
     cy.findByRole('heading', { level: 1, name: /New submission/ })
 
@@ -504,7 +504,7 @@ Cypress.Commands.add(
             })
         cy.wait('@submitHealthPlanPackageMutation', { timeout: 50_000 })
         if (success) {
-            cy.findByTestId('dashboard-page').should('exist')
+            cy.findByTestId('state-dashboard-page').should('exist')
             cy.findByRole('heading',{name:'Submissions'}).should('exist')
         }
 


### PR DESCRIPTION
## Summary
This PR fixes an issue that was introduced in https://github.com/Enterprise-CMCS/managed-care-review/pull/1910 by ensuring that logged in users can access the help page

[Relevant slack thread](https://cmsgov.slack.com/archives/C014CRU197U/p1694207335614259)

#### Related issues
https://qmacbis.atlassian.net/browse/MR-3339

## QA guidance

As a state user, make sure the links to the help page are accessible 
