### PR TITLE
MCR-3557: Cms sees link to submission on rate summary page and shared rate submissions

### DIFF
--- a/services/app-api/src/domain-models/contractAndRates/contractTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/contractTypes.ts
@@ -1,17 +1,13 @@
 import { z } from 'zod'
 import { contractRevisionWithRatesSchema } from './revisionTypes'
+import { statusSchema } from './statusType'
 
 // Contract represents the contract specific information in a submission package
 // All that data is contained in revisions, each revision represents the data in a single submission
 // submissions are kept intact here across time
 const contractSchema = z.object({
     id: z.string().uuid(),
-    status: z.union([
-        z.literal('SUBMITTED'),
-        z.literal('DRAFT'),
-        z.literal('UNLOCKED'),
-        z.literal('RESUBMITTED'),
-    ]),
+    status: statusSchema,
     stateCode: z.string(),
     mccrsID: z.string().optional(),
     stateNumber: z.number().min(1),

--- a/services/app-api/src/domain-models/contractAndRates/formDataTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/formDataTypes.ts
@@ -8,10 +8,10 @@ import {
     populationCoveredSchema,
     rateCapitationTypeSchema,
     rateTypeSchema,
-    sharedRateCertDisplay,
     stateContactSchema,
     submissionTypeSchema,
 } from '../../../../app-web/src/common-code/proto/healthPlanFormDataProto/zodSchemas'
+import { statusSchema } from './statusType'
 
 const documentSchema = z.object({
     name: z.string(),
@@ -25,6 +25,12 @@ const managedCareEntitiesSchema = z.union([
     z.literal('PAHP'),
     z.literal('PCCM'),
 ])
+
+const packagesWithSharedRateCerts = z.object({
+    packageName: z.string(),
+    packageId: z.string(),
+    packageStatus: statusSchema.optional(),
+})
 
 const contractFormDataSchema = z.object({
     programIDs: z.array(z.string()),
@@ -77,7 +83,9 @@ const rateFormDataSchema = z.object({
     certifyingActuaryContacts: z.array(actuaryContactSchema).optional(),
     addtlActuaryContacts: z.array(actuaryContactSchema).optional(),
     actuaryCommunicationPreference: actuaryCommunicationTypeSchema.optional(),
-    packagesWithSharedRateCerts: z.array(sharedRateCertDisplay).optional(),
+    packagesWithSharedRateCerts: z
+        .array(packagesWithSharedRateCerts)
+        .optional(),
 })
 
 type ContractFormDataType = z.infer<typeof contractFormDataSchema>

--- a/services/app-api/src/domain-models/contractAndRates/index.ts
+++ b/services/app-api/src/domain-models/contractAndRates/index.ts
@@ -11,6 +11,8 @@ export {
     rateRevisionSchema,
 } from './revisionTypes'
 
+export { statusSchema } from './statusType'
+
 export {
     convertContractWithRatesRevtoHPPRev,
     convertContractWithRatesToUnlockedHPP,

--- a/services/app-api/src/domain-models/contractAndRates/rateTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/rateTypes.ts
@@ -3,17 +3,13 @@ import {
     rateRevisionWithContractsSchema,
     rateRevisionSchema,
 } from './revisionTypes'
+import { statusSchema } from './statusType'
 
 const rateSchema = z.object({
     id: z.string().uuid(),
     createdAt: z.date(),
     updatedAt: z.date(),
-    status: z.union([
-        z.literal('SUBMITTED'),
-        z.literal('DRAFT'),
-        z.literal('UNLOCKED'),
-        z.literal('RESUBMITTED'),
-    ]),
+    status: statusSchema,
     stateCode: z.string(),
     stateNumber: z.number().min(1),
     // If this rate is in a DRAFT or UNLOCKED status, there will be a draftRevision

--- a/services/app-api/src/domain-models/contractAndRates/revisionTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/revisionTypes.ts
@@ -4,7 +4,7 @@ import { contractFormDataSchema, rateFormDataSchema } from './formDataTypes'
 
 const contractRevisionSchema = z.object({
     id: z.string().uuid(),
-    // contractID: z.string(),  // TODO we have this data in prisma but we lose it in the domain type - its needed for frontend which uses parent ids for routing
+    contractID: z.string(),
     submitInfo: updateInfoSchema.optional(),
     unlockInfo: updateInfoSchema.optional(),
     createdAt: z.date(),

--- a/services/app-api/src/domain-models/contractAndRates/revisionTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/revisionTypes.ts
@@ -4,7 +4,11 @@ import { contractFormDataSchema, rateFormDataSchema } from './formDataTypes'
 
 const contractRevisionSchema = z.object({
     id: z.string().uuid(),
-    contractID: z.string(),
+    contract: z.object({
+        id: z.string().uuid(),
+        stateCode: z.string(),
+        stateNumber: z.number().min(1),
+    }),
     submitInfo: updateInfoSchema.optional(),
     unlockInfo: updateInfoSchema.optional(),
     createdAt: z.date(),

--- a/services/app-api/src/domain-models/contractAndRates/statusType.ts
+++ b/services/app-api/src/domain-models/contractAndRates/statusType.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+const statusSchema = z.union([
+    z.literal('SUBMITTED'),
+    z.literal('DRAFT'),
+    z.literal('UNLOCKED'),
+    z.literal('RESUBMITTED'),
+])
+
+export { statusSchema }

--- a/services/app-api/src/postgres/contractAndRates/parseContractAndRates.test.ts
+++ b/services/app-api/src/postgres/contractAndRates/parseContractAndRates.test.ts
@@ -9,9 +9,9 @@ import type { ContractTableFullPayload } from './prismaSubmittedContractHelpers'
 
 describe('parseDomainData', () => {
     describe('parseDraftContract', () => {
+        const draftContract = createDraftContractData()
         it('can parse valid draft domain data with no errors', () => {
-            const draftData = createDraftContractData()
-            const validatedDraft = parseContractWithHistory(draftData)
+            const validatedDraft = parseContractWithHistory(draftContract)
             expect(validatedDraft).not.toBeInstanceOf(Error)
         })
 
@@ -37,7 +37,7 @@ describe('parseDomainData', () => {
                 contract: createDraftContractData({
                     stateCode: undefined,
                     revisions: [
-                        createContractRevision({
+                        createContractRevision(draftContract, {
                             submitInfo: {
                                 id: uuidv4(),
                                 updatedAt: new Date(),
@@ -69,11 +69,10 @@ describe('parseDomainData', () => {
         )
     })
     describe('parseDraftContractRevision', () => {
+        const contract = createContractData()
+
         it('cant parse valid contract revision with no errors', () => {
-            const contractRevision = createContractData()
-            expect(
-                parseContractWithHistory(contractRevision)
-            ).not.toBeInstanceOf(Error)
+            expect(parseContractWithHistory(contract)).not.toBeInstanceOf(Error)
         })
         const draftContractRevisionsWithInvalidData: {
             contract: ContractTableFullPayload
@@ -82,7 +81,7 @@ describe('parseDomainData', () => {
             {
                 contract: createContractData({
                     revisions: [
-                        createContractRevision({
+                        createContractRevision(contract, {
                             submissionType: undefined,
                         }),
                     ],
@@ -92,7 +91,7 @@ describe('parseDomainData', () => {
             {
                 contract: createContractData({
                     revisions: [
-                        createContractRevision({
+                        createContractRevision(contract, {
                             submissionDescription: undefined,
                         }),
                     ],
@@ -102,7 +101,7 @@ describe('parseDomainData', () => {
             {
                 contract: createContractData({
                     revisions: [
-                        createContractRevision({
+                        createContractRevision(contract, {
                             contractType: undefined,
                         }),
                     ],
@@ -112,7 +111,7 @@ describe('parseDomainData', () => {
             {
                 contract: createContractData({
                     revisions: [
-                        createContractRevision({
+                        createContractRevision(contract, {
                             managedCareEntities: undefined,
                         }),
                     ],
@@ -128,9 +127,9 @@ describe('parseDomainData', () => {
         )
     })
     describe('parseContractWithHistory', () => {
+        const contract = createContractData()
         it('can parse valid contract domain data with no errors', () => {
-            const contractData = createContractData()
-            const validatedContract = parseContractWithHistory(contractData)
+            const validatedContract = parseContractWithHistory(contract)
             expect(validatedContract).not.toBeInstanceOf(Error)
         })
 
@@ -153,7 +152,7 @@ describe('parseDomainData', () => {
             {
                 contract: createContractData({
                     revisions: [
-                        createContractRevision({
+                        createContractRevision(contract, {
                             rateRevisions: [
                                 {
                                     rateRevisionID: uuidv4(),

--- a/services/app-api/src/postgres/contractAndRates/parseContractWithHistory.ts
+++ b/services/app-api/src/postgres/contractAndRates/parseContractWithHistory.ts
@@ -83,6 +83,7 @@ function contractRevisionToDomainModel(
 ): ContractRevisionType {
     return {
         id: revision.id,
+        contractID: revision.contractID,
         createdAt: revision.createdAt,
         updatedAt: revision.updatedAt,
         submitInfo: convertUpdateInfoToDomainModel(revision.submitInfo),

--- a/services/app-api/src/postgres/contractAndRates/parseContractWithHistory.ts
+++ b/services/app-api/src/postgres/contractAndRates/parseContractWithHistory.ts
@@ -83,7 +83,7 @@ function contractRevisionToDomainModel(
 ): ContractRevisionType {
     return {
         id: revision.id,
-        contractID: revision.contractID,
+        contract: revision.contract,
         createdAt: revision.createdAt,
         updatedAt: revision.updatedAt,
         submitInfo: convertUpdateInfoToDomainModel(revision.submitInfo),

--- a/services/app-api/src/postgres/contractAndRates/prismaDraftContractHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaDraftContractHelpers.ts
@@ -89,6 +89,7 @@ function draftContractRevToDomainModel(
 
     return {
         id: revision.id,
+        contractID: revision.contractID,
         createdAt: revision.createdAt,
         updatedAt: revision.updatedAt,
         unlockInfo: convertUpdateInfoToDomainModel(revision.unlockInfo),

--- a/services/app-api/src/postgres/contractAndRates/prismaDraftContractHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaDraftContractHelpers.ts
@@ -89,7 +89,7 @@ function draftContractRevToDomainModel(
 
     return {
         id: revision.id,
-        contractID: revision.contractID,
+        contract: revision.contract,
         createdAt: revision.createdAt,
         updatedAt: revision.updatedAt,
         unlockInfo: convertUpdateInfoToDomainModel(revision.unlockInfo),

--- a/services/app-api/src/postgres/contractAndRates/prismaDraftContractHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaDraftContractHelpers.ts
@@ -6,47 +6,14 @@ import type {
 import {
     contractFormDataToDomainModel,
     convertUpdateInfoToDomainModel,
-    includeUpdateInfo,
+    includeRateFormData,
     rateRevisionToDomainModel,
 } from './prismaSharedContractRateHelpers'
 import type { ContractRevisionTableWithRates } from './prismaSubmittedContractHelpers'
 
 const includeDraftRates = {
     revisions: {
-        include: {
-            rateDocuments: {
-                orderBy: {
-                    position: 'asc',
-                },
-            },
-            supportingDocuments: {
-                orderBy: {
-                    position: 'asc',
-                },
-            },
-            certifyingActuaryContacts: {
-                orderBy: {
-                    position: 'asc',
-                },
-            },
-            addtlActuaryContacts: {
-                orderBy: {
-                    position: 'asc',
-                },
-            },
-            submitInfo: includeUpdateInfo,
-            unlockInfo: includeUpdateInfo,
-            contractsWithSharedRateRevision: {
-                include: {
-                    revisions: {
-                        take: 1,
-                        orderBy: {
-                            createdAt: 'desc',
-                        },
-                    },
-                },
-            },
-        },
+        include: includeRateFormData,
         take: 1,
         orderBy: {
             createdAt: 'desc',

--- a/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
@@ -23,6 +23,28 @@ type UpdateInfoTableWithUpdater = Prisma.UpdateInfoTableGetPayload<{
     include: typeof subincludeUpdateInfo
 }>
 
+const includeContractFormData = {
+    unlockInfo: includeUpdateInfo,
+    submitInfo: includeUpdateInfo,
+    contract: true,
+
+    stateContacts: {
+        orderBy: {
+            position: 'asc',
+        },
+    },
+    contractDocuments: {
+        orderBy: {
+            position: 'asc',
+        },
+    },
+    supportingDocuments: {
+        orderBy: {
+            position: 'asc',
+        },
+    },
+} satisfies Prisma.ContractRevisionTableInclude
+
 function convertUpdateInfoToDomainModel(
     info?: UpdateInfoTableWithUpdater | null
 ): UpdateInfoType | undefined {
@@ -91,7 +113,7 @@ const includeRateFormData = {
     contractsWithSharedRateRevision: {
         include: {
             revisions: {
-                take: 1,
+                include: includeContractFormData,
                 orderBy: {
                     createdAt: 'desc',
                 },
@@ -131,6 +153,7 @@ function rateFormDataToDomainModel(
                 contractPrograms,
                 statePrograms
             ),
+            packageStatus: getContractRateStatus(contract.revisions),
         })
     }
 
@@ -232,28 +255,6 @@ function ratesRevisionsToDomainModel(
 }
 
 // ------
-
-const includeContractFormData = {
-    unlockInfo: includeUpdateInfo,
-    submitInfo: includeUpdateInfo,
-    contract: true,
-
-    stateContacts: {
-        orderBy: {
-            position: 'asc',
-        },
-    },
-    contractDocuments: {
-        orderBy: {
-            position: 'asc',
-        },
-    },
-    supportingDocuments: {
-        orderBy: {
-            position: 'asc',
-        },
-    },
-} satisfies Prisma.ContractRevisionTableInclude
 
 type ContractRevisionTableWithFormData =
     Prisma.ContractRevisionTableGetPayload<{

--- a/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
@@ -236,6 +236,7 @@ function ratesRevisionsToDomainModel(
 const includeContractFormData = {
     unlockInfo: includeUpdateInfo,
     submitInfo: includeUpdateInfo,
+    contract: true,
 
     stateContacts: {
         orderBy: {

--- a/services/app-api/src/testHelpers/contractAndRates/contractHelpers.ts
+++ b/services/app-api/src/testHelpers/contractAndRates/contractHelpers.ts
@@ -9,6 +9,15 @@ import type { ContractFormDataType } from '../../domain-models/contractAndRates'
 import { findStatePrograms } from '../../postgres'
 import { must } from '../errorHelpers'
 
+const defaultContractData = () => ({
+    id: '24fb2a5f-6d0d-4e26-9906-4de28927c882',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    mccrsID: null,
+    stateCode: 'MN',
+    stateNumber: 111,
+})
+
 const createInsertContractData = ({
     stateCode = 'MN',
     ...formData
@@ -40,6 +49,7 @@ const createDraftContractData = (
     stateNumber: 111,
     revisions: contract?.revisions ?? [
         createContractRevision(
+            contract,
             {
                 rateRevisions: undefined,
                 submitInfo: null,
@@ -61,6 +71,7 @@ const createContractData = (
     stateNumber: 111,
     revisions: contract?.revisions ?? [
         createContractRevision(
+            contract,
             {
                 draftRates: undefined,
             },
@@ -71,6 +82,7 @@ const createContractData = (
 })
 
 const createContractRevision = (
+    contract?: Partial<ContractTableFullPayload>,
     revision?: Partial<ContractRevisionTableWithRates>,
     stateCode: StateCodeType = 'MN'
 ): ContractRevisionTableWithRates => {
@@ -78,6 +90,10 @@ const createContractRevision = (
 
     return {
         id: uuidv4(),
+        contract: {
+            ...defaultContractData(),
+            ...contract,
+        },
         createdAt: new Date(),
         updatedAt: new Date(),
         submitInfo: {

--- a/services/app-graphql/src/queries/fetchRate.graphql
+++ b/services/app-graphql/src/queries/fetchRate.graphql
@@ -69,6 +69,7 @@ query fetchRate($input: FetchRateInput!) {
                     packagesWithSharedRateCerts {
                         packageName
                         packageId
+                        packageStatus
                     }
                 }
                 contractRevisions {

--- a/services/app-graphql/src/queries/fetchRate.graphql
+++ b/services/app-graphql/src/queries/fetchRate.graphql
@@ -73,6 +73,7 @@ query fetchRate($input: FetchRateInput!) {
             }
              contractRevisions {
                     id
+                    contractID
                     createdAt
                     updatedAt
                     submitInfo {

--- a/services/app-graphql/src/queries/fetchRate.graphql
+++ b/services/app-graphql/src/queries/fetchRate.graphql
@@ -1,79 +1,83 @@
 query fetchRate($input: FetchRateInput!) {
     fetchRate(input: $input) {
         rate {
-        id
-        createdAt
-        updatedAt
-        stateCode
-        stateNumber
-        state {
-            code
-            name
-            programs {
-                id
-                name
-                fullName
-            }
-        }
-        status
-        initiallySubmittedAt
-        revisions {
             id
             createdAt
             updatedAt
-            unlockInfo {
-                updatedAt
-                updatedBy
-                updatedReason
-            }
-            submitInfo {
-                updatedAt
-                updatedBy
-                updatedReason
-            }
-            formData {
-                rateType,
-                rateCapitationType,
-                rateDocuments {
+            stateCode
+            stateNumber
+            state {
+                code
+                name
+                programs {
+                    id
                     name
-                    s3URL
-                    sha256
-                },
-                supportingDocuments {
-                    name
-                    s3URL
-                    sha256
-                },
-                rateDateStart,
-                rateDateEnd,
-                rateDateCertified,
-                amendmentEffectiveDateStart,
-                amendmentEffectiveDateEnd,
-                rateProgramIDs,
-                rateCertificationName,
-                certifyingActuaryContacts {
-                    name
-                    titleRole
-                    email
-                    actuarialFirm
-                    actuarialFirmOther
-                },
-                addtlActuaryContacts {
-                    name
-                    titleRole
-                    email
-                    actuarialFirm
-                    actuarialFirmOther
-                },
-                actuaryCommunicationPreference
-                packagesWithSharedRateCerts {
-                    packageName
-                    packageId
+                    fullName
                 }
             }
-             contractRevisions {
+            status
+            initiallySubmittedAt
+            revisions {
+                id
+                createdAt
+                updatedAt
+                unlockInfo {
+                    updatedAt
+                    updatedBy
+                    updatedReason
+                }
+                submitInfo {
+                    updatedAt
+                    updatedBy
+                    updatedReason
+                }
+                formData {
+                    rateType,
+                    rateCapitationType,
+                    rateDocuments {
+                        name
+                        s3URL
+                        sha256
+                    },
+                    supportingDocuments {
+                        name
+                        s3URL
+                        sha256
+                    },
+                    rateDateStart,
+                    rateDateEnd,
+                    rateDateCertified,
+                    amendmentEffectiveDateStart,
+                    amendmentEffectiveDateEnd,
+                    rateProgramIDs,
+                    rateCertificationName,
+                    certifyingActuaryContacts {
+                        name
+                        titleRole
+                        email
+                        actuarialFirm
+                        actuarialFirmOther
+                    },
+                    addtlActuaryContacts {
+                        name
+                        titleRole
+                        email
+                        actuarialFirm
+                        actuarialFirmOther
+                    },
+                    actuaryCommunicationPreference
+                    packagesWithSharedRateCerts {
+                        packageName
+                        packageId
+                    }
+                }
+                contractRevisions {
                     id
-                    contractID
+                    contract {
+                        id
+                        stateCode
+                        stateNumber
+                    }
                     createdAt
                     updatedAt
                     submitInfo {
@@ -86,9 +90,53 @@ query fetchRate($input: FetchRateInput!) {
                         updatedBy
                         updatedReason
                     }
+                    formData {
+                        programIDs
+                        populationCovered
+                        submissionType
+                        riskBasedContract
+                        submissionDescription
+                        stateContacts {
+                            name,
+                            title
+                            email
+                        }
+                        supportingDocuments {
+                            name
+                            s3URL
+                            sha256
+                        }
+                        contractType
+                        contractExecutionStatus
+                        contractDocuments {
+                            name
+                            s3URL
+                            sha256
+                        }
+                        contractDateStart
+                        contractDateEnd
+                        managedCareEntities
+                        federalAuthorities
+                        inLieuServicesAndSettings
+                        modifiedBenefitsProvided
+                        modifiedGeoAreaServed
+                        modifiedMedicaidBeneficiaries
+                        modifiedRiskSharingStrategy
+                        modifiedIncentiveArrangements
+                        modifiedWitholdAgreements
+                        modifiedStateDirectedPayments
+                        modifiedPassThroughPayments
+                        modifiedPaymentsForMentalDiseaseInstitutions
+                        modifiedMedicalLossRatioStandards
+                        modifiedOtherFinancialPaymentIncentive
+                        modifiedEnrollmentProcess
+                        modifiedGrevienceAndAppeal
+                        modifiedNetworkAdequacyStandards
+                        modifiedLengthOfContract
+                        modifiedNonRiskPaymentArrangements
+                    }
+                }
             }
-        }
-
         }
     }
 }

--- a/services/app-graphql/src/queries/fetchRate.graphql
+++ b/services/app-graphql/src/queries/fetchRate.graphql
@@ -1,3 +1,125 @@
+fragment rateRevisionFragment on RateRevision {
+    id
+    createdAt
+    updatedAt
+    unlockInfo {
+        updatedAt
+        updatedBy
+        updatedReason
+    }
+    submitInfo {
+        updatedAt
+        updatedBy
+        updatedReason
+    }
+    formData {
+        rateType,
+        rateCapitationType,
+        rateDocuments {
+            name
+            s3URL
+            sha256
+        },
+        supportingDocuments {
+            name
+            s3URL
+            sha256
+        },
+        rateDateStart,
+        rateDateEnd,
+        rateDateCertified,
+        amendmentEffectiveDateStart,
+        amendmentEffectiveDateEnd,
+        rateProgramIDs,
+        rateCertificationName,
+        certifyingActuaryContacts {
+            name
+            titleRole
+            email
+            actuarialFirm
+            actuarialFirmOther
+        },
+        addtlActuaryContacts {
+            name
+            titleRole
+            email
+            actuarialFirm
+            actuarialFirmOther
+        },
+        actuaryCommunicationPreference
+        packagesWithSharedRateCerts {
+            packageName
+            packageId
+            packageStatus
+        }
+    }
+    contractRevisions {
+        id
+        contract {
+            id
+            stateCode
+            stateNumber
+        }
+        createdAt
+        updatedAt
+        submitInfo {
+            updatedAt
+            updatedBy
+            updatedReason
+        }
+        unlockInfo {
+            updatedAt
+            updatedBy
+            updatedReason
+        }
+        formData {
+            programIDs
+            populationCovered
+            submissionType
+            riskBasedContract
+            submissionDescription
+            stateContacts {
+                name,
+                title
+                email
+            }
+            supportingDocuments {
+                name
+                s3URL
+                sha256
+            }
+            contractType
+            contractExecutionStatus
+            contractDocuments {
+                name
+                s3URL
+                sha256
+            }
+            contractDateStart
+            contractDateEnd
+            managedCareEntities
+            federalAuthorities
+            inLieuServicesAndSettings
+            modifiedBenefitsProvided
+            modifiedGeoAreaServed
+            modifiedMedicaidBeneficiaries
+            modifiedRiskSharingStrategy
+            modifiedIncentiveArrangements
+            modifiedWitholdAgreements
+            modifiedStateDirectedPayments
+            modifiedPassThroughPayments
+            modifiedPaymentsForMentalDiseaseInstitutions
+            modifiedMedicalLossRatioStandards
+            modifiedOtherFinancialPaymentIncentive
+            modifiedEnrollmentProcess
+            modifiedGrevienceAndAppeal
+            modifiedNetworkAdequacyStandards
+            modifiedLengthOfContract
+            modifiedNonRiskPaymentArrangements
+        }
+    }
+}
+
 query fetchRate($input: FetchRateInput!) {
     fetchRate(input: $input) {
         rate {
@@ -19,197 +141,11 @@ query fetchRate($input: FetchRateInput!) {
             initiallySubmittedAt
 
             draftRevision {
-                id
-                createdAt
-                updatedAt
-                unlockInfo {
-                    updatedAt
-                    updatedBy
-                    updatedReason
-                }
-                submitInfo {
-                    updatedAt
-                    updatedBy
-                    updatedReason
-                }
-                formData {
-                    rateType,
-                    rateCapitationType,
-                    rateDocuments {
-                        name
-                        s3URL
-                        sha256
-                    },
-                    supportingDocuments {
-                        name
-                        s3URL
-                        sha256
-                    },
-                    rateDateStart,
-                    rateDateEnd,
-                    rateDateCertified,
-                    amendmentEffectiveDateStart,
-                    amendmentEffectiveDateEnd,
-                    rateProgramIDs,
-                    rateCertificationName,
-                    certifyingActuaryContacts {
-                        name
-                        titleRole
-                        email
-                        actuarialFirm
-                        actuarialFirmOther
-                    },
-                    addtlActuaryContacts {
-                        name
-                        titleRole
-                        email
-                        actuarialFirm
-                        actuarialFirmOther
-                    },
-                    actuaryCommunicationPreference
-                    packagesWithSharedRateCerts {
-                        packageName
-                        packageId
-                        packageStatus
-                    }
-                }
-                contractRevisions {
-                    id
-                    contractID
-                    createdAt
-                    updatedAt
-                    submitInfo {
-                        updatedAt
-                        updatedBy
-                        updatedReason
-                    }
-                    unlockInfo {
-                        updatedAt
-                        updatedBy
-                        updatedReason
-                    }
-                }
+                ...rateRevisionFragment
             }
 
             revisions {
-                id
-                createdAt
-                updatedAt
-                unlockInfo {
-                    updatedAt
-                    updatedBy
-                    updatedReason
-                }
-                submitInfo {
-                    updatedAt
-                    updatedBy
-                    updatedReason
-                }
-                formData {
-                    rateType,
-                    rateCapitationType,
-                    rateDocuments {
-                        name
-                        s3URL
-                        sha256
-                    },
-                    supportingDocuments {
-                        name
-                        s3URL
-                        sha256
-                    },
-                    rateDateStart,
-                    rateDateEnd,
-                    rateDateCertified,
-                    amendmentEffectiveDateStart,
-                    amendmentEffectiveDateEnd,
-                    rateProgramIDs,
-                    rateCertificationName,
-                    certifyingActuaryContacts {
-                        name
-                        titleRole
-                        email
-                        actuarialFirm
-                        actuarialFirmOther
-                    },
-                    addtlActuaryContacts {
-                        name
-                        titleRole
-                        email
-                        actuarialFirm
-                        actuarialFirmOther
-                    },
-                    actuaryCommunicationPreference
-                    packagesWithSharedRateCerts {
-                        packageName
-                        packageId
-                    }
-                }
-                contractRevisions {
-                    id
-                    contract {
-                        id
-                        stateCode
-                        stateNumber
-                    }
-                    createdAt
-                    updatedAt
-                    submitInfo {
-                        updatedAt
-                        updatedBy
-                        updatedReason
-                    }
-                    unlockInfo {
-                        updatedAt
-                        updatedBy
-                        updatedReason
-                    }
-                    formData {
-                        programIDs
-                        populationCovered
-                        submissionType
-                        riskBasedContract
-                        submissionDescription
-                        stateContacts {
-                            name,
-                            title
-                            email
-                        }
-                        supportingDocuments {
-                            name
-                            s3URL
-                            sha256
-                        }
-                        contractType
-                        contractExecutionStatus
-                        contractDocuments {
-                            name
-                            s3URL
-                            sha256
-                        }
-                        contractDateStart
-                        contractDateEnd
-                        managedCareEntities
-                        federalAuthorities
-                        inLieuServicesAndSettings
-                        modifiedBenefitsProvided
-                        modifiedGeoAreaServed
-                        modifiedMedicaidBeneficiaries
-                        modifiedRiskSharingStrategy
-                        modifiedIncentiveArrangements
-                        modifiedWitholdAgreements
-                        modifiedStateDirectedPayments
-                        modifiedPassThroughPayments
-                        modifiedPaymentsForMentalDiseaseInstitutions
-                        modifiedMedicalLossRatioStandards
-                        modifiedOtherFinancialPaymentIncentive
-                        modifiedEnrollmentProcess
-                        modifiedGrevienceAndAppeal
-                        modifiedNetworkAdequacyStandards
-                        modifiedLengthOfContract
-                        modifiedNonRiskPaymentArrangements
-                    }
-                }
+                ...rateRevisionFragment
             }
         }
     }

--- a/services/app-graphql/src/queries/indexRates.graphql
+++ b/services/app-graphql/src/queries/indexRates.graphql
@@ -69,6 +69,7 @@ query indexRates {
                         packagesWithSharedRateCerts {
                             packageName
                             packageId
+                            packageStatus
                         }
 
                     }

--- a/services/app-graphql/src/queries/indexRates.graphql
+++ b/services/app-graphql/src/queries/indexRates.graphql
@@ -74,7 +74,11 @@ query indexRates {
                     }
                     contractRevisions {
                         id
-                        contractID
+                        contract {
+                            id
+                            stateCode
+                            stateNumber
+                        }
                         createdAt
                         updatedAt
                         submitInfo {
@@ -86,6 +90,51 @@ query indexRates {
                             updatedAt
                             updatedBy
                             updatedReason
+                        }
+                        formData {
+                            programIDs
+                            populationCovered
+                            submissionType
+                            riskBasedContract
+                            submissionDescription
+                            stateContacts {
+                                name,
+                                title
+                                email
+                            }
+                            supportingDocuments {
+                                name
+                                s3URL
+                                sha256
+                            }
+                            contractType
+                            contractExecutionStatus
+                            contractDocuments {
+                                name
+                                s3URL
+                                sha256
+                            }
+                            contractDateStart
+                            contractDateEnd
+                            managedCareEntities
+                            federalAuthorities
+                            inLieuServicesAndSettings
+                            modifiedBenefitsProvided
+                            modifiedGeoAreaServed
+                            modifiedMedicaidBeneficiaries
+                            modifiedRiskSharingStrategy
+                            modifiedIncentiveArrangements
+                            modifiedWitholdAgreements
+                            modifiedStateDirectedPayments
+                            modifiedPassThroughPayments
+                            modifiedPaymentsForMentalDiseaseInstitutions
+                            modifiedMedicalLossRatioStandards
+                            modifiedOtherFinancialPaymentIncentive
+                            modifiedEnrollmentProcess
+                            modifiedGrevienceAndAppeal
+                            modifiedNetworkAdequacyStandards
+                            modifiedLengthOfContract
+                            modifiedNonRiskPaymentArrangements
                         }
                     }
                 }

--- a/services/app-graphql/src/queries/indexRates.graphql
+++ b/services/app-graphql/src/queries/indexRates.graphql
@@ -74,6 +74,7 @@ query indexRates {
                     }
                     contractRevisions {
                         id
+                        contractID
                         createdAt
                         updatedAt
                         submitInfo {

--- a/services/app-graphql/src/queries/indexRates.graphql
+++ b/services/app-graphql/src/queries/indexRates.graphql
@@ -72,6 +72,7 @@ query indexRates {
                         packagesWithSharedRateCerts {
                             packageName
                             packageId
+                            packageStatus
                         }
                     }
                 }

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -845,6 +845,7 @@ type ActuaryContact  {
 type PackageWithSameRate  {
   packageName: String!
   packageId: String!
+  packageStatus: String
 }
 
 type RateFormData {

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -730,6 +730,84 @@ type GenericDocument {
 Rates are rate certifications and their associated actuary contacts and documents
 State users may create, update, and submit several rates at a time
 """
+
+enum PopulationCovered {
+    MEDICAID
+    CHIP
+    MEDICAID_AND_CHIP
+}
+
+enum SubmissionType {
+    CONTRACT_ONLY
+    CONTRACT_AND_RATES
+}
+
+enum ContractType {
+    BASE
+    AMENDMENT
+}
+
+enum ContractExecutionStatus {
+    EXECUTED
+    UNEXECUTED
+}
+
+enum ManagedCareEntity {
+    MCO
+    PIHP
+    PAHP
+    PCCM
+}
+
+enum FederalAuthority {
+    STATE_PLAN
+    WAIVER_1915B
+    WAIVER_1115
+    VOLUNTARY
+    BENCHMARK
+    TITLE_XXI
+}
+
+type StateContact {
+    name: String
+    title: String
+    email: String
+}
+
+type ContractFormData {
+    programIDs: [String!]!
+    populationCovered: PopulationCovered
+    submissionType: SubmissionType!
+    riskBasedContract: Boolean
+    submissionDescription: String!
+    stateContacts: [StateContact!]!
+    supportingDocuments: [GenericDocument!]!
+    contractType: ContractType
+    contractExecutionStatus: ContractExecutionStatus
+    contractDocuments: [GenericDocument!]!
+    contractDateStart: Date
+    contractDateEnd: Date
+    managedCareEntities: [ManagedCareEntity!]!
+    federalAuthorities: [FederalAuthority!]!
+    inLieuServicesAndSettings: Boolean,
+    modifiedBenefitsProvided: Boolean,
+    modifiedGeoAreaServed: Boolean,
+    modifiedMedicaidBeneficiaries: Boolean,
+    modifiedRiskSharingStrategy: Boolean,
+    modifiedIncentiveArrangements: Boolean,
+    modifiedWitholdAgreements: Boolean,
+    modifiedStateDirectedPayments: Boolean,
+    modifiedPassThroughPayments: Boolean,
+    modifiedPaymentsForMentalDiseaseInstitutions: Boolean,
+    modifiedMedicalLossRatioStandards: Boolean,
+    modifiedOtherFinancialPaymentIncentive: Boolean,
+    modifiedEnrollmentProcess: Boolean,
+    modifiedGrevienceAndAppeal: Boolean,
+    modifiedNetworkAdequacyStandards: Boolean,
+    modifiedLengthOfContract: Boolean,
+    modifiedNonRiskPaymentArrangements: Boolean,
+}
+
 enum RateType {
   NEW
   AMENDMENT
@@ -769,7 +847,6 @@ type PackageWithSameRate  {
   packageId: String!
 }
 
-
 type RateFormData {
     rateType: RateType
     rateCapitationType: RateCapitationType
@@ -788,13 +865,21 @@ type RateFormData {
     packagesWithSharedRateCerts: [PackageWithSameRate!]!
 }
 
+type ContractOnRevisionType {
+    id: String!
+    stateCode: String!
+    mccrsID: String
+    stateNumber: Int!
+}
+
 type RelatedContractRevisions {
     id: String!
-    contractID: String!
+    contract: ContractOnRevisionType!
     submitInfo: UpdateInformation
     unlockInfo: UpdateInformation
     createdAt: DateTime!
     updatedAt: DateTime!
+    formData: ContractFormData!
 }
 
 type RateRevision {

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -789,12 +789,12 @@ type RateFormData {
 }
 
 type RelatedContractRevisions {
-    id: String
-    # contractID: String  # this would be needed in order to link to submission summary
+    id: String!
+    contractID: String!
     submitInfo: UpdateInformation
     unlockInfo: UpdateInformation
-    createdAt: DateTime
-    updatedAt: DateTime
+    createdAt: DateTime!
+    updatedAt: DateTime!
 }
 
 type RateRevision {
@@ -833,7 +833,6 @@ type Rate {
     for the rate and contains the full data from when the rate cert was submitted
     """
     revisions: [RateRevision!]!
-    contractRevisions:[RelatedContractRevisions!]!
 }
 
 type RateEdge {

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -283,12 +283,18 @@ export const SingleRateSummarySection = ({
                 </SectionHeader>
                 <UploadedDocumentsTable
                     documents={formData.rateDocuments}
+                    packagesWithSharedRateCerts={
+                        formData.packagesWithSharedRateCerts
+                    }
                     multipleDocumentsAllowed={false}
                     documentDateLookupTable={documentDateLookupTable}
                     caption="Rate certification"
                 />
                 <UploadedDocumentsTable
                     documents={formData.supportingDocuments}
+                    packagesWithSharedRateCerts={
+                        formData.packagesWithSharedRateCerts
+                    }
                     documentDateLookupTable={documentDateLookupTable}
                     caption="Rate supporting documents"
                 />

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -120,8 +120,7 @@ export const SingleRateSummarySection = ({
     isSubmitted: boolean
     statePrograms: Program[]
 }): React.ReactElement | null => {
-    const rateRevision =
-        rate?.status === 'UNLOCKED' ? rate?.revisions[1] : rate?.revisions[0]
+    const rateRevision = rate.revisions[0]
     const formData: RateFormData = rateRevision?.formData
     const documentDateLookupTable = makeRateDocumentDateTable(rate.revisions)
     const isRateAmendment = formData.rateType === 'AMENDMENT'

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -25,6 +25,7 @@ import { recordJSException } from '../../../otelHelpers'
 import { Link } from '@trussworks/react-uswds'
 import { NavLink } from 'react-router-dom'
 import { packageName } from '../../../common-code/healthPlanFormDataType'
+import { UploadedDocumentsTableProps } from '../UploadedDocumentsTable/UploadedDocumentsTable'
 
 // This rate summary pages assumes we are using contract and rates API.
 // Eventually RateDetailsSummarySection should share code with this code
@@ -132,6 +133,15 @@ export const SingleRateSummarySection = ({
     const [zippedFilesURL, setZippedFilesURL] = useState<
         string | undefined | Error
     >(undefined)
+
+    const appendDraftToSharedPackages: UploadedDocumentsTableProps['packagesWithSharedRateCerts'] =
+        rateRevision?.formData.packagesWithSharedRateCerts.map((pkg) => ({
+            packageId: pkg.packageId,
+            packageName:
+                pkg.packageStatus === 'DRAFT'
+                    ? pkg.packageName.concat(' (Draft)')
+                    : pkg.packageName,
+        }))
 
     useDeepCompareEffect(() => {
         // get all the keys for the documents we want to zip
@@ -283,18 +293,14 @@ export const SingleRateSummarySection = ({
                 </SectionHeader>
                 <UploadedDocumentsTable
                     documents={formData.rateDocuments}
-                    packagesWithSharedRateCerts={
-                        formData.packagesWithSharedRateCerts
-                    }
+                    packagesWithSharedRateCerts={appendDraftToSharedPackages}
                     multipleDocumentsAllowed={false}
                     documentDateLookupTable={documentDateLookupTable}
                     caption="Rate certification"
                 />
                 <UploadedDocumentsTable
                     documents={formData.supportingDocuments}
-                    packagesWithSharedRateCerts={
-                        formData.packagesWithSharedRateCerts
-                    }
+                    packagesWithSharedRateCerts={appendDraftToSharedPackages}
                     documentDateLookupTable={documentDateLookupTable}
                     caption="Rate supporting documents"
                 />

--- a/services/app-web/src/pages/SubmissionSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/RateSummary.tsx
@@ -83,7 +83,7 @@ export const RateSummary = (): React.ReactElement => {
                     </Link>
                 </div>
                 <SingleRateSummarySection
-                    rate={{ ...rate, contractRevisions: [] }}
+                    rate={rate}
                     isSubmitted // can assume isSubmitted because we are building for CMS users
                     statePrograms={rate.state.programs}
                 />


### PR DESCRIPTION
## Summary
[MCR-3557](https://qmacbis.atlassian.net/browse/MCR-3557)

- `Submission this rate was submitted with` section
   - This will show the submission this rate was submitted with.
- The shared rates submission link is now on the documents section like the current summary pages.
- Prisma query changes
   - `includeContractFormData`
      - `contractID` was not enough to generate a package name, so I'm including the contract data the revision belongs to
      - This is mainly needed when querying rates and including its `contractRevisions`. Since querying contracts we have the data at the top level.
- GraphQL Schema and Domain Type changes
   - Domain Types
      - For `RateRevisionType`, the `contractRevisions` on this type only the `contractID` field; this was not enough data to generate a package name.
      - I could add `packageName` to the `ContractRevisionType` or add the contract data to the `ContractRevisionType` and generate the package name on the front end.
      - I decided to add contract data because it was less refactoring of our parsing functions, which would have involved finding programs and more error handling. On the front end, we have access to the state programs, so package name generation was less complicated without all the parsing functions in the API.
      - `packagesWithSharedRateCerts` now has a new `packageStatus` field to determine if we should display a link to the submission or just the name. Currently, with protobufs we have to make another `indexHealthPlanPackage` query and call functions to parse through it to find out if our shared rate packages are drafts. With the new DB we no longer have to do that.
      - GraphQL schema
         - Added types for contract data.
         - Updated rate queries
         - Added `packageStatus` to `packagesWithSharedRateCerts`
#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
