### PR TITLE
MCR-3549: Add parent contract id to contract revision

### DIFF
--- a/services/app-api/src/domain-models/contractAndRates/revisionTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/revisionTypes.ts
@@ -4,7 +4,7 @@ import { contractFormDataSchema, rateFormDataSchema } from './formDataTypes'
 
 const contractRevisionSchema = z.object({
     id: z.string().uuid(),
-    // contractID: z.string(),  // TODO we have this data in prisma but we lose it in the domain type - its needed for frontend which uses parent ids for routing
+    contractID: z.string(),
     submitInfo: updateInfoSchema.optional(),
     unlockInfo: updateInfoSchema.optional(),
     createdAt: z.date(),

--- a/services/app-api/src/postgres/contractAndRates/parseContractWithHistory.ts
+++ b/services/app-api/src/postgres/contractAndRates/parseContractWithHistory.ts
@@ -83,6 +83,7 @@ function contractRevisionToDomainModel(
 ): ContractRevisionType {
     return {
         id: revision.id,
+        contractID: revision.contractID,
         createdAt: revision.createdAt,
         updatedAt: revision.updatedAt,
         submitInfo: convertUpdateInfoToDomainModel(revision.submitInfo),

--- a/services/app-api/src/postgres/contractAndRates/prismaDraftContractHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaDraftContractHelpers.ts
@@ -89,6 +89,7 @@ function draftContractRevToDomainModel(
 
     return {
         id: revision.id,
+        contractID: revision.contractID,
         createdAt: revision.createdAt,
         updatedAt: revision.updatedAt,
         unlockInfo: convertUpdateInfoToDomainModel(revision.unlockInfo),

--- a/services/app-graphql/src/queries/fetchRate.graphql
+++ b/services/app-graphql/src/queries/fetchRate.graphql
@@ -73,6 +73,7 @@ query fetchRate($input: FetchRateInput!) {
             }
              contractRevisions {
                     id
+                    contractID
                     createdAt
                     updatedAt
                     submitInfo {

--- a/services/app-graphql/src/queries/indexRates.graphql
+++ b/services/app-graphql/src/queries/indexRates.graphql
@@ -74,6 +74,7 @@ query indexRates {
                     }
                     contractRevisions {
                         id
+                        contractID
                         createdAt
                         updatedAt
                         submitInfo {

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -789,12 +789,12 @@ type RateFormData {
 }
 
 type RelatedContractRevisions {
-    id: String
-    # contractID: String  # this would be needed in order to link to submission summary
+    id: String!
+    contractID: String!
     submitInfo: UpdateInformation
     unlockInfo: UpdateInformation
-    createdAt: DateTime
-    updatedAt: DateTime
+    createdAt: DateTime!
+    updatedAt: DateTime!
 }
 
 type RateRevision {
@@ -833,7 +833,6 @@ type Rate {
     for the rate and contains the full data from when the rate cert was submitted
     """
     revisions: [RateRevision!]!
-    contractRevisions:[RelatedContractRevisions!]!
 }
 
 type RateEdge {

--- a/services/app-web/src/pages/SubmissionSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/RateSummary.tsx
@@ -83,7 +83,7 @@ export const RateSummary = (): React.ReactElement => {
                     </Link>
                 </div>
                 <SingleRateSummarySection
-                    rate={{ ...rate, contractRevisions: [] }}
+                    rate={rate}
                     isSubmitted // can assume isSubmitted because we are building for CMS users
                     statePrograms={rate.state.programs}
                 />


### PR DESCRIPTION
## Summary
[MCR-3549](https://qmacbis.atlassian.net/browse/MCR-3549)

- Add `contractID` to the contract revision level data.
   - Update domain types
   - Update Graphql schemas
- Remove `contractRevision` from the `Rate` level in GraphQL schemas.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
