### PR TITLE
Update SecHub Epic for Jira Migration

### DIFF
--- a/.github/workflows/sechub-jira-sync.yml
+++ b/.github/workflows/sechub-jira-sync.yml
@@ -31,7 +31,7 @@ jobs:
           jira-username: ${{ secrets.JIRA_USERNAME }}
           jira-host: qmacbis.atlassian.net
           jira-project-key: MR # add issues to the 'MC-Review' project
-          jira-epic-key: MR-3092 # add issues to the '[Tech Maintenance] Security Hub' epic
+          jira-epic-key: MCR-2480 # add issues to the '[Tech Maintenance] Security Hub' epic
           jira-custom-fields: '{ "customfield_10006": 925 }' # add issues to the 'Tech Maintenance' sprint
           jira-ignore-statuses: Done
           aws-region: us-east-1


### PR DESCRIPTION
## Summary

We need to update the ID of the Security Hub findings epic for the sync tool. Since we had our Jira migrated over the weekend, this value has changed.
