### PR TITLE
update migrators handling of submittedAt and unlocked rates

### DIFF
--- a/services/app-api/src/handlers/proto_to_db.ts
+++ b/services/app-api/src/handlers/proto_to_db.ts
@@ -269,7 +269,7 @@ export const main: Handler = async (): Promise<APIGatewayProxyResultV2> => {
         }
 
         console.info(
-            `Migrated HealthPlanRevision ${revision.pkgID} successfully...`
+            `Migrated HealthPlanRevision ${revision.id} successfully...`
         )
     }
 

--- a/services/app-api/src/postgres/contractAndRates/proto_to_db_ContractRevisions.ts
+++ b/services/app-api/src/postgres/contractAndRates/proto_to_db_ContractRevisions.ts
@@ -106,7 +106,11 @@ async function migrateContractRevision(
         }
 
         // Add the unlocked info to the table if it exists
-        if (formData.status === 'SUBMITTED' && revision.unlockedBy) {
+        if (
+            revision.unlockedAt &&
+            revision.unlockedBy &&
+            revision.unlockedReason
+        ) {
             const user = await client.user.findFirst({
                 where: { email: revision.unlockedBy },
             })
@@ -114,11 +118,9 @@ async function migrateContractRevision(
             if (user) {
                 createDataObject.unlockInfo = {
                     create: {
-                        updatedAt: revision.unlockedAt ?? new Date(),
+                        updatedAt: revision.unlockedAt,
                         updatedByID: user.id,
-                        updatedReason:
-                            revision.unlockedReason ??
-                            'Migrated from previous system',
+                        updatedReason: revision.unlockedReason,
                     },
                 }
             } else {
@@ -129,14 +131,14 @@ async function migrateContractRevision(
         }
 
         // add the submit info to the table if it exists
-        if (formData.status === 'SUBMITTED' && revision.submittedBy) {
+        if (revision.submittedAt && revision.submittedBy) {
             const user = await client.user.findFirst({
                 where: { email: revision.submittedBy },
             })
             if (user) {
                 createDataObject.submitInfo = {
                     create: {
-                        updatedAt: formData.updatedAt,
+                        updatedAt: revision.submittedAt,
                         updatedByID: user.id,
                         updatedReason:
                             revision.submittedReason ??

--- a/services/app-api/src/postgres/contractAndRates/proto_to_db_RateRevisions.ts
+++ b/services/app-api/src/postgres/contractAndRates/proto_to_db_RateRevisions.ts
@@ -172,6 +172,16 @@ export async function migrateRateInfo(
             create: rateRevDocsArray,
         }
 
+        // Connect to shared contracts
+        if (rateInfo.packagesWithSharedRateCerts) {
+            const sharedContractIDs = rateInfo.packagesWithSharedRateCerts.map(
+                (pkg) => pkg.packageId
+            )
+            dataToCopy.contractsWithSharedRateRevision = {
+                connect: sharedContractIDs.map((cid) => ({ id: cid })),
+            }
+        }
+
         // if this package is unlocked, so are the rates and contracts
         // the only connection should be draftRates/draftContracts
         if (!revision.submittedAt) {

--- a/services/app-api/src/resolvers/healthPlanPackage/submitHealthPlanPackage.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/submitHealthPlanPackage.ts
@@ -535,6 +535,9 @@ export function submitHealthPlanPackageResolver(
                 })
             }
 
+            // We're getting weird tests b/c of the difference between updateInfo and submittedAt
+            maybeLocked.submittedAt = updateInfo.updatedAt
+
             // Save the package!
             const updateResult = await store.updateHealthPlanRevision(
                 input.pkgID,


### PR DESCRIPTION
## Summary

Found some issues when running this migration on dev.

* submittedAt was not being set correctly
* unlockedAt was not getting set at all on an unlocked unsubmitted package
* unlocked packages were not setting draftRates correctly so their rates were coming back empty
