### PR TITLE
MCR-3601 & MCR-3606: 438 attestation non compliance description and help page section

### DIFF
--- a/services/app-api/prisma/migrations/20231115003842_add_statutory_regulatory_attestation_description/migration.sql
+++ b/services/app-api/prisma/migrations/20231115003842_add_statutory_regulatory_attestation_description/migration.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+-- AlterTable
+ALTER TABLE "ContractRevisionTable" ADD COLUMN     "statutoryRegulatoryAttestationDescription" TEXT;
+
+COMMIT;

--- a/services/app-api/prisma/schema.prisma
+++ b/services/app-api/prisma/schema.prisma
@@ -116,6 +116,7 @@ model ContractRevisionTable {
   modifiedNonRiskPaymentArrangements           Boolean?
   inLieuServicesAndSettings                    Boolean?
   statutoryRegulatoryAttestation               Boolean?
+  statutoryRegulatoryAttestationDescription    String?
 }
 
 model RateRevisionTable {

--- a/services/app-api/src/domain-models/contractAndRates/convertContractWithRatesToHPP.ts
+++ b/services/app-api/src/domain-models/contractAndRates/convertContractWithRatesToHPP.ts
@@ -233,6 +233,8 @@ function convertContractWithRatesToFormData(
         },
         statutoryRegulatoryAttestation:
             contractRev.formData.statutoryRegulatoryAttestation,
+        statutoryRegulatoryAttestationDescription:
+            contractRev.formData.statutoryRegulatoryAttestationDescription,
         rateInfos,
     }
 

--- a/services/app-api/src/domain-models/contractAndRates/formDataTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/formDataTypes.ts
@@ -65,6 +65,7 @@ const contractFormDataSchema = z.object({
     modifiedLengthOfContract: z.boolean().optional(),
     modifiedNonRiskPaymentArrangements: z.boolean().optional(),
     statutoryRegulatoryAttestation: z.boolean().optional(),
+    statutoryRegulatoryAttestationDescription: z.string().optional(),
 })
 
 const rateFormDataSchema = z.object({

--- a/services/app-api/src/launchDarkly/launchDarkly.ts
+++ b/services/app-api/src/launchDarkly/launchDarkly.ts
@@ -64,7 +64,7 @@ function offlineLDService(): LDService {
         },
         allFlags: async (context) => {
             logError(
-                'getFeatureFlag',
+                'allFlags',
                 `No connection to LaunchDarkly, fallback to offlineLDService with default values`
             )
             setErrorAttributesOnActiveSpan(

--- a/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
@@ -341,6 +341,9 @@ function contractFormDataToDomainModel(
             contractRevision.inLieuServicesAndSettings ?? undefined,
         statutoryRegulatoryAttestation:
             contractRevision.statutoryRegulatoryAttestation ?? undefined,
+        statutoryRegulatoryAttestationDescription:
+            contractRevision.statutoryRegulatoryAttestationDescription ??
+            undefined,
     }
 }
 

--- a/services/app-api/src/postgres/contractAndRates/unlockContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/unlockContract.ts
@@ -143,6 +143,8 @@ async function unlockContract(
                         currentRev.modifiedNonRiskPaymentArrangements,
                     statutoryRegulatoryAttestation:
                         currentRev.statutoryRegulatoryAttestation,
+                    statutoryRegulatoryAttestationDescription:
+                        currentRev.statutoryRegulatoryAttestationDescription,
 
                     contractDocuments: {
                         create: currentRev.contractDocuments.map((d) => ({

--- a/services/app-api/src/postgres/contractAndRates/updateDraftContractWithRates.test.ts
+++ b/services/app-api/src/postgres/contractAndRates/updateDraftContractWithRates.test.ts
@@ -105,6 +105,8 @@ describe('updateDraftContract', () => {
             modifiedLengthOfContract: true,
             modifiedNonRiskPaymentArrangements: true,
             inLieuServicesAndSettings: true,
+            statutoryRegulatoryAttestation: false,
+            statutoryRegulatoryAttestationDescription: 'No compliance',
         }
     }
 

--- a/services/app-api/src/postgres/contractAndRates/updateDraftContractWithRates.ts
+++ b/services/app-api/src/postgres/contractAndRates/updateDraftContractWithRates.ts
@@ -131,6 +131,7 @@ async function updateDraftContractWithRates(
         modifiedNonRiskPaymentArrangements,
         inLieuServicesAndSettings,
         statutoryRegulatoryAttestation,
+        statutoryRegulatoryAttestationDescription,
     } = formData
 
     try {
@@ -507,6 +508,9 @@ async function updateDraftContractWithRates(
                     ),
                     statutoryRegulatoryAttestation: nullify(
                         statutoryRegulatoryAttestation
+                    ),
+                    statutoryRegulatoryAttestationDescription: nullify(
+                        statutoryRegulatoryAttestationDescription
                     ),
                     draftRates: {
                         disconnect: updateRates?.disconnectRates

--- a/services/app-api/src/resolvers/healthPlanPackage/contractAndRates/resolverHelper.test.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/contractAndRates/resolverHelper.test.ts
@@ -228,6 +228,8 @@ describe('convertHealthPlanPackageRatesToDomain', () => {
                     email: 'additionalactuarycontact1@test.com',
                 },
             ],
+            statutoryRegulatoryAttestation: false,
+            statutoryRegulatoryAttestationDescription: 'No compliance',
         }
 
         const expectDomainRates: RateFormDataType[] = [

--- a/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.test.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/updateHealthPlanFormData.test.ts
@@ -102,6 +102,7 @@ describe.each(flagValueTestParameters)(
                     },
                 },
                 statutoryRegulatoryAttestation: true,
+                statutoryRegulatoryAttestationDescription: undefined,
                 rateInfos: [],
             })
 

--- a/services/app-api/src/testHelpers/contractAndRates/contractHelpers.ts
+++ b/services/app-api/src/testHelpers/contractAndRates/contractHelpers.ts
@@ -207,6 +207,7 @@ const createContractRevision = (
         rateRevisions: [],
         draftRates: [],
         statutoryRegulatoryAttestation: null,
+        statutoryRegulatoryAttestationDescription: null,
         ...revision,
     }
 }

--- a/services/app-api/src/testHelpers/emailerHelpers.ts
+++ b/services/app-api/src/testHelpers/emailerHelpers.ts
@@ -338,6 +338,7 @@ const mockContractAndRatesFormData = (
         addtlActuaryCommunicationPreference: 'OACT_TO_ACTUARY',
         ...submissionPartial,
         statutoryRegulatoryAttestation: false,
+        statutoryRegulatoryAttestationDescription: 'No compliance',
     }
 }
 
@@ -422,6 +423,8 @@ const mockUnlockedContractAndRatesFormData = (
             },
         ],
         addtlActuaryCommunicationPreference: 'OACT_TO_ACTUARY',
+        statutoryRegulatoryAttestation: false,
+        statutoryRegulatoryAttestationDescription: 'No compliance',
         ...submissionPartial,
     }
 }
@@ -471,6 +474,8 @@ const mockUnlockedContractOnlyFormData = (
             },
         ],
         addtlActuaryContacts: [],
+        statutoryRegulatoryAttestation: false,
+        statutoryRegulatoryAttestationDescription: 'No compliance',
         ...submissionPartial,
     }
 }
