### PR TITLE
Further styling cleanup for rate summary/dashboard

### DIFF
--- a/services/app-web/package.json
+++ b/services/app-web/package.json
@@ -107,7 +107,7 @@
         "react-dom": "^18.2.0",
         "react-error-boundary": "^4.0.10",
         "react-router-dom": "^6.5.0",
-        "react-select": "^5.7.0",
+        "react-select": "^5.7.7",
         "sass": "^1.49.11",
         "typescript": "^4.4.4",
         "url-parse": "^1.5.2",

--- a/services/app-web/src/components/SectionHeader/SectionHeader.module.scss
+++ b/services/app-web/src/components/SectionHeader/SectionHeader.module.scss
@@ -13,15 +13,15 @@
     padding-bottom: units(1);
     min-height: 3rem;
 
-    &.alignTop {
+    &.hasSubheader {
         align-items: start;
+        a {
+            display: block;
+            margin-top: 17.5px;
+            padding-bottom: units(1);
+        }
     }
 
-    a {
-        display: block;
-        margin-top: 17.5px;
-        padding-bottom: units(1);
-    } 
 }
 
 .summarySectionHeaderBorder {

--- a/services/app-web/src/components/SectionHeader/SectionHeader.stories.tsx
+++ b/services/app-web/src/components/SectionHeader/SectionHeader.stories.tsx
@@ -20,7 +20,7 @@ WithAction.decorators = [(Story) => ProvidersDecorator(Story, {})]
 
 WithAction.args = {
     header: 'Contract details',
-    navigateTo: 'contract-details',
+    editNavigateTo: 'contract-details',
 }
 
 export const WithoutAction = Template.bind({})

--- a/services/app-web/src/components/SectionHeader/SectionHeader.test.tsx
+++ b/services/app-web/src/components/SectionHeader/SectionHeader.test.tsx
@@ -22,9 +22,9 @@ describe('SectionHeader', () => {
             screen.getByRole('button', { name: 'Click Me' })
         ).toBeInTheDocument()
     })
