### PR TITLE
[MCR-3568] CMS Dashboard Page Title Accessibility improvement 

### DIFF
--- a/services/app-web/src/constants/routes.ts
+++ b/services/app-web/src/constants/routes.ts
@@ -101,8 +101,8 @@ const QUESTION_RESPONSE_SHOW_SIDEBAR_ROUTES: RouteTWithUnknown[] = [
 */
 const PageHeadingsRecord: Partial<Record<RouteTWithUnknown, string>> = {
     ROOT: 'Dashboard',
-    DASHBOARD_SUBMISSIONS: 'Dashboard',
-    DASHBOARD_RATES: 'Dashboard',
+    DASHBOARD_SUBMISSIONS: 'Submissions Dashboard',
+    DASHBOARD_RATES: 'Rate Reviews Dashboard',
     SUBMISSIONS_NEW: 'New submission',
     UNKNOWN_ROUTE: '404',
 }

--- a/services/cypress/integration/stateWorkflow/dashboard/dashboard.spec.ts
+++ b/services/cypress/integration/stateWorkflow/dashboard/dashboard.spec.ts
@@ -108,7 +108,7 @@ describe('dashboard', () => {
 
             // Link back to dashboard, submission visible in default program
             cy.findByText('Back to state dashboard').should('exist').click()
-            cy.findByText('Dashboard').should('exist')
+            cy.findByText('Submissions Dashboard').should('exist')
             // check the table of submissions--find a draft row, then the link in the ID column
             cy.get('table')
                 .contains('span', 'Draft')

--- a/services/cypress/integration/stateWorkflow/login/login.spec.ts
+++ b/services/cypress/integration/stateWorkflow/login/login.spec.ts
@@ -17,7 +17,7 @@ describe('login', () => {
         cy.logInAsStateUser()
 
         cy.findByText('aang@example.com').should('exist')
-        cy.findByRole('heading', { name: 'Minnesota Dashboard' }).should(
+        cy.findByRole('heading', { name: 'Minnesota Submissions Dashboard' }).should(
             'exist'
         )
     })

--- a/services/cypress/support/loginCommands.ts
+++ b/services/cypress/support/loginCommands.ts
@@ -72,7 +72,7 @@ Cypress.Commands.add(
             // Default behavior on login is to go to CMS dashboard submissions
             cy.wait('@indexHealthPlanPackagesQuery', { timeout: 80_000 })
             cy.findByTestId('cms-dashboard-page',{timeout: 10_000 }).should('exist')
-            cy.findByRole('heading', {name: /Submissions/}).should('exist')
+            cy.findByRole('heading', {name: /Submissions Dashboard/}).should('exist')
         }
     }
 )


### PR DESCRIPTION
## Summary

This PR implements Hana's [suggestion](https://qmacbis.atlassian.net/browse/MCR-3568?focusedCommentId=125483) to add more details to the page titles for the dashboard submissions and rate review pages. 

- Replaces the previous "Dashboard" title for both the submissions and rate review pages to be "Submissions Dashboard" and "Rate Reviews Dashboard" so that the screen readers and all users are given more context on which page they're on when switching between the submissions and rate review tabs

#### Related issues
https://qmacbis.atlassian.net/browse/MCR-3568

#### Screenshots

https://github.com/Enterprise-CMCS/managed-care-review/assets/67110378/d189ca45-c4b9-4359-88b4-613c712bd239



