### PR TITLE
Connect QA to Contracts

### DIFF
--- a/services/app-api/prisma/migrations/20231031204348_migrate_questions_to_contracts/migration.sql
+++ b/services/app-api/prisma/migrations/20231031204348_migrate_questions_to_contracts/migration.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+ALTER TABLE "Question" ADD COLUMN "contractID" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "Question" ADD CONSTRAINT "Question_contractID_fkey" FOREIGN KEY ("contractID") REFERENCES "ContractTable"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- migrate data over
+UPDATE "Question" SET "contractID"="pkgID";
+
+-- make not nullable, drop pkgID
+ALTER TABLE "Question" 
+  ALTER COLUMN "contractID" SET NOT NULL,
+  DROP CONSTRAINT "Question_pkgID_fkey",
+  DROP COLUMN "pkgID";
+
+COMMIT;

--- a/services/app-api/prisma/schema.prisma
+++ b/services/app-api/prisma/schema.prisma
@@ -13,7 +13,6 @@ model HealthPlanPackageTable {
   stateCode String
   state     State                     @relation(fields: [stateCode], references: [stateCode])
   revisions HealthPlanRevisionTable[]
-  questions Question[]
 }
 
 model ProtoMigrationsTable {
@@ -41,8 +40,10 @@ model ContractTable {
 
   mccrsID     String?
   stateCode   String
-  state       State  @relation(fields: [stateCode], references: [stateCode])
+  state       State   @relation(fields: [stateCode], references: [stateCode])
   stateNumber Int
+
+  questions Question[]
 
   revisions          ContractRevisionTable[]
   // This relationship is a scam. We never call it in our code but Prisma
@@ -72,8 +73,8 @@ model ContractRevisionTable {
   contractID String
   contract   ContractTable @relation(fields: [contractID], references: [id])
 
-  rateRevisions                                RateRevisionsOnContractRevisionsTable[]
-  draftRates                                   RateTable[]
+  rateRevisions RateRevisionsOnContractRevisionsTable[]
+  draftRates    RateTable[]
 
   unlockInfoID String?
   unlockInfo   UpdateInfoTable? @relation("unlockContractInfo", fields: [unlockInfoID], references: [id])
@@ -130,21 +131,21 @@ model RateRevisionTable {
   submitInfoID String?
   submitInfo   UpdateInfoTable? @relation("submitRateInfo", fields: [submitInfoID], references: [id], onDelete: Cascade)
 
-  rateType                       RateType?
-  rateCapitationType             RateCapitationType?
-  rateDocuments                  RateDocument[]
-  supportingDocuments            RateSupportingDocument[] 
-  rateDateStart                  DateTime?                  @db.Date
-  rateDateEnd                    DateTime?                  @db.Date
-  rateDateCertified              DateTime?                  @db.Date
-  amendmentEffectiveDateStart    DateTime?                  @db.Date
-  amendmentEffectiveDateEnd      DateTime?                  @db.Date
-  rateProgramIDs                 String[]
-  rateCertificationName          String?
-  certifyingActuaryContacts      ActuaryContact[]           @relation(name: "CertifyingActuaryOnRateRevision")
-  addtlActuaryContacts           ActuaryContact[]           @relation(name: "AddtlActuaryOnRateRevision")
-  actuaryCommunicationPreference ActuaryCommunication?
-  contractsWithSharedRateRevision ContractTable[] @relation(name: "SharedRateRevisions")
+  rateType                        RateType?
+  rateCapitationType              RateCapitationType?
+  rateDocuments                   RateDocument[]
+  supportingDocuments             RateSupportingDocument[]
+  rateDateStart                   DateTime?                @db.Date
+  rateDateEnd                     DateTime?                @db.Date
+  rateDateCertified               DateTime?                @db.Date
+  amendmentEffectiveDateStart     DateTime?                @db.Date
+  amendmentEffectiveDateEnd       DateTime?                @db.Date
+  rateProgramIDs                  String[]
+  rateCertificationName           String?
+  certifyingActuaryContacts       ActuaryContact[]         @relation(name: "CertifyingActuaryOnRateRevision")
+  addtlActuaryContacts            ActuaryContact[]         @relation(name: "AddtlActuaryOnRateRevision")
+  actuaryCommunicationPreference  ActuaryCommunication?
+  contractsWithSharedRateRevision ContractTable[]          @relation(name: "SharedRateRevisions")
 }
 
 model RateRevisionsOnContractRevisionsTable {
@@ -291,12 +292,12 @@ model UserAudit {
 }
 
 model Question {
-  id            String                 @id @default(uuid())
-  createdAt     DateTime               @default(now())
-  updatedAt     DateTime               @default(now()) @updatedAt
-  pkgID         String
-  pkg           HealthPlanPackageTable @relation(fields: [pkgID], references: [id])
-  addedBy       User                   @relation(fields: [addedByUserID], references: [id])
+  id            String             @id @default(uuid())
+  createdAt     DateTime           @default(now())
+  updatedAt     DateTime           @default(now()) @updatedAt
+  contractID    String
+  contract      ContractTable      @relation(fields: [contractID], references: [id])
+  addedBy       User               @relation(fields: [addedByUserID], references: [id])
   addedByUserID String
   division      Division
   documents     QuestionDocument[]
@@ -327,10 +328,10 @@ model QuestionResponse {
   id            String                     @id @default(uuid())
   createdAt     DateTime                   @default(now())
   updatedAt     DateTime                   @updatedAt
-  question      Question                   @relation(fields: [questionID], references: [id])
-  addedBy       User                       @relation(fields: [addedByUserID], references: [id])
   questionID    String
+  question      Question                   @relation(fields: [questionID], references: [id])
   addedByUserID String
+  addedBy       User                       @relation(fields: [addedByUserID], references: [id])
   documents     QuestionResponseDocument[]
 }
 

--- a/services/app-api/src/domain-models/QuestionsType.ts
+++ b/services/app-api/src/domain-models/QuestionsType.ts
@@ -9,7 +9,7 @@ type Document = {
 
 type Question = {
     id: string
-    pkgID: string
+    contractID: string
     createdAt: Date
     addedBy: CMSUserType
     documents: Document[]
@@ -40,7 +40,7 @@ type CreateQuestionPayload = {
 }
 
 type CreateQuestionInput = {
-    pkgID: string
+    contractID: string
     documents: Document[]
 }
 

--- a/services/app-api/src/postgres/postgresStore.ts
+++ b/services/app-api/src/postgres/postgresStore.ts
@@ -43,7 +43,7 @@ import {
     insertManyUsers,
 } from './user'
 import {
-    findAllQuestionsByHealthPlanPackage,
+    findAllQuestionsByContract,
     insertQuestion,
     insertQuestionResponse,
 } from './questionResponse'
@@ -139,9 +139,7 @@ type Store = {
         user: CMSUserType
     ) => Promise<Question | StoreError>
 
-    findAllQuestionsByHealthPlanPackage: (
-        pkgID: string
-    ) => Promise<Question[] | StoreError>
+    findAllQuestionsByContract: (pkgID: string) => Promise<Question[] | Error>
 
     insertQuestionResponse: (
         questionInput: InsertQuestionResponseArgs,
@@ -240,8 +238,8 @@ function NewPostgresStore(client: PrismaClient): Store {
         findAllUsers: () => findAllUsers(client),
         insertQuestion: (questionInput, user) =>
             insertQuestion(client, questionInput, user),
-        findAllQuestionsByHealthPlanPackage: (pkgID) =>
-            findAllQuestionsByHealthPlanPackage(client, pkgID),
+        findAllQuestionsByContract: (pkgID) =>
+            findAllQuestionsByContract(client, pkgID),
         insertQuestionResponse: (questionInput, user) =>
             insertQuestionResponse(client, questionInput, user),
         /**

--- a/services/app-api/src/postgres/questionResponse/findAllQuestionsByContract.ts
+++ b/services/app-api/src/postgres/questionResponse/findAllQuestionsByContract.ts
@@ -4,17 +4,15 @@ import type {
     Question,
     QuestionResponseType,
 } from '../../domain-models'
-import type { StoreError } from '../storeError'
-import { convertPrismaErrorToStoreError } from '../storeError'
 
-export async function findAllQuestionsByHealthPlanPackage(
+export async function findAllQuestionsByContract(
     client: PrismaClient,
-    pkgID: string
-): Promise<Question[] | StoreError> {
+    contractID: string
+): Promise<Question[] | Error> {
     try {
         const findResult = await client.question.findMany({
             where: {
-                pkgID: pkgID,
+                contractID: contractID,
             },
             include: {
                 documents: {
@@ -49,6 +47,10 @@ export async function findAllQuestionsByHealthPlanPackage(
 
         return questions
     } catch (e: unknown) {
-        return convertPrismaErrorToStoreError(e)
+        if (e instanceof Error) {
+            return e
+        }
+        console.error('Unknown object thrown by Prisma', e)
+        return new Error('Unknown object thrown by Prisma')
     }
 }

--- a/services/app-api/src/postgres/questionResponse/index.ts
+++ b/services/app-api/src/postgres/questionResponse/index.ts
@@ -1,4 +1,4 @@
-export { findAllQuestionsByHealthPlanPackage } from './findAllQuestionsByHealthPlanPackage'
+export { findAllQuestionsByContract } from './findAllQuestionsByContract'
 export { insertQuestion } from './insertQuestion'
 export { convertToIndexQuestionsPayload } from './questionHelpers'
 export { insertQuestionResponse } from './insertQuestionResponse'

--- a/services/app-api/src/postgres/questionResponse/insertQuestion.ts
+++ b/services/app-api/src/postgres/questionResponse/insertQuestion.ts
@@ -25,9 +25,9 @@ export async function insertQuestion(
         const result = await client.question.create({
             data: {
                 id: uuidv4(),
-                pkg: {
+                contract: {
                     connect: {
-                        id: questionInput.pkgID,
+                        id: questionInput.contractID,
                     },
                 },
                 addedBy: {

--- a/services/app-api/src/resolvers/healthPlanPackage/healthPlanPackageResolver.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/healthPlanPackageResolver.ts
@@ -3,7 +3,6 @@ import { protoToBase64 } from '../../../../app-web/src/common-code/proto/healthP
 import statePrograms from '../../../../app-web/src/common-code/data/statePrograms.json'
 import type { Resolvers } from '../../gen/gqlServer'
 import type { Store } from '../../postgres'
-import { isStoreError } from '../../postgres'
 import { convertToIndexQuestionsPayload } from '../../postgres/questionResponse'
 import { logError } from '../../logger'
 import { setErrorAttributesOnActiveSpan } from '../attributeHelper'
@@ -59,15 +58,13 @@ export function healthPlanPackageResolver(
             }
             return state
         },
-        questions: async (parent, args, context) => {
+        questions: async (parent, _args, context) => {
             const { span } = context
             const pkgID = parent.id
-            const result = await store.findAllQuestionsByHealthPlanPackage(
-                pkgID
-            )
+            const result = await store.findAllQuestionsByContract(pkgID)
 
-            if (isStoreError(result)) {
-                const errMessage = `Issue finding questions of type ${result.code} for package with id: ${pkgID}. Message: ${result.message}`
+            if (result instanceof Error) {
+                const errMessage = `Issue finding questions for package with id: ${pkgID}. Message: ${result.message}`
                 logError('indexQuestions', errMessage)
                 setErrorAttributesOnActiveSpan(errMessage, span)
                 throw new GraphQLError(errMessage, {

--- a/services/app-api/src/resolvers/questionResponse/createQuestion.ts
+++ b/services/app-api/src/resolvers/questionResponse/createQuestion.ts
@@ -69,12 +69,8 @@ export function createQuestionResolver(
             })
         }
 
-        // Return error if package status is DRAFT
-        // TODO we should have a helper for this
-        if (
-            contractResult.revisions.length === 1 &&
-            contractResult.revisions[0].submitInfo === undefined
-        ) {
+        // Return error if package status is DRAFT, contract will have no submitted revisions
+        if (contractResult.revisions.length === 0) {
             const errMessage = `Issue creating question for health plan package. Message: Cannot create question for health plan package in DRAFT status`
             logError('createQuestion', errMessage)
             setErrorAttributesOnActiveSpan(errMessage, span)

--- a/services/app-api/src/resolvers/questionResponse/createQuestion.ts
+++ b/services/app-api/src/resolvers/questionResponse/createQuestion.ts
@@ -1,11 +1,12 @@
 import type { MutationResolvers } from '../../gen/gqlServer'
-import { isCMSUser, packageStatus } from '../../domain-models'
+import { isCMSUser } from '../../domain-models'
 import { logError, logSuccess } from '../../logger'
 import {
     setErrorAttributesOnActiveSpan,
     setSuccessAttributesOnActiveSpan,
 } from '../attributeHelper'
 import { ForbiddenError, UserInputError } from 'apollo-server-lambda'
+import { NotFoundError } from '../../postgres'
 import type { Store } from '../../postgres'
 import { isStoreError } from '../../postgres'
 import { GraphQLError } from 'graphql'
@@ -44,10 +45,20 @@ export function createQuestionResolver(
         }
 
         // Return error if package is not found or errors
-        const result = await store.findHealthPlanPackage(input.pkgID)
+        const contractResult = await store.findContractWithHistory(
+            input.contractID
+        )
+        if (contractResult instanceof Error) {
+            if (contractResult instanceof NotFoundError) {
+                const errMessage = `Package with id ${input.contractID} does not exist`
+                logError('createQuestion', errMessage)
+                setErrorAttributesOnActiveSpan(errMessage, span)
+                throw new GraphQLError(errMessage, {
+                    extensions: { code: 'NOT_FOUND' },
+                })
+            }
 
-        if (isStoreError(result)) {
-            const errMessage = `Issue finding a package of type ${result.code}. Message: ${result.message}`
+            const errMessage = `Issue finding a package. Message: ${contractResult.message}`
             logError('createQuestion', errMessage)
             setErrorAttributesOnActiveSpan(errMessage, span)
             throw new GraphQLError(errMessage, {
@@ -58,19 +69,12 @@ export function createQuestionResolver(
             })
         }
 
-        if (result === undefined) {
-            const errMessage = `Issue finding a package with id ${input.pkgID}. Message: Package with id ${input.pkgID} does not exist`
-            logError('createQuestion', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-            throw new GraphQLError(errMessage, {
-                extensions: { code: 'NOT_FOUND' },
-            })
-        }
-
         // Return error if package status is DRAFT
-        const packageStats = packageStatus(result)
-
-        if (packageStats === 'DRAFT') {
+        // TODO we should have a helper for this
+        if (
+            contractResult.revisions.length === 1 &&
+            contractResult.revisions[0].submitInfo === undefined
+        ) {
             const errMessage = `Issue creating question for health plan package. Message: Cannot create question for health plan package in DRAFT status`
             logError('createQuestion', errMessage)
             setErrorAttributesOnActiveSpan(errMessage, span)

--- a/services/app-api/src/resolvers/questionResponse/createQuestionResponse.test.ts
+++ b/services/app-api/src/resolvers/questionResponse/createQuestionResponse.test.ts
@@ -10,8 +10,10 @@ import {
     createDBUsersWithFullData,
     testCMSUser,
 } from '../../testHelpers/userHelpers'
+import { testLDService } from '../../testHelpers/launchDarklyHelpers'
 
 describe('createQuestionResponse', () => {
+    const mockLDService = testLDService({ ['rates-db-refactor']: true })
     const cmsUser = testCMSUser()
     beforeAll(async () => {
         //Inserting a new CMS user, with division assigned, in postgres in order to create the question to user relationship.
@@ -19,11 +21,14 @@ describe('createQuestionResponse', () => {
     })
 
     it('returns question response data', async () => {
-        const stateServer = await constructTestPostgresServer()
+        const stateServer = await constructTestPostgresServer({
+            ldService: mockLDService,
+        })
         const cmsServer = await constructTestPostgresServer({
             context: {
                 user: cmsUser,
             },
+            ldService: mockLDService,
         })
 
         const submittedPkg = await createAndSubmitTestHealthPlanPackage(
@@ -58,7 +63,9 @@ describe('createQuestionResponse', () => {
     })
 
     it('returns an error when attempting to create response for a question that does not exist', async () => {
-        const stateServer = await constructTestPostgresServer()
+        const stateServer = await constructTestPostgresServer({
+            ldService: mockLDService,
+        })
         const fakeID = 'abc-123'
 
         const createdResponse = await stateServer.executeOperation({
@@ -84,11 +91,14 @@ describe('createQuestionResponse', () => {
     })
 
     it('returns an error if a cms user attempts to create a question response for a package', async () => {
-        const stateServer = await constructTestPostgresServer()
+        const stateServer = await constructTestPostgresServer({
+            ldService: mockLDService,
+        })
         const cmsServer = await constructTestPostgresServer({
             context: {
                 user: cmsUser,
             },
+            ldService: mockLDService,
         })
         const submittedPkg = await createAndSubmitTestHealthPlanPackage(
             stateServer

--- a/services/app-api/src/testHelpers/gqlHelpers.ts
+++ b/services/app-api/src/testHelpers/gqlHelpers.ts
@@ -427,8 +427,8 @@ const fetchTestHealthPlanPackageById = async (
 
 const createTestQuestion = async (
     server: ApolloServer,
-    pkgID: string,
-    questionData?: Omit<CreateQuestionInput, 'pkgID'>
+    contractID: string,
+    questionData?: Omit<CreateQuestionInput, 'contractID'>
 ): Promise<CreateQuestionPayload> => {
     const question = questionData || {
         documents: [
@@ -442,7 +442,7 @@ const createTestQuestion = async (
         query: CREATE_QUESTION,
         variables: {
             input: {
-                pkgID,
+                contractID,
                 ...question,
             },
         },
@@ -462,13 +462,13 @@ const createTestQuestion = async (
 
 const indexTestQuestions = async (
     server: ApolloServer,
-    pkgID: string
+    contractID: string
 ): Promise<IndexQuestionsPayload> => {
     const indexQuestionsResult = await server.executeOperation({
         query: INDEX_QUESTIONS,
         variables: {
             input: {
-                pkgID: pkgID,
+                contractID,
             },
         },
     })

--- a/services/app-api/src/testHelpers/storeHelpers.ts
+++ b/services/app-api/src/testHelpers/storeHelpers.ts
@@ -95,8 +95,8 @@ function mockStoreThatErrors(): Store {
         insertQuestion: async (_ID) => {
             return genericStoreError
         },
-        findAllQuestionsByHealthPlanPackage: async (_pkgID) => {
-            return genericStoreError
+        findAllQuestionsByContract: async (_pkgID) => {
+            return genericError
         },
         insertQuestionResponse: async (_ID) => {
             return genericStoreError

--- a/services/app-graphql/src/mutations/createQuestion.graphql
+++ b/services/app-graphql/src/mutations/createQuestion.graphql
@@ -2,7 +2,7 @@ mutation createQuestion($input: CreateQuestionInput!) {
     createQuestion(input: $input) {
         question {
             id
-            pkgID
+            contractID
             createdAt
             addedBy {
                 id

--- a/services/app-graphql/src/queries/fetchHealthPlanPackageWithQuestions.graphql
+++ b/services/app-graphql/src/queries/fetchHealthPlanPackageWithQuestions.graphql
@@ -1,7 +1,7 @@
 fragment questionEdgeFragment on QuestionEdge {
     node {
         id
-        pkgID
+        contractID
         createdAt
         addedBy {
             id

--- a/services/app-graphql/src/queries/indexQuestions.graphql
+++ b/services/app-graphql/src/queries/indexQuestions.graphql
@@ -1,7 +1,7 @@
 fragment questionEdgeFragment on QuestionEdge {
     node {
         id
-        pkgID
+        contractID
         createdAt
         addedBy {
             id

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -308,7 +308,7 @@ type IndexHealthPlanPackagesPayload {
 
 input IndexQuestionsInput {
     "The ID of the package for which to fetch associated questions"
-    pkgID: ID!
+    contractID: ID!
 }
 
 type IndexQuestionsPayload {
@@ -338,7 +338,7 @@ input DocumentInput {
 
 input CreateQuestionInput {
     "The ID of the package for which to create a question"
-    pkgID: ID!
+    contractID: ID!
     "A list of documents to attach to the question"
     documents: [DocumentInput!]! # should be Generic Document with sha256
     "A note to attach to the question"
@@ -664,7 +664,7 @@ QuestionResponse with documents that answer the questions posed by CMS.
 """
 type Question {
     id: ID!
-    pkgID: ID!
+    contractID: ID!
     createdAt: DateTime!
     addedBy: CMSUser!
     documents: [Document!]!

--- a/services/app-web/src/gqlHelpers/mutationWrappersForUserFriendlyErrors.ts
+++ b/services/app-web/src/gqlHelpers/mutationWrappersForUserFriendlyErrors.ts
@@ -168,7 +168,7 @@ export const createQuestionWrapper = async (
                                 query: FetchHealthPlanPackageWithQuestionsDocument,
                                 variables: {
                                     input: {
-                                        pkgID: newQuestion.pkgID,
+                                        pkgID: newQuestion.contractID,
                                     },
                                 },
                             }

--- a/services/app-web/src/gqlHelpers/useIndexQuestionsQueryWrapper.ts
+++ b/services/app-web/src/gqlHelpers/useIndexQuestionsQueryWrapper.ts
@@ -10,7 +10,7 @@ function useIndexQuestionsQueryWrapper(id: string): WrappedFetchResultType {
         useIndexQuestionsQuery({
             variables: {
                 input: {
-                    pkgID: id,
+                    contractID: id,
                 },
             },
         })

--- a/services/app-web/src/pages/QuestionResponse/QATable/QATable.test.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/QATable.test.tsx
@@ -14,7 +14,7 @@ const cmsUser = mockValidCMSUser() as CmsUser
 
 const testQuestionData: QuestionData = {
     id: 'question-1-id',
-    pkgID: '15',
+    contractID: '15',
     createdAt: new Date('2022-12-23T00:00:00.000Z'),
     addedBy: cmsUser,
     documents: [
@@ -133,7 +133,7 @@ it('renders question correctly as a state user', async () => {
 it('renders multiple documents', async () => {
     const testQuestionDocLinks: QuestionData = {
         id: 'question-1-id',
-        pkgID: '15',
+        contractID: '15',
         createdAt: new Date('2022-12-23T00:00:00.000Z'),
         addedBy: cmsUser,
         documents: [

--- a/services/app-web/src/pages/QuestionResponse/QATable/QATable.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/QATable.tsx
@@ -1,5 +1,5 @@
 import styles from './QATable.module.scss'
-import React, { useState } from 'react'
+import { useState } from 'react'
 import {
     CmsUser,
     Document,
@@ -20,7 +20,7 @@ type QuestionDocumentWithLink = {
 
 export type QuestionData = {
     id: string
-    pkgID: string
+    contractID: string
     createdAt: Date
     addedBy: CmsUser
     documents: Document[]

--- a/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadQuestions.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadQuestions.tsx
@@ -80,7 +80,7 @@ export const UploadQuestions = () => {
         })
 
         const input: CreateQuestionInput = {
-            pkgID: id as string,
+            contractID: id as string,
             documents: questionDocs,
         }
 

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -111,7 +111,7 @@ describe('RateDetails', () => {
             ).not.toBeInTheDocument()
             const requiredLabels = await screen.findAllByText('Required')
             expect(requiredLabels).toHaveLength(6)
-            const optionalLabels = await screen.queryAllByText('Optional')
+            const optionalLabels = screen.queryAllByText('Optional')
             expect(optionalLabels).toHaveLength(1)
         })
 

--- a/services/app-web/src/testHelpers/apolloMocks/questionResponseDataMocks.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/questionResponseDataMocks.ts
@@ -1,7 +1,7 @@
 import { CmsUser, IndexQuestionsPayload, StateUser } from '../../gen/gqlClient'
 import { mockValidCMSUser, mockValidUser } from './userGQLMock'
 
-function mockQuestionsPayload(pkgID: string): IndexQuestionsPayload {
+function mockQuestionsPayload(contractID: string): IndexQuestionsPayload {
     return {
         DMCOQuestions: {
             totalCount: 2,
@@ -11,7 +11,7 @@ function mockQuestionsPayload(pkgID: string): IndexQuestionsPayload {
                     node: {
                         __typename: 'Question' as const,
                         id: 'dmco-question-1-id',
-                        pkgID,
+                        contractID,
                         createdAt: new Date('2022-12-15'),
                         addedBy: mockValidCMSUser({
                             divisionAssignment: 'DMCO',
@@ -45,7 +45,7 @@ function mockQuestionsPayload(pkgID: string): IndexQuestionsPayload {
                     node: {
                         __typename: 'Question' as const,
                         id: 'dmco-question-2-id',
-                        pkgID,
+                        contractID,
                         createdAt: new Date('2022-12-18'),
                         addedBy: mockValidCMSUser() as CmsUser,
                         documents: [
@@ -86,7 +86,7 @@ function mockQuestionsPayload(pkgID: string): IndexQuestionsPayload {
                     node: {
                         __typename: 'Question' as const,
                         id: 'dmcp-question-1-id',
-                        pkgID,
+                        contractID,
                         createdAt: new Date('2022-12-15'),
                         addedBy: mockValidCMSUser({
                             divisionAssignment: 'DMCP',
@@ -125,7 +125,7 @@ function mockQuestionsPayload(pkgID: string): IndexQuestionsPayload {
                     node: {
                         __typename: 'Question' as const,
                         id: 'oact-question-1-id',
-                        pkgID,
+                        contractID,
                         createdAt: new Date('2022-12-15'),
                         addedBy: mockValidCMSUser({
                             divisionAssignment: 'OACT',

--- a/services/app-web/src/testHelpers/apolloMocks/questionResponseGQLMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/questionResponseGQLMock.ts
@@ -4,7 +4,6 @@ import {
     CreateQuestionResponseDocument,
     CreateQuestionInput,
     CreateQuestionMutation,
-    Question as QuestionType,
     QuestionResponse as QuestionResponseType,
     FetchHealthPlanPackageWithQuestionsDocument,
     FetchHealthPlanPackageWithQuestionsQuery,
@@ -25,8 +24,8 @@ const createQuestionSuccess = (
     question?: CreateQuestionInput | Partial<CreateQuestionInput>
 ): MockedResponse<CreateQuestionMutation> => {
     const defaultQuestionInput: CreateQuestionInput = {
-        dueDate: new Date('11-11-2100'),
-        pkgID: '123-abc',
+        // dueDate: new Date('11-11-2100'),
+        contractID: '123-abc',
         documents: [
             {
                 name: 'Test document',
@@ -47,7 +46,7 @@ const createQuestionSuccess = (
                 createQuestion: {
                     question: {
                         id: 'test123',
-                        pkgID: testInput.pkgID,
+                        contractID: testInput.contractID,
                         createdAt: new Date(),
                         addedBy: mockValidCMSUser(),
                         division: 'DMCO',
@@ -60,15 +59,18 @@ const createQuestionSuccess = (
 }
 
 const createQuestionNetworkFailure = (
-    question?: QuestionType | Partial<QuestionType>
+    input: CreateQuestionInput
 ): MockedResponse<CreateQuestionMutation> => {
     return {
-        request: { query: CreateQuestionDocument },
+        request: {
+            query: CreateQuestionDocument,
+            variables: { input },
+        },
         error: new Error('A network error occurred'),
     }
 }
 const createQuestionResponseNetworkFailure = (
-    question?: QuestionResponseType | Partial<QuestionResponseType>
+    _question?: QuestionResponseType | Partial<QuestionResponseType>
 ): MockedResponse<CreateQuestionMutation> => {
     return {
         request: { query: CreateQuestionResponseDocument },

--- a/services/app-web/src/testHelpers/jestHelpers.tsx
+++ b/services/app-web/src/testHelpers/jestHelpers.tsx
@@ -47,8 +47,9 @@ const renderWithProviders = (
 
     const { route } = routerProvider
     const s3Client: S3ClientT = s3Provider ?? testS3Client()
+    const user = userEvent.setup()
 
-    return render(
+    const renderResult = render(
         <MockedProvider {...apolloProvider}>
             <MemoryRouter initialEntries={[route || '']}>
                 <AuthProvider authMode={'AWS_COGNITO'} {...authProvider}>
@@ -60,6 +61,10 @@ const renderWithProviders = (
             </MemoryRouter>
         </MockedProvider>
     )
+    return {
+        user,
+        ...renderResult,
+    }
 }
 
 const WithLocation = ({

--- a/services/app-web/src/testHelpers/s3Helpers.ts
+++ b/services/app-web/src/testHelpers/s3Helpers.ts
@@ -2,9 +2,11 @@ import { S3ClientT } from '../s3'
 import { parseKey } from '../common-code/s3URLEncoding'
 
 export const testS3Client: () => S3ClientT = () => {
+    let fakeKeyID = 0
+
     return {
         uploadFile: async (file: File): Promise<string> => {
-            return `${Date.now()}-${file.name}`
+            return `fakeS3Key${fakeKeyID++}-${file.name}`
         },
         deleteFile: async (filename: string): Promise<void> => {
             return

--- a/services/cypress/integration/stateWorkflow/questionResponse/questionResponse.spec.ts
+++ b/services/cypress/integration/stateWorkflow/questionResponse/questionResponse.spec.ts
@@ -5,9 +5,10 @@ describe('Q&A', () => {
         cy.interceptGraphQL()
     })
 
-    it.skip('can add questions and responses', () => {
+    it('can add questions and responses', () => {
         cy.interceptFeatureFlags({
             'cms-questions': true,
+            'rates-db-refactor': true
         })
 
         // Assign Division to CMS user zuko

--- a/services/cypress/support/apiCommands.ts
+++ b/services/cypress/support/apiCommands.ts
@@ -23,6 +23,7 @@ import {
     CMSUserType,
 } from '../utils/apollo-test-utils'
 import { ApolloClient, DocumentNode, NormalizedCacheObject } from '@apollo/client'
+import {UnlockedHealthPlanFormDataType} from 'app-web/src/common-code/healthPlanFormDataType';
 
 const createAndSubmitContractOnlyPackage = async (
     apolloClient: ApolloClient<NormalizedCacheObject>
@@ -47,7 +48,7 @@ const createAndSubmitContractOnlyPackage = async (
         ...contractOnlyData(),
     }
 
-    const formDataProto = domainToBase64(fullFormData)
+    const formDataProto = domainToBase64(fullFormData as UnlockedHealthPlanFormDataType)
 
     await apolloClient.mutate({
         mutation: UpdateHealthPlanFormDataDocument,
@@ -94,7 +95,7 @@ const createAndSubmitContractWithRates = async (
         ...contractAndRatesData(),
     }
 
-    const formDataProto = domainToBase64(fullFormData1)
+    const formDataProto = domainToBase64(fullFormData1 as UnlockedHealthPlanFormDataType)
 
     await apolloClient.mutate({
         mutation: UpdateHealthPlanFormDataDocument,


### PR DESCRIPTION
## Summary

This PR changes Questions to be related to the ContractTable rather than the HPPTable and migrates all existing Questions over to the new table (these only exist in dev/val)

When we add questions to Rates it will add complexity but this PR is pretty simple. 

Joy: almost all the code changes were driven by compiler errors. 

#### Related issues

https://qmacbis.atlassian.net/browse/MCR-2640

## QA guidance

Should be able to create questions in environments with the db refactor (which is all of them now)
