### PR TITLE
Update GQL Rate to have draft rate and only return individual rate revs

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/findRateWithHistory.test.ts
+++ b/services/app-api/src/postgres/contractAndRates/findRateWithHistory.test.ts
@@ -614,7 +614,7 @@ describe('findRate', () => {
 
         // Each Revision needs a Reason, one of the contracts or revisions associated with it should have changed and why.
 
-        expect(revisions).toHaveLength(4)
+        expect(revisions).toHaveLength(2)
         expect(revisions[0].contractRevisions).toHaveLength(1)
         expect(
             revisions[0].contractRevisions &&
@@ -632,43 +632,43 @@ describe('findRate', () => {
         expect(revisions[0].submitInfo?.updatedReason).toBe('Rate Submit')
         expect(revisions[0].unlockInfo).toBeUndefined()
 
-        expect(revisions[1].contractRevisions).toHaveLength(1)
-        expect(
-            revisions[1].contractRevisions &&
-                revisions[1].contractRevisions[0].formData
-        ).toEqual(
-            expect.objectContaining({
-                submissionType: 'CONTRACT_AND_RATES',
-                submissionDescription: 'one contract',
-                contractType: 'BASE',
-                programIDs: draftContractData.programIDs,
-                populationCovered: 'MEDICAID',
-                riskBasedContract: false,
-            })
-        )
+        expect(revisions[1].contractRevisions).toHaveLength(0)
+        // expect(
+        //     revisions[1].contractRevisions &&
+        //         revisions[1].contractRevisions[0].formData
+        // ).toEqual(
+        //     expect.objectContaining({
+        //         submissionType: 'CONTRACT_AND_RATES',
+        //         submissionDescription: 'one contract',
+        //         contractType: 'BASE',
+        //         programIDs: draftContractData.programIDs,
+        //         populationCovered: 'MEDICAID',
+        //         riskBasedContract: false,
+        //     })
+        // )
         expect(revisions[1].submitInfo?.updatedReason).toBe('1.1 new name')
         expect(revisions[1].unlockInfo?.updatedReason).toBe('unlock for 1.1')
         expect(revisions[1].unlockInfo?.updatedBy).toBe('zuko@example.com')
 
-        expect(revisions[2].contractRevisions).toHaveLength(1)
-        expect(
-            revisions[2].contractRevisions &&
-                revisions[2].contractRevisions[0].formData
-        ).toEqual(
-            expect.objectContaining({
-                submissionType: 'CONTRACT_AND_RATES',
-                submissionDescription: 'a.1 body',
-                contractType: 'BASE',
-                programIDs: draftContractData.programIDs,
-                populationCovered: 'MEDICAID',
-                riskBasedContract: false,
-            })
-        )
-        expect(revisions[2].submitInfo?.updatedReason).toBe('Submitting A.1')
-        expect(revisions[2].unlockInfo?.updatedReason).toBe('unlocking A.0')
-        expect(revisions[2].unlockInfo?.updatedBy).toBe('zuko@example.com')
+        // expect(revisions[2].contractRevisions).toHaveLength(1)
+        // expect(
+        //     revisions[2].contractRevisions &&
+        //         revisions[2].contractRevisions[0].formData
+        // ).toEqual(
+        //     expect.objectContaining({
+        //         submissionType: 'CONTRACT_AND_RATES',
+        //         submissionDescription: 'a.1 body',
+        //         contractType: 'BASE',
+        //         programIDs: draftContractData.programIDs,
+        //         populationCovered: 'MEDICAID',
+        //         riskBasedContract: false,
+        //     })
+        // )
+        // expect(revisions[2].submitInfo?.updatedReason).toBe('Submitting A.1')
+        // expect(revisions[2].unlockInfo?.updatedReason).toBe('unlocking A.0')
+        // expect(revisions[2].unlockInfo?.updatedBy).toBe('zuko@example.com')
 
-        expect(revisions[3].contractRevisions).toHaveLength(0)
-        expect(revisions[3].submitInfo?.updatedReason).toBe('Submitting A.2')
+        // expect(revisions[3].contractRevisions).toHaveLength(0)
+        // expect(revisions[3].submitInfo?.updatedReason).toBe('Submitting A.2')
     })
 })

--- a/services/app-api/src/postgres/contractAndRates/parseRateWithHistory.ts
+++ b/services/app-api/src/postgres/contractAndRates/parseRateWithHistory.ts
@@ -155,7 +155,7 @@ function rateWithHistoryToDomainModel(
 
         allEntries.push(initialEntry)
 
-        let lastEntry = initialEntry
+        const lastEntry = initialEntry
         // go through every contract revision with this rate
         for (const contractRev of rateRev.contractRevisions) {
             if (!contractRev.contractRevision.submitInfo) {
@@ -185,16 +185,20 @@ function rateWithHistoryToDomainModel(
                     lastContracts.push(contractRev.contractRevision)
                 }
 
-                const newRev: RateRevisionSet = {
-                    rateRev,
-                    submitInfo: contractRev.contractRevision.submitInfo,
-                    unlockInfo:
-                        contractRev.contractRevision.unlockInfo || undefined,
-                    contractRevs: lastContracts,
-                }
+                // For now, we just put the most current version of contracts on this rate
+                // skip making entries for each contract revision
+                initialEntry.contractRevs = lastContracts
 
-                lastEntry = newRev
-                allEntries.push(newRev)
+                // const newRev: RateRevisionSet = {
+                //     rateRev,
+                //     submitInfo: contractRev.contractRevision.submitInfo,
+                //     unlockInfo:
+                //         contractRev.contractRevision.unlockInfo || undefined,
+                //     contractRevs: lastContracts,
+                // }
+
+                // lastEntry = newRev
+                // allEntries.push(newRev) // For now, don't make revisions out of contracts
             }
         }
     }

--- a/services/app-api/src/postgres/contractAndRates/prismaDraftRatesHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaDraftRatesHelpers.ts
@@ -6,6 +6,7 @@ import type {
 import type { RateRevisionTableWithContracts } from './prismaSubmittedRateHelpers'
 import { contractRevisionToDomainModel } from './parseContractWithHistory'
 import {
+    convertUpdateInfoToDomainModel,
     includeContractFormData,
     includeUpdateInfo,
     rateFormDataToDomainModel,
@@ -53,6 +54,7 @@ function draftRateRevToDomainModel(
         createdAt: revision.createdAt,
         updatedAt: revision.updatedAt,
         formData,
+        unlockInfo: convertUpdateInfoToDomainModel(revision.unlockInfo),
         contractRevisions: draftContractsToDomainModel(revision.draftContracts),
     }
 }

--- a/services/app-api/src/resolvers/contractAndRates/fetchRate.test.ts
+++ b/services/app-api/src/resolvers/contractAndRates/fetchRate.test.ts
@@ -1,0 +1,65 @@
+import FETCH_RATE from '../../../../app-graphql/src/queries/fetchRate.graphql'
+import {
+    constructTestPostgresServer,
+    createAndSubmitTestHealthPlanPackage,
+    unlockTestHealthPlanPackage,
+} from '../../testHelpers/gqlHelpers'
+import { testCMSUser } from '../../testHelpers/userHelpers'
+import { testLDService } from '../../testHelpers/launchDarklyHelpers'
+import { latestFormData } from '../../testHelpers/healthPlanPackageHelpers'
+
+describe('fetchRate', () => {
+    const mockLDService = testLDService({ 'rates-db-refactor': true })
+
+    it('returns the right revisions as a rate is unlocked', async () => {
+        const cmsUser = testCMSUser()
+        const server = await constructTestPostgresServer({
+            ldService: mockLDService,
+        })
+
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+            ldService: mockLDService,
+        })
+
+        const unlockedSubmission = await createAndSubmitTestHealthPlanPackage(
+            server
+        )
+
+        // unlock two
+        await unlockTestHealthPlanPackage(
+            cmsServer,
+            unlockedSubmission.id,
+            'Test reason'
+        )
+
+        const unlockedRateID =
+            latestFormData(unlockedSubmission).rateInfos[0].id
+
+        const input = {
+            rateID: unlockedRateID,
+        }
+
+        // fetch rate
+        const result = await cmsServer.executeOperation({
+            query: FETCH_RATE,
+            variables: {
+                input,
+            },
+        })
+
+        const unlockedRate = result.data?.fetchRate.rate
+        expect(result.errors).toBeUndefined()
+        expect(unlockedRate).toBeDefined()
+
+        expect(unlockedRate.draftRevision).toBeDefined()
+        expect(unlockedRate.draftRevision?.submitInfo).toBeNull()
+        expect(unlockedRate.draftRevision?.unlockInfo).toBeTruthy()
+
+        expect(unlockedRate.revisions).toHaveLength(1)
+        expect(unlockedRate.revisions[0].submitInfo).toBeTruthy()
+        expect(unlockedRate.revisions[0].unlockInfo).toBeNull()
+    })
+})

