### PR TITLE
MCR-3600 & MCR-3605: 438 Attestation

### DIFF
--- a/services/app-api/prisma/migrations/20231113040740_add_statutory_regulatory_attestation/migration.sql
+++ b/services/app-api/prisma/migrations/20231113040740_add_statutory_regulatory_attestation/migration.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+-- AlterTable
+ALTER TABLE "ContractRevisionTable" ADD COLUMN     "statutoryRegulatoryAttestation" BOOLEAN;
+
+COMMIT;

--- a/services/app-api/prisma/schema.prisma
+++ b/services/app-api/prisma/schema.prisma
@@ -115,6 +115,7 @@ model ContractRevisionTable {
   modifiedLengthOfContract                     Boolean?
   modifiedNonRiskPaymentArrangements           Boolean?
   inLieuServicesAndSettings                    Boolean?
+  statutoryRegulatoryAttestation               Boolean?
 }
 
 model RateRevisionTable {

--- a/services/app-api/src/domain-models/contractAndRates/convertContractWithRatesToHPP.ts
+++ b/services/app-api/src/domain-models/contractAndRates/convertContractWithRatesToHPP.ts
@@ -231,6 +231,8 @@ function convertContractWithRatesToFormData(
                     contractRev.formData.modifiedNonRiskPaymentArrangements,
             },
         },
+        statutoryRegulatoryAttestation:
+            contractRev.formData.statutoryRegulatoryAttestation,
         rateInfos,
     }
 

--- a/services/app-api/src/domain-models/contractAndRates/formDataTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/formDataTypes.ts
@@ -64,6 +64,7 @@ const contractFormDataSchema = z.object({
     modifiedNetworkAdequacyStandards: z.boolean().optional(),
     modifiedLengthOfContract: z.boolean().optional(),
     modifiedNonRiskPaymentArrangements: z.boolean().optional(),
+    statutoryRegulatoryAttestation: z.boolean().optional(),
 })
 
 const rateFormDataSchema = z.object({

--- a/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
@@ -339,6 +339,8 @@ function contractFormDataToDomainModel(
             contractRevision.modifiedNonRiskPaymentArrangements ?? undefined,
         inLieuServicesAndSettings:
             contractRevision.inLieuServicesAndSettings ?? undefined,
+        statutoryRegulatoryAttestation:
+            contractRevision.statutoryRegulatoryAttestation ?? undefined,
     }
 }
 

--- a/services/app-api/src/postgres/contractAndRates/unlockContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/unlockContract.ts
@@ -141,6 +141,8 @@ async function unlockContract(
                         currentRev.modifiedLengthOfContract,
                     modifiedNonRiskPaymentArrangements:
                         currentRev.modifiedNonRiskPaymentArrangements,
+                    statutoryRegulatoryAttestation:
+                        currentRev.statutoryRegulatoryAttestation,
 
                     contractDocuments: {
                         create: currentRev.contractDocuments.map((d) => ({

--- a/services/app-api/src/postgres/contractAndRates/updateDraftContractWithRates.ts
+++ b/services/app-api/src/postgres/contractAndRates/updateDraftContractWithRates.ts
@@ -130,6 +130,7 @@ async function updateDraftContractWithRates(
         modifiedLengthOfContract,
         modifiedNonRiskPaymentArrangements,
         inLieuServicesAndSettings,
+        statutoryRegulatoryAttestation,
     } = formData
 
     try {
@@ -503,6 +504,9 @@ async function updateDraftContractWithRates(
                     modifiedLengthOfContract: nullify(modifiedLengthOfContract),
                     modifiedNonRiskPaymentArrangements: nullify(
                         modifiedNonRiskPaymentArrangements
+                    ),
+                    statutoryRegulatoryAttestation: nullify(
+                        statutoryRegulatoryAttestation
                     ),
                     draftRates: {
                         disconnect: updateRates?.disconnectRates

--- a/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.test.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.test.ts
@@ -101,6 +101,7 @@ describe.each(flagValueTestParameters)(
                         modifiedNonRiskPaymentArrangements: undefined,
                     },
                 },
+                statutoryRegulatoryAttestation: true,
                 rateInfos: [],
             })
 

--- a/services/app-api/src/testHelpers/contractAndRates/contractHelpers.ts
+++ b/services/app-api/src/testHelpers/contractAndRates/contractHelpers.ts
@@ -206,6 +206,7 @@ const createContractRevision = (
         inLieuServicesAndSettings: null,
         rateRevisions: [],
         draftRates: [],
+        statutoryRegulatoryAttestation: null,
         ...revision,
     }
 }

--- a/services/app-api/src/testHelpers/emailerHelpers.ts
+++ b/services/app-api/src/testHelpers/emailerHelpers.ts
@@ -337,6 +337,7 @@ const mockContractAndRatesFormData = (
         ],
         addtlActuaryCommunicationPreference: 'OACT_TO_ACTUARY',
         ...submissionPartial,
+        statutoryRegulatoryAttestation: false,
     }
 }
 
@@ -520,6 +521,7 @@ const mockContractOnlyFormData = (
             },
         ],
         addtlActuaryContacts: [],
+        statutoryRegulatoryAttestation: false,
         ...submissionPartial,
     }
 }
