### PR TITLE
Increase timeout when creating bulk download zip file.

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -209,6 +209,7 @@ functions:
           method: post
           cors: true
           authorizer: aws_iam
+    timeout: 60 # zipping large amount of files hits default time out of 6 seconds
 
   cleanup:
     handler: src/handlers/cleanup.main


### PR DESCRIPTION
## Summary
Prod is hitting the timeout when trying to create a large bulk download file. Increasing the timeout from around 6 to 60 seconds to see if that fixes the issue.

#### Related issues

#### Screenshots

<img width="947" alt="Screenshot 2023-12-07 at 3 51 26 PM" src="https://github.com/Enterprise-CMCS/managed-care-review/assets/98117700/f906c854-6731-4f35-91e8-eef3d2ac048d">

<img width="1022" alt="Screenshot 2023-12-07 at 3 51 46 PM" src="https://github.com/Enterprise-CMCS/managed-care-review/assets/98117700/a6db09d6-5dd6-4e6a-b3a8-76334080b798">


#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