@@ -522,6 +527,7 @@ const mockContractOnlyFormData = (
         ],
         addtlActuaryContacts: [],
         statutoryRegulatoryAttestation: false,
+        statutoryRegulatoryAttestationDescription: 'No compliance',
         ...submissionPartial,
     }
 }
@@ -609,6 +615,7 @@ const mockContractAmendmentFormData = (
         ],
         addtlActuaryCommunicationPreference: 'OACT_TO_ACTUARY',
         statutoryRegulatoryAttestation: false,
+        statutoryRegulatoryAttestationDescription: 'No compliance',
         ...submissionPartial,
     }
 }

--- a/services/app-api/src/testHelpers/gqlHelpers.ts
+++ b/services/app-api/src/testHelpers/gqlHelpers.ts
@@ -299,7 +299,8 @@ const createAndUpdateTestHealthPlanPackage = async (
             modifiedNonRiskPaymentArrangements: true,
         },
     }
-    draft.statutoryRegulatoryAttestation = true
+    draft.statutoryRegulatoryAttestation = false
+    draft.statutoryRegulatoryAttestationDescription = 'No compliance'
 
     Object.assign(draft, partialUpdates)
 

--- a/services/app-api/src/testHelpers/launchDarklyHelpers.ts
+++ b/services/app-api/src/testHelpers/launchDarklyHelpers.ts
@@ -21,6 +21,7 @@ function testLDService(mockFeatureFlags?: FeatureFlagSettings): LDService {
 
     return {
         getFeatureFlag: async (user, flag) => featureFlags[flag],
+        allFlags: async (user) => featureFlags,
     }
 }
 

--- a/services/app-proto/src/health_plan_form_data.proto
+++ b/services/app-proto/src/health_plan_form_data.proto
@@ -82,6 +82,7 @@ message ContractInfo {
   repeated Document contract_documents = 6;
   optional ContractExecutionStatus contract_execution_status = 7;
   optional bool statutory_regulatory_attestation = 8;
+  optional string statutory_regulatory_attestation_description = 9;
 
   // Rates Refactor: No need for nested contract amendment info
   optional ContractAmendmentInfo contract_amendment_info  = 50;

--- a/services/app-web/src/common-code/healthPlanFormDataMocks/healthPlanFormData.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataMocks/healthPlanFormData.ts
@@ -58,6 +58,7 @@ function newHealthPlanFormData(): UnlockedHealthPlanFormDataType {
         federalAuthorities: [],
         stateContacts: [],
         addtlActuaryContacts: [],
+        statutoryRegulatoryAttestation: true,
     }
 }
 
@@ -85,6 +86,7 @@ function basicHealthPlanFormData(): UnlockedHealthPlanFormDataType {
         federalAuthorities: ['VOLUNTARY', 'BENCHMARK'],
         stateContacts: [],
         addtlActuaryContacts: [],
+        statutoryRegulatoryAttestation: true,
     }
 }
 
@@ -112,6 +114,7 @@ function contractOnly(): UnlockedHealthPlanFormDataType {
         federalAuthorities: ['VOLUNTARY', 'BENCHMARK'],
         stateContacts: [],
         addtlActuaryContacts: [],
+        statutoryRegulatoryAttestation: true,
     }
 }
 
@@ -160,6 +163,8 @@ function contractAmendedOnly(): UnlockedHealthPlanFormDataType {
                 modifiedNonRiskPaymentArrangements: true,
             },
         },
+        statutoryRegulatoryAttestation: false,
+        statutoryRegulatoryAttestationDescription: 'No compliance',
     }
 }
 
@@ -248,6 +253,8 @@ function unlockedWithContacts(): UnlockedHealthPlanFormDataType {
             },
         ],
         addtlActuaryCommunicationPreference: 'OACT_TO_ACTUARY',
+        statutoryRegulatoryAttestation: false,
+        statutoryRegulatoryAttestationDescription: 'No compliance',
     }
 }
 
@@ -363,6 +370,8 @@ function unlockedWithDocuments(): UnlockedHealthPlanFormDataType {
             },
         ],
         addtlActuaryCommunicationPreference: 'OACT_TO_ACTUARY',
+        statutoryRegulatoryAttestation: false,
+        statutoryRegulatoryAttestationDescription: 'No compliance',
     }
 }
 
@@ -471,6 +480,8 @@ function unlockedWithFullRates(): UnlockedHealthPlanFormDataType {
             },
         ],
         addtlActuaryCommunicationPreference: 'OACT_TO_ACTUARY',
+        statutoryRegulatoryAttestation: false,
+        statutoryRegulatoryAttestationDescription: 'No compliance',
     }
 }
 
@@ -607,6 +618,8 @@ function unlockedWithFullContracts(): UnlockedHealthPlanFormDataType {
             },
         ],
         addtlActuaryCommunicationPreference: 'OACT_TO_ACTUARY',
+        statutoryRegulatoryAttestation: false,
+        statutoryRegulatoryAttestationDescription: 'No compliance',
     }
 }
 
@@ -747,6 +760,8 @@ function unlockedWithALittleBitOfEverything(): UnlockedHealthPlanFormDataType {
             },
         ],
         addtlActuaryCommunicationPreference: 'OACT_TO_ACTUARY',
+        statutoryRegulatoryAttestation: false,
+        statutoryRegulatoryAttestationDescription: 'No compliance',
     }
 }
 
@@ -763,7 +778,6 @@ function basicLockedHealthPlanFormData(): LockedHealthPlanFormDataType {
         programIDs: [mockMNState().programs[0].id],
         submissionType: 'CONTRACT_ONLY',
         riskBasedContract: false,
-        statutoryRegulatoryAttestation: false,
         submissionDescription: 'A real submission',
         documents: [],
         contractType: 'BASE',
@@ -789,6 +803,8 @@ function basicLockedHealthPlanFormData(): LockedHealthPlanFormDataType {
         ],
         addtlActuaryContacts: [],
         rateInfos: [],
+        statutoryRegulatoryAttestation: false,
+        statutoryRegulatoryAttestationDescription: 'No compliance',
     }
 }
 

