### PR TITLE
Fix promote cypress-prod actions/download-artifact name.

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -225,12 +225,12 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: app-web-gen
+          name: app-web-gen deploy prod
           path: ./services/app-web/src/gen
 
       - uses: actions/download-artifact@v4
         with:
-          name: cypress-gen
+          name: cypress-gen deploy prod
           path: ./services/cypress/gen
 
       - name: Cypress chrome fix


### PR DESCRIPTION
## Summary
We changed the upload-artifact name for the `gen` folders on prod. `cypress-prod` needs to look for the new artifact name for the download steps.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
