### PR TITLE
Copy contractsWithSharedRateRevision when unlocking rate.

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/unlockRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/unlockRate.ts
@@ -62,6 +62,7 @@ async function unlockRate(
                             position: 'asc',
                         },
                     },
+                    contractsWithSharedRateRevision: true,
 
                     contractRevisions: {
                         where: {
@@ -94,6 +95,11 @@ async function unlockRate(
             const previouslySubmittedContractIDs =
                 currentRev.contractRevisions.map(
                     (c) => c.contractRevision.contractID
+                )
+
+            const prevContractsWithSharedRateRevisionIDs =
+                currentRev.contractsWithSharedRateRevision.map(
+                    (contract) => contract.id
                 )
 
             await tx.rateRevisionTable.create({
@@ -167,6 +173,13 @@ async function unlockRate(
                             actuarialFirm: c.actuarialFirm,
                             actuarialFirmOther: c.actuarialFirmOther,
                         })),
+                    },
+                    contractsWithSharedRateRevision: {
+                        connect: prevContractsWithSharedRateRevisionIDs.map(
+                            (contractID) => ({
+                                id: contractID,
+                            })
+                        ),
                     },
                 },
                 include: {


### PR DESCRIPTION
## Summary

This work fixes unlock rate not copying over `contractsWithSharedRateRevision`.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
