### PR TITLE
Fix additional actuary duplication and add tests.

### DIFF
--- a/services/app-api/src/domain-models/contractAndRates/convertContractWithRatesToHPP.ts
+++ b/services/app-api/src/domain-models/contractAndRates/convertContractWithRatesToHPP.ts
@@ -17,6 +17,7 @@ import {
 import type { ContractRevisionWithRatesType } from './revisionTypes'
 import { parsePartialHPFD } from '../../../../app-web/src/common-code/proto/healthPlanFormDataProto/toDomain'
 import type { PartialHealthPlanFormData } from '../../../../app-web/src/common-code/proto/healthPlanFormDataProto/toDomain'
+import { isEqualData } from '../../resolvers/healthPlanPackage/contractAndRates/resolverHelpers'
 
 function convertContractWithRatesToUnlockedHPP(
     contract: ContractType
@@ -91,7 +92,7 @@ function convertContractWithRatesToFormData(
     stateNumber: number
 ): HealthPlanFormDataType | Error {
     // additional certifying actuaries are on every rate post refactor but on the package pre-refactor
-    const pkgAdditionalCertifyingActuaries: Set<ActuaryContact> = new Set()
+    const pkgAdditionalCertifyingActuaries: ActuaryContact[] = []
     let pkgActuaryCommsPref: ActuaryCommunicationType | undefined = undefined
 
     const rateInfos: RateInfoType[] = contractRev.rateRevisions.map(
@@ -115,7 +116,13 @@ function convertContractWithRatesToFormData(
             } = rateRev.formData
 
             for (const additionalActuary of addtlActuaryContacts) {
-                pkgAdditionalCertifyingActuaries.add(additionalActuary)
+                if (
+                    !pkgAdditionalCertifyingActuaries.find((actuary) =>
+                        isEqualData(actuary, additionalActuary)
+                    )
+                ) {
+                    pkgAdditionalCertifyingActuaries.push(additionalActuary)
+                }
             }
 
             // The first time we find a rate that has an actuary comms pref, we use that to set the package's prefs

--- a/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.test.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.test.ts
@@ -257,6 +257,22 @@ describe.each(flagValueTestParameters)(
 
             // update that draft form data.
             const formData = Object.assign(latestFormData(createdDraft), {
+                addtlActuaryContacts: [
+                    {
+                        name: 'additional actuary 1',
+                        titleRole: 'additional actuary title 1',
+                        email: 'additionalactuary1@example.com',
+                        actuarialFirm: 'MERCER' as const,
+                        actuarialFirmOther: '',
+                    },
+                    {
+                        name: 'additional actuary 2',
+                        titleRole: 'additional actuary title 2',
+                        email: 'additionalactuary1@example.com',
+                        actuarialFirm: 'MERCER' as const,
+                        actuarialFirmOther: '',
+                    },
+                ],
                 rateInfos: [rate1, rate2],
             })
 


### PR DESCRIPTION
## Summary
Fixes additional actuaries getting copied multiple times based on the number of rates on a contract when converting our new domain contract data to HPP contract data.

Using `Set.add()` does not check for the equality of objects when adding them to the array. This caused every additional actuary contract from every rate to be copied to the `contract.addtlActuaryContacts` then when saving to the db, that `contract.addtlActuaryContacts` is then set to every `rate.addtlActuaryContacts`. Run this circle a few times, and it will duplicate the contacts exponentially. 

#### Related issues

#### Screenshots

#### Test cases covered

`updateHealthPlanFormData.test.ts`
- `'creates, updates, and deletes rates in the contract'` - Update to test additional actuaries.

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
