### PR TITLE
Fix graphQL schema errors and the graphQL explorer tool

### DIFF
--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -737,16 +737,6 @@ enum PopulationCovered {
     MEDICAID_AND_CHIP
 }
 
-enum SubmissionType {
-    CONTRACT_ONLY
-    CONTRACT_AND_RATES
-}
-
-enum ContractType {
-    BASE
-    AMENDMENT
-}
-
 enum ContractExecutionStatus {
     EXECUTED
     UNEXECUTED


### PR DESCRIPTION
## Summary
[MCR-3754](https://qmacbis.atlassian.net/browse/MCR-3754)
Duplicate enums in `schema.graphql` caused errors that broke the explorer tool.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

Visit the endpoint `/dev/graphql-explorer` and make sure the schema loads without errors, and you can run a query. If there is an error, a pop-up will appear at the lower right of the app.

<!---These are developer instructions on how to test or validate the work -->