--- a/services/app-graphql/codegen.yml
+++ b/services/app-graphql/codegen.yml
@@ -21,6 +21,7 @@ generates:
         CMSUser: ../domain-models#CMSUserType
         HealthPlanPackage: ../domain-models#HealthPlanPackageType
         Rate: ../domain-models#RateType
+        RateRevision: ../domain-models#RateRevisionType
   ../app-web/src/gen/gqlClient.tsx:
     documents:
       - src/queries/*.graphql

--- a/services/app-graphql/src/queries/fetchRate.graphql
+++ b/services/app-graphql/src/queries/fetchRate.graphql
@@ -1,77 +1,78 @@
 query fetchRate($input: FetchRateInput!) {
     fetchRate(input: $input) {
         rate {
-        id
-        createdAt
-        updatedAt
-        stateCode
-        stateNumber
-        state {
-            code
-            name
-            programs {
-                id
-                name
-                fullName
-            }
-        }
-        status
-        initiallySubmittedAt
-        revisions {
             id
             createdAt
             updatedAt
-            unlockInfo {
-                updatedAt
-                updatedBy
-                updatedReason
-            }
-            submitInfo {
-                updatedAt
-                updatedBy
-                updatedReason
-            }
-            formData {
-                rateType,
-                rateCapitationType,
-                rateDocuments {
+            stateCode
+            stateNumber
+            state {
+                code
+                name
+                programs {
+                    id
                     name
-                    s3URL
-                    sha256
-                },
-                supportingDocuments {
-                    name
-                    s3URL
-                    sha256
-                },
-                rateDateStart,
-                rateDateEnd,
-                rateDateCertified,
-                amendmentEffectiveDateStart,
-                amendmentEffectiveDateEnd,
-                rateProgramIDs,
-                rateCertificationName,
-                certifyingActuaryContacts {
-                    name
-                    titleRole
-                    email
-                    actuarialFirm
-                    actuarialFirmOther
-                },
-                addtlActuaryContacts {
-                    name
-                    titleRole
-                    email
-                    actuarialFirm
-                    actuarialFirmOther
-                },
-                actuaryCommunicationPreference
-                packagesWithSharedRateCerts {
-                    packageName
-                    packageId
+                    fullName
                 }
             }
-             contractRevisions {
+            status
+            initiallySubmittedAt
+
+            draftRevision {
+                id
+                createdAt
+                updatedAt
+                unlockInfo {
+                    updatedAt
+                    updatedBy
+                    updatedReason
+                }
+                submitInfo {
+                    updatedAt
+                    updatedBy
+                    updatedReason
+                }
+                formData {
+                    rateType,
+                    rateCapitationType,
+                    rateDocuments {
+                        name
+                        s3URL
+                        sha256
+                    },
+                    supportingDocuments {
+                        name
+                        s3URL
+                        sha256
+                    },
+                    rateDateStart,
+                    rateDateEnd,
+                    rateDateCertified,
+                    amendmentEffectiveDateStart,
+                    amendmentEffectiveDateEnd,
+                    rateProgramIDs,
+                    rateCertificationName,
+                    certifyingActuaryContacts {
+                        name
+                        titleRole
+                        email
+                        actuarialFirm
+                        actuarialFirmOther
+                    },
+                    addtlActuaryContacts {
+                        name
+                        titleRole
+                        email
+                        actuarialFirm
+                        actuarialFirmOther
+                    },
+                    actuaryCommunicationPreference
+                    packagesWithSharedRateCerts {
+                        packageName
+                        packageId
+                    }
+                }
+                contractRevisions {
                     id
                     contractID
                     createdAt
@@ -81,14 +82,85 @@ query fetchRate($input: FetchRateInput!) {
                         updatedBy
                         updatedReason
                     }
-                    unlockInfo{
+                    unlockInfo {
                         updatedAt
                         updatedBy
                         updatedReason
                     }
+                }
             }
-        }
 
+            revisions {
+                id
+                createdAt
+                updatedAt
+                unlockInfo {
+                    updatedAt
+                    updatedBy
+                    updatedReason
+                }
+                submitInfo {
+                    updatedAt
+                    updatedBy
+                    updatedReason
+                }
+                formData {
+                    rateType,
+                    rateCapitationType,
+                    rateDocuments {
+                        name
+                        s3URL
+                        sha256
+                    },
+                    supportingDocuments {
+                        name
+                        s3URL
+                        sha256
+                    },
+                    rateDateStart,
+                    rateDateEnd,
+                    rateDateCertified,
+                    amendmentEffectiveDateStart,
+                    amendmentEffectiveDateEnd,
+                    rateProgramIDs,
+                    rateCertificationName,
+                    certifyingActuaryContacts {
+                        name
+                        titleRole
+                        email
+                        actuarialFirm
+                        actuarialFirmOther
+                    },
+                    addtlActuaryContacts {
+                        name
+                        titleRole
+                        email
+                        actuarialFirm
+                        actuarialFirmOther
+                    },
+                    actuaryCommunicationPreference
+                    packagesWithSharedRateCerts {
+                        packageName
+                        packageId
+                    }
+                }
+                contractRevisions {
+                    id
+                    contractID
+                    createdAt
+                    updatedAt
+                    submitInfo {
+                        updatedAt
+                        updatedBy
+                        updatedReason
+                    }
+                    unlockInfo {
+                        updatedAt
+                        updatedBy
+                        updatedReason
+                    }
+                }
+            }
         }
     }
 }

--- a/services/app-graphql/src/queries/indexRates.graphql
+++ b/services/app-graphql/src/queries/indexRates.graphql
@@ -4,6 +4,8 @@ query indexRates {
         edges {
             node {
                 id
+                createdAt
+                updatedAt
                 stateCode
                 stateNumber
                 state {
@@ -17,6 +19,63 @@ query indexRates {
                 }
                 status
                 initiallySubmittedAt
+
+                draftRevision {
+                    id
+                    createdAt
+                    updatedAt
+                    unlockInfo {
+                        updatedAt
+                        updatedBy
+                        updatedReason
+                    }
+                    submitInfo {
+                        updatedAt
+                        updatedBy
+                        updatedReason
+                    }
+                    formData {
+                        rateType,
+                        rateCapitationType,
+                        rateDocuments {
+                            name
+                            s3URL
+                            sha256
+                        },
+                        supportingDocuments {
+                            name
+                            s3URL
+                            sha256
+                        },
+                        rateDateStart,
+                        rateDateEnd,
+                        rateDateCertified,
+                        amendmentEffectiveDateStart,
+                        amendmentEffectiveDateEnd,
+                        rateProgramIDs,
+                        rateCertificationName,
+                        certifyingActuaryContacts {
+                            name
+                            titleRole
+                            email
+                            actuarialFirm
+                            actuarialFirmOther
+                        },
+                        addtlActuaryContacts {
+                            name
+                            titleRole
+                            email
+                            actuarialFirm
+                            actuarialFirmOther
+                        },
+                        actuaryCommunicationPreference
+                        packagesWithSharedRateCerts {
+                            packageName
+                            packageId
+                        }
+                    }
+                }
+
                 revisions {
                     id
                     createdAt
@@ -70,7 +129,6 @@ query indexRates {
                             packageName
                             packageId
                         }
-
                     }
                     contractRevisions {
                         id
@@ -82,7 +140,7 @@ query indexRates {
                             updatedBy
                             updatedReason
                         }
-                        unlockInfo{
+                        unlockInfo {
                             updatedAt
                             updatedBy
                             updatedReason

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -828,6 +828,8 @@ type Rate {
     "Fuller state data for the submitting state"
     state: State!
     stateNumber: Int!
+    "The currently modifiable revision if the rate is DRAFT or UNLOCKED"
+    draftRevision: RateRevision
     """
     Array of revisions for this rate. Each revision represents a single submission
     for the rate and contains the full data from when the rate cert was submitted

--- a/services/app-web/src/pages/CMSDashboard/CMSDashboard.tsx
+++ b/services/app-web/src/pages/CMSDashboard/CMSDashboard.tsx
@@ -225,8 +225,9 @@ const RateReviewsDashboard = (): React.ReactElement => {
         .map((edge) => edge.node)
         .forEach((rate) => {
             const currentRevision = rate.revisions[0]
+
             // Set rate display data - could be based on either current or previous revision depending on status
-            let displayRateFormData = currentRevision.formData
+            const displayRateFormData = currentRevision.formData
             let lastUpdated = mostRecentDate([
                 currentRevision.submitInfo?.updatedAt,
                 currentRevision.unlockInfo?.updatedAt,
@@ -234,16 +235,20 @@ const RateReviewsDashboard = (): React.ReactElement => {
 
             if (rate.status === 'UNLOCKED') {
                 // Errors - data handling
-                const previousRevision = rate.revisions[1]
-                const previousFormData = previousRevision.formData
+                const draftRevision = rate.draftRevision
 
-                // reset package display data since unlock submissions rely on previous revision data
-                displayRateFormData = previousFormData
+                if (draftRevision === undefined) {
+                    console.error(
+                        'Programming Error: an unlocked rate came back with no draft',
+                        rate
+                    )
+                }
+
+                // lastUpdated comes from the draft
                 lastUpdated = mostRecentDate([
                     currentRevision?.submitInfo?.updatedAt,
                     currentRevision?.unlockInfo?.updatedAt,
-                    previousRevision?.submitInfo?.updatedAt,
-                    previousRevision?.unlockInfo?.updatedAt,
+                    draftRevision?.unlockInfo?.updatedAt,
                 ])
             }
             if (
@@ -286,10 +291,7 @@ const RateReviewsDashboard = (): React.ReactElement => {
                 updatedAt: lastUpdated,
                 rateType: displayRateFormData.rateType || 'NEW',
                 stateName: rate.state.name,
-                contractRevisions:
-                    rate.status === 'UNLOCKED'
-                        ? rate.revisions[1].contractRevisions
-                        : rate.revisions[0].contractRevisions,
+                contractRevisions: currentRevision.contractRevisions,
             })
         })
 

--- a/services/app-web/src/pages/SubmissionSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/RateSummary.tsx
@@ -38,8 +38,7 @@ export const RateSummary = (): React.ReactElement => {
     })
 
     const rate = data?.fetchRate.rate
-    const currentRateRev =
-        rate?.status === 'UNLOCKED' ? rate?.revisions[1] : rate?.revisions[0]
+    const currentRateRev = rate?.revisions[0]
 
     if (loading) {
         return (


### PR DESCRIPTION
## Summary
We saw an error on prod.

In app-web, we were treating Rate.revisions like we have been treating HPP.revisions, where the first revision can be a draft or not. If the package is unlocked, we would then use the second revision as the data to display in the table b/c the first is assumed to be the draft.

RateType no longer puts the draft in the list of revisions, we have a separate draft revision in place. 

In prod, against _migrated_ data, this errored because there was no second revision. 

Locally, we didn't see errors, because we were returning duplicate revisions for _unmigrated_ data. This is because we were still using the revision mapping code that spits out a revision for every related submission action, code we ditched on packages and code I've reconsidered, ultimately. 

So by changing the db to return one revision per _Rate_ submission (as opposed to a revision per rate or contract submission) this bug reproduced. I added draftRevision to the Rate type in graphql and updated the CMSDashboard to be draft aware.

