### PR TITLE
Fix rate history contract revisions

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/parseRateWithHistory.ts
+++ b/services/app-api/src/postgres/contractAndRates/parseRateWithHistory.ts
@@ -166,14 +166,20 @@ function rateWithHistoryToDomainModel(
                 )
             }
 
-            // Finding the contract rev submitted right after rate rev submission date time.
-            //  - It should always be the contract rev right after submission
-            //  - any disconnections will no longer include the contract rev in the prisma query.
+            // Finding the single earliest contract rev submitted right after rate rev submission date time.
             if (
                 contractRev.contractRevision.submitInfo.updatedAt >=
                 rateRev.submitInfo.updatedAt
             ) {
-                initialEntry.contractRevs.push(contractRev.contractRevision)
+                const exists = initialEntry.contractRevs.find(
+                    (cc) =>
+                        cc.contractID ===
+                        contractRev.contractRevision.contractID
+                )
+
+                if (!exists) {
+                    initialEntry.contractRevs.push(contractRev.contractRevision)
+                }
             }
 
             // // if it's from before this rate was submitted, it's there at the beginning.

--- a/services/app-api/src/postgres/contractAndRates/parseRateWithHistory.ts
+++ b/services/app-api/src/postgres/contractAndRates/parseRateWithHistory.ts
@@ -181,43 +181,6 @@ function rateWithHistoryToDomainModel(
                     initialEntry.contractRevs.push(contractRev.contractRevision)
                 }
             }
-
-            // // if it's from before this rate was submitted, it's there at the beginning.
-            // if (
-            //     contractRev.contractRevision.submitInfo.updatedAt <=
-            //     rateRev.submitInfo.updatedAt
-            // ) {
-            //     if (!contractRev.isRemoval) {
-            //         initialEntry.contractRevs.push(contractRev.contractRevision)
-            //     }
-            // } else {
-            //     // if after, then it's always a new entry in the list
-            //     let lastContracts = [...lastEntry.contractRevs]
-            //
-            //     // take out the previous contract revision this revision supersedes
-            //     lastContracts = lastContracts.filter(
-            //         (c) =>
-            //             c.contractID !== contractRev.contractRevision.contractID
-            //     )
-            //     if (!contractRev.isRemoval) {
-            //         lastContracts.push(contractRev.contractRevision)
-            //     }
-            //
-            //     // For now, we just put the most current version of contracts on this rate
-            //     // skip making entries for each contract revision
-            //     initialEntry.contractRevs = lastContracts
-            //
-            //     // const newRev: RateRevisionSet = {
-            //     //     rateRev,
-            //     //     submitInfo: contractRev.contractRevision.submitInfo,
-            //     //     unlockInfo:
-            //     //         contractRev.contractRevision.unlockInfo || undefined,
-            //     //     contractRevs: lastContracts,
-            //     // }
-            //
-            //     // lastEntry = newRev
-            //     // allEntries.push(newRev) // For now, don't make revisions out of contracts
-            // }
         }
     }
 

