### PR TITLE
MR-2369: turn on rates db refactor flag for cypress

### DIFF
--- a/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -61,16 +61,7 @@ describe('CMS user', () => {
             cy.logInAsCMSUser({ initialURL: submissionURL })
 
             // click on the unlock button, type in reason and confirm
-            cy.findByRole('button', { name: 'Unlock submission', timeout: 5_000 }).click()
-            cy.findAllByTestId('modalWindow').eq(1).should('be.visible')
-            cy.get('#unlockSubmitModalInput').type('Unlock submission reason.')
-            cy.findByRole('button', { name: 'Unlock' }).click()
-
-
-            cy.findByRole('button', { name: 'Unlock submission'}).should(
-                'be.disabled', {timeout: 50_000 }
-            )
-            cy.findAllByTestId('modalWindow').eq(1).should('be.hidden')
+            cy.unlockSubmission()
 
             //Unlock banner for CMS user to be present with correct data.
             cy.findByTestId('unlockedBanner')
@@ -156,7 +147,7 @@ describe('CMS user', () => {
                     'not.be.disabled'
                 )
 
-                //CSM user should not see unlock banner and should see updated submission banner
+                //CMS user should not see unlock banner and should see updated submission banner
                 cy.findByTestId('unlockedBanner').should('not.exist')
                 cy.findByTestId('updatedSubmissionBanner').should('exist')
 

--- a/services/cypress/integration/stateWorkflow/questionResponse/questionResponse.spec.ts
+++ b/services/cypress/integration/stateWorkflow/questionResponse/questionResponse.spec.ts
@@ -5,7 +5,7 @@ describe('Q&A', () => {
         cy.interceptGraphQL()
     })
 
-    it('can add questions and responses', () => {
+    it.skip('can add questions and responses', () => {
         cy.interceptFeatureFlags({
             'cms-questions': true,
         })

--- a/services/cypress/integration/stateWorkflow/stateSubmissionForm/documents.spec.ts
+++ b/services/cypress/integration/stateWorkflow/stateSubmissionForm/documents.spec.ts
@@ -25,14 +25,8 @@ describe('documents', () => {
             cy.findByTestId('file-input-input').attachFile(
                 'documents/trussel-guide.pdf'
             )
-            // click the checkbox so the row won't be in an error state
-            cy.findAllByRole('checkbox', {
-                name: 'rate-supporting',
-            })
-                .eq(0)
-                .click({ force: true })
             cy.findByText(/0 complete, 1 error, 1 pending/).should('exist')
-            cy.waitForDocumentsToLoad({tableView: true})
+            cy.waitForDocumentsToLoad()
             cy.findByText(/1 complete, 1 error, 0 pending/).should('exist')
             cy.findByText('Duplicate file, please remove').should('exist')
             cy.navigateFormByDirectLink(
@@ -49,25 +43,21 @@ describe('documents', () => {
                 'documents/trussel-guide.pdf'
             )
             cy.findByText('Duplicate file, please remove').should('exist')
-            cy.findAllByRole('row').should('have.length', 4)
+
+            cy.findByTestId('file-input-preview-list').within(() => {
+                cy.findAllByRole('listitem').should('have.length', 3)
+            })
 
             cy.findByText(/3 files added/).should('exist')
-            // click the second column in the second row to make sure multiple rows are handled correctly
-            cy.findAllByRole('checkbox', {
-                name: 'rate-supporting',
-            })
-                .eq(0)
-                .click({ force: true })
-            cy.findAllByRole('checkbox', {
-                name: 'rate-supporting',
-            })
-                .eq(1)
-                .click({ force: true })
             cy.findByText(/0 complete, 1 error, 2 pending/).should('exist')
 
-            cy.waitForDocumentsToLoad({tableView: true})
+            cy.waitForDocumentsToLoad()
             cy.findByText('Duplicate file, please remove').should('exist')
-            cy.findAllByRole('row').should('have.length', 4)
+
+            cy.findByTestId('file-input-preview-list').within(() => {
+                cy.findAllByRole('listitem').should('have.length', 3)
+            })
+
             cy.findByText(/2 complete, 1 error, 0 pending/)
             cy.navigateFormByButtonClick('BACK')
             cy.findByRole('heading', { level: 2, name: /Contacts/ })
@@ -76,12 +66,11 @@ describe('documents', () => {
             cy.navigateFormByDirectLink(
                 `/submissions/${draftSubmissionID}/edit/documents`
             )
-            cy.findAllByRole('row').should('have.length', 3)
-            cy.findAllByRole('checkbox', {
-                name: 'rate-supporting',
+
+            cy.findByTestId('file-input-preview-list').within(() => {
+                cy.findAllByRole('listitem').should('have.length', 2)
             })
-                .eq(1)
-                .should('be.checked')
+
             cy.verifyDocumentsHaveNoErrors()
 
             //  Save as draft
@@ -124,15 +113,19 @@ describe('documents', () => {
                 .attachFile(
                     [
                         'documents/how-to-open-source.pdf',
-                        'documents/testing.docx',
+                        'documents/trussel-guide.pdf',
                     ],
                     {
                         subjectType: 'drag-n-drop',
                         force: true,
                     }
                 )
-            cy.findAllByRole('row').should('have.length', 3)
-            cy.waitForDocumentsToLoad({tableView: true})
+
+            cy.findByTestId('file-input-preview-list').within(() => {
+                cy.findAllByRole('listitem').should('have.length', 2)
+            })
+
+            cy.waitForDocumentsToLoad()
             cy.verifyDocumentsHaveNoErrors()
 
             cy.navigateFormByButtonClick('CONTINUE')

--- a/services/cypress/integration/stateWorkflow/virusScan/virusScan.spec.ts
+++ b/services/cypress/integration/stateWorkflow/virusScan/virusScan.spec.ts
@@ -19,10 +19,9 @@ describe.only('documents', () => {
                     filePath: 'documents/eicar_com.pdf',
                     encoding: 'binary',
                 })
-                cy.findAllByTestId('upload-finished-indicator', {
+                cy.findByText('Failed security scan, please remove', {
                     timeout: 200_000,
-                })
-                cy.findByText('Failed security scan, please remove').should(
+                }).should(
                     'exist'
                 )
             })

--- a/services/cypress/support/index.ts
+++ b/services/cypress/support/index.ts
@@ -14,6 +14,7 @@ import './commands'
 import '@cypress/code-coverage/support'
 import './loginCommands'
 import './stateSubmissionFormCommands'
+import './submissionReviewCommands'
 import './dashboardCommands'
 import './navigateCommands'
 import './questionResponseCommands'
@@ -64,7 +65,10 @@ declare global {
             fillOutSupportingDocuments(): void
             waitForDocumentsToLoad( args?: {tableView?: boolean}): void
             verifyDocumentsHaveNoErrors(): void
-            submitStateSubmissionForm( args?: {success?: boolean, resubmission?: boolean}): void
+            submitStateSubmissionForm( args?: {success?: boolean, resubmission?: boolean, summary?: string}): void
+
+            // submission review commands
+            unlockSubmission(unlockReason?: string): void
 
             // navigate commands
             navigateFormByButtonClick(

--- a/services/cypress/support/launchDarklyCommands.ts
+++ b/services/cypress/support/launchDarklyCommands.ts
@@ -85,6 +85,8 @@ Cypress.Commands.add('stubFeatureFlags', () => {
      **/
     cy.interceptFeatureFlags({
         'packages-with-shared-rates': true,
+        'rates-db-refactor': true,
+        'supporting-docs-by-rate': true
     })
 })
 

--- a/services/cypress/support/stateSubmissionFormCommands.ts
+++ b/services/cypress/support/stateSubmissionFormCommands.ts
@@ -342,8 +342,9 @@ Cypress.Commands.add('fillOutNewRateCertification', () => {
     cy.findAllByLabelText('Email').eq(0).type('actuarycontact@example.com')
     cy.findAllByLabelText('Mercer').eq(0).safeClick()
 
-    cy.findByTestId('file-input-input').attachFile(
-        'documents/trussel-guide.pdf'
+    // Upload a rate certification and rate supporting document
+    cy.findAllByTestId('file-input-input').each(fileInput =>
+        cy.wrap(fileInput).attachFile('documents/trussel-guide.pdf')
     )
 
     cy.verifyDocumentsHaveNoErrors()
@@ -390,8 +391,9 @@ Cypress.Commands.add('fillOutAmendmentToPriorRateCertification', (id = 0) => {
     cy.findAllByLabelText('Email').eq(0).type('actuarycontact@example.com')
     cy.findAllByLabelText('Mercer').eq(0).safeClick()
 
-    cy.findByTestId('file-input-input').attachFile(
-        'documents/trussel-guide.pdf'
+    // Upload a rate certification and rate supporting document
+    cy.findAllByTestId('file-input-input').each(fileInput =>
+        cy.wrap(fileInput).attachFile('documents/trussel-guide.pdf')
     )
 
     cy.verifyDocumentsHaveNoErrors()
@@ -441,22 +443,10 @@ Cypress.Commands.add('fillOutSupportingDocuments', () => {
 
     cy.verifyDocumentsHaveNoErrors()
 
-    cy.findAllByRole('checkbox', {
-        name: 'contract-supporting',
-    })
-        .eq(1)
-        .click({ force: true })
-
-    cy.findAllByRole('checkbox', {
-        name: 'rate-supporting',
-    })
-        .eq(0)
-        .click({ force: true })
-
     // twice because there could be validation errors with checkbox
     cy.verifyDocumentsHaveNoErrors()
 
-    cy.waitForDocumentsToLoad({tableView: true})
+    cy.waitForDocumentsToLoad()
     cy.findAllByTestId('errorMessage').should('have.length', 0)
 })
 
@@ -483,7 +473,7 @@ Cypress.Commands.add('verifyDocumentsHaveNoErrors', () => {
 
 Cypress.Commands.add(
     'submitStateSubmissionForm',
-    ({success, resubmission}=  {success: true, resubmission: false}) => {
+    ({success, resubmission, summary} = { success: true, resubmission: false }) => {
         cy.findByRole('heading', { level: 2, name: /Review and submit/ })
         cy.findByRole('button', {
             name: 'Submit',
@@ -495,7 +485,7 @@ Cypress.Commands.add(
             .within(() => {
                 if (resubmission) {
                     cy.get('#unlockSubmitModalInput').type(
-                        'Resubmission summary'
+                        summary || 'Resubmission summary'
                     )
                     cy.findByTestId('resubmit-modal-submit').click()
                 } else {

--- a/services/cypress/support/submissionReviewCommands.ts
+++ b/services/cypress/support/submissionReviewCommands.ts
@@ -1,0 +1,17 @@
+Cypress.Commands.add('unlockSubmission', (unlockReason) => {
+    // click on the unlock button, type in reason and confirm
+    cy.findByRole('button', { name: 'Unlock submission', timeout: 5_000 }).click()
+    cy.findAllByTestId('modalWindow').eq(1).should('be.visible')
+    cy.get('#unlockSubmitModalInput').type(
+        unlockReason || 'Unlock submission reason.'
+    )
+    cy.findByRole('button', { name: 'Unlock' }).click()
+
+    cy.findByRole('button', { name: 'Unlock submission'}).should(
+        'be.disabled', {timeout: 50_000 }
+    )
+    cy.findAllByTestId('modalWindow').eq(1).should('be.hidden')
+
+    // Unlock banner for CMS user to be present with correct data.
+    cy.findByTestId('unlockedBanner').should('exist')
+})


### PR DESCRIPTION
## Summary
[MR-2369](https://qmacbis.atlassian.net/browse/MCR-2369)

- Turns on `rates-db-refactor` flag for Cypress tests
- Turns on `supporting-docs-by-rate` flag for Cypress tests
   - Since `supporting-docs-by-rate` is dependent on `rates-db-refactor`, the UI changes behind it were never activated in `dev`. By activating `rates-db-refactor` in dev we now see the UI in dev Cypress tests.
   - All tests have been updated for the UI changes.
- Skip `questionsResponse.spec` tests because we have not migrated the Q&A API endpoint yet.
- **NOTE** Currently, the change history is incorrect and our cypress tests does not accurately test the change history and its order.
   - This test is in `unlockResubmit.spec`
   - It still passes
   - I will have a follow-up ticket to address this once we fix the change history.  See the [rates db refactor notes](https://docs.google.com/document/d/1E1kcXBZYfM6aGjFyrWR7clX9lflHwnfr6Ijxyob_4_M/edit#heading=h.1gehl816ra0k) doc for more info on the investigation of the bug.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
