### PR TITLE
MR-2923 Add tabs and empty rates dashboard

### DIFF
--- a/services/app-web/src/common-code/featureFlags/flags.ts
+++ b/services/app-web/src/common-code/featureFlags/flags.ts
@@ -70,6 +70,13 @@ const featureFlags = {
         defaultValue: false,
     },
     /**
+     * Controls the rates review dashboard UI. This flag should not be turned on without rates-db-refactor also on.
+     */
+    RATE_REVIEWS_DASHBOARD: {
+        flag: 'rate-reviews-dashboard',
+        defaultValue: false,
+    },
+    /**
      * Used in testing to simulate errors in fetching flag value.
      * This flag does not exist in LaunchDarkly dashboard so fetching this will return the defaultValue.
      */
@@ -77,8 +84,8 @@ const featureFlags = {
         flag: 'test-error-fetching-flag',
         defaultValue: undefined,
     },
-    /* 
-    Temporary flag for the cutover to a new support email address 
+    /*
+    Temporary flag for the cutover to a new support email address
     */
     HELPDESK_EMAIL: {
         flag: 'helpdesk-email',

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
@@ -50,6 +50,7 @@ export type PackageInDashboardType = {
 export type PackageTableProps = {
     tableData: PackageInDashboardType[]
     user: User
+    tableVariant?: 'RATES' | 'SUBMISSIONS'
     showFilters?: boolean
     caption?: string
 }
@@ -139,6 +140,7 @@ const columnHash = atomWithHash('filters', [] as ColumnFiltersState, {
 export const HealthPlanPackageTable = ({
     caption,
     tableData,
+    tableVariant = 'SUBMISSIONS',
     user,
     showFilters = false,
 }: PackageTableProps): React.ReactElement => {
@@ -146,9 +148,9 @@ export const HealthPlanPackageTable = ({
     const [columnFilters, setColumnFilters] = useAtom(columnHash)
 
     /* we store the last clicked element in a ref so that when the url is updated and the page rerenders
-        we can focus that element.  this useEffect (with no dependency array) will run once on each render. 
-        Note that the React-y way to do this is to use forwardRef, but the clearFilters button is deeply nested 
-        and we'd wind up passing down the ref through several layers to achieve what we can do here in a few lines 
+        we can focus that element.  this useEffect (with no dependency array) will run once on each render.
+        Note that the React-y way to do this is to use forwardRef, but the clearFilters button is deeply nested
+        and we'd wind up passing down the ref through several layers to achieve what we can do here in a few lines
         with DOM methods */
     useEffect(() => {
         const currentValue = lastClickedElement?.current
@@ -483,7 +485,13 @@ export const HealthPlanPackageTable = ({
                     data-testid="dashboard-table"
                     className={styles.panelEmptyNoSubmissionsYet}
                 >
-                    <h3>You have no submissions yet</h3>
+                    <h3>
+                        You have no{' '}
+                        {tableVariant === 'SUBMISSIONS'
+                            ? 'submissions'
+                            : 'rate reviews'}{' '}
+                        yet
+                    </h3>
                 </div>
             )}
         </>

--- a/services/app-web/src/components/Modal/UnlockSubmitModal.test.tsx
+++ b/services/app-web/src/components/Modal/UnlockSubmitModal.test.tsx
@@ -84,7 +84,7 @@ describe('UnlockSubmitModal', () => {
             await userEvent.click(screen.getByTestId('submit-modal-submit'))
 
             await waitFor(() =>
-                expect(testLocation.pathname).toBe(`/dashboard`)
+                expect(testLocation.pathname).toBe(`/dashboard/submissions`)
             )
             await waitFor(() =>
                 expect(testLocation.search).toBe(
@@ -133,7 +133,7 @@ describe('UnlockSubmitModal', () => {
             await userEvent.click(screen.getByTestId('submit-modal-submit'))
 
             await waitFor(() =>
-                expect(testLocation.pathname).toBe(`/dashboard`)
+                expect(testLocation.pathname).toBe(`/dashboard/submissions`)
             )
             await waitFor(() =>
                 expect(testLocation.search).toBe(
@@ -597,7 +597,7 @@ describe('UnlockSubmitModal', () => {
                 expect(mockSetIsSubmitting).toHaveBeenCalledTimes(2)
             )
             await waitFor(() =>
-                expect(testLocation.pathname).toBe(`/dashboard`)
+                expect(testLocation.pathname).toBe(`/dashboard/submissions`)
             )
             await waitFor(() =>
                 expect(testLocation.search).toBe(

--- a/services/app-web/src/components/Modal/UnlockSubmitModal.tsx
+++ b/services/app-web/src/components/Modal/UnlockSubmitModal.tsx
@@ -169,7 +169,9 @@ export const UnlockSubmitModal = ({
                         }
                     }
                 )
-                navigate(`/dashboard?justSubmitted=${submissionName}`)
+                navigate(
+                    `/dashboard/submissions?justSubmitted=${submissionName}`
+                )
             } else {
                 // Updating the cache here with unlockInfo before manually re-fetching query.
                 // This will prevent the loading animation to happen and have up-to-date unlock banner.
@@ -222,7 +224,9 @@ export const UnlockSubmitModal = ({
         } else {
             modalRef.current?.toggleModal(undefined, false)
             if (modalType !== 'UNLOCK' && submissionName) {
-                navigate(`/dashboard?justSubmitted=${submissionName}`)
+                navigate(
+                    `/dashboard/submissions?justSubmitted=${submissionName}`
+                )
             }
         }
     }

--- a/services/app-web/src/components/Tabs/TabPanel.tsx
+++ b/services/app-web/src/components/Tabs/TabPanel.tsx
@@ -7,6 +7,7 @@ type TabPanelProps = {
     id: string
     tabName: string
     children: React.ReactNode
+    nestedRoute?: string //relevant if we are dynamically changing URL on click
     isActive?: boolean
 }
 

--- a/services/app-web/src/components/Tabs/Tabs.module.scss
+++ b/services/app-web/src/components/Tabs/Tabs.module.scss
@@ -64,7 +64,8 @@
         padding: 0;
         background: none;
         border: 0;
-        font-weight: bold;
+        font-size: 100%;
+        font-weight: 700;
 
         &:hover {
             cursor: pointer;

--- a/services/app-web/src/components/Tabs/Tabs.test.tsx
+++ b/services/app-web/src/components/Tabs/Tabs.test.tsx
@@ -1,10 +1,10 @@
-import { render } from '@testing-library/react'
 import { Tabs } from './Tabs'
 import { TabPanel } from './TabPanel'
+import { renderWithProviders } from '../../testHelpers'
 
 describe('Tabs', () => {
     it('renders without errors', async () => {
-        const { getByTestId } = render(
+        const { getByTestId } = renderWithProviders(
             <Tabs>
                 <TabPanel id="Test-Pepperoni" tabName="Pepperoni">
                     <h1>Pepperoni</h1>

--- a/services/app-web/src/components/Tabs/Tabs.tsx
+++ b/services/app-web/src/components/Tabs/Tabs.tsx
@@ -42,7 +42,7 @@ export const Tabs = ({
                                 // aria-selected={activeTab === tab.name}
                                 aria-controls={tab.id}
                                 onClick={() => {
-                                    navigate(tab.route)
+                                    if (tab.route) navigate(tab.route)
                                     setActiveTab(tab.name)
                                 }}
                             >

--- a/services/app-web/src/components/Tabs/Tabs.tsx
+++ b/services/app-web/src/components/Tabs/Tabs.tsx
@@ -2,10 +2,11 @@ import React, { useState } from 'react'
 import classnames from 'classnames'
 
 import styles from './Tabs.module.scss'
+import { useNavigate } from 'react-router-dom'
 
 type TabsProps = {
     defaultActiveTab?: string
-    children: React.ReactElement[]
+    children: React.ReactElement[] // TabPanels
 } & JSX.IntrinsicElements['div']
 
 export const Tabs = ({
@@ -13,9 +14,12 @@ export const Tabs = ({
     children,
     ...tabProps
 }: TabsProps): React.ReactElement => {
+    const navigate = useNavigate()
+
     const tabs = children.map((child) => ({
         id: child.props.id,
         name: child.props.tabName,
+        route: child.props.nestedRoute,
     }))
     const [activeTab, setActiveTab] = useState(defaultActiveTab || tabs[0].name)
 
@@ -37,7 +41,10 @@ export const Tabs = ({
                                 className={styles['easi-tabs__tab-btn']}
                                 // aria-selected={activeTab === tab.name}
                                 aria-controls={tab.id}
-                                onClick={() => setActiveTab(tab.name)}
+                                onClick={() => {
+                                    navigate(tab.route)
+                                    setActiveTab(tab.name)
+                                }}
                             >
                                 <span className={styles['easi-tabs__tab-text']}>
                                     {tab.name}

--- a/services/app-web/src/components/Tabs/Tabs.tsx
+++ b/services/app-web/src/components/Tabs/Tabs.tsx
@@ -24,7 +24,7 @@ export const Tabs = ({
         route: child.props.nestedRoute,
     }))
     const [activeTab, setActiveTab] = useState(defaultActiveTab || tabs[0].name)
-
+    const adjustContentWithRoutes = tabs[0].route
     return (
         <div className={styles['easi-tabs']} data-testid="tabs" {...tabProps}>
             <div className={styles['easi-tabs__navigation']}>
@@ -72,7 +72,9 @@ export const Tabs = ({
                         isActive: true,
                     })
                 }
-                return null
+                // if we are displaying traditional HTML tabs, everything is on page with initial render
+                // if we are adjusting tab content based on route, only the active tab should have content
+                return adjustContentWithRoutes ? null : child
             })}
         </div>
     )

--- a/services/app-web/src/components/Tabs/Tabs.tsx
+++ b/services/app-web/src/components/Tabs/Tabs.tsx
@@ -6,16 +6,18 @@ import { useNavigate } from 'react-router-dom'
 
 type TabsProps = {
     defaultActiveTab?: string
+    headingLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5'
     children: React.ReactElement[] // TabPanels
 } & JSX.IntrinsicElements['div']
 
 export const Tabs = ({
     defaultActiveTab,
+    headingLevel = 'h3',
     children,
     ...tabProps
 }: TabsProps): React.ReactElement => {
     const navigate = useNavigate()
-
+    const Heading = headingLevel
     const tabs = children.map((child) => ({
         id: child.props.id,
         name: child.props.tabName,
@@ -35,21 +37,27 @@ export const Tabs = ({
                                     activeTab === tab.name,
                             })}
                             role="tab"
+                            aria-selected={activeTab === tab.name}
                         >
-                            <button
-                                type="button"
-                                className={styles['easi-tabs__tab-btn']}
-                                // aria-selected={activeTab === tab.name}
-                                aria-controls={tab.id}
-                                onClick={() => {
-                                    if (tab.route) navigate(tab.route)
-                                    setActiveTab(tab.name)
-                                }}
-                            >
-                                <span className={styles['easi-tabs__tab-text']}>
-                                    {tab.name}
-                                </span>
-                            </button>
+                            <Heading className={styles['easi-tabs__tab-btn']}>
+                                <button
+                                    type="button"
+                                    className={styles['easi-tabs__tab-btn']}
+                                    aria-controls={tab.id}
+                                    onClick={() => {
+                                        if (tab.route) navigate(tab.route)
+                                        setActiveTab(tab.name)
+                                    }}
+                                >
+                                    <span
+                                        className={
+                                            styles['easi-tabs__tab-text']
+                                        }
+                                    >
+                                        {tab.name}
+                                    </span>
+                                </button>
+                            </Heading>
                         </li>
                     ))}
                 </ul>
@@ -64,7 +72,7 @@ export const Tabs = ({
                         isActive: true,
                     })
                 }
-                return child
+                return null
             })}
         </div>
     )

--- a/services/app-web/src/constants/routes.ts
+++ b/services/app-web/src/constants/routes.ts
@@ -1,11 +1,13 @@
 /*
     Every application route is named here.
-    These types ensure we use valid routes throughout the application.. 
+    These types ensure we use valid routes throughout the application..
 */
 const ROUTES = [
     'ROOT',
     'AUTH',
     'DASHBOARD',
+    'DASHBOARD_SUBMISSIONS',
+    'DASHBOARD_RATES',
     'GRAPHQL_EXPLORER',
     'HELP',
     'REPORTS',
@@ -13,7 +15,7 @@ const ROUTES = [
     'SUBMISSIONS',
     'SUBMISSIONS_NEW',
     'SUBMISSIONS_TYPE',
-    'SUBMISSIONS_FORM',
+    'SUBMISSIONS_EDIT_TOP_LEVEL',
     'SUBMISSIONS_CONTRACT_DETAILS',
     'SUBMISSIONS_RATE_DETAILS',
     'SUBMISSIONS_CONTACTS',
@@ -25,24 +27,28 @@ const ROUTES = [
     'SUBMISSIONS_UPLOAD_QUESTION',
     'SUBMISSIONS_UPLOAD_RESPONSE',
 ] as const // iterable union type
-type RouteT = typeof ROUTES[number]
+type RouteT = (typeof ROUTES)[number]
 type RouteTWithUnknown = RouteT | 'UNKNOWN_ROUTE'
 /*
     Every application url (excluding query parameters) is found in the RoutesRecord.
     These types ensure we use valid route throughout the application
+
+    The suffix "_TOP_LEVEL" mean this route contains an global asterike has several descendant routes it covers
 
 */
 const RoutesRecord: Record<RouteT, string> = {
     ROOT: '/',
     AUTH: '/auth',
     DASHBOARD: '/dashboard',
+    DASHBOARD_SUBMISSIONS: '/dashboard/submissions',
+    DASHBOARD_RATES: '/dashboard/rate-reviews',
     GRAPHQL_EXPLORER: '/dev/graphql-explorer',
     HELP: '/help',
     REPORTS: '/reports',
     SETTINGS: '/settings',
     SUBMISSIONS: '/submissions',
     SUBMISSIONS_NEW: '/submissions/new',
-    SUBMISSIONS_FORM: '/submissions/:id/edit/*',
+    SUBMISSIONS_EDIT_TOP_LEVEL: '/submissions/:id/edit/*',
     SUBMISSIONS_TYPE: '/submissions/:id/edit/type',
     SUBMISSIONS_CONTRACT_DETAILS: '/submissions/:id/edit/contract-details',
     SUBMISSIONS_RATE_DETAILS: '/submissions/:id/edit/rate-details',
@@ -57,6 +63,12 @@ const RoutesRecord: Record<RouteT, string> = {
     SUBMISSIONS_UPLOAD_RESPONSE:
         '/submissions/:id/question-and-answers/:division/:questionID/upload-response',
 }
+
+// Constants for releated descendant routes
+const DASHBOARD_ROUTES: RouteTWithUnknown[] = [
+    'DASHBOARD_RATES',
+    'DASHBOARD_SUBMISSIONS',
+]
 
 const STATE_SUBMISSION_FORM_ROUTES: RouteTWithUnknown[] = [
     'SUBMISSIONS_TYPE',
@@ -80,22 +92,22 @@ const QUESTION_RESPONSE_SHOW_SIDEBAR_ROUTES: RouteTWithUnknown[] = [
 /*
     Page headings used in the <header> when user logged in.
     Dynamic headings, when necessary, are set in page specific parent component.
-    Every route does not need a page heading in the record. 
+    Every route does not need a page heading in the record.
     It is a design choice what goes here. For example, we do not any headings when logged in user is on the help page.
     For a quick way to check page headings, look for the h1 of the application in the DOM tree. It is the dark blue row of the header.
 
 */
 const PageHeadingsRecord: Partial<Record<RouteTWithUnknown, string>> = {
     ROOT: 'Dashboard',
-    DASHBOARD: 'Dashboard',
+    DASHBOARD_SUBMISSIONS: 'Dashboard',
     SUBMISSIONS_NEW: 'New submission',
     UNKNOWN_ROUTE: '404',
 }
 
-/* 
+/*
     Static page titles used in <title>.
     Every route must have a page title in the record for accessibility reasons. Dynamic page titles, when necessary, are set in AppRoutes
-    For a quick way to check page titles, look at the tab text in your browser. 
+    For a quick way to check page titles, look at the tab text in your browser.
 */
 const PageTitlesRecord: Record<RouteT | 'UNKNOWN_ROUTE', string> = {
     ROOT: 'Home',
@@ -105,9 +117,11 @@ const PageTitlesRecord: Record<RouteT | 'UNKNOWN_ROUTE', string> = {
     REPORTS: 'Reports',
     SETTINGS: 'Settings',
     DASHBOARD: 'Dashboard',
+    DASHBOARD_RATES: 'Rate Review Dashboard',
+    DASHBOARD_SUBMISSIONS: 'Dashboard',
     SUBMISSIONS: 'Submissions',
     SUBMISSIONS_NEW: 'New submission',
-    SUBMISSIONS_FORM: 'Submissions',
+    SUBMISSIONS_EDIT_TOP_LEVEL: 'Submissions',
     SUBMISSIONS_TYPE: 'Submission type',
     SUBMISSIONS_CONTRACT_DETAILS: 'Contract details',
     SUBMISSIONS_RATE_DETAILS: 'Rate details',
@@ -130,6 +144,7 @@ export {
     STATE_SUBMISSION_FORM_ROUTES,
     STATE_SUBMISSION_SUMMARY_ROUTES,
     QUESTION_RESPONSE_SHOW_SIDEBAR_ROUTES,
+    DASHBOARD_ROUTES,
 }
 
 export type { RouteT, RouteTWithUnknown }

--- a/services/app-web/src/constants/tealium.ts
+++ b/services/app-web/src/constants/tealium.ts
@@ -32,13 +32,15 @@ const CONTENT_TYPE_BY_ROUTE: Record<RouteT | 'UNKNOWN_ROUTE', string> = {
     ROOT: 'root',
     AUTH: 'login',
     DASHBOARD: 'table',
+    DASHBOARD_SUBMISSIONS: 'table',
+    DASHBOARD_RATES: 'table',
     HELP: 'glossary',
     GRAPHQL_EXPLORER: 'dev',
     REPORTS: 'table',
     SETTINGS: 'table',
     SUBMISSIONS: 'form',
     SUBMISSIONS_NEW: 'form',
-    SUBMISSIONS_FORM: 'form',
+    SUBMISSIONS_EDIT_TOP_LEVEL: 'form',
     SUBMISSIONS_TYPE: 'form',
     SUBMISSIONS_CONTRACT_DETAILS: 'form',
     SUBMISSIONS_RATE_DETAILS: 'form',
@@ -111,7 +113,7 @@ const getTealiumPageName = ({
                 })
             }
             return formatPageName({ heading, title: PageTitlesRecord[route] })
-        case 'DASHBOARD':
+        case 'DASHBOARD_SUBMISSIONS' || 'DASHBOARD_RATES':
             if (user && user.__typename === 'CMSUser') {
                 return formatPageName({ title: 'CMS Dashboard' })
             } else if (user && user.__typename === 'StateUser') {

--- a/services/app-web/src/gqlHelpers/apolloErrors.ts
+++ b/services/app-web/src/gqlHelpers/apolloErrors.ts
@@ -2,8 +2,8 @@ import { ServerError } from '@apollo/client'
 import { ApolloError, GraphQLErrors, NetworkError } from '@apollo/client/errors'
 import { recordJSException } from '../otelHelpers'
 
-/* 
-Adds OTEL logging for graphql api errors 
+/*
+Adds OTEL logging for graphql api errors
 - Reminder, we handle graphql requests via apollo client in our web app.
 */
 

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -75,11 +75,23 @@ const StateUserRoutes = ({
     return (
         <AuthenticatedRouteWrapper setAlert={setAlert} authMode={authMode}>
             <Routes>
-                <Route path={RoutesRecord.ROOT} element={<StateDashboard />} />
+                <Route
+                    path={RoutesRecord.ROOT}
+                    element={
+                        <Navigate to={RoutesRecord.DASHBOARD_SUBMISSIONS} />
+                    }
+                />
                 <Route
                     path={RoutesRecord.DASHBOARD}
+                    element={
+                        <Navigate to={RoutesRecord.DASHBOARD_SUBMISSIONS} />
+                    }
+                />
+                <Route
+                    path={RoutesRecord.DASHBOARD_SUBMISSIONS}
                     element={<StateDashboard />}
                 />
+
                 <Route
                     path={RoutesRecord.SUBMISSIONS}
                     element={<StateDashboard />}

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -140,6 +140,11 @@ const CMSUserRoutes = ({
     showQuestionResponse: boolean
     stageName?: string
 }): React.ReactElement => {
+    const ldClient = useLDClient()
+    const showRateReviews = ldClient?.variation(
+        featureFlags.RATE_REVIEWS_DASHBOARD.flag,
+        featureFlags.RATE_REVIEWS_DASHBOARD.defaultValue
+    )
     return (
         <AuthenticatedRouteWrapper authMode={authMode} setAlert={setAlert}>
             <Routes>
@@ -160,12 +165,12 @@ const CMSUserRoutes = ({
                         path={`submissions`}
                         element={<SubmissionsDashboard />}
                     />
-                    {/* {showRateReviews && */}
-                    <Route
-                        path={'rate-reviews'}
-                        element={<RateReviewsDashboard />}
-                    />
-                    {/* } */}
+                    {showRateReviews && (
+                        <Route
+                            path={'rate-reviews'}
+                            element={<RateReviewsDashboard />}
+                        />
+                    )}
                 </Route>
 
                 <Route element={<SubmissionSideNav />}>

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useEffect, useState } from 'react'
-import { useNavigate, useLocation } from 'react-router'
+import { useNavigate, useLocation, Navigate } from 'react-router'
 import { Route, Routes } from 'react-router-dom'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { extendSession, idmRedirectURL } from '../../pages/Auth/cognitoAuth'
@@ -11,7 +11,11 @@ import { usePage } from '../../contexts/PageContext'
 import { useTitle } from '../../hooks/useTitle'
 import { LocalLogin } from '../../localAuth'
 import { CognitoLogin } from '../Auth/CognitoLogin'
-import { CMSDashboard } from '../CMSDashboard/CMSDashboard'
+import {
+    CMSDashboard,
+    SubmissionsDashboard,
+    RateReviewsDashboard,
+} from '../CMSDashboard/CMSDashboard'
 import { StateDashboard } from '../StateDashboard/StateDashboard'
 import { Settings } from '../Settings/Settings'
 import { AuthenticatedRouteWrapper } from '../Wrapper/AuthenticatedRouteWrapper'
@@ -109,7 +113,7 @@ const StateUserRoutes = ({
                     element={<SubmissionRevisionSummary />}
                 />
                 <Route
-                    path={RoutesRecord.SUBMISSIONS_FORM}
+                    path={RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL}
                     element={<StateSubmissionForm />}
                 />
                 {UniversalRoutes}
@@ -139,11 +143,31 @@ const CMSUserRoutes = ({
     return (
         <AuthenticatedRouteWrapper authMode={authMode} setAlert={setAlert}>
             <Routes>
-                <Route path={RoutesRecord.ROOT} element={<CMSDashboard />} />
                 <Route
-                    path={RoutesRecord.DASHBOARD}
-                    element={<CMSDashboard />}
+                    path={RoutesRecord.ROOT}
+                    element={
+                        <Navigate to={RoutesRecord.DASHBOARD_SUBMISSIONS} />
+                    }
                 />
+                <Route path={RoutesRecord.DASHBOARD} element={<CMSDashboard />}>
+                    <Route
+                        index
+                        element={
+                            <Navigate to={RoutesRecord.DASHBOARD_SUBMISSIONS} />
+                        }
+                    />
+                    <Route
+                        path={`submissions`}
+                        element={<SubmissionsDashboard />}
+                    />
+                    {/* {showRateReviews && */}
+                    <Route
+                        path={'rate-reviews'}
+                        element={<RateReviewsDashboard />}
+                    />
+                    {/* } */}
+                </Route>
+
                 <Route element={<SubmissionSideNav />}>
                     {showQuestionResponse && (
                         <>
@@ -310,7 +334,7 @@ export const AppRoutes = ({
     */
     const title =
         route === 'ROOT' && loggedInUser
-            ? PageTitlesRecord['DASHBOARD']
+            ? PageTitlesRecord['DASHBOARD_SUBMISSIONS']
             : PageTitlesRecord[route]
 
     useTitle(title)

--- a/services/app-web/src/pages/CMSDashboard/CMSDashboard.test.tsx
+++ b/services/app-web/src/pages/CMSDashboard/CMSDashboard.test.tsx
@@ -6,185 +6,321 @@ import {
     mockMNState,
     mockSubmittedHealthPlanPackage,
     mockUnlockedHealthPlanPackage,
+    mockValidCMSUser,
 } from '../../testHelpers/apolloMocks'
-import { renderWithProviders } from '../../testHelpers/jestHelpers'
-import { CMSDashboard } from './CMSDashboard'
-import { User } from '../../gen/gqlClient'
+import {
+    ldUseClientSpy,
+    renderWithProviders,
+} from '../../testHelpers/jestHelpers'
+import {
+    CMSDashboard,
+    RateReviewsDashboard,
+    SubmissionsDashboard,
+} from './CMSDashboard'
+import {
+    FeatureFlagLDConstant,
+    FlagValue,
+} from '../../common-code/featureFlags'
+import { Navigate, Route, Routes } from 'react-router-dom'
+import { RoutesRecord } from '../../constants'
+
+// copy paste from AppRoutes - this is to allow texting of the react router Outlet
+const CMSDashboardNestedRoutes = () => (
+    <Routes>
+        <Route path={RoutesRecord.DASHBOARD} element={<CMSDashboard />}>
+            <Route
+                index
+                element={<Navigate to={RoutesRecord.DASHBOARD_SUBMISSIONS} />}
+            />
+            <Route path={`submissions`} element={<SubmissionsDashboard />} />
+            <Route path={'rate-reviews'} element={<RateReviewsDashboard />} />
+        </Route>
+    </Routes>
+)
 
 describe('CMSDashboard', () => {
-    const mockUser: User = {
-        __typename: 'CMSUser' as const,
-        id: 'bob@dmas.mn.gov',
-        role: 'CMS_USER',
-        email: 'bob@dmas.mn.gov',
-        givenName: 'b',
-        familyName: 'bob',
-        stateAssignments: [],
-    }
-    it('should display cms dashboard page', async () => {
-        const screen = renderWithProviders(<CMSDashboard />, {
-            apolloProvider: {
-                mocks: [
-                    fetchCurrentUserMock({ statusCode: 200, user: mockUser }),
-                    indexHealthPlanPackagesMockSuccess([]),
-                ],
-            },
-        })
-        expect(screen.findByTestId('cms-dashboard-page')).not.toBeNull()
+    afterEach(() => {
+        jest.resetAllMocks()
     })
-
-    it('displays submissions table excluding any in progress drafts', async () => {
-        const draft = mockDraftHealthPlanPackage()
-        const submitted = mockSubmittedHealthPlanPackage()
-        const unlocked = mockUnlockedHealthPlanPackage()
-        draft.id = 'test-abc-draft'
-        submitted.id = 'test-abc-submitted'
-        unlocked.id = 'test-abc-unlocked'
-
-        const submissions = [draft, submitted, unlocked]
-
-        renderWithProviders(<CMSDashboard />, {
-            apolloProvider: {
-                mocks: [
-                    fetchCurrentUserMock({ statusCode: 200, user: mockUser }),
-                    indexHealthPlanPackagesMockSuccess(submissions),
-                ],
-            },
-        })
-
-        await screen.findByRole('heading', { name: 'Submissions' })
-        const rows = await screen.findAllByRole('row')
-        rows.shift() // remove the column header row
-
-        // confirm initial draft packages don't display to CMS user
-        expect(rows).toHaveLength(2)
-
-        rows.forEach((row) => {
-            const submissionLink = within(row).queryByRole('link')
-            expect(submissionLink).not.toHaveAttribute(
-                'href',
-                `/submissions/${draft.id}`
-            )
-        })
+    afterAll(() => {
+        jest.clearAllMocks()
     })
-
-    it('displays submission type as expected for current revision that is submitted/resubmitted', async () => {
-        const submitted = mockSubmittedHealthPlanPackage()
-        submitted.id = '123-4'
-        const submissions = [submitted]
-        renderWithProviders(<CMSDashboard />, {
+    it('rate reviews feature flag - should show rate reviews and tabs when expected', () => {
+        ldUseClientSpy({ 'rate-reviews-dashboard': true })
+        const screen = renderWithProviders(<CMSDashboardNestedRoutes />, {
             apolloProvider: {
                 mocks: [
                     fetchCurrentUserMock({
                         statusCode: 200,
-                        user: mockUser,
+                        user: mockValidCMSUser(),
                     }),
-                    indexHealthPlanPackagesMockSuccess(submissions),
+                    indexHealthPlanPackagesMockSuccess([]),
                 ],
             },
+            routerProvider: { route: '/dashboard/rate-reviews' },
         })
-        await screen.findByRole('heading', { name: 'Submissions' })
-        const row = await screen.findByTestId(`row-${submitted.id}`)
-        const submissionType = within(row).getByTestId('submission-type')
-        expect(submissionType).toHaveTextContent('Contract action only')
+
+        expect(screen.getByTestId('tabs')).toBeInTheDocument()
+        expect(
+            screen.getByRole('heading', { name: 'Rate Reviews' })
+        ).toBeInTheDocument()
+        expect(
+            screen.getByRole('heading', { name: 'Submissions' })
+        ).toBeInTheDocument()
+        expect(screen.getByText('RATE REVIEWS DASHBOARD')).toBeInTheDocument() // this can be replaced when actual rate reviews table when shipped
     })
 
-    it('displays each health plan package status tag as expected for current revision that is submitted/resubmitted', async () => {
-        const unlocked = mockUnlockedHealthPlanPackage()
-        const submitted = mockSubmittedHealthPlanPackage()
-        submitted.id = 'test-abc-submitted'
-        unlocked.id = 'test-abc-unlocked'
-
-        const submissions = [unlocked, submitted]
-        renderWithProviders(<CMSDashboard />, {
+    // delete this test when flag is removed
+    it('rate reviews feature flag - should hide tabs and rate reviews when expected', () => {
+        ldUseClientSpy({ 'rate-reviews-dashboard': false })
+        const screen = renderWithProviders(<CMSDashboardNestedRoutes />, {
             apolloProvider: {
                 mocks: [
-                    fetchCurrentUserMock({ statusCode: 200, user: mockUser }),
-                    indexHealthPlanPackagesMockSuccess(submissions),
+                    fetchCurrentUserMock({
+                        statusCode: 200,
+                        user: mockValidCMSUser(),
+                    }),
+                    indexHealthPlanPackagesMockSuccess([]),
                 ],
             },
+            routerProvider: { route: '/dashboard/rate-reviews' },
         })
-        await screen.findByRole('heading', { name: 'Submissions' })
-        const unlockedRow = await screen.findByTestId(`row-${unlocked.id}`)
-        const tag1 = within(unlockedRow).getByTestId('submission-status')
-        expect(tag1).toHaveTextContent('Unlocked')
 
-        const submittedRow = await screen.findByTestId(`row-${submitted.id}`)
-        const tag2 = within(submittedRow).getByTestId('submission-status')
-        expect(tag2).toHaveTextContent('Submitted')
+        expect(screen.queryByTestId('tabs')).toBeNull()
+        expect(
+            screen.queryByRole('heading', { name: 'Rate Reviews' })
+        ).toBeNull()
     })
 
-    it('displays name, type, programs and last update based on previously submitted revision for UNLOCKED package', async () => {
-        const mockMN = mockMNState() // this is the state used in apolloMocks
+    const flagValueTestParameters: {
+        flagName: FeatureFlagLDConstant
+        flagValue: FlagValue
+        testName: string
+    }[] = [
+        {
+            flagName: 'rate-reviews-dashboard',
+            flagValue: false,
+            testName: 'submissions tab - Rate reviews feature flag off',
+        },
+        {
+            flagName: 'rate-reviews-dashboard',
+            flagValue: true,
+            testName: 'submissions tab - Rate reviews feature flag on',
+        },
+    ]
+    describe.each(flagValueTestParameters)(
+        `Tests $testName`,
+        ({ flagName, flagValue }) => {
+            ldUseClientSpy({ [flagName]: flagValue })
 
-        // Set new data on the unlocked form. This would be a state users update and the CMS user should not see this data.
-        const unlocked = mockUnlockedHealthPlanPackage(
-            {
-                submissionType: 'CONTRACT_ONLY',
-                updatedAt: new Date('2022-01-15'),
-                programIDs: [mockMN.programs[2].id],
-            },
-            { updatedAt: new Date('2100-01-22') }
-        )
-        unlocked.id = 'test-state-edit-in-progress-unlocked'
+            it('should display cms dashboard page', async () => {
+                const screen = renderWithProviders(
+                    <CMSDashboardNestedRoutes />,
+                    {
+                        apolloProvider: {
+                            mocks: [
+                                fetchCurrentUserMock({
+                                    statusCode: 200,
+                                    user: mockValidCMSUser(),
+                                }),
+                                indexHealthPlanPackagesMockSuccess([]),
+                            ],
+                        },
+                        routerProvider: { route: '/dashboard/submissions' },
+                    }
+                )
+                expect(screen.findByTestId('cms-dashboard-page')).not.toBeNull()
+            })
 
-        const submissions = [unlocked]
-        renderWithProviders(<CMSDashboard />, {
-            apolloProvider: {
-                mocks: [
-                    fetchCurrentUserMock({ statusCode: 200, user: mockUser }),
-                    indexHealthPlanPackagesMockSuccess(submissions),
-                ],
-            },
-        })
-        await screen.findByRole('heading', { name: 'Submissions' })
-        const unlockedRow = await screen.findByTestId(`row-${unlocked.id}`)
+            it('displays submissions table excluding any in progress drafts', async () => {
+                const draft = mockDraftHealthPlanPackage()
+                const submitted = mockSubmittedHealthPlanPackage()
+                const unlocked = mockUnlockedHealthPlanPackage()
+                draft.id = 'test-abc-draft'
+                submitted.id = 'test-abc-submitted'
+                unlocked.id = 'test-abc-unlocked'
 
-        // Confirm UNLOCKED status
-        const tag1 = within(unlockedRow).getByTestId('submission-status')
-        expect(tag1).toHaveTextContent('Unlocked')
+                const submissions = [draft, submitted, unlocked]
 
-        // Confirm we are using previous submitted revision type
-        const submissionType =
-            within(unlockedRow).getByTestId('submission-type')
-        expect(submissionType).toHaveTextContent(
-            'Contract action and rate certification'
-        )
+                renderWithProviders(<CMSDashboardNestedRoutes />, {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                statusCode: 200,
+                                user: mockValidCMSUser(),
+                            }),
+                            indexHealthPlanPackagesMockSuccess(submissions),
+                        ],
+                    },
+                    routerProvider: { route: '/dashboard/submissions' },
+                })
 
-        const submissionPrograms =
-            within(unlockedRow).getAllByTestId('program-tag')
-        // Confirm we are using previous submitted revision programs
-        expect(submissionPrograms).toHaveLength(3)
-        const submissionNameLink =
-            within(unlockedRow).getByTestId('submission-id')
-        expect(submissionNameLink).toHaveTextContent('MSC+-PMAP-SNBC')
+                await screen.findByRole('heading', { name: 'Submissions' })
+                const rows = await screen.findAllByRole('row')
+                rows.shift() // remove the column header row
 
-        // Confirm we are using updated at from the previous submitted revision unlock info
-        const lastUpdated = within(unlockedRow).getByTestId(
-            'submission-last-updated'
-        )
-        expect(lastUpdated).toHaveTextContent('01/22/2100')
-    })
+                // confirm initial draft packages don't display to CMS user
+                expect(rows).toHaveLength(2)
 
-    it('should display filters on cms dashboard', async () => {
-        const unlocked = mockUnlockedHealthPlanPackage()
-        const submitted = mockSubmittedHealthPlanPackage()
-        submitted.id = 'test-abc-submitted'
-        unlocked.id = 'test-abc-unlocked'
-        const screen = renderWithProviders(<CMSDashboard />, {
-            apolloProvider: {
-                mocks: [
-                    fetchCurrentUserMock({ statusCode: 200, user: mockUser }),
-                    indexHealthPlanPackagesMockSuccess([submitted, unlocked]),
-                ],
-            },
-        })
+                rows.forEach((row) => {
+                    const submissionLink = within(row).queryByRole('link')
+                    expect(submissionLink).not.toHaveAttribute(
+                        'href',
+                        `/submissions/${draft.id}`
+                    )
+                })
+            })
 
-        await waitFor(() => {
-            expect(
-                screen.queryByTestId('cms-dashboard-page')
-            ).toBeInTheDocument()
-            expect(screen.queryByTestId('accordion')).toBeInTheDocument()
-        })
-    })
+            it('displays submission type as expected for current revision that is submitted/resubmitted', async () => {
+                const submitted = mockSubmittedHealthPlanPackage()
+                submitted.id = '123-4'
+                const submissions = [submitted]
+                renderWithProviders(<CMSDashboardNestedRoutes />, {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                statusCode: 200,
+                                user: mockValidCMSUser(),
+                            }),
+                            indexHealthPlanPackagesMockSuccess(submissions),
+                        ],
+                    },
+                    routerProvider: { route: '/dashboard/submissions' },
+                })
+                await screen.findByRole('heading', { name: 'Submissions' })
+                const row = await screen.findByTestId(`row-${submitted.id}`)
+                const submissionType =
+                    within(row).getByTestId('submission-type')
+                expect(submissionType).toHaveTextContent('Contract action only')
+            })
+
+            it('displays each health plan package status tag as expected for current revision that is submitted/resubmitted', async () => {
+                const unlocked = mockUnlockedHealthPlanPackage()
+                const submitted = mockSubmittedHealthPlanPackage()
+                submitted.id = 'test-abc-submitted'
+                unlocked.id = 'test-abc-unlocked'
+
+                const submissions = [unlocked, submitted]
+                renderWithProviders(<CMSDashboardNestedRoutes />, {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                statusCode: 200,
+                                user: mockValidCMSUser(),
+                            }),
+                            indexHealthPlanPackagesMockSuccess(submissions),
+                        ],
+                    },
+                    routerProvider: { route: '/dashboard/submissions' },
+                })
+                await screen.findByRole('heading', { name: 'Submissions' })
+                const unlockedRow = await screen.findByTestId(
+                    `row-${unlocked.id}`
+                )
+                const tag1 =
+                    within(unlockedRow).getByTestId('submission-status')
+                expect(tag1).toHaveTextContent('Unlocked')
+
+                const submittedRow = await screen.findByTestId(
+                    `row-${submitted.id}`
+                )
+                const tag2 =
+                    within(submittedRow).getByTestId('submission-status')
+                expect(tag2).toHaveTextContent('Submitted')
+            })
+
+            it('displays name, type, programs and last update based on previously submitted revision for UNLOCKED package', async () => {
+                const mockMN = mockMNState() // this is the state used in apolloMocks
+
+                // Set new data on the unlocked form. This would be a state users update and the CMS user should not see this data.
+                const unlocked = mockUnlockedHealthPlanPackage(
+                    {
+                        submissionType: 'CONTRACT_ONLY',
+                        updatedAt: new Date('2022-01-15'),
+                        programIDs: [mockMN.programs[2].id],
+                    },
+                    { updatedAt: new Date('2100-01-22') }
+                )
+                unlocked.id = 'test-state-edit-in-progress-unlocked'
+
+                const submissions = [unlocked]
+                renderWithProviders(<CMSDashboardNestedRoutes />, {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                statusCode: 200,
+                                user: mockValidCMSUser(),
+                            }),
+                            indexHealthPlanPackagesMockSuccess(submissions),
+                        ],
+                    },
+                    routerProvider: { route: '/dashboard/submissions' },
+                })
+                await screen.findByRole('heading', { name: 'Submissions' })
+                const unlockedRow = await screen.findByTestId(
+                    `row-${unlocked.id}`
+                )
+
+                // Confirm UNLOCKED status
+                const tag1 =
+                    within(unlockedRow).getByTestId('submission-status')
+                expect(tag1).toHaveTextContent('Unlocked')
+
+                // Confirm we are using previous submitted revision type
+                const submissionType =
+                    within(unlockedRow).getByTestId('submission-type')
+                expect(submissionType).toHaveTextContent(
+                    'Contract action and rate certification'
+                )
+
+                const submissionPrograms =
+                    within(unlockedRow).getAllByTestId('program-tag')
+                // Confirm we are using previous submitted revision programs
+                expect(submissionPrograms).toHaveLength(3)
+                const submissionNameLink =
+                    within(unlockedRow).getByTestId('submission-id')
+                expect(submissionNameLink).toHaveTextContent('MSC+-PMAP-SNBC')
+
+                // Confirm we are using updated at from the previous submitted revision unlock info
+                const lastUpdated = within(unlockedRow).getByTestId(
+                    'submission-last-updated'
+                )
+                expect(lastUpdated).toHaveTextContent('01/22/2100')
+            })
+
+            it('should display filters on cms dashboard', async () => {
+                const unlocked = mockUnlockedHealthPlanPackage()
+                const submitted = mockSubmittedHealthPlanPackage()
+                submitted.id = 'test-abc-submitted'
+                unlocked.id = 'test-abc-unlocked'
+                const screen = renderWithProviders(
+                    <CMSDashboardNestedRoutes />,
+                    {
+                        apolloProvider: {
+                            mocks: [
+                                fetchCurrentUserMock({
+                                    statusCode: 200,
+                                    user: mockValidCMSUser(),
+                                }),
+                                indexHealthPlanPackagesMockSuccess([
+                                    submitted,
+                                    unlocked,
+                                ]),
+                            ],
+                        },
+                        routerProvider: { route: '/dashboard/submissions' },
+                    }
+                )
+
+                await waitFor(() => {
+                    expect(
+                        screen.queryByTestId('cms-dashboard-page')
+                    ).toBeInTheDocument()
+                    expect(
+                        screen.queryByTestId('accordion')
+                    ).toBeInTheDocument()
+                })
+            })
+        }
+    )
 })

--- a/services/app-web/src/pages/CMSDashboard/CMSDashboard.test.tsx
+++ b/services/app-web/src/pages/CMSDashboard/CMSDashboard.test.tsx
@@ -45,7 +45,7 @@ describe('CMSDashboard', () => {
     afterAll(() => {
         jest.clearAllMocks()
     })
-    it('rate reviews feature flag - should show rate reviews and tabs when expected', () => {
+    it('rate reviews feature flag - should show rate review tab when expected', () => {
         ldUseClientSpy({ 'rate-reviews-dashboard': true })
         const screen = renderWithProviders(<CMSDashboardNestedRoutes />, {
             apolloProvider: {
@@ -62,16 +62,15 @@ describe('CMSDashboard', () => {
 
         expect(screen.getByTestId('tabs')).toBeInTheDocument()
         expect(
-            screen.getByRole('heading', { name: 'Rate Reviews' })
+            screen.getByRole('heading', { name: 'Rate reviews' })
         ).toBeInTheDocument()
         expect(
             screen.getByRole('heading', { name: 'Submissions' })
         ).toBeInTheDocument()
-        expect(screen.getByText('RATE REVIEWS DASHBOARD')).toBeInTheDocument() // this can be replaced when actual rate reviews table when shipped
     })
 
     // delete this test when flag is removed
-    it('rate reviews feature flag - should hide tabs and rate reviews when expected', () => {
+    it('rate reviews feature flag - should hide rate review tab when expected', () => {
         ldUseClientSpy({ 'rate-reviews-dashboard': false })
         const screen = renderWithProviders(<CMSDashboardNestedRoutes />, {
             apolloProvider: {
@@ -88,7 +87,7 @@ describe('CMSDashboard', () => {
 
         expect(screen.queryByTestId('tabs')).toBeNull()
         expect(
-            screen.queryByRole('heading', { name: 'Rate Reviews' })
+            screen.queryByRole('heading', { name: 'Rate reviews' })
         ).toBeNull()
     })
 

--- a/services/app-web/src/pages/CMSDashboard/CMSDashboard.tsx
+++ b/services/app-web/src/pages/CMSDashboard/CMSDashboard.tsx
@@ -32,31 +32,39 @@ const CMSDashboard = (): React.ReactElement => {
         featureFlags.RATE_REVIEWS_DASHBOARD.flag,
         featureFlags.RATE_REVIEWS_DASHBOARD.defaultValue
     )
-
     return (
-        <>
-            {showRateReviews ? (
-                <Tabs className={styles.tabs}>
-                    <TabPanel
-                        id="submissions"
-                        nestedRoute={RoutesRecord.DASHBOARD_SUBMISSIONS}
-                        tabName="Submissions"
-                    >
-                        <Outlet />
-                    </TabPanel>
+        <div data-testid={DASHBOARD_ATTRIBUTE} className={styles.wrapper}>
+            <GridContainer className={styles.container}>
+                <div className={styles.panelHeader}>
+                    <h2>
+                        Submissions
+                        {showRateReviews && <span> and rate reviews</span>}
+                    </h2>
+                </div>
 
-                    <TabPanel
-                        id="rate-reviews"
-                        nestedRoute={RoutesRecord.DASHBOARD_RATES}
-                        tabName="Rate Reviews"
-                    >
-                        <Outlet />
-                    </TabPanel>
-                </Tabs>
-            ) : (
-                <Outlet />
-            )}
-        </>
+                {showRateReviews ? (
+                    <Tabs className={styles.tabs}>
+                        <TabPanel
+                            id="submissions"
+                            nestedRoute={RoutesRecord.DASHBOARD_SUBMISSIONS}
+                            tabName="Submissions"
+                        >
+                            <Outlet />
+                        </TabPanel>
+
+                        <TabPanel
+                            id="rate-reviews"
+                            nestedRoute={RoutesRecord.DASHBOARD_RATES}
+                            tabName="Rate Reviews"
+                        >
+                            <Outlet />
+                        </TabPanel>
+                    </Tabs>
+                ) : (
+                    <Outlet />
+                )}
+            </GridContainer>
+        </div>
     )
 }
 
@@ -175,22 +183,13 @@ const SubmissionsDashboard = (): React.ReactElement => {
         })
 
     return (
-        <>
-            <div data-testid={DASHBOARD_ATTRIBUTE} className={styles.wrapper}>
-                <GridContainer className={styles.container}>
-                    <section className={styles.panel}>
-                        <div className={styles.panelHeader}>
-                            <h2>Submissions</h2>
-                        </div>
-                        <HealthPlanPackageTable
-                            tableData={submissionRows}
-                            user={loggedInUser}
-                            showFilters
-                        />
-                    </section>
-                </GridContainer>
-            </div>
-        </>
+        <section className={styles.panel}>
+            <HealthPlanPackageTable
+                tableData={submissionRows}
+                user={loggedInUser}
+                showFilters
+            />
+        </section>
     )
 }
 const RateReviewsDashboard = (): React.ReactElement => {

--- a/services/app-web/src/pages/Errors/Error404Page.tsx
+++ b/services/app-web/src/pages/Errors/Error404Page.tsx
@@ -5,6 +5,7 @@ import styles from './Errors.module.scss'
 
 import { PageHeading } from '../../components/PageHeading'
 import { GridContainer } from '@trussworks/react-uswds'
+import { RoutesRecord } from '../../constants'
 
 export const Error404 = (): React.ReactElement => {
     return (
@@ -14,7 +15,10 @@ export const Error404 = (): React.ReactElement => {
                 <p>You might want to double-check your link and try again.</p>
                 <p>
                     <span>Or return to your </span>
-                    <NavLink to="/dashboard">Dashboard</NavLink>.
+                    <NavLink to={RoutesRecord.DASHBOARD_SUBMISSIONS}>
+                        Dashboard
+                    </NavLink>
+                    .
                 </p>
             </GridContainer>
         </section>

--- a/services/app-web/src/pages/Errors/ErrorFailedRequestPage.tsx
+++ b/services/app-web/src/pages/Errors/ErrorFailedRequestPage.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import styles from './Errors.module.scss'
+
+import { PageHeading } from '../../components/PageHeading'
+import { GridContainer } from '@trussworks/react-uswds'
+import { ApolloError } from '@apollo/client'
+import {
+    handleApolloError,
+    isLikelyUserAuthError,
+} from '../../gqlHelpers/apolloErrors'
+import { ErrorAlertFailedRequest, ErrorAlertSignIn } from '../../components'
+import { useAuth } from '../../contexts/AuthContext'
+
+/*
+    For use with an unknown ApolloError coming back from API requests
+    - full takeover of the main app content below the header
+    - specific ErrorAlert displayed at top of page
+    - handles OTEL logging
+*/
+
+export const ErrorFailedRequestPage = ({
+    error,
+    testID,
+}: {
+    error: ApolloError
+    testID: string
+}): React.ReactElement => {
+    const { loginStatus } = useAuth()
+    const isAuthenticated = loginStatus === 'LOGGED_IN'
+    handleApolloError(error, isAuthenticated)
+
+    return (
+        <section data-testid={testID} className={styles.errorsContainer}>
+            <GridContainer>
+                <PageHeading> Error </PageHeading>
+                {isLikelyUserAuthError(error, isAuthenticated) ? (
+                    <ErrorAlertSignIn />
+                ) : (
+                    <ErrorAlertFailedRequest />
+                )}
+            </GridContainer>
+        </section>
+    )
+}

--- a/services/app-web/src/pages/Errors/ErrorInvalidSubmissionStatusPage.tsx
+++ b/services/app-web/src/pages/Errors/ErrorInvalidSubmissionStatusPage.tsx
@@ -5,6 +5,7 @@ import styles from './Errors.module.scss'
 
 import { PageHeading } from '../../components/PageHeading'
 import { GridContainer } from '@trussworks/react-uswds'
+import { RoutesRecord } from '../../constants'
 
 export const ErrorInvalidSubmissionStatus = (): React.ReactElement => {
     return (
@@ -13,7 +14,10 @@ export const ErrorInvalidSubmissionStatus = (): React.ReactElement => {
                 <PageHeading>This submission was sent to CMS</PageHeading>
                 <p>
                     <span>It cannot be edited. Return to your </span>
-                    <NavLink to="/dashboard">Dashboard</NavLink>.
+                    <NavLink to={RoutesRecord.DASHBOARD_SUBMISSIONS}>
+                        Dashboard
+                    </NavLink>
+                    .
                 </p>
             </GridContainer>
         </section>

--- a/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadQuestions.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadQuestions.tsx
@@ -26,9 +26,11 @@ import { SideNavOutletContextType } from '../../SubmissionSideNav/SubmissionSide
 import { usePage } from '../../../contexts/PageContext'
 import { Breadcrumbs } from '../../../components/Breadcrumbs/Breadcrumbs'
 import { createQuestionWrapper } from '../../../gqlHelpers/mutationWrappersForUserFriendlyErrors'
+import { RoutesRecord } from '../../../constants'
 
 export const UploadQuestions = () => {
     // router context
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     const { division, id } = useParams<{ division: string; id: string }>()
     const navigate = useNavigate()
     const { packageName } = useOutletContext<SideNavOutletContextType>()
@@ -96,7 +98,7 @@ export const UploadQuestions = () => {
             <Breadcrumbs
                 items={[
                     {
-                        link: `/dashboard`,
+                        link: RoutesRecord.DASHBOARD_SUBMISSIONS,
                         text: 'Dashboard',
                     },
                     { link: `/submissions/${id}`, text: packageName },

--- a/services/app-web/src/pages/QuestionResponse/UploadResponse/UploadResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadResponse/UploadResponse.tsx
@@ -27,12 +27,16 @@ import { usePage } from '../../../contexts/PageContext'
 import { SideNavOutletContextType } from '../../SubmissionSideNav/SubmissionSideNav'
 import { Breadcrumbs } from '../../../components/Breadcrumbs/Breadcrumbs'
 import { createResponseWrapper } from '../../../gqlHelpers/mutationWrappersForUserFriendlyErrors'
+import { RoutesRecord } from '../../../constants'
 
 export const UploadResponse = () => {
     // router context
     const { division, id, questionID } = useParams<{
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
         division: string
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
         id: string
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
         questionID: string
     }>()
     const navigate = useNavigate()
@@ -105,7 +109,10 @@ export const UploadResponse = () => {
         <GridContainer>
             <Breadcrumbs
                 items={[
-                    { link: `/dashboard`, text: 'Dashboard' },
+                    {
+                        link: RoutesRecord.DASHBOARD_SUBMISSIONS,
+                        text: 'Dashboard',
+                    },
                     { link: `/submissions/${id}`, text: packageName },
                     { text: 'Add response' },
                 ]}

--- a/services/app-web/src/pages/StateDashboard/StateDashboard.module.scss
+++ b/services/app-web/src/pages/StateDashboard/StateDashboard.module.scss
@@ -30,6 +30,7 @@
         display: flex;
         align-items: center;
         justify-content: space-between;
+        font-weight: 700;
     }
 }
 

--- a/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
@@ -35,6 +35,7 @@ import { useFocus } from '../../../hooks/useFocus'
 import { PageActions } from '../PageActions'
 import type { HealthPlanFormPageProps } from '../StateSubmissionForm'
 import { ActuaryContactFields } from './ActuaryContactFields'
+import { RoutesRecord } from '../../../constants'
 
 export interface ContactsFormValues {
     stateContacts: StateContact[]
@@ -261,7 +262,7 @@ export const Contacts = ({
                 )
             } else if (updatedSubmission) {
                 if (redirectToDashboard.current) {
-                    navigate(`/dashboard`)
+                    navigate(RoutesRecord.DASHBOARD_SUBMISSIONS)
                 } else {
                     navigate(`../documents`)
                 }
@@ -573,7 +574,7 @@ export const Contacts = ({
                         <PageActions
                             saveAsDraftOnClick={() => {
                                 if (!dirty) {
-                                    navigate(`/dashboard`)
+                                    navigate(`/dashboard/submissions`)
                                 } else {
                                     setShouldValidate(true)
                                     setFocusErrorSummaryHeading(true)

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -61,6 +61,7 @@ import {
     isContractAmendment,
     isContractWithProvisions,
 } from '../../../common-code/healthPlanFormDataType/healthPlanFormData'
+import { RoutesRecord } from '../../../constants'
 
 function formattedDatePlusOneDay(initialValue: string): string {
     const dayjsValue = dayjs(initialValue)
@@ -856,7 +857,8 @@ export const ContractDetails = ({
                                         setSubmitting,
                                         {
                                             shouldValidateDocuments: false,
-                                            redirectPath: '/dashboard',
+                                            redirectPath:
+                                                RoutesRecord.DASHBOARD_SUBMISSIONS,
                                         }
                                     )
                                 } else {
@@ -865,7 +867,8 @@ export const ContractDetails = ({
                                         setSubmitting,
                                         {
                                             shouldValidateDocuments: true,
-                                            redirectPath: '/dashboard',
+                                            redirectPath:
+                                                RoutesRecord.DASHBOARD_SUBMISSIONS,
                                         }
                                     )
                                 }

--- a/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
+++ b/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
@@ -19,6 +19,7 @@ import { ErrorSummary } from '../../../components/Form'
 import type { HealthPlanFormPageProps } from '../StateSubmissionForm'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { featureFlags } from '../../../common-code/featureFlags'
+import { RoutesRecord } from '../../../constants'
 
 export const Documents = ({
     draftSubmission,
@@ -340,7 +341,7 @@ export const Documents = ({
                     saveAsDraftOnClick={async (e) => {
                         await handleFormSubmit({
                             shouldValidateDocuments: true,
-                            redirectPath: '/dashboard',
+                            redirectPath: RoutesRecord.DASHBOARD_SUBMISSIONS,
                         })(e)
                     }}
                     backOnClick={async (e) => {

--- a/services/app-web/src/pages/StateSubmission/RateDetails/PackagesWithSharedRates/PackagesWithSharedRates.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/PackagesWithSharedRates/PackagesWithSharedRates.tsx
@@ -17,6 +17,7 @@ import {
 } from '../SingleRateCert/SingleRateCert'
 
 import styles from '../../StateSubmissionForm.module.scss'
+import { RoutesRecord } from '../../../../constants'
 
 export type PackagesWithSharedRatesProps = {
     index: number
@@ -133,7 +134,7 @@ export const PackagesWithSharedRates = ({
                     </Label>
                     <Link
                         aria-label="View all submissions (opens in new window)"
-                        href={'/dashboard'}
+                        href={RoutesRecord.DASHBOARD_SUBMISSIONS}
                         variant="external"
                         target="_blank"
                     >

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -30,6 +30,7 @@ import {
 import { useS3 } from '../../../contexts/S3Context'
 import { S3ClientT } from '../../../s3'
 import { isLoadingOrHasFileErrors } from '../../../components/FileUpload'
+import { RoutesRecord } from '../../../constants'
 
 // This function is used to get initial form values as well return empty form values when we add a new rate or delete a rate
 // We need to include the getKey function in params because there are no guarantees currently file is in s3 even if when we load data from API
@@ -405,7 +406,8 @@ export const RateDetails = ({
                                         setSubmitting,
                                         {
                                             shouldValidateDocuments: true,
-                                            redirectPath: '/dashboard',
+                                            redirectPath:
+                                                RoutesRecord.DASHBOARD_SUBMISSIONS,
                                         }
                                     )
                                 }}

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
@@ -19,6 +19,7 @@ import { ActionButton } from '../../../components/ActionButton'
 import { UnlockSubmitModal } from '../../../components/Modal/UnlockSubmitModal'
 import { useStatePrograms } from '../../../hooks/useStatePrograms'
 import { DocumentDateLookupTableType } from '../../../documentHelpers/makeDocumentDateLookupTable'
+import { RoutesRecord } from '../../../constants'
 
 export const ReviewSubmit = ({
     draftSubmission,
@@ -82,7 +83,9 @@ export const ReviewSubmit = ({
                     <ActionButton
                         type="button"
                         variant="linkStyle"
-                        onClick={() => navigate('/dashboard')}
+                        onClick={() =>
+                            navigate(RoutesRecord.DASHBOARD_SUBMISSIONS)
+                        }
                         disabled={isSubmitting}
                     >
                         Save as draft

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.test.tsx
@@ -34,7 +34,7 @@ describe('StateSubmissionForm', () => {
             renderWithProviders(
                 <Routes>
                     <Route
-                        path={RoutesRecord.SUBMISSIONS_FORM}
+                        path={RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL}
                         element={<StateSubmissionForm />}
                     />
                 </Routes>,
@@ -67,7 +67,7 @@ describe('StateSubmissionForm', () => {
             renderWithProviders(
                 <Routes>
                     <Route
-                        path={RoutesRecord.SUBMISSIONS_FORM}
+                        path={RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL}
                         element={<StateSubmissionForm />}
                     />
                 </Routes>,
@@ -129,7 +129,7 @@ describe('StateSubmissionForm', () => {
             renderWithProviders(
                 <Routes>
                     <Route
-                        path={RoutesRecord.SUBMISSIONS_FORM}
+                        path={RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL}
                         element={<StateSubmissionForm />}
                     />
                 </Routes>,
@@ -167,7 +167,7 @@ describe('StateSubmissionForm', () => {
             renderWithProviders(
                 <Routes>
                     <Route
-                        path={RoutesRecord.SUBMISSIONS_FORM}
+                        path={RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL}
                         element={<StateSubmissionForm />}
                     />
                 </Routes>,
@@ -200,7 +200,7 @@ describe('StateSubmissionForm', () => {
             renderWithProviders(
                 <Routes>
                     <Route
-                        path={RoutesRecord.SUBMISSIONS_FORM}
+                        path={RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL}
                         element={<StateSubmissionForm />}
                     />
                 </Routes>,
@@ -254,7 +254,7 @@ describe('StateSubmissionForm', () => {
             renderWithProviders(
                 <Routes>
                     <Route
-                        path={RoutesRecord.SUBMISSIONS_FORM}
+                        path={RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL}
                         element={<StateSubmissionForm />}
                     />
                 </Routes>,
@@ -322,7 +322,7 @@ describe('StateSubmissionForm', () => {
             renderWithProviders(
                 <Routes>
                     <Route
-                        path={RoutesRecord.SUBMISSIONS_FORM}
+                        path={RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL}
                         element={<StateSubmissionForm />}
                     />
                 </Routes>,
@@ -370,7 +370,7 @@ describe('StateSubmissionForm', () => {
             renderWithProviders(
                 <Routes>
                     <Route
-                        path={RoutesRecord.SUBMISSIONS_FORM}
+                        path={RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL}
                         element={<StateSubmissionForm />}
                     />
                 </Routes>,
@@ -393,7 +393,7 @@ describe('StateSubmissionForm', () => {
             renderWithProviders(
                 <Routes>
                     <Route
-                        path={RoutesRecord.SUBMISSIONS_FORM}
+                        path={RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL}
                         element={<StateSubmissionForm />}
                     />
                 </Routes>,
@@ -418,7 +418,7 @@ describe('StateSubmissionForm', () => {
             renderWithProviders(
                 <Routes>
                     <Route
-                        path={RoutesRecord.SUBMISSIONS_FORM}
+                        path={RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL}
                         element={<StateSubmissionForm />}
                     />
                 </Routes>,
@@ -446,7 +446,7 @@ describe('StateSubmissionForm', () => {
             renderWithProviders(
                 <Routes>
                     <Route
-                        path={RoutesRecord.SUBMISSIONS_FORM}
+                        path={RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL}
                         element={<StateSubmissionForm />}
                     />
                 </Routes>,
@@ -490,7 +490,7 @@ describe('StateSubmissionForm', () => {
             renderWithProviders(
                 <Routes>
                     <Route
-                        path={RoutesRecord.SUBMISSIONS_FORM}
+                        path={RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL}
                         element={<StateSubmissionForm />}
                     />
                 </Routes>,
@@ -525,7 +525,7 @@ describe('StateSubmissionForm', () => {
             renderWithProviders(
                 <Routes>
                     <Route
-                        path={RoutesRecord.SUBMISSIONS_FORM}
+                        path={RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL}
                         element={<StateSubmissionForm />}
                     />
                 </Routes>,

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
@@ -51,7 +51,7 @@ import {
 
 const getRelativePathFromNestedRoute = (formRouteType: RouteT): string =>
     getRelativePath({
-        basePath: RoutesRecord.SUBMISSIONS_FORM,
+        basePath: RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL,
         targetPath: RoutesRecord[formRouteType],
     })
 
@@ -116,6 +116,7 @@ export type HealthPlanFormPageProps = {
     ) => Promise<HealthPlanPackage | Error>
 }
 export const StateSubmissionForm = (): React.ReactElement => {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     const { id } = useParams<{ id: string }>()
     // IF not id throw new error
     if (!id) {

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
@@ -44,6 +44,7 @@ import {
     yesNoFormValueAsBoolean,
 } from '../../../components/Form/FieldYesNo/FieldYesNo'
 import { SubmissionTypeFormSchema } from './SubmissionTypeSchema'
+import { RoutesRecord } from '../../../constants'
 
 export interface SubmissionTypeFormValues {
     populationCovered?: PopulationCoveredType
@@ -539,7 +540,9 @@ export const SubmissionType = ({
                             pageVariant={
                                 isNewSubmission ? 'FIRST' : 'EDIT_FIRST'
                             }
-                            backOnClick={() => navigate('/dashboard')}
+                            backOnClick={() =>
+                                navigate(RoutesRecord.DASHBOARD_SUBMISSIONS)
+                            }
                             continueOnClick={() => {
                                 setShouldValidate(true)
                                 setFocusErrorSummaryHeading(true)
@@ -548,7 +551,7 @@ export const SubmissionType = ({
                                 await handleFormSubmit(
                                     values,
                                     { setSubmitting },
-                                    '/dashboard'
+                                    RoutesRecord.DASHBOARD_SUBMISSIONS
                                 )
                             }}
                             actionInProgress={isSubmitting}

--- a/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.test.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.test.tsx
@@ -198,7 +198,7 @@ describe('SubmissionSideNav', () => {
             screen.getByRole('link', { name: /Back to dashboard/ })
         )
         await waitFor(() => {
-            expect(testLocation.pathname).toBe(`/dashboard`)
+            expect(testLocation.pathname).toBe(`/dashboard/submissions`)
         })
     })
 

--- a/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
@@ -8,6 +8,7 @@ import sprite from 'uswds/src/img/sprite.svg'
 import {
     QUESTION_RESPONSE_SHOW_SIDEBAR_ROUTES,
     RouteT,
+    RoutesRecord,
 } from '../../constants/routes'
 import { getRouteName } from '../../routeHelpers'
 import { useFetchHealthPlanPackageWithQuestionsWrapper } from '../../gqlHelpers'
@@ -43,6 +44,7 @@ export type SideNavOutletContextType = {
 }
 
 export const SubmissionSideNav = () => {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     const { id } = useParams<{ id: string }>()
     if (!id) {
         throw new Error(
@@ -157,7 +159,8 @@ export const SubmissionSideNav = () => {
                             <Link
                                 asCustom={NavLink}
                                 to={{
-                                    pathname: '/dashboard',
+                                    pathname:
+                                        RoutesRecord.DASHBOARD_SUBMISSIONS,
                                 }}
                             >
                                 <svg

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -28,6 +28,7 @@ import { UnlockSubmitModal } from '../../components/Modal/UnlockSubmitModal'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { featureFlags } from '../../common-code/featureFlags'
 import { SideNavOutletContextType } from '../SubmissionSideNav/SubmissionSideNav'
+import { RoutesRecord } from '../../constants'
 
 function UnlockModalButton({
     disabled,
@@ -135,7 +136,7 @@ export const SubmissionSummary = (): React.ReactElement => {
                     <Link
                         asCustom={NavLink}
                         to={{
-                            pathname: '/dashboard',
+                            pathname: RoutesRecord.DASHBOARD_SUBMISSIONS,
                         }}
                     >
                         <svg

--- a/services/app-web/src/routeHelpers/getRelativePath.test.ts
+++ b/services/app-web/src/routeHelpers/getRelativePath.test.ts
@@ -6,32 +6,32 @@ describe('getRelativePath', () => {
         const validCombinations: [string, string, string][] = [
             [
                 RoutesRecord.SUBMISSIONS_TYPE,
-                RoutesRecord.SUBMISSIONS_FORM,
+                RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL,
                 '/type',
             ],
             [
                 RoutesRecord.SUBMISSIONS_CONTRACT_DETAILS,
-                RoutesRecord.SUBMISSIONS_FORM,
+                RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL,
                 '/contract-details',
             ],
             [
                 RoutesRecord.SUBMISSIONS_RATE_DETAILS,
-                RoutesRecord.SUBMISSIONS_FORM,
+                RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL,
                 '/rate-details',
             ],
             [
                 RoutesRecord.SUBMISSIONS_CONTRACT_DETAILS,
-                RoutesRecord.SUBMISSIONS_FORM,
+                RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL,
                 '/contract-details',
             ],
             [
                 RoutesRecord.SUBMISSIONS_CONTACTS,
-                RoutesRecord.SUBMISSIONS_FORM,
+                RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL,
                 '/contacts',
             ],
             [
                 RoutesRecord.SUBMISSIONS_DOCUMENTS,
-                RoutesRecord.SUBMISSIONS_FORM,
+                RoutesRecord.SUBMISSIONS_EDIT_TOP_LEVEL,
                 '/documents',
             ],
         ]

--- a/services/app-web/src/routeHelpers/getRouteName.test.ts
+++ b/services/app-web/src/routeHelpers/getRouteName.test.ts
@@ -1,10 +1,13 @@
 import { getRouteName } from './'
-import { RouteT } from '../constants/routes'
+import { RouteT, RoutesRecord } from '../constants/routes'
 
 describe('getRouteName', () => {
     describe('calculates valid routes properly', () => {
         const testCases: [string, RouteT][] = [
-            ['/dashboard', 'DASHBOARD' as const],
+            [
+                RoutesRecord.DASHBOARD_SUBMISSIONS,
+                'DASHBOARD_SUBMISSIONS' as const,
+            ],
             ['/submissions/new', 'SUBMISSIONS_NEW' as const],
             ['/submissions/23324234', 'SUBMISSIONS_SUMMARY' as const],
             ['/submissions/123213/edit/type', 'SUBMISSIONS_TYPE' as const],

--- a/services/app-web/src/styles/custom.scss
+++ b/services/app-web/src/styles/custom.scss
@@ -34,12 +34,6 @@ $width-max-contained: 50rem;
         0px 0px 24px rgb(0 0 0 / 5%);
 }
 
-h3 {
-    margin-top: 0;
-    font-weight: normal;
-    font-size: 1.3em;
-}
-
 .usa-logo {
     @include u-margin-y(2);
 }

--- a/services/cypress/integration/smokeTest/smokeTest.spec.ts
+++ b/services/cypress/integration/smokeTest/smokeTest.spec.ts
@@ -5,7 +5,7 @@ describe('smoke test', () => {
     })
     it('can log in as a state user', () => {
         cy.logInAsStateUser()
-        cy.location('pathname', { timeout: 10_000 }).should('eq', '/')
+        cy.location('pathname', { timeout: 10_000 }).should('eq', '/dashboard/submissions')
         cy.findByRole('heading', { level: 1, name: /Dashboard/ })
     })
 
@@ -17,5 +17,5 @@ describe('smoke test', () => {
     it('can contact the API and connect to the database', () => {
         cy.logInAsStateUser()
         cy.startNewContractOnlySubmissionWithBaseContract()
-    }) 
+    })
 })

--- a/services/cypress/integration/stateWorkflow/login/login.spec.ts
+++ b/services/cypress/integration/stateWorkflow/login/login.spec.ts
@@ -9,7 +9,7 @@ describe('login', () => {
         cy.url().should('eq', Cypress.config().baseUrl + '/')
         cy.findByRole('button', { name: /Sign out/i }).safeClick()
 
-        cy.location('pathname').should('eq', '/')
+        cy.location('pathname').should('eq', '/submissions/dashboard')
         cy.findByRole('link', { name: /Sign In/i }).should('exist')
     })
 

--- a/services/cypress/integration/stateWorkflow/login/login.spec.ts
+++ b/services/cypress/integration/stateWorkflow/login/login.spec.ts
@@ -6,7 +6,7 @@ describe('login', () => {
     it('can log in and log out as expected', () => {
         cy.logInAsStateUser()
 
-        cy.url().should('eq', Cypress.config().baseUrl + '/submissions/dashboard')
+        cy.url().should('eq', Cypress.config().baseUrl + '/dashboard/submissions')
         cy.findByRole('button', { name: /Sign out/i }).safeClick()
 
         cy.location('pathname').should('eq', '/')

--- a/services/cypress/integration/stateWorkflow/login/login.spec.ts
+++ b/services/cypress/integration/stateWorkflow/login/login.spec.ts
@@ -6,10 +6,10 @@ describe('login', () => {
     it('can log in and log out as expected', () => {
         cy.logInAsStateUser()
 
-        cy.url().should('eq', Cypress.config().baseUrl + '/')
+        cy.url().should('eq', Cypress.config().baseUrl + '/submissions/dashboard')
         cy.findByRole('button', { name: /Sign out/i }).safeClick()
 
-        cy.location('pathname').should('eq', '/submissions/dashboard')
+        cy.location('pathname').should('eq', '/')
         cy.findByRole('link', { name: /Sign In/i }).should('exist')
     })
 

--- a/services/cypress/integration/stateWorkflow/stateSubmissionForm/rateDetails.spec.ts
+++ b/services/cypress/integration/stateWorkflow/stateSubmissionForm/rateDetails.spec.ts
@@ -54,10 +54,10 @@ describe('rate details', () => {
                 .within(() => {
                     cy.findByText('Yes').click()
                 })
-            cy.findByRole('combobox', { name: 'submission (required)' }).click({
-                force: true,
-            })
-            cy.findAllByText(/MCR-MN-0001-PMAP/i).first().click()
+
+            // use keyboard to select related submissions
+            cy.findByRole('combobox', { name: 'submission (required)' }).type('MCR-MN-0001-PMAP{enter}{enter}');
+
             // Navigate to contacts page by clicking continue
             cy.navigateFormByButtonClick('CONTINUE')
             cy.findByRole('heading', { level: 2, name: /Contacts/ })

--- a/services/cypress/integration/stateWorkflow/stateSubmissionForm/rateDetails.spec.ts
+++ b/services/cypress/integration/stateWorkflow/stateSubmissionForm/rateDetails.spec.ts
@@ -56,20 +56,17 @@ describe('rate details', () => {
                 })
 
             // use keyboard to select related submissions
-            cy.findByRole('combobox', { name: 'submission (required)' }).type('MCR-MN-0001-PMAP{enter}{enter}');
-
+            cy.findByRole('combobox', { name: 'submission (required)' }).type('MCR-MN{enter}{enter}');
             // Navigate to contacts page by clicking continue
             cy.navigateFormByButtonClick('CONTINUE')
             cy.findByRole('heading', { level: 2, name: /Contacts/ })
 
-            // check accessibility of filled out rate details page
             cy.navigateFormByButtonClick('BACK')
-            cy.findByText(/MCR-MN-0001-PMAP/i).should('be.visible')
             // check that selections can be removed
             cy.findByRole('button', {
-                name: /Remove MCR-MN-0001-PMAP/i,
+                name: /Remove MCR-MN-/i,
             }).click()
-            cy.findByText(/Remove MCR-MN-0001-PMAP/i).should('not.exist')
+            cy.findByText(/Remove MCR-MN-/i).should('not.exist')
             // Commented out to get react-scripts/webpack 5 upgrade through
             // cy.pa11y({
             //     actions: ['wait for element #form-guidance to be visible'],

--- a/services/cypress/integration/stateWorkflow/stateSubmissionForm/rateDetails.spec.ts
+++ b/services/cypress/integration/stateWorkflow/stateSubmissionForm/rateDetails.spec.ts
@@ -57,7 +57,7 @@ describe('rate details', () => {
             cy.findByRole('combobox', { name: 'submission (required)' }).click({
                 force: true,
             })
-            cy.findByText(/MCR-MN-0001-PMAP/i).click()
+            cy.findAllByText(/MCR-MN-0001-PMAP/i).first().click()
             // Navigate to contacts page by clicking continue
             cy.navigateFormByButtonClick('CONTINUE')
             cy.findByRole('heading', { level: 2, name: /Contacts/ })


### PR DESCRIPTION
## Summary
Get tabs, routes, and empty state for dashboard working. Add tests.

#### Related issues
https://qmacbis.atlassian.net/browse/MCR-2559

#### Screenshots
![Screenshot 2023-09-19 at 4 49 30 PM](https://github.com/Enterprise-CMCS/managed-care-review/assets/10750442/71c20eef-ba7e-41c9-af53-c72c04510b11)

#### Test cases covered
- I made all existing CMSDashboard tests loop through both variants of the feature flag 
- I added tests to check for presence of tabs for rate reviews flag on

## QA guidance
- Log in as CMS user with both the rates refactor and rates dashboard LD feature flags turned on
- Go to the main dashboard
- State user works the same as before just now dashboard is behind dashboard/submissions to match CMS