### PR TITLE
Reorder migrator to migrate rates after contracts to prevent linking errors

### DIFF
--- a/.github/workflows/deploy-app-to-env.yml
+++ b/.github/workflows/deploy-app-to-env.yml
@@ -136,12 +136,3 @@ jobs:
           STAGE_NAME: ${{ inputs.stage_name }}
         run: |
           ./scripts/invoke-migrate-lambda.sh app-api-$STAGE_NAME-migrate \$LATEST "Migration of the database failed."
-
-      - name: invoke proto_to_db lambda -- (rates refactor migrate)
-        id: invoke-proto_to_db
-        working-directory: services/app-api
-        continue-on-error: true
-        env:
-          STAGE_NAME: ${{ inputs.stage_name }}
-        run: |
-          ./scripts/invoke-migrate-lambda.sh app-api-$STAGE_NAME-proto_to_db \$LATEST "Migration of the protos to the database failed."

--- a/services/app-api/src/handlers/proto_to_db.test.ts
+++ b/services/app-api/src/handlers/proto_to_db.test.ts
@@ -17,7 +17,7 @@ import UNLOCK_HEALTH_PLAN_PACKAGE from 'app-graphql/src/mutations/unlockHealthPl
 import {
     cleanupPreviousProtoMigrate,
     decodeFormDataProto,
-    migrateRevision,
+    migrateHealthPlanRevisions,
 } from './proto_to_db'
 import { sharedTestPrismaClient } from '../testHelpers/storeHelpers'
 import { findAllRevisions } from '../postgres/healthPlanPackage'
@@ -250,20 +250,16 @@ describe('test that we migrate things', () => {
             }
         }
 
-        const migratedContracts = []
-        for (const revision of revisionsToMigrate) {
-            const migratedRevision = await migrateRevision(
-                prismaClient,
-                revision
+        const migrateErrors = await migrateHealthPlanRevisions(
+            prismaClient,
+            revisionsToMigrate
+        )
+        if (migrateErrors.length > 0) {
+            const error = new Error(
+                `Could not get a migrated revision back: ${migrateErrors}`
             )
-            if (migratedRevision instanceof Error) {
-                const error = new Error(
-                    `Could not get a migrated revision back: ${migratedRevision}`
-                )
-                console.error(error)
-                throw error
-            }
-            migratedContracts.push(migratedRevision)
+            console.error(error)
+            throw error
         }
 
         const stateServerPost = await constructTestPostgresServer({
@@ -381,20 +377,16 @@ describe('test that we migrate things', () => {
             }
         }
 
-        const migratedContracts = []
-        for (const revision of revisionsToMigrate) {
-            const migratedRevision = await migrateRevision(
-                prismaClient,
-                revision
+        const migrateErrors = await migrateHealthPlanRevisions(
+            prismaClient,
+            revisionsToMigrate
+        )
+        if (migrateErrors.length > 0) {
+            const error = new Error(
+                `Could not get a migrated revision back: ${migrateErrors}`
             )
-            if (migratedRevision instanceof Error) {
-                const error = new Error(
-                    `Could not get a migrated revision back: ${migratedRevision}`
-                )
-                console.error(error)
-                throw error
-            }
-            migratedContracts.push(migratedRevision)
+            console.error(error)
+            throw error
         }
 
         // Now compare new to old.
@@ -520,20 +512,16 @@ describe('test that we migrate things', () => {
             }
         }
 
-        const migratedContracts = []
-        for (const revision of revisionsToMigrate) {
-            const migratedRevision = await migrateRevision(
-                prismaClient,
-                revision
+        const migrateErrors = await migrateHealthPlanRevisions(
+            prismaClient,
+            revisionsToMigrate
+        )
+        if (migrateErrors.length > 0) {
+            const error = new Error(
+                `Could not get a migrated revision back: ${migrateErrors}`
             )
-            if (migratedRevision instanceof Error) {
-                const error = new Error(
-                    `Could not get a migrated revision back: ${migratedRevision}`
-                )
-                console.error(error)
-                throw error
-            }
-            migratedContracts.push(migratedRevision)
+            console.error(error)
+            throw error
         }
 
         // Now compare new to old.
@@ -674,20 +662,16 @@ describe('test that we migrate things', () => {
             }
         }
 
-        const migratedContracts = []
-        for (const revisionToMig of revisionsToMigrate) {
-            const migratedRevision = await migrateRevision(
-                prismaClient,
-                revisionToMig
+        const migrateErrors = await migrateHealthPlanRevisions(
+            prismaClient,
+            revisionsToMigrate
+        )
+        if (migrateErrors.length > 0) {
+            const error = new Error(
+                `Could not get a migrated revision back: ${migrateErrors}`
             )
-            if (migratedRevision instanceof Error) {
-                const error = new Error(
-                    `Could not get a migrated revision back: ${migratedRevision}`
-                )
-                console.error(error)
-                throw error
-            }
-            migratedContracts.push(migratedRevision)
+            console.error(error)
+            throw error
         }
 
         // Now compare new to old.


### PR DESCRIPTION
## Summary

We encountered an error migrating dev where a rate revision was not able to be created because the contract it linked to did not exist yet. This PR reorganizes the migrator to migrate all the contracts and then all the rates. 