@@ -606,6 +608,7 @@ const mockContractAmendmentFormData = (
             },
         ],
         addtlActuaryCommunicationPreference: 'OACT_TO_ACTUARY',
+        statutoryRegulatoryAttestation: false,
         ...submissionPartial,
     }
 }

--- a/services/app-api/src/testHelpers/gqlHelpers.ts
+++ b/services/app-api/src/testHelpers/gqlHelpers.ts
@@ -299,6 +299,7 @@ const createAndUpdateTestHealthPlanPackage = async (
             modifiedNonRiskPaymentArrangements: true,
         },
     }
+    draft.statutoryRegulatoryAttestation = true
 
     Object.assign(draft, partialUpdates)
 

--- a/services/app-proto/src/health_plan_form_data.proto
+++ b/services/app-proto/src/health_plan_form_data.proto
@@ -81,6 +81,7 @@ message ContractInfo {
   repeated FederalAuthority federal_authorities = 5;
   repeated Document contract_documents = 6;
   optional ContractExecutionStatus contract_execution_status = 7;
+  optional bool statutory_regulatory_attestation = 8;
 
   // Rates Refactor: No need for nested contract amendment info
   optional ContractAmendmentInfo contract_amendment_info  = 50;

--- a/services/app-web/src/common-code/featureFlags/flags.ts
+++ b/services/app-web/src/common-code/featureFlags/flags.ts
@@ -76,6 +76,10 @@ const featureFlags = {
         flag: 'rate-filters',
         defaultValue: false,
     },
+    CONTRACT_438_ATTESTATION: {
+        flag: '438-attestation',
+        defaultValue: false,
+    },
     /**
      * Used in testing to simulate errors in fetching flag value.
      * This flag does not exist in LaunchDarkly dashboard so fetching this will return the defaultValue.

--- a/services/app-web/src/common-code/healthPlanFormDataMocks/healthPlanFormData.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataMocks/healthPlanFormData.ts
@@ -763,6 +763,7 @@ function basicLockedHealthPlanFormData(): LockedHealthPlanFormDataType {
         programIDs: [mockMNState().programs[0].id],
         submissionType: 'CONTRACT_ONLY',
         riskBasedContract: false,
+        statutoryRegulatoryAttestation: false,
         submissionDescription: 'A real submission',
         documents: [],
         contractType: 'BASE',

--- a/services/app-web/src/common-code/healthPlanFormDataType/LockedHealthPlanFormDataType.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/LockedHealthPlanFormDataType.ts
@@ -42,4 +42,5 @@ export type LockedHealthPlanFormDataType = {
     stateContacts: StateContact[]
     addtlActuaryContacts: ActuaryContact[]
     addtlActuaryCommunicationPreference?: ActuaryCommunicationType
+    statutoryRegulatoryAttestation: boolean
 }

--- a/services/app-web/src/common-code/healthPlanFormDataType/UnlockedHealthPlanFormDataType.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/UnlockedHealthPlanFormDataType.ts
@@ -118,6 +118,7 @@ type UnlockedHealthPlanFormDataType = {
     federalAuthorities: FederalAuthority[]
     contractAmendmentInfo?: UnlockedContractAmendmentInfo
     rateInfos: RateInfoType[]
+    statutoryRegulatoryAttestation?: boolean
 }
 
 export type {

--- a/services/app-web/src/common-code/proto/healthPlanFormDataProto/toDomain.ts
+++ b/services/app-web/src/common-code/proto/healthPlanFormDataProto/toDomain.ts
@@ -543,6 +543,8 @@ const toDomain = (
         stateContacts: cleanedStateContacts,
         addtlActuaryContacts: parseActuaryContacts(addtlActuaryContacts),
         documents: parseProtoDocuments(formDataMessage.documents),
+        statutoryRegulatoryAttestation:
+            contractInfo?.statutoryRegulatoryAttestation ?? undefined,
     }
 
     // Now that we've gotten things into our combined draft & state domain format.

--- a/services/app-web/src/common-code/proto/healthPlanFormDataProto/toProtoBuffer.ts
+++ b/services/app-web/src/common-code/proto/healthPlanFormDataProto/toProtoBuffer.ts
@@ -65,7 +65,9 @@ function domainEnumStringToProtoString(
     return protoEnumString
 }
 
-const domainDocsToProtoDocs = (domainDocs:SubmissionDocument[]): mcreviewproto.IDocument[] | null | undefined => {
+const domainDocsToProtoDocs = (
+    domainDocs: SubmissionDocument[]
+): mcreviewproto.IDocument[] | null | undefined => {
     return domainDocs.map((doc) => ({
         s3Url: doc.s3URL,
         name: doc.name,
@@ -190,8 +192,12 @@ const toProtoBuffer = (
                 mcreviewproto.FederalAuthority,
                 domainData.federalAuthorities
             ),
-            contractDocuments: domainDocsToProtoDocs(domainData.contractDocuments),
+            contractDocuments: domainDocsToProtoDocs(
+                domainData.contractDocuments
+            ),
             contractAmendmentInfo: contractAmendmentInfo,
+            statutoryRegulatoryAttestation:
+                domainData.statutoryRegulatoryAttestation,
         },
         rateInfos:
             domainData.rateInfos && domainData.rateInfos.length
@@ -215,8 +221,12 @@ const toProtoBuffer = (
                           rateDateCertified: domainDateToProtoDate(
                               rateInfo.rateDateCertified
                           ),
-                          rateDocuments: domainDocsToProtoDocs(rateInfo.rateDocuments),
-                          supportingDocuments: domainDocsToProtoDocs(rateInfo.supportingDocuments),
+                          rateDocuments: domainDocsToProtoDocs(
+                              rateInfo.rateDocuments
+                          ),
+                          supportingDocuments: domainDocsToProtoDocs(
+                              rateInfo.supportingDocuments
+                          ),
                           rateCertificationName: generateRateName(
                               domainData,
                               rateInfo,

--- a/services/app-web/src/common-code/proto/healthPlanFormDataProto/zodSchemas.ts
+++ b/services/app-web/src/common-code/proto/healthPlanFormDataProto/zodSchemas.ts
@@ -38,7 +38,7 @@ const submissionDocumentSchema = z.object({
             .optional()
     ),
     sha256: z.string().optional(),
-    id: z.string().optional() // doesn't exist for newly created
+    id: z.string().optional(), // doesn't exist for newly created
 })
 
 const contractAmendmentInfoSchema = z.object({
@@ -168,6 +168,7 @@ const unlockedHealthPlanFormDataZodSchema = z.object({
     federalAuthorities: z.array(federalAuthoritySchema),
     contractAmendmentInfo: contractAmendmentInfoSchema.optional(),
     rateInfos: z.array(rateInfosTypeSchema),
+    statutoryRegulatoryAttestation: z.boolean().optional(),
 })
 
 /*

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -34,6 +34,14 @@ import { DocumentDateLookupTableType } from '../../../documentHelpers/makeDocume
 import { recordJSException } from '../../../otelHelpers'
 import useDeepCompareEffect from 'use-deep-compare-effect'
 import { InlineDocumentWarning } from '../../DocumentWarning'
+import { useLDClient } from 'launchdarkly-react-client-sdk'
+import { featureFlags } from '../../../common-code/featureFlags'
+import { Grid } from '@trussworks/react-uswds'
+import { booleanAsYesNoFormValue } from '../../Form/FieldYesNo'
+import {
+    StatutoryRegulatoryAttestation,
+    StatutoryRegulatoryAttestationQuestion,
+} from '../../../constants/statutoryRegulatoryAttestation'
 
 export type ContractDetailsSummarySectionProps = {
     submission: HealthPlanFormDataType
@@ -72,6 +80,17 @@ export const ContractDetailsSummarySection = ({
     const [zippedFilesURL, setZippedFilesURL] = useState<
         string | undefined | Error
     >(undefined)
+    const ldClient = useLDClient()
+
+    const contract438Attestation = ldClient?.variation(
+        featureFlags.CONTRACT_438_ATTESTATION.flag,
+        featureFlags.CONTRACT_438_ATTESTATION.defaultValue
+    )
+
+    const attestationYesNo = booleanAsYesNoFormValue(
+        submission.statutoryRegulatoryAttestation
+    )
+
     const contractSupportingDocuments = submission.documents.filter((doc) =>
         doc.documentCategories.includes('CONTRACT_RELATED' as const)
     )
@@ -143,6 +162,23 @@ export const ContractDetailsSummarySection = ({
                     renderDownloadButton(zippedFilesURL)}
             </SectionHeader>
             <dl>
+                {contract438Attestation && (
+                    <Grid row gap className={styles.singleColumnGrid}>
+                        <Grid col={12}>
+                            <DataDetail
+                                id="statutoryRegulatoryAttestation"
+                                label={StatutoryRegulatoryAttestationQuestion}
+                                explainMissingData={!isSubmitted(submission)}
+                                children={
+                                    attestationYesNo !== undefined &&
+                                    StatutoryRegulatoryAttestation[
+                                        attestationYesNo
+                                    ]
+                                }
+                            />
+                        </Grid>
+                    </Grid>
+                )}
                 <DoubleColumnGrid>
                     <DataDetail
                         id="contractExecutionStatus"

--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionSummarySection.module.scss
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionSummarySection.module.scss
@@ -92,6 +92,13 @@
         line-height: 1.5;
     }
 }
+
+.singleColumnGrid {
+    @include at-media(tablet) {
+        margin-bottom: units(2);
+    }
+}
+
 @media print {
     header,
     footer,

--- a/services/app-web/src/constants/statutoryRegulatoryAttestation.ts
+++ b/services/app-web/src/constants/statutoryRegulatoryAttestation.ts
@@ -1,6 +1,6 @@
 const StatutoryRegulatoryAttestation = {
     YES: 'Yes the contract fully complies with all applicable requirements.',
-    NO: 'No the contract does not fully comply with all applicable requirements',
+    NO: 'No the contract does not fully comply with all applicable requirements.',
 }
 
 const StatutoryRegulatoryAttestationQuestion =

--- a/services/app-web/src/constants/statutoryRegulatoryAttestation.ts
+++ b/services/app-web/src/constants/statutoryRegulatoryAttestation.ts
@@ -1,6 +1,6 @@
 const StatutoryRegulatoryAttestation = {
-    YES: 'Yes the contract fully complies with all applicable requirements.',
-    NO: 'No the contract does not fully comply with all applicable requirements.',
+    YES: 'Yes, the contract fully complies with all applicable requirements',
+    NO: 'No, the contract does not fully comply with all applicable requirements',
 }
 
 const StatutoryRegulatoryAttestationQuestion =

--- a/services/app-web/src/constants/statutoryRegulatoryAttestation.ts
+++ b/services/app-web/src/constants/statutoryRegulatoryAttestation.ts
@@ -1,0 +1,12 @@
+const StatutoryRegulatoryAttestation = {
+    YES: 'Yes the contract fully complies with all applicable requirements.',
+    NO: 'No the contract does not fully comply with all applicable requirements',
+}
+
+const StatutoryRegulatoryAttestationQuestion =
+    'Do you attest that this contract complies with all applicable statutory and regulatory requirements including those contained in Title 42 Part 438 and Part 457 of the Code of Federal Regulations (CFR)?'
+
+export {
+    StatutoryRegulatoryAttestation,
+    StatutoryRegulatoryAttestationQuestion,
+}

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
@@ -38,6 +38,10 @@ describe('ContractDetails', () => {
         ...mockDraft(),
     }
 
+    const defaultApolloProvider = {
+        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+    }
+
     it('displays correct form guidance', async () => {
         renderWithProviders(
             <ContractDetails
@@ -46,9 +50,7 @@ describe('ContractDetails', () => {
                 previousDocuments={[]}
             />,
             {
-                apolloProvider: {
-                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                },
+                apolloProvider: defaultApolloProvider,
             }
         )
         expect(
@@ -69,9 +71,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
 
@@ -106,9 +106,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
 
@@ -129,9 +127,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
 
@@ -155,20 +151,27 @@ describe('ContractDetails', () => {
     })
 
     describe('Federal authorities', () => {
-        it('displays correct form fields for federal authorities with medicaid contract', () => {
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={{
-                        ...mockDraft(),
-                        populationCovered: 'MEDICAID',
-                    }}
-                    updateDraft={jest.fn()}
-                    previousDocuments={[]}
-                />
-            )
+        it('displays correct form fields for federal authorities with medicaid contract', async () => {
+            await waitFor(() => {
+                renderWithProviders(
+                    <ContractDetails
+                        draftSubmission={{
+                            ...mockDraft(),
+                            populationCovered: 'MEDICAID',
+                        }}
+                        updateDraft={jest.fn()}
+                        previousDocuments={[]}
+                    />,
+                    {
+                        apolloProvider: defaultApolloProvider,
+                    }
+                )
+            })
+
             const fedAuthQuestion = screen.getByRole('group', {
                 name: 'Active federal operating authority',
             })
+
             expect(fedAuthQuestion).toBeInTheDocument()
             expect(
                 within(fedAuthQuestion).getAllByRole('checkbox')
@@ -189,7 +192,10 @@ describe('ContractDetails', () => {
                     }}
                     updateDraft={jest.fn()}
                     previousDocuments={[]}
-                />
+                />,
+                {
+                    apolloProvider: defaultApolloProvider,
+                }
             )
             const fedAuthQuestion = await screen.findByRole('group', {
                 name: 'Active federal operating authority',
@@ -233,9 +239,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
             await screen.findByRole('form')
@@ -281,9 +285,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
             // trigger validations
@@ -343,9 +345,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
             await screen.findByRole('form')
@@ -378,9 +378,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
 
@@ -433,9 +431,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
             await screen.findByRole('form')
@@ -457,9 +453,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
             await screen.findByRole('form')
@@ -501,9 +495,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
 
@@ -566,9 +558,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
 
@@ -592,9 +582,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
 
@@ -623,9 +611,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
 
@@ -634,7 +620,7 @@ describe('ContractDetails', () => {
             })
             expect(continueButton).not.toHaveAttribute('aria-disabled')
 
-            continueButton.click()
+            await userEvent.click(continueButton)
 
             await waitFor(() => {
                 expect(
@@ -653,9 +639,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
 
@@ -667,9 +651,10 @@ describe('ContractDetails', () => {
             await userEvent.upload(input, [TEST_DOC_FILE])
             await userEvent.upload(input, []) // clear input and ensure we add same file twice
             await userEvent.upload(input, [TEST_DOC_FILE])
-            expect(continueButton).not.toHaveAttribute('aria-disabled')
 
-            continueButton.click()
+            expect(continueButton).not.toHaveAttribute('aria-disabled')
+            await userEvent.click(continueButton)
+
             await waitFor(() => {
                 expect(
                     screen.getAllByText(
@@ -689,9 +674,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
             const continueButton = screen.getByRole('button', {
@@ -706,7 +689,7 @@ describe('ContractDetails', () => {
             ).toBeInTheDocument()
 
             expect(continueButton).not.toHaveAttribute('aria-disabled')
-            continueButton.click()
+            await userEvent.click(continueButton)
 
             expect(
                 await screen.findAllByText(
@@ -724,9 +707,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
             const continueButton = screen.getByRole('button', {
@@ -749,14 +730,16 @@ describe('ContractDetails', () => {
                 'file-input-preview-image'
             )[1]
             expect(imageElFile2).toHaveClass('is-loading')
-            fireEvent.click(continueButton)
-            expect(continueButton).toHaveAttribute('aria-disabled', 'true')
+            await waitFor(() => {
+                fireEvent.click(continueButton)
+                expect(continueButton).toHaveAttribute('aria-disabled', 'true')
 
-            expect(
-                screen.getAllByText(
-                    'You must wait for all documents to finish uploading before continuing'
-                )
-            ).toHaveLength(2)
+                expect(
+                    screen.getAllByText(
+                        'You must wait for all documents to finish uploading before continuing'
+                    )
+                ).toHaveLength(2)
+            })
         })
     })
 
@@ -770,9 +753,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
 
@@ -797,9 +778,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
 
@@ -826,9 +805,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
 
@@ -864,9 +841,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
 
@@ -891,9 +866,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
             const input = screen.getByLabelText('Upload contract')
@@ -931,9 +904,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
 
@@ -957,9 +928,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
 
@@ -986,9 +955,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
 
@@ -1013,9 +980,7 @@ describe('ContractDetails', () => {
                     previousDocuments={[]}
                 />,
                 {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
+                    apolloProvider: defaultApolloProvider,
                 }
             )
 

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
@@ -1028,7 +1028,7 @@ describe('ContractDetails', () => {
     })
 
     describe('Contract 438 attestation', () => {
-        it('renders 438 attestation question errors', async () => {
+        it('renders 438 attestation question without errors', async () => {
             ldUseClientSpy({ '438-attestation': true })
             const draft = mockBaseContract({
                 statutoryRegulatoryAttestation: true,

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -604,13 +604,45 @@ export const ContractDetails = ({
                                                 }
                                             </b>
                                         </legend>
-                                        <span
+                                        <div
+                                            role="note"
                                             className={
-                                                styles.requiredOptionalText
+                                                styles.contractAttestationHint
                                             }
                                         >
-                                            Required
-                                        </span>
+                                            <span
+                                                className={
+                                                    styles.requiredOptionalText
+                                                }
+                                            >
+                                                Required
+                                            </span>
+                                            <span>
+                                                <Link
+                                                    aria-label="Managed Care Contract Review and Approval State Guide (opens in new window)"
+                                                    href={
+                                                        'https://www.medicaid.gov/sites/default/files/2022-01/mce-checklist-state-user-guide.pdf'
+                                                    }
+                                                    variant="external"
+                                                    target="_blank"
+                                                >
+                                                    Managed Care Contract Review
+                                                    and Approval State Guide
+                                                </Link>
+                                                <Link
+                                                    aria-label="CHIP Managed Care Contract Review and Approval State Guide (opens in new window)"
+                                                    href={
+                                                        'https://www.medicaid.gov/sites/default/files/2022-04/chip-managed-care-contract-guide_0.pdf'
+                                                    }
+                                                    variant="external"
+                                                    target="_blank"
+                                                >
+                                                    CHIP Managed Care Contract
+                                                    Review and Approval State
+                                                    Guide
+                                                </Link>
+                                            </span>
+                                        </div>
                                         {showFieldErrors(
                                             errors.statutoryRegulatoryAttestation
                                         ) && (

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetailsSchema.ts
@@ -52,7 +52,11 @@ export const ContractDetailsFormSchema = (
         }
     }
 
+    // Errors in the error summary is ordered by the position of each ket in the yup object.
     return Yup.object().shape({
+        statutoryRegulatoryAttestation: activeFeatureFlags['438-attestation']
+            ? Yup.string().defined('You must select yes or no')
+            : Yup.string(),
         contractExecutionStatus: Yup.string().defined(
             'You must select a contract status'
         ),
@@ -134,8 +138,5 @@ export const ContractDetailsFormSchema = (
         modifiedNonRiskPaymentArrangements: yesNoError(
             'modifiedNonRiskPaymentArrangements'
         ),
-        statutoryRegulatoryAttestation: activeFeatureFlags['438-attestation']
-            ? Yup.string().defined('You must select yes or no')
-            : Yup.string(),
     })
 }

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetailsSchema.ts
@@ -17,11 +17,13 @@ import {
     isMedicaidAmendmentProvision,
     isMedicaidBaseProvision,
 } from '../../../common-code/healthPlanFormDataType/ModifiedProvisions'
+import { FeatureFlagSettings } from '../../../common-code/featureFlags'
 
 Yup.addMethod(Yup.date, 'validateDateFormat', validateDateFormat)
 
 export const ContractDetailsFormSchema = (
-    draftSubmission: UnlockedHealthPlanFormDataType
+    draftSubmission: UnlockedHealthPlanFormDataType,
+    activeFeatureFlags: FeatureFlagSettings = {}
 ) => {
     const yesNoError = (provision: GeneralizedProvisionType) => {
         const noValidation = Yup.string().nullable()
@@ -132,5 +134,8 @@ export const ContractDetailsFormSchema = (
         modifiedNonRiskPaymentArrangements: yesNoError(
             'modifiedNonRiskPaymentArrangements'
         ),
+        statutoryRegulatoryAttestation: activeFeatureFlags['438-attestation']
+            ? Yup.string().defined('You must select yes or no')
+            : Yup.string(),
     })
 }

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.module.scss
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.module.scss
@@ -149,3 +149,10 @@
     display: flex;
     flex-direction: column;
 }
+
+.contractAttestationHint {
+    margin-bottom: units(3);
+    a {
+        margin-top: units(1);
+    }
+}

--- a/services/app-web/src/testHelpers/apolloMocks/healthPlanFormDataMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/healthPlanFormDataMock.ts
@@ -116,6 +116,7 @@ function mockBaseContract(
         ],
         addtlActuaryContacts: [],
         addtlActuaryCommunicationPreference: undefined,
+        statutoryRegulatoryAttestation: true,
         ...partial,
     }
 }

--- a/services/app-web/src/testHelpers/apolloMocks/healthPlanFormDataMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/healthPlanFormDataMock.ts
@@ -318,6 +318,7 @@ function mockStateSubmission(): LockedHealthPlanFormDataType {
         ],
         addtlActuaryContacts: [],
         addtlActuaryCommunicationPreference: undefined,
+        statutoryRegulatoryAttestation: false,
     }
 }
 
@@ -417,6 +418,7 @@ function mockStateSubmissionContractAmendment(): LockedHealthPlanFormDataType {
         ],
         addtlActuaryContacts: [],
         addtlActuaryCommunicationPreference: undefined,
+        statutoryRegulatoryAttestation: false,
     }
 }
 

--- a/services/app-web/src/testHelpers/apolloMocks/healthPlanFormDataMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/healthPlanFormDataMock.ts
@@ -211,6 +211,7 @@ function mockContractAndRatesDraft(
             },
         ],
         addtlActuaryCommunicationPreference: 'OACT_TO_ACTUARY',
+        statutoryRegulatoryAttestation: true,
         ...partial,
     }
 }

--- a/services/app-web/src/testHelpers/jestHelpers.tsx
+++ b/services/app-web/src/testHelpers/jestHelpers.tsx
@@ -23,6 +23,8 @@ import {
     FeatureFlagLDConstant,
     FlagValue,
     FeatureFlagSettings,
+    featureFlagKeys,
+    featureFlags,
 } from '../common-code/featureFlags'
 
 /* Render */
@@ -77,6 +79,13 @@ const WithLocation = ({
     return null
 }
 
+const getDefaultFeatureFlags = (): FeatureFlagSettings =>
+    featureFlagKeys.reduce((a, c) => {
+        const flag = featureFlags[c].flag
+        const defaultValue = featureFlags[c].defaultValue
+        return Object.assign(a, { [flag]: defaultValue })
+    }, {} as FeatureFlagSettings)
+
 //WARNING: This required tests using this function to clear mocks afterwards.
 const ldUseClientSpy = (featureFlags: FeatureFlagSettings) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -108,6 +117,11 @@ const ldUseClientSpy = (featureFlags: FeatureFlagSettings) => {
                 return featureFlags[flag] === undefined
                     ? defaultValue
                     : featureFlags[flag]
+            },
+            allFlags: () => {
+                const defaultFeatureFlags = getDefaultFeatureFlags()
+                Object.assign(defaultFeatureFlags, featureFlags)
+                return defaultFeatureFlags
             },
         }
     })

