### PR TITLE
Fix VAL rates dashboard crash

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.ts
@@ -26,6 +26,12 @@ async function findAllRatesWithHistoryBySubmitInfo(
                 stateCode: {
                     not: 'AS', // exclude test state as per ADR 019
                 },
+                draftContractRevisions: {
+                    // rates must be associated with some contract and rate package - do not display bugs from rates refactor where excess rates were created for contract only
+                    some: {
+                        submissionType: 'CONTRACT_AND_RATES',
+                    },
+                },
             },
             include: {
                 ...includeFullRate,

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -835,10 +835,10 @@ enum ActuarialFirm {
 }
 
 type ActuaryContact  {
-  name: String!
-  titleRole: String!
-  email: String!
-  actuarialFirm: ActuarialFirm!
+  name: String
+  titleRole: String
+  email: String
+  actuarialFirm: ActuarialFirm
   actuarialFirmOther: String
 }
 


### PR DESCRIPTION
## Summary
Addresses the bug superficially.  I loosened graphql types further for rates (those actuary fields were throwing the error). Also, adjusted `indexRates` to not return invalid rates.

#### Related issues
MCR-3569: [CHIP only submissions crash rates dashboard ](https://qmacbis.atlassian.net/browse/MCR-3569)

## QA guidance

This is a hopeful fix. Cannot verify until it gets to higher environment. I couldn't replicate the crash. However, I did see that even partial rates removed from a draft package still get submitted and show up in rates dashboard. For example, create draft contract and rates, change to CHIP only, then submit and you will see rates hanging around.

Having partial rates get through the door outside the submit validators leads to all kinds of unexpected behavior.

With my change those partial rates should stop returning from index rates and therefore can't crash API or frontend in unexpected ways. _The con to this is it will make it harder for us to see when bad rates exist. Looking for feedback on that._
