### PR TITLE
[MR-3576] Design and accessibility tweaks to  required and optional labels

### DIFF
--- a/services/app-web/src/pages/StateSubmission/Contacts/ActuaryContactFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/ActuaryContactFields.tsx
@@ -47,12 +47,14 @@ export const ActuaryContactFields = ({
                 type="text"
                 inputRef={inputRef}
                 variant="SUBHEAD"
+                aria-required
             />
 
             <FieldTextInput
                 name={`${fieldNamePrefix}.titleRole`}
                 id={`${fieldNamePrefix}.titleRole`}
                 label="Title/Role"
+                aria-required
                 showError={Boolean(
                     showFieldErrors(
                         getIn(errors, `${fieldNamePrefix}.titleRole`)
@@ -66,6 +68,7 @@ export const ActuaryContactFields = ({
                 name={`${fieldNamePrefix}.email`}
                 id={`${fieldNamePrefix}.email`}
                 label="Email"
+                aria-required
                 showError={Boolean(
                     showFieldErrors(getIn(errors, `${fieldNamePrefix}.email`))
                 )}

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -515,7 +515,10 @@ export const ContractDetails = ({
                                 />
                             )}
 
-                            <FormGroup error={showFileUploadError}>
+                            <FormGroup
+                                error={showFileUploadError}
+                                className="margin-top-0"
+                            >
                                 <FileUpload
                                     id="documents"
                                     name="documents"

--- a/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateCert/SingleRateCert.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateCert/SingleRateCert.tsx
@@ -305,7 +305,6 @@ export const SingleRateCert = ({
                     legend="Rate certification type"
                     role="radiogroup"
                     aria-required
-                    aria-label="Required"
                 >
                     <span className={styles.requiredOptionalText}>
                         Required

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.module.scss
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.module.scss
@@ -106,10 +106,6 @@
     }
 }
 
-.rateCertContainer {
-     margin-top: units(2);
-}
-
 .rateCertContainer + .rateCertContainer {
      margin-top: units(6);
 }

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
@@ -324,6 +324,7 @@ export const SubmissionType = ({
                                 error={showFieldErrors(
                                     errors.populationCovered
                                 )}
+                                className="margin-top-0"
                             >
                                 <Fieldset
                                     className={styles.radioGroup}

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
@@ -530,7 +530,10 @@ export const SubmissionType = ({
                                 )}
                                 hint={
                                     <>
-                                        <p id="submissionDescriptionHelp">
+                                        <p
+                                            id="submissionDescriptionHelp"
+                                            role="note"
+                                        >
                                             Provide a 1-2 paragraph summary of
                                             your submission that highlights any
                                             important changes CMS reviewers will


### PR DESCRIPTION
## Summary
This PR updates the following:
- Adjust the margin on the Submission type, Contract and Rate details pages so that there's only the 32px padding applied to the form container
- On the Submission Type page ensure JAWS reads out that the Submission description field is required
- On the Rate details page: ensure JAWS doesn't skip the Rate certification type label and gets rid of the redundant "Required group, required." announcement
- On the Rate details page ensure that JAWS calls out the Certifying actuary fields as required

This PR doesn't include the following
- Changes the order of announcement on the rate and contract pages between the labels and upload links. I'll wait for confirmation from Design and Hana if there's a preference. Same with the optional call out on the supporting docs page



#### Related issues
https://qmacbis.atlassian.net/browse/MCR-1790

#### QA
- Sign in as a state user and navigate the app using a screen reader. All required labels should be read out

#### Screenshots

<img width="753" alt="Screenshot 2023-09-21 at 11 26 25 AM" src="https://github.com/Enterprise-CMCS/managed-care-review/assets/67110378/1050106b-437a-4b31-bea8-6bb6f36067fb">
<img width="579" alt="Screenshot 2023-09-21 at 11 27 10 AM" src="https://github.com/Enterprise-CMCS/managed-care-review/assets/67110378/9d1a59a3-fc3d-4d64-b050-6e139f12b3ac">
<img width="462" alt="Screenshot 2023-09-21 at 11 27 01 AM" src="https://github.com/Enterprise-CMCS/managed-care-review/assets/67110378/46ee96a4-23bc-4828-80bd-73744e035b03">