--- a/services/cypress/support/launchDarklyCommands.ts
+++ b/services/cypress/support/launchDarklyCommands.ts
@@ -86,7 +86,8 @@ Cypress.Commands.add('stubFeatureFlags', () => {
     cy.interceptFeatureFlags({
         'packages-with-shared-rates': true,
         'rates-db-refactor': true,
-        'supporting-docs-by-rate': true
+        'supporting-docs-by-rate': true,
+        '438-attestation': true
     })
 })
 

--- a/services/cypress/support/stateSubmissionFormCommands.ts
+++ b/services/cypress/support/stateSubmissionFormCommands.ts
@@ -177,6 +177,9 @@ Cypress.Commands.add('fillOutBaseContractDetails', () => {
 
 Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
     // Must be on '/submissions/:id/edit/contract-details'
+    // Contract 438 attestation question
+    cy.findByText('No the contract does not fully comply with all applicable requirements.').click()
+
     cy.findByText('Unexecuted by some or all parties').click()
 
     cy.findAllByLabelText('Start date', {timeout: 2000})

--- a/services/cypress/support/stateSubmissionFormCommands.ts
+++ b/services/cypress/support/stateSubmissionFormCommands.ts
@@ -100,7 +100,7 @@ Cypress.Commands.add('fillOutContractActionAndRateCertification', () => {
 Cypress.Commands.add('fillOutBaseContractDetails', () => {
     // Must be on '/submissions/:id/edit/contract-details'
     // Contract 438 attestation question
-    cy.findByText('Yes the contract fully complies with all applicable requirements').click()
+    cy.findByText('Yes, the contract fully complies with all applicable requirements').click()
 
     cy.findByText('Fully executed').click()
     cy.findAllByLabelText('Start date', {timeout: 2000})
@@ -178,7 +178,7 @@ Cypress.Commands.add('fillOutBaseContractDetails', () => {
 Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
     // Must be on '/submissions/:id/edit/contract-details'
     // Contract 438 attestation question
-    cy.findByText('No the contract does not fully comply with all applicable requirements').click()
+    cy.findByText('No, the contract does not fully comply with all applicable requirements').click()
 
     cy.findByText('Unexecuted by some or all parties').click()
 

--- a/services/cypress/support/stateSubmissionFormCommands.ts
+++ b/services/cypress/support/stateSubmissionFormCommands.ts
@@ -99,6 +99,9 @@ Cypress.Commands.add('fillOutContractActionAndRateCertification', () => {
     })
 Cypress.Commands.add('fillOutBaseContractDetails', () => {
     // Must be on '/submissions/:id/edit/contract-details'
+    // Contract 438 attestation question
+    cy.findByText('Yes the contract fully complies with all applicable requirements.').click()
+
     cy.findByText('Fully executed').click()
     cy.findAllByLabelText('Start date', {timeout: 2000})
         .parents()

--- a/services/cypress/support/stateSubmissionFormCommands.ts
+++ b/services/cypress/support/stateSubmissionFormCommands.ts
@@ -100,7 +100,7 @@ Cypress.Commands.add('fillOutContractActionAndRateCertification', () => {
 Cypress.Commands.add('fillOutBaseContractDetails', () => {
     // Must be on '/submissions/:id/edit/contract-details'
     // Contract 438 attestation question
-    cy.findByText('Yes the contract fully complies with all applicable requirements.').click()
+    cy.findByText('Yes the contract fully complies with all applicable requirements').click()
 
     cy.findByText('Fully executed').click()
     cy.findAllByLabelText('Start date', {timeout: 2000})
@@ -178,7 +178,7 @@ Cypress.Commands.add('fillOutBaseContractDetails', () => {
 Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
     // Must be on '/submissions/:id/edit/contract-details'
     // Contract 438 attestation question
-    cy.findByText('No the contract does not fully comply with all applicable requirements.').click()
+    cy.findByText('No the contract does not fully comply with all applicable requirements').click()
 
     cy.findByText('Unexecuted by some or all parties').click()
 

--- a/services/cypress/utils/apollo-test-utils.ts
+++ b/services/cypress/utils/apollo-test-utils.ts
@@ -100,6 +100,7 @@ const contractOnlyData = (): Partial<UnlockedHealthPlanFormDataType>=> ({
     managedCareEntities: ['MCO'],
     federalAuthorities: ['STATE_PLAN'],
     rateInfos: [],
+    statutoryRegulatoryAttestation: true
 })
 
 const contractAndRatesData = (): Partial<UnlockedHealthPlanFormDataType>=> ({
@@ -200,9 +201,8 @@ const contractAndRatesData = (): Partial<UnlockedHealthPlanFormDataType>=> ({
                 actuaryCommunicationPreference: 'OACT_TO_ACTUARY' as const,
                 packagesWithSharedRateCerts: [],
             },
-    ]
-
-
+    ],
+    statutoryRegulatoryAttestation: true
 })
 
 const newSubmissionInput = (overrides?: Partial<UnlockedHealthPlanFormDataType> ): Partial<UnlockedHealthPlanFormDataType> => {


### PR DESCRIPTION
## Summary
[MCR-3600](https://qmacbis.atlassian.net/browse/MCR-3600)

- Database and schema work
   - Add `statutoryRegulatoryAttestation` to `ContractRevisionTable`
   - Add `statutoryRegulatoryAttestation` to `ContractFormDataType ` Domain types
   - Add `statutoryRegulatoryAttestation` to `ContractInfo` Protobuf schema
   - Add `statutoryRegulatoryAttestation` to `UnlockedHealthPlanFormDataType` and `LockedHealthPlanFormDataType`
   - Add `statutoryRegulatoryAttestation` to  `app-web/src/common-code/proto/healthPlanFormDataProto/zodSchemas.ts`.
- API Work
   -  `updateDraftContractWithRates` and `unlockContract` handler to update `statutoryRegulatoryAttestation`
   - Update `submitHealthPlanPackage` resolver to validate on `statutoryRegulatoryAttestation`
   - Update `contractFormDataToDomainModel` and `convertContractWithRatesToFormData` for `statutoryRegulatoryAttestation`
   - Update test helpers and mocks
- Frontend Work
   - Add feature flag `438-attestation`
   - Update `toDomain` and `toProtoBuffer` for `statutoryRegulatoryAttestation`
   - Add attestation question and radio to `Contract Details` page
   - Display attestation question and answer on summary pages.
   - Fixed warnings on existing unit tests in `ContractDetails.test.ts` and `ContractDetailsSummarySection.test.ts`.
   - Mocked `useLDClient.allFlags` method for jest tests
   - Update helpers and mocks
   
[MCR-3605](https://qmacbis.atlassian.net/browse/MCR-3605)

- Add two links for the contract 438 attestation question on the `Contract details` page.
![Screenshot 2023-11-14 at 12 59 19 PM](https://github.com/Enterprise-CMCS/managed-care-review/assets/98117700/5536efb5-41ec-4f3b-9624-0fd1d9dda47d)

#### Related issues

#### Screenshots

#### Test cases covered

- Unit Tests
   - `submitHealthPlanPackage.test.ts`
      - `'errors when contract 4348 attestation question is undefined'`
      - `'successfully submits when contract 4348 attestation question is valid'`
   -`ContractDetailsSummarySection.test.ts`
      - `'displays correct contract 438 attestation yes and no text'`
   - `ContractDetails.test.ts`
      - `'renders 438 attestation question without errors'`
      - `'errors when continuing without answering 438 attestation question'`

- Cypress Tests:
   - `fillOutBaseContractDetails` and `fillOutAmendmentToBaseContractDetails ` command. Added 438 attestation answer selection.
   - `stubFeatureFlags` command. Set `438-attestation` flag to true on all tests.
<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