--- a/services/app-web/src/common-code/healthPlanFormDataType/LockedHealthPlanFormDataType.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/LockedHealthPlanFormDataType.ts
@@ -43,4 +43,5 @@ export type LockedHealthPlanFormDataType = {
     addtlActuaryContacts: ActuaryContact[]
     addtlActuaryCommunicationPreference?: ActuaryCommunicationType
     statutoryRegulatoryAttestation: boolean
+    statutoryRegulatoryAttestationDescription?: string
 }

--- a/services/app-web/src/common-code/healthPlanFormDataType/UnlockedHealthPlanFormDataType.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/UnlockedHealthPlanFormDataType.ts
@@ -119,6 +119,7 @@ type UnlockedHealthPlanFormDataType = {
     contractAmendmentInfo?: UnlockedContractAmendmentInfo
     rateInfos: RateInfoType[]
     statutoryRegulatoryAttestation?: boolean
+    statutoryRegulatoryAttestationDescription?: string
 }
 
 export type {

--- a/services/app-web/src/common-code/proto/healthPlanFormDataProto/toDomain.ts
+++ b/services/app-web/src/common-code/proto/healthPlanFormDataProto/toDomain.ts
@@ -545,6 +545,9 @@ const toDomain = (
         documents: parseProtoDocuments(formDataMessage.documents),
         statutoryRegulatoryAttestation:
             contractInfo?.statutoryRegulatoryAttestation ?? undefined,
+        statutoryRegulatoryAttestationDescription:
+            contractInfo?.statutoryRegulatoryAttestationDescription ??
+            undefined,
     }
 
     // Now that we've gotten things into our combined draft & state domain format.

--- a/services/app-web/src/common-code/proto/healthPlanFormDataProto/toProtoBuffer.ts
+++ b/services/app-web/src/common-code/proto/healthPlanFormDataProto/toProtoBuffer.ts
@@ -198,6 +198,8 @@ const toProtoBuffer = (
             contractAmendmentInfo: contractAmendmentInfo,
             statutoryRegulatoryAttestation:
                 domainData.statutoryRegulatoryAttestation,
+            statutoryRegulatoryAttestationDescription:
+                domainData.statutoryRegulatoryAttestationDescription,
         },
         rateInfos:
             domainData.rateInfos && domainData.rateInfos.length

--- a/services/app-web/src/common-code/proto/healthPlanFormDataProto/zodSchemas.ts
+++ b/services/app-web/src/common-code/proto/healthPlanFormDataProto/zodSchemas.ts
@@ -169,6 +169,7 @@ const unlockedHealthPlanFormDataZodSchema = z.object({
     contractAmendmentInfo: contractAmendmentInfoSchema.optional(),
     rateInfos: z.array(rateInfosTypeSchema),
     statutoryRegulatoryAttestation: z.boolean().optional(),
+    statutoryRegulatoryAttestationDescription: z.string().optional(),
 })
 
 /*

--- a/services/app-web/src/components/FilterAccordion/FilterDateRange/FilterDateRange.module.scss
+++ b/services/app-web/src/components/FilterAccordion/FilterDateRange/FilterDateRange.module.scss
@@ -2,21 +2,20 @@
 @import '../../../styles/custom.scss';
 
 .dateRangePicker {
-  [class^='usa-label'] {
+  [class='usa-label'] {
     font-weight: normal;
   }
-  [class^='usa-form-group'] {
+  [class='usa-legend'] {
+    font-weight: normal;
+  }
+
+  [class='usa-form-group'] {
     margin-top: 0rem;
     width: 100%;
   }
+
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   column-gap: 32px;
   align-items: end;
-}
-
-[class='usa-fieldset'] {
-  legend {
-    font-weight: normal;
-  }
 }

--- a/services/app-web/src/components/FilterAccordion/FilterDateRange/FilterDateRange.tsx
+++ b/services/app-web/src/components/FilterAccordion/FilterDateRange/FilterDateRange.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, forwardRef, useImperativeHandle, useState } from 'react'
-import { FormGroup, Label } from '@trussworks/react-uswds'
+import { Fieldset, FormGroup, Label } from '@trussworks/react-uswds'
 import {
     DatePicker,
     DatePickerProps,
@@ -8,10 +8,10 @@ import {
 import { formatDate, parseDateString } from './_DatePicker/utils'
 import { DEFAULT_EXTERNAL_DATE_FORMAT } from './_DatePicker/constants'
 import classnames from 'classnames'
-import styles from './FilterDateRange.module.scss'
 import { formatUserInputDate } from '../../../formHelpers'
 import { dayjs } from '../../../common-code/dateHelpers/dayjs'
 import { PoliteErrorMessage } from '../../PoliteErrorMessage'
+import styles from './FilterDateRange.module.scss'
 
 /**
  *  This component recreates the @trussworks/react-uswds DateRangePicker with a modification to validate and clear
@@ -27,6 +27,7 @@ import { PoliteErrorMessage } from '../../PoliteErrorMessage'
  */
 
 export type FilterDateRangePropType = {
+    legend?: string
     startDateLabel?: string
     startDateHint?: string
     startDatePickerProps: Omit<DatePickerProps, 'rangeDate'>
@@ -46,6 +47,7 @@ export const FilterDateRange = forwardRef(
         ref: React.Ref<FilterDateRangeRef>
     ): React.ReactElement => {
         const {
+            legend,
             startDateLabel,
             startDateHint,
             startDatePickerProps,
@@ -250,7 +252,11 @@ export const FilterDateRange = forwardRef(
         }
 
         return (
-            <div className={classes} data-testid="filter-date-range-picker">
+            <Fieldset
+                className={classes}
+                data-testid="filter-date-range-picker"
+                legend={legend}
+            >
                 <FormGroup error={showStartDateError}>
                     {startDateLabel && (
                         <Label
@@ -318,7 +324,7 @@ export const FilterDateRange = forwardRef(
                         onBlur={onBlurValidation}
                     />
                 </FormGroup>
-            </div>
+            </Fieldset>
         )
     }
 )

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
@@ -165,7 +165,7 @@ describe('ContractDetailsSummarySection', () => {
         ).toBeInTheDocument()
     })
 
-    it('displays correct contract 438 attestation yes and no text', async () => {
+    it('displays correct contract 438 attestation yes and no text and description', async () => {
         ldUseClientSpy({ '438-attestation': true })
         const submission = mockContractAndRatesDraft({
             statutoryRegulatoryAttestation: false,

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
@@ -168,7 +168,8 @@ describe('ContractDetailsSummarySection', () => {
     it('displays correct contract 438 attestation yes and no text', async () => {
         ldUseClientSpy({ '438-attestation': true })
         const submission = mockContractAndRatesDraft({
-            statutoryRegulatoryAttestation: true,
+            statutoryRegulatoryAttestation: false,
+            statutoryRegulatoryAttestationDescription: 'No compliance',
         })
         renderWithProviders(
             <ContractDetailsSummarySection
@@ -182,14 +183,20 @@ describe('ContractDetailsSummarySection', () => {
             }
         )
 
-        const attestationYes = StatutoryRegulatoryAttestation.YES
-
         expect(
             screen.getByRole('definition', {
                 name: StatutoryRegulatoryAttestationQuestion,
             })
         ).toBeInTheDocument()
-        expect(await screen.findByText(attestationYes)).toBeInTheDocument()
+        expect(
+            screen.getByRole('definition', {
+                name: 'Non-compliance description',
+            })
+        ).toBeInTheDocument()
+        expect(
+            await screen.findByText(StatutoryRegulatoryAttestation.NO)
+        ).toBeInTheDocument()
+        expect(await screen.findByText('No compliance')).toBeInTheDocument()
     })
 
     it('displays correct effective dates text for base contract', async () => {

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -164,7 +164,10 @@ export const ContractDetailsSummarySection = ({
             <dl>
                 {contract438Attestation && (
                     <Grid row gap className={styles.singleColumnGrid}>
-                        <Grid col={12}>
+                        <Grid
+                            tablet={{ col: 12 }}
+                            key="statutoryRegulatoryAttestation"
+                        >
                             <DataDetail
                                 id="statutoryRegulatoryAttestation"
                                 label={StatutoryRegulatoryAttestationQuestion}
@@ -177,6 +180,21 @@ export const ContractDetailsSummarySection = ({
                                 }
                             />
                         </Grid>
+                        {attestationYesNo === 'NO' && (
+                            <Grid
+                                tablet={{ col: 12 }}
+                                key="statutoryRegulatoryAttestationDescription"
+                            >
+                                <DataDetail
+                                    id="statutoryRegulatoryAttestationDescription"
+                                    label="Non-compliance description"
+                                    explainMissingData={!isSubmitted}
+                                    children={
+                                        submission.statutoryRegulatoryAttestationDescription
+                                    }
+                                />
+                            </Grid>
+                        )}
                     </Grid>
                 )}
                 <DoubleColumnGrid>

--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionSummarySection.module.scss
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionSummarySection.module.scss
@@ -95,7 +95,9 @@
 
 .singleColumnGrid {
     @include at-media(tablet) {
-        margin-bottom: units(2);
+        > * {
+            margin-bottom: units(2);
+        }
     }
 }
 

--- a/services/app-web/src/constants/routes.ts
+++ b/services/app-web/src/constants/routes.ts
@@ -101,8 +101,8 @@ const QUESTION_RESPONSE_SHOW_SIDEBAR_ROUTES: RouteTWithUnknown[] = [
 */
 const PageHeadingsRecord: Partial<Record<RouteTWithUnknown, string>> = {
     ROOT: 'Dashboard',
-    DASHBOARD_SUBMISSIONS: 'Submissions Dashboard',
-    DASHBOARD_RATES: 'Rate Reviews Dashboard',
+    DASHBOARD_SUBMISSIONS: 'Submissions dashboard',
+    DASHBOARD_RATES: 'Rate reviews dashboard',
     SUBMISSIONS_NEW: 'New submission',
     UNKNOWN_ROUTE: '404',
 }
@@ -119,7 +119,7 @@ const PageTitlesRecord: Record<RouteT | 'UNKNOWN_ROUTE', string> = {
     HELP: 'Help',
     SETTINGS: 'Settings',
     DASHBOARD: 'Dashboard',
-    DASHBOARD_RATES: 'Rate Review Dashboard',
+    DASHBOARD_RATES: 'Rate review dashboard',
     DASHBOARD_SUBMISSIONS: 'Dashboard',
     RATES_SUMMARY: 'Rate summary',
     SUBMISSIONS: 'Submissions',

--- a/services/app-web/src/constants/statutoryRegulatoryAttestation.ts
+++ b/services/app-web/src/constants/statutoryRegulatoryAttestation.ts
@@ -6,7 +6,11 @@ const StatutoryRegulatoryAttestation = {
 const StatutoryRegulatoryAttestationQuestion =
     'Do you attest that this contract complies with all applicable statutory and regulatory requirements including those contained in Title 42 Part 438 and Part 457 of the Code of Federal Regulations (CFR)?'
 
+const StatutoryRegulatoryAttestationDescription =
+    'Please provide a brief description of the contract’s non-compliance (with regulatory citations) and expected timeframe for remediation'
+
 export {
     StatutoryRegulatoryAttestation,
     StatutoryRegulatoryAttestationQuestion,
+    StatutoryRegulatoryAttestationDescription,
 }

--- a/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsTable.tsx
+++ b/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsTable.tsx
@@ -23,7 +23,7 @@ import {
     RelatedContractRevisions,
 } from '../../../gen/gqlClient'
 import styles from '../../../components/HealthPlanPackageTable/HealthPlanPackageTable.module.scss'
-import { Table, Tag, Link, Fieldset } from '@trussworks/react-uswds'
+import { Table, Tag, Link } from '@trussworks/react-uswds'
 import { NavLink } from 'react-router-dom'
 import dayjs from 'dayjs'
 import qs from 'qs'
@@ -521,46 +521,42 @@ export const RateReviewsTable = ({
                                     }
                                 />
                             </DoubleColumnGrid>
-                            <Fieldset
-                                data-testid={'rating-period-filter'}
+                            <FilterDateRange
+                                ref={filterDateRangeRef}
                                 legend={'Rating period start date'}
-                            >
-                                <FilterDateRange
-                                    ref={filterDateRangeRef}
-                                    startDateHint="mm/dd/yyyy"
-                                    startDateLabel="From"
-                                    startDatePickerProps={{
-                                        id: 'ratingPeriodStartFrom',
-                                        name: 'ratingPeriodStartFrom',
-                                        defaultValue: getDateRangeFilterFromUrl(
-                                            defaultColumnFilters,
-                                            'rateDateStart'
-                                        )[0],
-                                        onChange: (date) =>
-                                            updateRatingPeriodFilter(
-                                                [date, undefined],
-                                                rateDateStartColumn,
-                                                'ratingPeriodStartFrom'
-                                            ),
-                                    }}
-                                    endDateHint="mm/dd/yyyy"
-                                    endDateLabel="To"
-                                    endDatePickerProps={{
-                                        id: 'ratingPeriodStartTo',
-                                        name: 'ratingPeriodStartTo',
-                                        defaultValue: getDateRangeFilterFromUrl(
-                                            defaultColumnFilters,
-                                            'rateDateStart'
-                                        )[1],
-                                        onChange: (date) =>
-                                            updateRatingPeriodFilter(
-                                                [undefined, date],
-                                                rateDateStartColumn,
-                                                'ratingPeriodStartTo'
-                                            ),
-                                    }}
-                                />
-                            </Fieldset>
+                                startDateHint="mm/dd/yyyy"
+                                startDateLabel="From"
+                                startDatePickerProps={{
+                                    id: 'ratingPeriodStartFrom',
+                                    name: 'ratingPeriodStartFrom',
+                                    defaultValue: getDateRangeFilterFromUrl(
+                                        defaultColumnFilters,
+                                        'rateDateStart'
+                                    )[0],
+                                    onChange: (date) =>
+                                        updateRatingPeriodFilter(
+                                            [date, undefined],
+                                            rateDateStartColumn,
+                                            'ratingPeriodStartFrom'
+                                        ),
+                                }}
+                                endDateHint="mm/dd/yyyy"
+                                endDateLabel="To"
+                                endDatePickerProps={{
+                                    id: 'ratingPeriodStartTo',
+                                    name: 'ratingPeriodStartTo',
+                                    defaultValue: getDateRangeFilterFromUrl(
+                                        defaultColumnFilters,
+                                        'rateDateStart'
+                                    )[1],
+                                    onChange: (date) =>
+                                        updateRatingPeriodFilter(
+                                            [undefined, date],
+                                            rateDateStartColumn,
+                                            'ratingPeriodStartTo'
+                                        ),
+                                }}
+                            />
                         </FilterAccordion>
                     )}
                     <div aria-live="polite" aria-atomic>

--- a/services/app-web/src/pages/Help/Help.tsx
+++ b/services/app-web/src/pages/Help/Help.tsx
@@ -65,6 +65,49 @@ export const Help = (): React.ReactElement => {
                 </p>
             </section>
             <section className={styles.helpSection}>
+                <h3 id="non-compliance-guidance">Non-compliance guidance</h3>
+                <h4>Contractual versus operational compliance</h4>
+                <p className="line-height-sans-4 measure-6">
+                    A contract action is contractually compliant if the
+                    requirements are explicitly stated in the contract.
+                </p>
+                <p className="line-height-sans-4 measure-6">
+                    A contract action is operationally compliant if the
+                    associated health plans adhere to the requirement, but the
+                    requirement is not stated explicitly in the contract.
+                    Operational compliance does not achieve contractual
+                    compliance.
+                </p>
+                <p className="line-height-sans-4 measure-6">
+                    If the contract action is only operationally compliant, you
+                    must select, “No, the contract does not fully comply with
+                    all applicable requirements.” and complete the question that
+                    follows.
+                </p>
+                <h4>Example #1</h4>
+                <p className="line-height-sans-4 measure-6">
+                    This contract action is not compliant with § 438.71(a), due
+                    to the need for legislative approval. We plan to incorporate
+                    this new requirement into our contracts effective July 1,
+                    2024, and submit the amendment to CMS no later than August
+                    1, 2024. We have communicated this new requirement to health
+                    plans, informing them that the system must be implemented no
+                    later than July 1, 2024.
+                </p>
+                <h4>Example #2</h4>
+                <p className="line-height-sans-4 measure-6">
+                    This contract action does not include the requirement at
+                    §438.10(c)(6)(ii). The state overlooked this requirement
+                    when developing SFY24 contracts. However, we conduct ongoing
+                    monitoring of plans’ compliance with all information
+                    requirements, and attest to the plans’ operational
+                    compliance with §438.10(c)(6)(ii). We will be updating our
+                    contracts with this provision, effective July 1, 2024, and
+                    will submit the amendment to CMS no later than August 1,
+                    2024.
+                </p>
+            </section>
+            <section className={styles.helpSection}>
                 <h3 id="rate-cert-type-definitions">
                     Rate certification type definitions
                 </h3>

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -8,7 +8,7 @@ import {
     DateRangePicker,
 } from '@trussworks/react-uswds'
 import { v4 as uuidv4 } from 'uuid'
-import { useNavigate } from 'react-router-dom'
+import { Link as ReactRouterLink, useNavigate } from 'react-router-dom'
 import { Formik, FormikErrors } from 'formik'
 
 import styles from '../StateSubmissionForm.module.scss'
@@ -22,6 +22,7 @@ import {
     ErrorSummary,
     PoliteErrorMessage,
     FieldYesNo,
+    FieldTextarea,
 } from '../../../components'
 import {
     formatForForm,
@@ -66,6 +67,7 @@ import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { featureFlags } from '../../../common-code/featureFlags'
 import {
     StatutoryRegulatoryAttestation,
+    StatutoryRegulatoryAttestationDescription,
     StatutoryRegulatoryAttestationQuestion,
 } from '../../../constants/statutoryRegulatoryAttestation'
 
@@ -120,6 +122,7 @@ export interface ContractDetailsFormValues {
     modifiedLengthOfContract: string | undefined
     modifiedNonRiskPaymentArrangements: string | undefined
     statutoryRegulatoryAttestation: string | undefined
+    statutoryRegulatoryAttestationDescription: string | undefined
 }
 type FormError =
     FormikErrors<ContractDetailsFormValues>[keyof FormikErrors<ContractDetailsFormValues>]
@@ -338,6 +341,9 @@ export const ContractDetails = ({
         statutoryRegulatoryAttestation: formatForForm(
             draftSubmission?.statutoryRegulatoryAttestation
         ),
+        statutoryRegulatoryAttestationDescription: formatForForm(
+            draftSubmission?.statutoryRegulatoryAttestationDescription
+        ),
     }
 
     const showFieldErrors = (error?: FormError) =>
@@ -410,6 +416,9 @@ export const ContractDetails = ({
         draftSubmission.statutoryRegulatoryAttestation = formatYesNoForProto(
             values.statutoryRegulatoryAttestation
         )
+        // If contract is in compliance, we set the description to undefined. This clears out previous non-compliance description
+        draftSubmission.statutoryRegulatoryAttestationDescription =
+            values.statutoryRegulatoryAttestationDescription
 
         if (isContractWithProvisions(draftSubmission)) {
             draftSubmission.contractAmendmentInfo = {
@@ -595,21 +604,12 @@ export const ContractDetails = ({
                                     <Fieldset
                                         role="radiogroup"
                                         aria-required
-                                        className={styles.radioGroup}
+                                        className={styles.contractAttestation}
+                                        legend={
+                                            StatutoryRegulatoryAttestationQuestion
+                                        }
                                     >
-                                        <legend>
-                                            <b>
-                                                {
-                                                    StatutoryRegulatoryAttestationQuestion
-                                                }
-                                            </b>
-                                        </legend>
-                                        <div
-                                            role="note"
-                                            className={
-                                                styles.contractAttestationHint
-                                            }
-                                        >
+                                        <div role="note">
                                             <span
                                                 className={
                                                     styles.requiredOptionalText
@@ -658,7 +658,7 @@ export const ContractDetails = ({
                                                 StatutoryRegulatoryAttestation.YES
                                             }
                                             id="statutoryRegulatoryAttestationYes"
-                                            value="YES"
+                                            value={'YES'}
                                             aria-required
                                         />
                                         <FieldRadio
@@ -667,12 +667,46 @@ export const ContractDetails = ({
                                                 StatutoryRegulatoryAttestation.NO
                                             }
                                             id="statutoryRegulatoryAttestationNo"
-                                            value="NO"
+                                            value={'NO'}
                                             aria-required
                                         />
                                     </Fieldset>
                                 </FormGroup>
                             )}
+                            {contract438Attestation &&
+                                values.statutoryRegulatoryAttestation ===
+                                    'NO' && (
+                                    <div className={styles.contractAttestation}>
+                                        <FieldTextarea
+                                            label={
+                                                StatutoryRegulatoryAttestationDescription
+                                            }
+                                            id="statutoryRegulatoryAttestationDescription"
+                                            name="statutoryRegulatoryAttestationDescription"
+                                            aria-required
+                                            showError={showFieldErrors(
+                                                errors.statutoryRegulatoryAttestationDescription
+                                            )}
+                                            hint={
+                                                <Link
+                                                    variant="external"
+                                                    asCustom={ReactRouterLink}
+                                                    className={
+                                                        'margin-bottom-1'
+                                                    }
+                                                    to={{
+                                                        pathname: '/help',
+                                                        hash: '#non-compliance-guidance',
+                                                    }}
+                                                    target="_blank"
+                                                >
+                                                    Non-compliance definitions
+                                                    and examples
+                                                </Link>
+                                            }
+                                        />
+                                    </div>
+                                )}
                             <FormGroup
                                 error={showFieldErrors(
                                     errors.contractExecutionStatus

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetailsSchema.ts
@@ -56,7 +56,20 @@ export const ContractDetailsFormSchema = (
     return Yup.object().shape({
         statutoryRegulatoryAttestation: activeFeatureFlags['438-attestation']
             ? Yup.string().defined('You must select yes or no')
-            : Yup.string(),
+            : Yup.string().notRequired(),
+        statutoryRegulatoryAttestationDescription: Yup.string().when(
+            ['statutoryRegulatoryAttestation'],
+            {
+                is: (statutoryRegulatoryAttestation: string) =>
+                    statutoryRegulatoryAttestation === 'NO' &&
+                    activeFeatureFlags['438-attestation'],
+                then: (schema) =>
+                    schema.defined(
+                        'You must provide a description of the contract’s non-compliance'
+                    ),
+                otherwise: (schema) => schema.notRequired(),
+            }
+        ),
         contractExecutionStatus: Yup.string().defined(
             'You must select a contract status'
         ),

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.module.scss
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.module.scss
@@ -150,9 +150,15 @@
     flex-direction: column;
 }
 
-.contractAttestationHint {
-    margin-bottom: units(3);
-    a {
-        margin-top: units(1);
+.contractAttestation {
+    max-width: none;
+    legend {
+        max-width: none;
+    }
+    label {
+        max-width: none;
+    }
+    div[role=note] {
+        margin-top: units(0);
     }
 }

--- a/services/app-web/src/testHelpers/apolloMocks/healthPlanFormDataMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/healthPlanFormDataMock.ts
@@ -55,6 +55,8 @@ function mockDraft(
         stateContacts: [],
         addtlActuaryContacts: [],
         addtlActuaryCommunicationPreference: undefined,
+        statutoryRegulatoryAttestation: false,
+        statutoryRegulatoryAttestationDescription: 'No compliance',
         ...partial,
     }
 }
@@ -116,7 +118,8 @@ function mockBaseContract(
         ],
         addtlActuaryContacts: [],
         addtlActuaryCommunicationPreference: undefined,
-        statutoryRegulatoryAttestation: true,
+        statutoryRegulatoryAttestation: false,
+        statutoryRegulatoryAttestationDescription: 'No compliance',
         ...partial,
     }
 }
@@ -139,7 +142,14 @@ function mockContractAndRatesDraft(
         documents: [],
         contractType: 'AMENDMENT',
         contractExecutionStatus: 'EXECUTED',
-        contractDocuments: [],
+        contractDocuments: [
+            {
+                s3URL: 's3://bucketname/key/contract',
+                sha256: 'fakesha',
+                name: 'contract',
+                documentCategories: ['CONTRACT' as const],
+            },
+        ],
         contractDateStart: new Date(),
         contractDateEnd: new Date(),
         contractAmendmentInfo: {
@@ -212,7 +222,8 @@ function mockContractAndRatesDraft(
             },
         ],
         addtlActuaryCommunicationPreference: 'OACT_TO_ACTUARY',
-        statutoryRegulatoryAttestation: true,
+        statutoryRegulatoryAttestation: false,
+        statutoryRegulatoryAttestationDescription: 'No compliance',
         ...partial,
     }
 }
@@ -321,6 +332,7 @@ function mockStateSubmission(): LockedHealthPlanFormDataType {
         addtlActuaryContacts: [],
         addtlActuaryCommunicationPreference: undefined,
         statutoryRegulatoryAttestation: false,
+        statutoryRegulatoryAttestationDescription: 'No compliance',
     }
 }
 
@@ -421,6 +433,7 @@ function mockStateSubmissionContractAmendment(): LockedHealthPlanFormDataType {
         addtlActuaryContacts: [],
         addtlActuaryCommunicationPreference: undefined,
         statutoryRegulatoryAttestation: false,
+        statutoryRegulatoryAttestationDescription: 'No compliance',
     }
 }
 

--- a/services/cypress/integration/smokeTest/smokeTest.spec.ts
+++ b/services/cypress/integration/smokeTest/smokeTest.spec.ts
@@ -6,7 +6,7 @@ describe('smoke test', () => {
     it('can log in as a state user', () => {
         cy.logInAsStateUser()
         cy.location('pathname', { timeout: 10_000 }).should('eq', '/dashboard/submissions')
-        cy.findByRole('heading', { level: 1, name: /Dashboard/ })
+        cy.findByRole('heading', { level: 1, name: /Submissions dashboard/ })
     })
 
     it('can log in as a CMS user', () => {

--- a/services/cypress/integration/stateWorkflow/dashboard/dashboard.spec.ts
+++ b/services/cypress/integration/stateWorkflow/dashboard/dashboard.spec.ts
@@ -108,7 +108,7 @@ describe('dashboard', () => {
 
             // Link back to dashboard, submission visible in default program
             cy.findByText('Back to state dashboard').should('exist').click()
-            cy.findByText('Submissions Dashboard').should('exist')
+            cy.findByText('Submissions dashboard').should('exist')
             // check the table of submissions--find a draft row, then the link in the ID column
             cy.get('table')
                 .contains('span', 'Draft')

--- a/services/cypress/integration/stateWorkflow/login/login.spec.ts
+++ b/services/cypress/integration/stateWorkflow/login/login.spec.ts
@@ -17,7 +17,7 @@ describe('login', () => {
         cy.logInAsStateUser()
 
         cy.findByText('aang@example.com').should('exist')
-        cy.findByRole('heading', { name: 'Minnesota Submissions Dashboard' }).should(
+        cy.findByRole('heading', { name: 'Minnesota Submissions dashboard' }).should(
             'exist'
         )
     })

--- a/services/cypress/integration/stateWorkflow/stateSubmissionForm/contacts.spec.ts
+++ b/services/cypress/integration/stateWorkflow/stateSubmissionForm/contacts.spec.ts
@@ -29,7 +29,7 @@ describe('contacts', () => {
             cy.findByRole('heading', { level: 2, name: /Contacts/ })
             cy.fillOutStateContact()
             cy.navigateFormByButtonClick('SAVE_DRAFT')
-            cy.findByRole('heading', { level: 1, name: /Dashboard/ })
+            cy.findByRole('heading', { level: 1, name: /Submissions dashboard/ })
         })
     })
     it('can navigate back and save as draft from contacts page with contract and rates submission', () => {
@@ -94,7 +94,7 @@ describe('contacts', () => {
             ).click()
 
             cy.navigateFormByButtonClick('SAVE_DRAFT')
-            cy.findByRole('heading', { level: 1, name: /Dashboard/ })
+            cy.findByRole('heading', { level: 1, name: /Submissions dashboard/ })
         })
     })
 

--- a/services/cypress/integration/stateWorkflow/stateSubmissionForm/contractDetails.spec.ts
+++ b/services/cypress/integration/stateWorkflow/stateSubmissionForm/contractDetails.spec.ts
@@ -25,7 +25,7 @@ describe('contract details', () => {
                 /Primary Care Case Management Entity/
             ).safeClick()
             cy.navigateFormByButtonClick('SAVE_DRAFT')
-            cy.findByRole('heading', { level: 1, name: /Dashboard/ })
+            cy.findByRole('heading', { level: 1, name: /Submissions dashboard/ })
         })
     })
 

--- a/services/cypress/integration/stateWorkflow/stateSubmissionForm/documents.spec.ts
+++ b/services/cypress/integration/stateWorkflow/stateSubmissionForm/documents.spec.ts
@@ -75,7 +75,7 @@ describe('documents', () => {
 
             //  Save as draft
             cy.navigateFormByButtonClick('SAVE_DRAFT')
-            cy.findByRole('heading', { level: 1, name: /Dashboard/ })
+            cy.findByRole('heading', { level: 1, name: /Submissions dashboard/ })
         })
     })
 

--- a/services/cypress/integration/stateWorkflow/stateSubmissionForm/newSubmission.spec.ts
+++ b/services/cypress/integration/stateWorkflow/stateSubmissionForm/newSubmission.spec.ts
@@ -12,7 +12,7 @@ describe('new submission', () => {
         // Navigate to dashboard page by clicking cancel
         cy.findByRole('button', { name: /Cancel/ }).click()
         cy.wait('@indexHealthPlanPackagesQuery', { timeout: 50_000 })
-        cy.findByRole('heading', { level: 1, name: /Dashboard/ })
+        cy.findByRole('heading', { level: 1, name: /Submissions dashboard/ })
 
         // Navigate to new page
         cy.visit(`/submissions/new`)

--- a/services/cypress/integration/stateWorkflow/stateSubmissionForm/rateDetails.spec.ts
+++ b/services/cypress/integration/stateWorkflow/stateSubmissionForm/rateDetails.spec.ts
@@ -27,7 +27,7 @@ describe('rate details', () => {
 
             // Navigate to dashboard page by clicking save as draft
             cy.navigateFormByButtonClick('SAVE_DRAFT')
-            cy.findByRole('heading', { level: 1, name: /Dashboard/ })
+            cy.findByRole('heading', { level: 1, name: /Submissions dashboard/ })
         })
     })
 

--- a/services/cypress/integration/stateWorkflow/stateSubmissionForm/reviewAndSubmit.spec.ts
+++ b/services/cypress/integration/stateWorkflow/stateSubmissionForm/reviewAndSubmit.spec.ts
@@ -26,7 +26,7 @@ describe('review and submit', () => {
 
             // Navigate to dashboard page by clicking save as draft
             cy.navigateFormByButtonClick('SAVE_DRAFT', false)
-            cy.findByRole('heading', { level: 1, name: /Dashboard/ })
+            cy.findByRole('heading', { level: 1, name: /Submissions dashboard/ })
         })
     })
 

--- a/services/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
+++ b/services/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
@@ -23,7 +23,7 @@ describe('submission type', () => {
 
             // Navigate to dashboard page by clicking cancel
             cy.findByRole('button', { name: /Cancel/, timeout: 5_000}).click()
-            cy.findByRole('heading', { level: 1, name: /Dashboard/ })
+            cy.findByRole('heading', { level: 1, name: /Submissions dashboard/ })
 
             // Navigate to type page
             cy.navigateFormByDirectLink(
@@ -32,7 +32,7 @@ describe('submission type', () => {
 
             // Navigate to dashboard page by clicking save as draft
             cy.navigateFormByButtonClick('SAVE_DRAFT')
-            cy.findByRole('heading', { level: 1, name: /Dashboard/ })
+            cy.findByRole('heading', { level: 1, name: /Submissions dashboard/ })
 
             // Navigate to back to submission type page
             cy.navigateFormByDirectLink(
@@ -96,7 +96,7 @@ describe('submission type', () => {
             // Navigate to dashboard page by clicking cancel
             cy.findByRole('button', { name: /Cancel/ }).click()
             cy.wait('@indexHealthPlanPackagesQuery', { timeout: 50_000 })
-            cy.findByRole('heading', { level: 1, name: /Dashboard/ })
+            cy.findByRole('heading', { level: 1, name: /Submissions dashboard/ })
 
             // Navigate to type page
             cy.navigateFormByDirectLink(
@@ -121,7 +121,7 @@ describe('submission type', () => {
 
             // Click Save as draft button to save changes and navigate to dashboard
             cy.navigateFormByButtonClick('SAVE_DRAFT')
-            cy.findByRole('heading', { level: 1, name: /Dashboard/ })
+            cy.findByRole('heading', { level: 1, name: /Submissions dashboard/ })
 
             // Navigate back to submission type page
             cy.navigateFormByDirectLink(

--- a/services/cypress/support/loginCommands.ts
+++ b/services/cypress/support/loginCommands.ts
@@ -72,7 +72,7 @@ Cypress.Commands.add(
             // Default behavior on login is to go to CMS dashboard submissions
             cy.wait('@indexHealthPlanPackagesQuery', { timeout: 80_000 })
             cy.findByTestId('cms-dashboard-page',{timeout: 10_000 }).should('exist')
-            cy.findByRole('heading', {name: /Submissions Dashboard/}).should('exist')
+            cy.findByRole('heading', {name: /Submissions dashboard/}).should('exist')
         }
     }
 )

--- a/services/cypress/support/stateSubmissionFormCommands.ts
+++ b/services/cypress/support/stateSubmissionFormCommands.ts
@@ -100,7 +100,10 @@ Cypress.Commands.add('fillOutContractActionAndRateCertification', () => {
 Cypress.Commands.add('fillOutBaseContractDetails', () => {
     // Must be on '/submissions/:id/edit/contract-details'
     // Contract 438 attestation question
-    cy.findByText('Yes, the contract fully complies with all applicable requirements').click()
+    cy.findByText('No, the contract does not fully comply with all applicable requirements').click()
+
+    cy.findByRole('textbox', {name: 'Please provide a brief description of the contract’s non-compliance (with regulatory citations) and expected timeframe for remediation'})
+        .type('Non compliance explanation')
 
     cy.findByText('Fully executed').click()
     cy.findAllByLabelText('Start date', {timeout: 2000})
@@ -179,6 +182,8 @@ Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
     // Must be on '/submissions/:id/edit/contract-details'
     // Contract 438 attestation question
     cy.findByText('No, the contract does not fully comply with all applicable requirements').click()
+    cy.findByRole('textbox', {name: 'Please provide a brief description of the contract’s non-compliance (with regulatory citations) and expected timeframe for remediation'})
+        .type('Non compliance explanation')
 
     cy.findByText('Unexecuted by some or all parties').click()
 

--- a/services/cypress/utils/apollo-test-utils.ts
+++ b/services/cypress/utils/apollo-test-utils.ts
@@ -202,7 +202,8 @@ const contractAndRatesData = (): Partial<UnlockedHealthPlanFormDataType>=> ({
                 packagesWithSharedRateCerts: [],
             },
     ],
-    statutoryRegulatoryAttestation: true
+    statutoryRegulatoryAttestation: false,
+    statutoryRegulatoryAttestationDescription: 'No compliance'
 })
 
 const newSubmissionInput = (overrides?: Partial<UnlockedHealthPlanFormDataType> ): Partial<UnlockedHealthPlanFormDataType> => {


### PR DESCRIPTION
## Summary
[MCR-3601](https://qmacbis.atlassian.net/browse/MCR-3601):
- Database and schema work
   - Add `statutoryRegulatoryAttestationDescription` to `ContractRevisionTable`
   - Add `statutoryRegulatoryAttestationDescription` to `ContractFormDataType ` Domain types
   - Add `statutoryRegulatoryAttestationDescription` to `ContractInfo` Protobuf schema
   - Add `statutoryRegulatoryAttestationDescription` to `UnlockedHealthPlanFormDataType` and `LockedHealthPlanFormDataType`
   - Add `statutoryRegulatoryAttestationDescription` to  `app-web/src/common-code/proto/healthPlanFormDataProto/zodSchemas.ts`.
- API Work
   -  `updateDraftContractWithRates` and `unlockContract` handlers to update `statutoryRegulatoryAttestationDescription`
   - `updateDraftContractWithRates` will clear out existing `statutoryRegulatoryAttestationDescription` if `statutoryRegulatoryAttestation` is `true.
   - Update `submitHealthPlanPackage` resolver to validate on `statutoryRegulatoryAttestationDescription`
   - Update `contractFormDataToDomainModel` and `convertContractWithRatesToFormData` for `statutoryRegulatoryAttestationDescription`
   - Update test helpers and mocks
   - Add new `allFlags` method to `ldService` resolver dependency.
- Frontend Work
   - Update `toDomain` and `toProtoBuffer` for `statutoryRegulatoryAttestationDescription`
   - Add an attestation description text box on the `Contract Details` page if ` No, ...` is selected.
   - Display attestation noncompliance explanation on summary pages.
   - Update helpers and mocks

[MCR-3606](https://qmacbis.atlassian.net/browse/MCR-3606):
- Add new `Non-compliance guidance` section to the help page
- Add a link to the new section above the 438 noncompliance description text box.

Other:
- Fix styling on 438 guidance pdf links.
- Fix `label` and `legend` stylings for entire app.
- Fix dashboard page headers.

#### Related issues

#### Screenshots

#### Test cases covered

- Unit Tests
   - `submitHealthPlanPackage.test.ts`
      - UPDATED: `'errors when contract 4348 attestation question is undefined'`
      - `'errors when contract 4348 attestation question is false without a description'`
   -`ContractDetailsSummarySection.test.ts`
      - `'displays correct contract 438 attestation yes and no text'` -> `'displays correct contract 438 attestation yes and no text and description'`
   - `ContractDetails.test.ts`
      - `'errors when continuing without description for 438 non-compliance`

- Cypress Tests:
   - `fillOutBaseContractDetails` and `fillOutAmendmentToBaseContractDetails ` command. Added 438 attestation non-compliance description.

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
