### PR TITLE
Bump actions download and upload artifact from 3 to 4

### DIFF
--- a/.github/workflows/deploy-app-to-env.yml
+++ b/.github/workflows/deploy-app-to-env.yml
@@ -85,13 +85,13 @@ jobs:
       - name: upload app web gen directory
         uses: actions/upload-artifact@v4
         with:
-          name: app-web-gen - app to env
+          name: app-web-gen deploy
           path: ./services/app-web/src/gen
 
       - name: upload cypress gen directory
         uses: actions/upload-artifact@v4
         with:
-          name: cypress-gen - app to env
+          name: cypress-gen deploy
           path: ./services/cypress/gen
 
       - uses: actions/download-artifact@v4

--- a/.github/workflows/deploy-app-to-env.yml
+++ b/.github/workflows/deploy-app-to-env.yml
@@ -82,13 +82,13 @@ jobs:
       - name: Generate Code
         run: npx lerna run generate
 
-      - name: upload app web gen directory
+      - name: upload app web gen directory - app to env
         uses: actions/upload-artifact@v4
         with:
           name: app-web-gen
           path: ./services/app-web/src/gen
 
-      - name: upload cypress gen directory
+      - name: upload cypress gen directory - app to env
         uses: actions/upload-artifact@v4
         with:
           name: cypress-gen

--- a/.github/workflows/deploy-app-to-env.yml
+++ b/.github/workflows/deploy-app-to-env.yml
@@ -85,13 +85,13 @@ jobs:
       - name: upload app web gen directory - app to env
         uses: actions/upload-artifact@v4
         with:
-          name: app-web-gen
+          name: app-web-gen - app to env
           path: ./services/app-web/src/gen
 
       - name: upload cypress gen directory - app to env
         uses: actions/upload-artifact@v4
         with:
-          name: cypress-gen
+          name: cypress-gen - app to env
           path: ./services/cypress/gen
 
       - uses: actions/download-artifact@v4

--- a/.github/workflows/deploy-app-to-env.yml
+++ b/.github/workflows/deploy-app-to-env.yml
@@ -94,7 +94,7 @@ jobs:
           name: cypress-gen
           path: ./services/cypress/gen
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: lambda-layers-prisma-client-migration
           path: ./services/app-api/lambda-layers-prisma-client-migration
@@ -104,7 +104,7 @@ jobs:
           tar -C ./services/app-api/lambda-layers-prisma-client-migration -xf ./services/app-api/lambda-layers-prisma-client-migration/nodejs.tar.gz
           rm -rf ./services/app-api/lambda-layers-prisma-client-migration/nodejs.tar.gz
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: lambda-layers-prisma-client-engine
           path: ./services/app-api/lambda-layers-prisma-client-engine

--- a/.github/workflows/deploy-app-to-env.yml
+++ b/.github/workflows/deploy-app-to-env.yml
@@ -82,13 +82,13 @@ jobs:
       - name: Generate Code
         run: npx lerna run generate
 
-      - name: upload app web gen directory - app to env
+      - name: upload app web gen directory
         uses: actions/upload-artifact@v4
         with:
           name: app-web-gen - app to env
           path: ./services/app-web/src/gen
 
-      - name: upload cypress gen directory - app to env
+      - name: upload cypress gen directory
         uses: actions/upload-artifact@v4
         with:
           name: cypress-gen - app to env

--- a/.github/workflows/deploy-app-to-env.yml
+++ b/.github/workflows/deploy-app-to-env.yml
@@ -83,13 +83,13 @@ jobs:
         run: npx lerna run generate
 
       - name: upload app web gen directory
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: app-web-gen
           path: ./services/app-web/src/gen
 
       - name: upload cypress gen directory
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-gen
           path: ./services/cypress/gen

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -458,12 +458,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: app-web-gen
           path: ./services/app-web/src/gen
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: cypress-gen
           path: ./services/cypress/gen
@@ -560,7 +560,7 @@ jobs:
           echo $(pwd)
           ls
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
 
       - name: Create combined test coverage report
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -518,7 +518,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always() && steps.cypress.outcome != 'skipped'
         with:
