### PR TITLE
run avScan in tmp dirs

### DIFF
--- a/services/uploads/jest.config.ts
+++ b/services/uploads/jest.config.ts
@@ -21,4 +21,7 @@ module.exports = {
     moduleFileExtensions: ['js', 'json', 'jsx', 'd.ts', 'ts', 'node'],
     coveragePathIgnorePatterns: [],
     modulePathIgnorePatterns: ['local_buckets'],
+    moduleNameMapper: {
+        '^uuid$': require.resolve('uuid'),
+    },
 }

--- a/services/uploads/src/lambdas/avScan.ts
+++ b/services/uploads/src/lambdas/avScan.ts
@@ -81,8 +81,7 @@ async function avScan(event: S3Event, _context: Context) {
             clamAV,
             s3ObjectKey,
             s3ObjectBucket,
-            maxFileSize,
-            '/tmp/downloads'
+            maxFileSize
         )
 
         // Record the duration of the av scan

--- a/services/uploads/src/lib/avScan.test.ts
+++ b/services/uploads/src/lib/avScan.test.ts
@@ -12,7 +12,6 @@ describe('avScan', () => {
     it('tags clean for a clean file', async () => {
         const thisDir = __dirname
         const tmpDefsDir = await mkdtemp('/tmp/freshclam-')
-        const tmpScanDir = await mkdtemp('/tmp/clamscan-')
 
         const s3Client = NewTestS3UploadsClient()
 
@@ -61,7 +60,6 @@ describe('avScan', () => {
             goodFileKey,
             'test-uploads',
             MAX_FILE_SIZE,
-            tmpScanDir
         )
         if (scanResult instanceof Error) {
             throw scanResult
@@ -78,13 +76,11 @@ describe('avScan', () => {
         expect(virusScanStatus(res2)).toBe('CLEAN')
 
         await rm(tmpDefsDir, { force: true, recursive: true })
-        await rm(tmpScanDir, { force: true, recursive: true })
     })
 
     it('marks infected for an infected file', async () => {
         const thisDir = __dirname
         const tmpDefsDir = await mkdtemp('/tmp/freshclam-')
-        const tmpScanDir = await mkdtemp('/tmp/clamscan-')
 
         const s3Client = NewTestS3UploadsClient()
 
@@ -133,7 +129,6 @@ describe('avScan', () => {
             badFileKey,
             'test-uploads',
             MAX_FILE_SIZE,
-            tmpScanDir
         )
         if (scanResult instanceof Error) {
             throw scanResult
@@ -150,13 +145,11 @@ describe('avScan', () => {
         expect(virusScanStatus(res2)).toBe('INFECTED')
 
         await rm(tmpDefsDir, { force: true, recursive: true })
-        await rm(tmpScanDir, { force: true, recursive: true })
     })
 
     it('marks skipped for too big a file (config a smaller max size)', async () => {
         const thisDir = __dirname
         const tmpDefsDir = await mkdtemp('/tmp/freshclam-')
-        const tmpScanDir = await mkdtemp('/tmp/clamscan-')
 
         const s3Client = NewTestS3UploadsClient()
 
@@ -205,7 +198,6 @@ describe('avScan', () => {
             badFileKey,
             'test-uploads',
             2,
-            tmpScanDir
         )
         if (scanResult instanceof Error) {
             throw scanResult
@@ -222,13 +214,11 @@ describe('avScan', () => {
         expect(virusScanStatus(res2)).toBe('SKIPPED')
 
         await rm(tmpDefsDir, { force: true, recursive: true })
-        await rm(tmpScanDir, { force: true, recursive: true })
     })
 
     it('marks error if ClamAV errors', async () => {
         const thisDir = __dirname
         const tmpDefsDir = await mkdtemp('/tmp/freshclam-')
-        const tmpScanDir = await mkdtemp('/tmp/clamscan-')
 
         const s3Client = NewTestS3UploadsClient()
 
@@ -281,7 +271,6 @@ describe('avScan', () => {
             badFileKey,
             'test-uploads',
             MAX_FILE_SIZE,
-            tmpScanDir
         )
         if (scanResult instanceof Error) {
             throw scanResult
@@ -298,13 +287,11 @@ describe('avScan', () => {
         expect(virusScanStatus(res2)).toBe('ERROR')
 
         await rm(tmpDefsDir, { force: true, recursive: true })
-        await rm(tmpScanDir, { force: true, recursive: true })
     })
 
     it('returns not found if the key doesnt exist', async () => {
         const thisDir = __dirname
         const tmpDefsDir = await mkdtemp('/tmp/freshclam-')
-        const tmpScanDir = await mkdtemp('/tmp/clamscan-')
 
         const s3Client = NewTestS3UploadsClient()
 
@@ -336,7 +323,6 @@ describe('avScan', () => {
             badFileKey,
             'test-uploads',
             MAX_FILE_SIZE,
-            tmpScanDir
         )
         if (!(scanResult instanceof Error)) {
             throw new Error('Didnt error on a nonexistant file')
@@ -344,6 +330,5 @@ describe('avScan', () => {
         expect(scanResult.name).toBe('NotFound')
 
         await rm(tmpDefsDir, { force: true, recursive: true })
-        await rm(tmpScanDir, { force: true, recursive: true })
     })
 })


### PR DESCRIPTION
## Summary

We've had a long standing issue where occasionally files in our CI tests are marked as viruses. It looks like that's because we run avScan on a directory of files that gets added to on subsequent scans, so a single valid failure can then mark future scans as failures. 

This fix does all scanning in a tmp directory which should fix this bug restoring peace to our CI runs. 

#### Related issues

https://qmacbis.atlassian.net/browse/MCR-2647