--- a/services/app-api/src/postgres/contractAndRates/parseRateWithHistory.ts
+++ b/services/app-api/src/postgres/contractAndRates/parseRateWithHistory.ts
@@ -156,7 +156,8 @@ function rateWithHistoryToDomainModel(
 
         allEntries.push(initialEntry)
 
-        const lastEntry = initialEntry
+        // const lastEntry = initialEntry
+
         // go through every contract revision with this rate
         for (const contractRev of rateRev.contractRevisions) {
             if (!contractRev.contractRevision.submitInfo) {
@@ -165,42 +166,52 @@ function rateWithHistoryToDomainModel(
                 )
             }
 
-            // if it's from before this rate was submitted, it's there at the beginning.
+            // Finding the contract rev submitted right after rate rev submission date time.
+            //  - It should always be the contract rev right after submission
+            //  - any disconnections will no longer include the contract rev in the prisma query.
             if (
-                contractRev.contractRevision.submitInfo.updatedAt <=
+                contractRev.contractRevision.submitInfo.updatedAt >=
                 rateRev.submitInfo.updatedAt
             ) {
-                if (!contractRev.isRemoval) {
-                    initialEntry.contractRevs.push(contractRev.contractRevision)
-                }
-            } else {
-                // if after, then it's always a new entry in the list
-                let lastContracts = [...lastEntry.contractRevs]
-
-                // take out the previous contract revision this revision supersedes
-                lastContracts = lastContracts.filter(
-                    (c) =>
-                        c.contractID !== contractRev.contractRevision.contractID
-                )
-                if (!contractRev.isRemoval) {
-                    lastContracts.push(contractRev.contractRevision)
-                }
-
-                // For now, we just put the most current version of contracts on this rate
-                // skip making entries for each contract revision
-                initialEntry.contractRevs = lastContracts
-
-                // const newRev: RateRevisionSet = {
-                //     rateRev,
-                //     submitInfo: contractRev.contractRevision.submitInfo,
-                //     unlockInfo:
-                //         contractRev.contractRevision.unlockInfo || undefined,
-                //     contractRevs: lastContracts,
-                // }
-
-                // lastEntry = newRev
-                // allEntries.push(newRev) // For now, don't make revisions out of contracts
+                initialEntry.contractRevs.push(contractRev.contractRevision)
             }
+
+            // // if it's from before this rate was submitted, it's there at the beginning.
+            // if (
+            //     contractRev.contractRevision.submitInfo.updatedAt <=
+            //     rateRev.submitInfo.updatedAt
+            // ) {
+            //     if (!contractRev.isRemoval) {
+            //         initialEntry.contractRevs.push(contractRev.contractRevision)
+            //     }
+            // } else {
+            //     // if after, then it's always a new entry in the list
+            //     let lastContracts = [...lastEntry.contractRevs]
+            //
+            //     // take out the previous contract revision this revision supersedes
+            //     lastContracts = lastContracts.filter(
+            //         (c) =>
+            //             c.contractID !== contractRev.contractRevision.contractID
+            //     )
+            //     if (!contractRev.isRemoval) {
+            //         lastContracts.push(contractRev.contractRevision)
+            //     }
+            //
+            //     // For now, we just put the most current version of contracts on this rate
+            //     // skip making entries for each contract revision
+            //     initialEntry.contractRevs = lastContracts
+            //
+            //     // const newRev: RateRevisionSet = {
+            //     //     rateRev,
+            //     //     submitInfo: contractRev.contractRevision.submitInfo,
+            //     //     unlockInfo:
+            //     //         contractRev.contractRevision.unlockInfo || undefined,
+            //     //     contractRevs: lastContracts,
+            //     // }
+            //
+            //     // lastEntry = newRev
+            //     // allEntries.push(newRev) // For now, don't make revisions out of contracts
+            // }
         }
     }
 

--- a/services/app-api/src/testHelpers/contractAndRates/contractHelpers.ts
+++ b/services/app-api/src/testHelpers/contractAndRates/contractHelpers.ts
@@ -10,7 +10,7 @@ import { findStatePrograms } from '../../postgres'
 import { must } from '../errorHelpers'
 
 const defaultContractData = () => ({
-    id: '24fb2a5f-6d0d-4e26-9906-4de28927c882',
+    id: uuidv4(),
     createdAt: new Date(),
     updatedAt: new Date(),
     mccrsID: null,
@@ -35,13 +35,14 @@ const createInsertContractData = ({
         programIDs: formData?.programIDs ?? [statePrograms[0].id],
         populationCovered: formData?.populationCovered ?? 'MEDICAID',
         riskBasedContract: formData?.riskBasedContract ?? false,
+        ...formData,
     }
 }
 
 const createDraftContractData = (
     contract?: Partial<ContractTableFullPayload>
 ): ContractTableFullPayload => ({
-    id: '24fb2a5f-6d0d-4e26-9906-4de28927c882',
+    id: uuidv4(),
     createdAt: new Date(),
     updatedAt: new Date(),
     mccrsID: null,
@@ -63,7 +64,7 @@ const createDraftContractData = (
 const createContractData = (
     contract?: Partial<ContractTableFullPayload>
 ): ContractTableFullPayload => ({
-    id: '24fb2a5f-6d0d-4e26-9906-4de28927c882',
+    id: uuidv4(),
     createdAt: new Date(),
     updatedAt: new Date(),
     mccrsID: null,


### PR DESCRIPTION
## Summary

Fixes rate history revisions contract data.

This fix refactors `rateWithHistoryToDomainModel` to only include the earliest submitted contract after the rate revision submission `submitInfo.updatedAt`. Any proceeding contract revision with the same `contractID` will be skipped.

There was a discussion in [DTBM 10.24.23](https://docs.google.com/document/d/1uVi5I_7KUPskeUQpkdWeWg4qP4ejwNJAiF1GJlfQFM4/edit) around the `Submission this rate was submitted with` and if it should link to the latest submission summary or the submission summary that this rate was submitted with. Specifically, when a rate was removed, the summary is still linked to the latest submission summary.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