-          name: cypress-videos
+          name: cypress-videos deploy
           path: services/cypress/videos
       - name: upload partial cypress coverage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -278,7 +278,7 @@ jobs:
       needs.api-unit-tests.result == 'success' &&
       needs.build-prisma-client-lambda-layer.result == 'success' &&
       needs.begin-deployment.result == 'success'
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@dependabot/github_actions/actions/upload-artifact-4
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@Bump-actions-download-and-upload-artifact-from-3-to-4
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,19 +109,19 @@ jobs:
         run: yarn test:once --coverage
 
       - name: upload app web gen directory
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: app-web-gen
           path: ./services/app-web/src/gen
 
       - name: upload cypress gen directory
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-gen
           path: ./services/cypress/gen
 
       - name: upload unit test coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: unit-test-coverage
           path: ./services/app-web/coverage/coverage-final.json
@@ -189,7 +189,7 @@ jobs:
           yarn test:once --coverage
 
       - name: upload api test coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: api-test-coverage
           path: ./services/app-api/coverage/coverage-final.json
@@ -239,12 +239,12 @@ jobs:
         working-directory: services/app-api
         run: ./scripts/prepare-prisma-layer.sh
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: lambda-layers-prisma-client-migration
           path: ./services/app-api/lambda-layers-prisma-client-migration
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: lambda-layers-prisma-client-engine
           path: ./services/app-api/lambda-layers-prisma-client-engine
@@ -278,7 +278,7 @@ jobs:
       needs.api-unit-tests.result == 'success' &&
       needs.build-prisma-client-lambda-layer.result == 'success' &&
       needs.begin-deployment.result == 'success'
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@dependabot/github_actions/actions/upload-artifact-4
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name }}
@@ -508,26 +508,26 @@ jobs:
           CYPRESS_VIDEOS_FOLDER: services/cypress/videos
 
       - name: Upload cypress screenshots
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure() && steps.cypress.outcome == 'failure'
         with:
           name: cypress-screenshots
           path: services/cypress/screenshots
 
       - name: Upload cypress video
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() && steps.cypress.outcome != 'skipped'
         with:
           name: cypress-videos
           path: services/cypress/videos
       - name: upload partial cypress coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: partial-cypress-coverage-${{ matrix.containers}}
           path: ./coverage-cypress/lcov.info
 
       - name: upload partial cypress coverage json
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-json-coverage-${{ matrix.containers}}
           path: ./coverage-cypress/coverage-final.json
@@ -597,7 +597,7 @@ jobs:
           cd coverage-all
           echo "Coverage reports merged"
       - name: Upload combined test coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: combined-test-coverage
           path: ./coverage-all/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -511,14 +511,14 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure() && steps.cypress.outcome == 'failure'
         with:
-          name: cypress-screenshots
+          name: cypress-screenshots-${{ matrix.containers}}
           path: services/cypress/screenshots
 
       - name: Upload cypress video
         uses: actions/upload-artifact@v4
         if: always() && steps.cypress.outcome != 'skipped'
         with:
-          name: cypress-videos deploy
+          name: cypress-videos-${{ matrix.containers}}
           path: services/cypress/videos
       - name: upload partial cypress coverage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -223,12 +223,12 @@ jobs:
       - name: Setup env
         uses: ./.github/actions/setup_env
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: app-web-gen
           path: ./services/app-web/src/gen
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: cypress-gen
           path: ./services/cypress/gen

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -107,12 +107,12 @@ jobs:
         working-directory: services/app-api
         run: ./scripts/prepare-prisma-layer.sh
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: lambda-layers-prisma-client-migration
           path: ./services/app-api/lambda-layers-prisma-client-migration
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: lambda-layers-prisma-client-engine
           path: ./services/app-api/lambda-layers-prisma-client-engine
@@ -264,7 +264,7 @@ jobs:
           CYPRESS_VIDEOS_FOLDER: services/cypress/videos
 
       - name: Upload cypress video
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure() && steps.cypress.outcome == 'failure'
         with:
           name: cypress-videos


### PR DESCRIPTION
## Summary
Bumps [actions/download-artifact](https://github.com/actions/download-artifact) from 3 to 4.
Bumps [actions/upload-artifact](https://github.com/actions/upload-artifact) from 3 to 4.

- Both need to be on 4 for them to merge. See the comment from @mojotalantikite [here](https://github.com/Enterprise-CMCS/managed-care-review/pull/2125#issuecomment-1861385208).
- Changed some duplicate action/upload-artifact names. Duplicate names no longer allowed [actions/upload-artifact breaking changes](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes)

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