-    it('displays Edit link if navigateTo prop is passed in', () => {
+    it('displays Edit link if editNavigateTo prop is passed in', () => {
         renderWithProviders(
-            <SectionHeader header="Page 2" navigateTo="/some-edit-path">
+            <SectionHeader header="Page 2" editNavigateTo="/some-edit-path">
                 <button>Click Me</button>
             </SectionHeader>
         )

--- a/services/app-web/src/components/SectionHeader/SectionHeader.tsx
+++ b/services/app-web/src/components/SectionHeader/SectionHeader.tsx
@@ -5,9 +5,9 @@ import classNames from 'classnames'
 
 export type SectionHeaderProps = {
     header: string
-    navigateTo?: string
     children?: React.ReactNode
-    subHeaderComponent?: React.ReactNode
+    editNavigateTo?: string // Controls appearance of edit link to the right of main heading - should be pathname substring for use with NavLink
+    subHeaderComponent?: React.ReactNode // Controls appearance of additional component below main heading
     sectionId?: string
     headerId?: string
     hideBorder?: boolean
@@ -16,7 +16,7 @@ export type SectionHeaderProps = {
 export const SectionHeader = ({
     header,
     subHeaderComponent,
-    navigateTo,
+    editNavigateTo,
     children,
     sectionId,
     headerId,
@@ -25,7 +25,7 @@ export const SectionHeader = ({
     const classes = classNames({
         [styles.summarySectionHeader]: true,
         [styles.summarySectionHeaderBorder]: !hideBorder,
-        [styles.alignTop]: subHeaderComponent,
+        [styles.hasSubheader]: subHeaderComponent,
     })
     return (
         <div className={classes} id={sectionId}>
@@ -34,12 +34,12 @@ export const SectionHeader = ({
                 {subHeaderComponent}
             </div>
             <div>
-                {navigateTo && (
+                {editNavigateTo && (
                     <Link
                         variant="unstyled"
                         asCustom={NavLink}
                         className="usa-button usa-button--outline"
-                        to={navigateTo}
+                        to={editNavigateTo}
                     >
                         Edit <span className="srOnly">{header}</span>
                     </Link>

--- a/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/ContactsSummarySection.stories.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/ContactsSummarySection.stories.tsx
@@ -24,7 +24,7 @@ WithAction.decorators = [(Story) => ProvidersDecorator(Story, {})]
 
 WithAction.args = {
     submission: mockContractAndRatesDraft(),
-    navigateTo: 'contract-details',
+    editNavigateTo: 'contract-details',
 }
 
 export const WithoutAction = Template.bind({})

--- a/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/ContactsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/ContactsSummarySection.test.tsx
@@ -15,7 +15,7 @@ describe('ContactsSummarySection', () => {
         renderWithProviders(
             <ContactsSummarySection
                 submission={draftSubmission}
-                navigateTo="contacts"
+                editNavigateTo="contacts"
             />
         )
 
@@ -54,7 +54,7 @@ describe('ContactsSummarySection', () => {
         renderWithProviders(
             <ContactsSummarySection
                 submission={draftSubmission}
-                navigateTo="contacts"
+                editNavigateTo="contacts"
             />
         )
 

--- a/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/ContactsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/ContactsSummarySection.tsx
@@ -11,7 +11,7 @@ import { DataDetail, DataDetailContactField } from '../../DataDetail'
 
 export type ContactsSummarySectionProps = {
     submission: HealthPlanFormDataType
-    navigateTo?: string
+    editNavigateTo?: string
 }
 
 export const getActuaryFirm = (actuaryContact: ActuaryContact): string => {
@@ -32,13 +32,16 @@ export const getActuaryFirm = (actuaryContact: ActuaryContact): string => {
 
 export const ContactsSummarySection = ({
     submission,
-    navigateTo,
+    editNavigateTo,
 }: ContactsSummarySectionProps): React.ReactElement => {
     const isSubmitted = submission.status === 'SUBMITTED'
 
     return (
         <section id="stateContacts" className={styles.summarySection}>
-            <SectionHeader header="State contacts" navigateTo={navigateTo} />
+            <SectionHeader
+                header="State contacts"
+                editNavigateTo={editNavigateTo}
+            />
 
             <GridContainer>
                 <Grid row>

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.stories.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.stories.tsx
@@ -24,7 +24,7 @@ WithAction.decorators = [(Story) => ProvidersDecorator(Story, {})]
 
 WithAction.args = {
     submission: mockContractAndRatesDraft(),
-    navigateTo: 'contract-details',
+    editNavigateTo: 'contract-details',
 }
 
 export const WithoutAction = Template.bind({})

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
@@ -36,7 +36,7 @@ describe('ContractDetailsSummarySection', () => {
             <ContractDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={testSubmission}
-                navigateTo="contract-details"
+                editNavigateTo="contract-details"
                 submissionName="MN-PMAP-0001"
             />,
             {
@@ -105,7 +105,7 @@ describe('ContractDetailsSummarySection', () => {
             <ContractDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={mockContractAndRatesDraft()}
-                navigateTo="contract-details"
+                editNavigateTo="contract-details"
                 submissionName="MN-PMAP-0001"
             />
         )
@@ -616,7 +616,7 @@ describe('ContractDetailsSummarySection', () => {
                     }}
                     submission={contractWithUnansweredProvisions}
                     submissionName="MN-PMAP-0001"
-                    navigateTo="contract-details"
+                    editNavigateTo="contract-details"
                 />,
                 {
                     apolloProvider: {
@@ -667,7 +667,7 @@ describe('ContractDetailsSummarySection', () => {
                     }}
                     submission={contractWithUnansweredProvisions}
                     submissionName="MN-PMAP-0001"
-                    navigateTo="contract-details"
+                    editNavigateTo="contract-details"
                 />,
                 {
                     apolloProvider: {
@@ -772,7 +772,7 @@ describe('ContractDetailsSummarySection', () => {
                     }}
                     submission={contractWithAllUnmodifiedProvisions}
                     submissionName="MN-PMAP-0001"
-                    navigateTo="contract-details"
+                    editNavigateTo="contract-details"
                 />,
                 {
                     apolloProvider: {

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -37,7 +37,7 @@ import { InlineDocumentWarning } from '../../DocumentWarning'
 
 export type ContractDetailsSummarySectionProps = {
     submission: HealthPlanFormDataType
-    navigateTo?: string
+    editNavigateTo?: string
     documentDateLookupTable: DocumentDateLookupTableType
     isCMSUser?: boolean
     submissionName: string
@@ -60,7 +60,7 @@ function renderDownloadButton(zippedFilesURL: string | undefined | Error) {
 
 export const ContractDetailsSummarySection = ({
     submission,
-    navigateTo, // this is the edit link for the section. When this prop exists, summary section is loaded in edit mode
+    editNavigateTo, // this is the edit link for the section. When this prop exists, summary section is loaded in edit mode
     documentDateLookupTable,
     submissionName,
     onDocumentError,
@@ -75,7 +75,7 @@ export const ContractDetailsSummarySection = ({
     const contractSupportingDocuments = submission.documents.filter((doc) =>
         doc.documentCategories.includes('CONTRACT_RELATED' as const)
     )
-    const isEditing = !isSubmitted(submission) && navigateTo !== undefined
+    const isEditing = !isSubmitted(submission) && editNavigateTo !== undefined
     const applicableFederalAuthorities = isCHIPOnly(submission)
         ? submission.federalAuthorities.filter((authority) =>
               federalAuthorityKeysForCHIP.includes(
@@ -134,7 +134,10 @@ export const ContractDetailsSummarySection = ({
 
     return (
         <section id="contractDetailsSection" className={styles.summarySection}>
-            <SectionHeader header="Contract details" navigateTo={navigateTo}>
+            <SectionHeader
+                header="Contract details"
+                editNavigateTo={editNavigateTo}
+            >
                 {isSubmitted(submission) &&
                     !isPreviousSubmission &&
                     renderDownloadButton(zippedFilesURL)}

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.stories.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.stories.tsx
@@ -24,7 +24,7 @@ WithAction.decorators = [(Story) => ProvidersDecorator(Story, {})]
 
 WithAction.args = {
     submission: mockContractAndRatesDraft(),
-    navigateTo: 'contract-details',
+    editNavigateTo: 'contract-details',
     submissionName: 'StoryBook',
     statePrograms: [],
 }

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.test.tsx
@@ -97,7 +97,7 @@ describe('RateDetailsSummarySection', () => {
             <RateDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
-                navigateTo="rate-details"
+                editNavigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
             />,
@@ -157,7 +157,7 @@ describe('RateDetailsSummarySection', () => {
             <RateDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
-                navigateTo="rate-details"
+                editNavigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
             />,
@@ -203,7 +203,7 @@ describe('RateDetailsSummarySection', () => {
                         previousSubmissionDate: '01/01/01',
                     }}
                     submission={submission}
-                    navigateTo="rate-details"
+                    editNavigateTo="rate-details"
                     submissionName="MN-MSHO-0003"
                     statePrograms={statePrograms}
                 />,
@@ -238,7 +238,7 @@ describe('RateDetailsSummarySection', () => {
             <RateDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={submission}
-                navigateTo="rate-details"
+                editNavigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
             />,
@@ -334,7 +334,7 @@ describe('RateDetailsSummarySection', () => {
             <RateDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={testSubmission}
-                navigateTo="/rate-details'"
+                editNavigateTo="/rate-details'"
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
             />,
@@ -432,7 +432,7 @@ describe('RateDetailsSummarySection', () => {
             <RateDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
-                navigateTo="rate-details"
+                editNavigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
             />,
@@ -459,7 +459,7 @@ describe('RateDetailsSummarySection', () => {
             <RateDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
-                navigateTo="rate-details"
+                editNavigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
             />,
@@ -489,7 +489,7 @@ describe('RateDetailsSummarySection', () => {
             <RateDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
-                navigateTo="rate-details"
+                editNavigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
             />,
@@ -516,7 +516,7 @@ describe('RateDetailsSummarySection', () => {
             <RateDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
-                navigateTo="rate-details"
+                editNavigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
             />,
@@ -539,7 +539,7 @@ describe('RateDetailsSummarySection', () => {
             <RateDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
-                navigateTo="rate-details"
+                editNavigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
             />,
@@ -562,7 +562,7 @@ describe('RateDetailsSummarySection', () => {
             <RateDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
-                navigateTo="rate-details"
+                editNavigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
             />,
@@ -585,7 +585,7 @@ describe('RateDetailsSummarySection', () => {
             <RateDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
-                navigateTo="rate-details"
+                editNavigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
             />,
@@ -618,7 +618,7 @@ describe('RateDetailsSummarySection', () => {
             <RateDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
-                navigateTo="rate-details"
+                editNavigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
             />,
@@ -697,7 +697,7 @@ describe('RateDetailsSummarySection', () => {
             <RateDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={testSubmission}
-                navigateTo="rate-details"
+                editNavigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
             />,
@@ -801,7 +801,7 @@ describe('RateDetailsSummarySection', () => {
             <RateDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={testSubmission}
-                navigateTo="rate-details"
+                editNavigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
             />,
@@ -871,7 +871,7 @@ describe('RateDetailsSummarySection', () => {
             <RateDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={testSubmission}
-                navigateTo="rate-details"
+                editNavigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
             />,
@@ -897,7 +897,7 @@ describe('RateDetailsSummarySection', () => {
             <RateDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
                 submission={draftSubmission}
-                navigateTo="rate-details"
+                editNavigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
             />,

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -38,7 +38,7 @@ type PackageNamesLookupType = {
 
 export type RateDetailsSummarySectionProps = {
     submission: HealthPlanFormDataType
-    navigateTo?: string
+    editNavigateTo?: string
     documentDateLookupTable: DocumentDateLookupTableType
     isCMSUser?: boolean
     submissionName: string
@@ -64,7 +64,7 @@ export function renderDownloadButton(
 
 export const RateDetailsSummarySection = ({
     submission,
-    navigateTo,
+    editNavigateTo,
     documentDateLookupTable,
     isCMSUser,
     submissionName,
@@ -82,7 +82,7 @@ export const RateDetailsSummarySection = ({
         React.useState<PackageNamesLookupType | null>(null)
 
     const isSubmitted = submission.status === 'SUBMITTED'
-    const isEditing = !isSubmitted && navigateTo !== undefined
+    const isEditing = !isSubmitted && editNavigateTo !== undefined
     const isPreviousSubmission = usePreviousSubmission()
     const submissionLevelRateSupportingDocuments = submission.documents.filter(
         (doc) => doc.documentCategories.includes('RATES_RELATED')
@@ -260,7 +260,10 @@ export const RateDetailsSummarySection = ({
 
     return (
         <section id="rateDetails" className={styles.summarySection}>
-            <SectionHeader header="Rate details" navigateTo={navigateTo}>
+            <SectionHeader
+                header="Rate details"
+                editNavigateTo={editNavigateTo}
+            >
                 {isSubmitted &&
                     !isPreviousSubmission &&
                     renderDownloadButton(zippedFilesURL)}

--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.stories.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.stories.tsx
@@ -26,7 +26,7 @@ WithAction.args = {
     submission: mockContractAndRatesDraft(),
     //TODO: Use better mock program data
     statePrograms: [],
-    navigateTo: 'submission-type',
+    editNavigateTo: 'submission-type',
 }
 
 export const WithoutAction = Template.bind({})

--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.test.tsx
@@ -21,7 +21,7 @@ describe('SubmissionTypeSummarySection', () => {
             <SubmissionTypeSummarySection
                 submission={draftSubmission}
                 statePrograms={statePrograms}
-                navigateTo="submission-type"
+                editNavigateTo="submission-type"
                 submissionName="MN-PMAP-0001"
             />
         )
@@ -70,7 +70,7 @@ describe('SubmissionTypeSummarySection', () => {
             <SubmissionTypeSummarySection
                 submission={draftSubmission}
                 statePrograms={statePrograms}
-                navigateTo="submission-type"
+                editNavigateTo="submission-type"
                 submissionName="MN-PMAP-0001"
             />
         )
@@ -109,7 +109,7 @@ describe('SubmissionTypeSummarySection', () => {
                     } as unknown as HealthPlanFormDataType
                 } // allow type coercion to be able to test edge case
                 statePrograms={statePrograms}
-                navigateTo="submission-type"
+                editNavigateTo="submission-type"
                 submissionName="MN-PMAP-0001"
             />
         )
@@ -138,7 +138,7 @@ describe('SubmissionTypeSummarySection', () => {
                     } as unknown as HealthPlanFormDataType
                 } // allow type coercion to be able to test edge case
                 statePrograms={statePrograms}
-                navigateTo="submission-type"
+                editNavigateTo="submission-type"
                 submissionName="MN-PMAP-0001"
             />
         )
@@ -165,7 +165,7 @@ describe('SubmissionTypeSummarySection', () => {
             <SubmissionTypeSummarySection
                 submission={{ ...stateSubmission, status: 'SUBMITTED' }}
                 statePrograms={statePrograms}
-                navigateTo="submission-type"
+                editNavigateTo="submission-type"
                 submissionName="MN-MSHO-0003"
             />
         )
@@ -187,7 +187,7 @@ describe('SubmissionTypeSummarySection', () => {
             <SubmissionTypeSummarySection
                 submission={draftSubmission}
                 statePrograms={statePrograms}
-                navigateTo="submission-type"
+                editNavigateTo="submission-type"
                 submissionName="MN-PMAP-0001"
             />
         )
@@ -200,7 +200,7 @@ describe('SubmissionTypeSummarySection', () => {
             <SubmissionTypeSummarySection
                 submission={draftSubmission}
                 statePrograms={statePrograms}
-                navigateTo="submission-type"
+                editNavigateTo="submission-type"
                 headerChildComponent={<button>Test button</button>}
                 submissionName="MN-PMAP-0001"
             />

--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.tsx
@@ -17,7 +17,7 @@ import styles from '../SubmissionSummarySection.module.scss'
 export type SubmissionTypeSummarySectionProps = {
     submission: HealthPlanFormDataType
     statePrograms: Program[]
-    navigateTo?: string
+    editNavigateTo?: string
     headerChildComponent?: React.ReactElement
     subHeaderComponent?: React.ReactElement
     initiallySubmittedAt?: Date
@@ -27,7 +27,7 @@ export type SubmissionTypeSummarySectionProps = {
 export const SubmissionTypeSummarySection = ({
     submission,
     statePrograms,
-    navigateTo,
+    editNavigateTo,
     subHeaderComponent,
     headerChildComponent,
     initiallySubmittedAt,
@@ -44,7 +44,7 @@ export const SubmissionTypeSummarySection = ({
             <SectionHeader
                 header={submissionName}
                 subHeaderComponent={subHeaderComponent}
-                navigateTo={navigateTo}
+                editNavigateTo={editNavigateTo}
                 headerId={'submissionName'}
             >
                 {headerChildComponent && headerChildComponent}

--- a/services/app-web/src/components/SubmissionSummarySection/SupportingDocumentsSummarySection/SupportingDocumentsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SupportingDocumentsSummarySection/SupportingDocumentsSummarySection.test.tsx
@@ -39,7 +39,7 @@ describe('SupportingDocumentsSummarySection', () => {
         renderWithProviders(
             <SupportingDocumentsSummarySection
                 submission={testSubmission}
-                navigateTo="documents"
+                editNavigateTo="documents"
             />,
             {
                 apolloProvider: {

--- a/services/app-web/src/components/SubmissionSummarySection/SupportingDocumentsSummarySection/SupportingDocumentsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SupportingDocumentsSummarySection/SupportingDocumentsSummarySection.tsx
@@ -16,7 +16,7 @@ type DocumentWithLink = { url: string | null } & SubmissionDocument
 
 export type SupportingDocumentsSummarySectionProps = {
     submission: HealthPlanFormDataType
-    navigateTo?: string
+    editNavigateTo?: string
     submissionName?: string
     onDocumentError?: (error: true) => void
 }
@@ -45,7 +45,7 @@ function renderDownloadButton(zippedFilesURL: string | undefined | Error) {
 // since supporting documents are now displayed in the rate and contract sections
 export const SupportingDocumentsSummarySection = ({
     submission,
-    navigateTo,
+    editNavigateTo,
     submissionName,
     onDocumentError,
 }: SupportingDocumentsSummarySectionProps): React.ReactElement | null => {
@@ -139,7 +139,7 @@ export const SupportingDocumentsSummarySection = ({
         <section id="documents" className={styles.summarySection}>
             <SectionHeader
                 header="Supporting documents"
-                navigateTo={navigateTo}
+                editNavigateTo={editNavigateTo}
             >
                 {isSubmitted && renderDownloadButton(zippedFilesURL)}
             </SectionHeader>

--- a/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsDashboard.test.tsx
+++ b/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsDashboard.test.tsx
@@ -33,7 +33,9 @@ describe('RateReviewsDashboard', () => {
         })
 
         // Expect 3 rates to be displayed
-        expect(screen.getByText('Displaying 3 of 3 rates')).toBeInTheDocument()
+        expect(
+            screen.getByText('Displaying 3 of 3 rate reviews')
+        ).toBeInTheDocument()
     })
 
     it('renders error failed request page', async () => {

--- a/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsTable.test.tsx
+++ b/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsTable.test.tsx
@@ -74,7 +74,7 @@ describe('RateReviewsTable', () => {
 
         await waitFor(() => {
             expect(
-                screen.queryByText('Displaying 3 of 3 rates')
+                screen.queryByText('Displaying 3 of 3 rate reviews')
             ).toBeInTheDocument()
         })
         // expect filter accordion to be present
@@ -183,6 +183,8 @@ describe('RateReviewsTable', () => {
         const rows = await screen.findAllByRole('row')
         expect(rows).toHaveLength(2)
         expect(rows[1]).toHaveTextContent('Ohio') // row[0] is the header
-        expect(screen.getByText('Displaying 1 of 3 rates')).toBeInTheDocument()
+        expect(
+            screen.getByText('Displaying 1 of 3 rate reviews')
+        ).toBeInTheDocument()
     })
 })

--- a/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsTable.tsx
+++ b/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsTable.tsx
@@ -230,7 +230,7 @@ export const RateReviewsTable = ({
             }),
             columnHelper.accessor('rateType', {
                 id: 'rateType',
-                header: 'Rate type',
+                header: 'Rate Type',
                 cell: (info) => <span>{info.getValue()}</span>,
                 meta: {
                     dataTestID: 'rate-type',
@@ -313,7 +313,7 @@ export const RateReviewsTable = ({
     const submissionCount = !showFilters
         ? `${tableData.length} ${pluralize('rate', tableData.length)}`
         : `Displaying ${filteredRows.length} of ${tableData.length} ${pluralize(
-              'rate',
+              'rate reviews',
               tableData.length
           )}`
 

--- a/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsTable.tsx
+++ b/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsTable.tsx
@@ -313,7 +313,7 @@ export const RateReviewsTable = ({
     const submissionCount = !showFilters
         ? `${tableData.length} ${pluralize('rate', tableData.length)}`
         : `Displaying ${filteredRows.length} of ${tableData.length} ${pluralize(
-              'rate reviews',
+              'rate review',
               tableData.length
           )}`
 

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
@@ -47,13 +47,13 @@ export const ReviewSubmit = ({
             <SubmissionTypeSummarySection
                 submission={draftSubmission}
                 submissionName={submissionName}
-                navigateTo="../type"
+                editNavigateTo="../type"
                 statePrograms={statePrograms}
             />
 
             <ContractDetailsSummarySection
                 submission={draftSubmission}
-                navigateTo="../contract-details"
+                editNavigateTo="../contract-details"
                 submissionName={submissionName}
                 documentDateLookupTable={documentDateLookupTable}
             />
@@ -61,7 +61,7 @@ export const ReviewSubmit = ({
             {isContractActionAndRateCertification && (
                 <RateDetailsSummarySection
                     submission={draftSubmission}
-                    navigateTo="../rate-details"
+                    editNavigateTo="../rate-details"
                     submissionName={submissionName}
                     documentDateLookupTable={documentDateLookupTable}
                     statePrograms={statePrograms}
@@ -70,12 +70,12 @@ export const ReviewSubmit = ({
 
             <ContactsSummarySection
                 submission={draftSubmission}
-                navigateTo="../contacts"
+                editNavigateTo="../contacts"
             />
 
             <SupportingDocumentsSummarySection
                 submission={draftSubmission}
-                navigateTo="../documents"
+                editNavigateTo="../documents"
             />
 
             <PageActionsContainer

--- a/yarn.lock
+++ b/yarn.lock
@@ -9753,13 +9753,12 @@
   dependencies:
     jest-get-type "^29.6.3"
 
-"@jest/expect@^29.7.0":
+"@jest/expect-utils@^29.7.0":
   version "29.7.0"
-  resolved "https://registry.yarnpkg.com/@jest/expect/-/expect-29.7.0.tgz#76a3edb0cb753b70dfbfe23283510d3d45432bf2"
-  integrity sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.7.0.tgz#023efe5d26a8a70f21677d0a1afc0f0a44e3a1c6"
+  integrity sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==
   dependencies:
-    expect "^29.7.0"
-    jest-snapshot "^29.7.0"
+    jest-get-type "^29.6.3"
 
 "@jest/fake-timers@^27.5.1":
   version "27.5.1"
@@ -10066,6 +10065,18 @@
     chalk "^4.0.0"
 
 "@jest/types@^29.0.0", "@jest/types@^29.6.1", "@jest/types@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.6.3.tgz#1131f8cf634e7e84c5e77bab12f052af585fba59"
+  integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.8"
+    chalk "^4.0.0"
+
+"@jest/types@^29.6.3":
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.6.3.tgz#1131f8cf634e7e84c5e77bab12f052af585fba59"
   integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
@@ -15000,6 +15011,14 @@
   version "29.5.6"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.6.tgz#f4cf7ef1b5b0bfc1aa744e41b24d9cc52533130b"
   integrity sha512-/t9NnzkOpXb4Nfvg17ieHE6EeSjDS2SGSpNYfoLbUAeL/EOueU/RSdOWFpfQTXBEM7BguYW1XQ0EbM+6RlIh6w==
+  dependencies:
+    expect "^29.0.0"
+    pretty-format "^29.0.0"
+
+"@types/jest@^29.5.6":
+  version "29.5.7"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.7.tgz#2c0dafe2715dd958a455bc10e2ec3e1ec47b5036"
+  integrity sha512-HLyetab6KVPSiF+7pFcUyMeLsx25LDNDemw9mGsJBkai/oouwrjTycocSDYopMEwFhN2Y4s9oPyOCZNofgSt2g==
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"
@@ -21397,16 +21416,6 @@ expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-expect@^27.5.1:
-  version "27.5.1"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-27.5.1.tgz#83ce59f1e5bdf5f9d2b94b61d2050db48f3fef74"
-  integrity sha512-E1q5hSUG2AmYQwQJ041nvgpkODHQvB+RKlB4IYdru6uJsyFTRyZAP463M+1lINorwbqAmUggi6+WwkD8lCS/Dw==
-  dependencies:
-    "@jest/types" "^27.5.1"
-    jest-get-type "^27.5.1"
-    jest-matcher-utils "^27.5.1"
-    jest-message-util "^27.5.1"
-
 expect@^29.0.0, expect@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz#578874590dcb3214514084c08115d8aee61e11bc"
@@ -25008,6 +25017,16 @@ jest-matcher-utils@^29.7.0:
     jest-get-type "^29.6.3"
     pretty-format "^29.7.0"
 
+jest-matcher-utils@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz#ae8fec79ff249fd592ce80e3ee474e83a6c44f12"
+  integrity sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^29.7.0"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
+
 jest-message-util@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-27.5.1.tgz#bdda72806da10d9ed6425e12afff38cd1458b6cf"
@@ -25035,6 +25054,21 @@ jest-message-util@^28.1.3:
     graceful-fs "^4.2.9"
     micromatch "^4.0.4"
     pretty-format "^28.1.3"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
+jest-message-util@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.7.0.tgz#8bc392e204e95dfe7564abbe72a404e28e51f7f3"
+  integrity sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^29.6.3"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    micromatch "^4.0.4"
+    pretty-format "^29.7.0"
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
@@ -30350,10 +30384,10 @@ react-select-event@^5.5.0:
   dependencies:
     "@testing-library/dom" ">=7"
 
-react-select@^5.7.0:
-  version "5.7.4"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.7.4.tgz#d8cad96e7bc9d6c8e2709bdda8f4363c5dd7ea7d"
-  integrity sha512-NhuE56X+p9QDFh4BgeygHFIvJJszO1i1KSkg/JPcIJrbovyRtI+GuOEa4XzFCEpZRAEoEI8u/cAHK+jG/PgUzQ==
+react-select@^5.7.7:
+  version "5.7.7"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.7.7.tgz#dbade9dbf711ef2a181970c10f8ab319ac37fbd0"
+  integrity sha512-HhashZZJDRlfF/AKj0a0Lnfs3sRdw/46VJIRd8IbB9/Ovr74+ZIwkAdSBjSPXsFMG+u72c5xShqwLSKIJllzqw==
   dependencies:
     "@babel/runtime" "^7.12.0"
     "@emotion/cache" "^11.4.0"


### PR DESCRIPTION
## Summary
- Fix text display on filters and in rate table as per this [comment](https://qmacbis.atlassian.net/browse/MCR-2617?focusedCommentId=125108 )
- Update react-select so we get better a11y behavior - should announce "deselected" clearly now.
- Fix `SectionHeader.module.scss` - target mcrrs styles more to bring download buttons back in alignment.
    -  See images for before/after.
- Rename `navigateTo` since now they are other links in the section header (such as mc-crs id) 

#### Related issues
https://qmacbis.atlassian.net/browse/MCR-2617

#### Screenshots

Before:
<img src="https://github.com/Enterprise-CMCS/managed-care-review/assets/10750442/399405a4-80ee-4160-9ee6-8d412927f5e2"  width="300" />

After:
<img src="https://github.com/Enterprise-CMCS/managed-care-review/assets/10750442/bfda150b-d76a-41cd-ac97-9dced398cdf7" width="300" />


## Manual QA
react-select (any program or package dropdown) should still be working well for us
