### PR TITLE
[MCR-2616] add breadcrumbs to mccrs id page

### DIFF
--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -207,17 +207,16 @@ const CMSUserRoutes = ({
                         path={RoutesRecord.SUBMISSIONS_SUMMARY}
                         element={<SubmissionSummary />}
                     />
-                    {
-                        <Route
-                            path={RoutesRecord.SUBMISSIONS_MCCRSID}
-                            element={<MccrsId />}
-                        />
-                    }
                 </Route>
 
                 <Route
                     path={RoutesRecord.RATES_SUMMARY}
                     element={<RateSummary />}
+                />
+
+                <Route
+                    path={RoutesRecord.SUBMISSIONS_MCCRSID}
+                    element={<MccrsId />}
                 />
 
                 <Route

--- a/services/app-web/src/pages/MccrsId/MccrsId.module.scss
+++ b/services/app-web/src/pages/MccrsId/MccrsId.module.scss
@@ -5,15 +5,13 @@
     width: 100%;
 }
 
-// [class^='grid-container'] {
-//     flex-direction: column;
-
-//     [class^='usa-alert'] {
-//         min-width: 40rem;
-//         max-width: 20rem;
-//         margin: 0 auto;
-//     }
-// }
+.mccrsIDForm  {
+    [class^='usa-breadcrumb'] {
+        min-width: 40rem;
+        max-width: 20rem;
+        margin: 0 auto;
+    }
+}
 
 .formContainer.tableContainer {
 

--- a/services/app-web/src/pages/MccrsId/MccrsId.test.tsx
+++ b/services/app-web/src/pages/MccrsId/MccrsId.test.tsx
@@ -1,7 +1,6 @@
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Route, Routes } from 'react-router'
-import { SubmissionSideNav } from '../SubmissionSideNav'
 import { RoutesRecord } from '../../constants/routes'
 import {
     fetchCurrentUserMock,
@@ -20,12 +19,10 @@ describe('MCCRSID', () => {
     it('renders without errors', async () => {
         renderWithProviders(
             <Routes>
-                <Route element={<SubmissionSideNav />}>
-                    <Route
-                        path={RoutesRecord.SUBMISSIONS_MCCRSID}
-                        element={<MccrsId />}
-                    />
-                </Route>
+                <Route
+                    path={RoutesRecord.SUBMISSIONS_MCCRSID}
+                    element={<MccrsId />}
+                />
             </Routes>,
             {
                 apolloProvider: {
@@ -56,12 +53,10 @@ describe('MCCRSID', () => {
     it('displays the text field for mccrs id', async () => {
         renderWithProviders(
             <Routes>
-                <Route element={<SubmissionSideNav />}>
-                    <Route
-                        path={RoutesRecord.SUBMISSIONS_MCCRSID}
-                        element={<MccrsId />}
-                    />
-                </Route>
+                <Route
+                    path={RoutesRecord.SUBMISSIONS_MCCRSID}
+                    element={<MccrsId />}
+                />
             </Routes>,
             {
                 apolloProvider: {
@@ -87,12 +82,10 @@ describe('MCCRSID', () => {
     it('cannot continue with MCCRS ID with non number input', async () => {
         renderWithProviders(
             <Routes>
-                <Route element={<SubmissionSideNav />}>
-                    <Route
-                        path={RoutesRecord.SUBMISSIONS_MCCRSID}
-                        element={<MccrsId />}
-                    />
-                </Route>
+                <Route
+                    path={RoutesRecord.SUBMISSIONS_MCCRSID}
+                    element={<MccrsId />}
+                />
             </Routes>,
             {
                 apolloProvider: {
@@ -131,12 +124,10 @@ describe('MCCRSID', () => {
     it('edit - prepopulates the mccrs id when a submission has one', async () => {
         renderWithProviders(
             <Routes>
-                <Route element={<SubmissionSideNav />}>
-                    <Route
-                        path={RoutesRecord.SUBMISSIONS_MCCRSID}
-                        element={<MccrsId />}
-                    />
-                </Route>
+                <Route
+                    path={RoutesRecord.SUBMISSIONS_MCCRSID}
+                    element={<MccrsId />}
+                />
             </Routes>,
             {
                 apolloProvider: {


### PR DESCRIPTION
## Summary
- Adds `<Breadcrumbs>`
- Changes the placement of the `/mccrs-record-number` route so that it's no longer embedded within the `SideNav` route. This is because [design says](https://qmacbis.atlassian.net/browse/MCR-2616?focusedCommentId=125169) this page won't ever display the side nav. So instead of getting the package through the side nav context this PR updates the mccrs id page to fetch the health plan package instead

#### Related issues
https://qmacbis.atlassian.net/browse/MCR-2616

#### To Do

- [ ] update local build to display breadcrumb icons or check that they render correctly in review app once deployed

#### Screenshots
<img width="753" alt="Screenshot 2023-10-27 at 11 55 16 AM" src="https://github.com/Enterprise-CMCS/managed-care-review/assets/67110378/b09a588b-3c9c-4beb-8f69-1b2e741754dd">


## QA guidance

Breadcrumbs have been added to the `/mccrs-record-number` page
