### PR TITLE
Add createAPIToken endpoint and jwtLib service

### DIFF
--- a/docs/technical-design/api-jwt-security.md
+++ b/docs/technical-design/api-jwt-security.md
@@ -15,4 +15,4 @@ The JWT will have 3 claims in it:
 
 These are all standard fields and are explicitly accounted for in the JWT library we are using
 
-
+We are using the library [jsonwebtoken](https://www.npmjs.com/package/jsonwebtoken) to sign and verify JWTs, wrapped in our jwt module.

--- a/docs/technical-design/api-jwt-security.md
+++ b/docs/technical-design/api-jwt-security.md
@@ -1,0 +1,18 @@
+# API JWT Security
+
+In order to allow access to our API from automated 3rd party API clients instead of through the standard IDM/Cognito/React path, we are going to open up a new endpoint that uses a Lambda Authorizer to check the validity of a JWT bearer token to perform Authentication. 
+
+A [JWT](https://jwt.io/introduction) (pronounced "jot") is a small JSON object with standard keys that is signed with a secret controlled by the server. 
+
+The JWT will be sent in a Bearer header. 
+
+The JWT will be validated against a secret stored in Secret Manager. 
+
+The JWT will have 3 claims in it: 
+* issuer (iss): a string unique to this environment and application, ensuring that tokens aren't used across environments and identifying the environment it comes from.
+* subject (sub): the ID of the user the JWT belongs to and authorizes as
+* expiration (exp): the unix time stamp after which this JWT is no longer valid
+
+These are all standard fields and are explicitly accounted for in the JWT library we are using
+
+

--- a/services/app-api/package.json
+++ b/services/app-api/package.json
@@ -59,6 +59,7 @@
         "neverthrow": "^6.0.0",
         "path-to-regexp": "^6.2.1",
         "protobufjs": "^6.11.2",
+        "purify-ts": "^2.0.1",
         "request": "^2.88.2",
         "uuid": "^9.0.0",
         "zod": "^3.11.6"

--- a/services/app-api/src/domain-models/apiKey.ts
+++ b/services/app-api/src/domain-models/apiKey.ts
@@ -1,0 +1,6 @@
+interface APIKeyType {
+    key: string
+    expiresAt: Date
+}
+
+export type { APIKeyType }

--- a/services/app-api/src/domain-models/index.ts
+++ b/services/app-api/src/domain-models/index.ts
@@ -67,3 +67,5 @@ export type {
     QuestionResponseType,
     QuestionResponseDocument,
 } from './QuestionResponseType'
+
+export type { APIKeyType } from './apiKey'

--- a/services/app-api/src/handlers/apollo_gql.ts
+++ b/services/app-api/src/handlers/apollo_gql.ts
@@ -32,6 +32,7 @@ import {
     ApolloServerPluginLandingPageLocalDefault,
     ApolloServerPluginLandingPageDisabled,
 } from 'apollo-server-core'
+import { newJWTLib } from '../jwt'
 
 const requestSpanKey = 'REQUEST_SPAN'
 let tracer: Tracer
@@ -307,6 +308,13 @@ async function initializeGQLHandler(): Promise<Handler> {
         plugins = [ApolloServerPluginLandingPageLocalDefault({ embed: true })]
     }
 
+    // Hard coding this for now, next job is to run this config to this app.
+    const jwtLib = newJWTLib({
+        issuer: 'fakeIssuer',
+        signingKey: 'notrandom',
+        expirationDurationS: 90 * 24 * 60 * 60, // 90 days
+    })
+
     // Print out all the variables we've been configured with. Leave sensitive ones out, please.
     console.info('Running With Config: ', {
         authMode,
@@ -353,7 +361,8 @@ async function initializeGQLHandler(): Promise<Handler> {
         store,
         emailer,
         emailParameterStore,
-        launchDarkly
+        launchDarkly,
+        jwtLib
     )
 
     const userFetcher =

--- a/services/app-api/src/jwt/index.ts
+++ b/services/app-api/src/jwt/index.ts
@@ -1,0 +1,2 @@
+export { newJWTLib } from './jwt'
+export type { JWTLib } from './jwt'

--- a/services/app-api/src/jwt/jwt.test.ts
+++ b/services/app-api/src/jwt/jwt.test.ts
@@ -1,0 +1,104 @@
+import { newJWTLib } from './jwt'
+
+describe('jwtLib', () => {
+    it('works symmetricly', () => {
+        const jwt = newJWTLib({
+            issuer: 'mctest',
+            signingKey: 'foo', //pragma: allowlist secret
+            expirationDurationS: 1000,
+        })
+
+        const userID = 'bar'
+
+        const token = jwt.createValidJWT(userID)
+
+        const decodedID = jwt.userIDFromToken(token.key)
+
+        expect(decodedID).toBe(userID)
+
+        const higherDate = new Date(Date.now() + 1005)
+        const lowerDate = new Date(Date.now() + 995)
+
+        expect(token.expiresAt.getTime()).toBeLessThan(higherDate.getTime())
+        expect(token.expiresAt.getTime()).toBeGreaterThan(lowerDate.getTime())
+    })
+
+    // error cases
+    it('errors with wrong issuer', () => {
+        const jwtWriter = newJWTLib({
+            issuer: 'wrong',
+            signingKey: 'foo',
+            expirationDurationS: 1000,
+        })
+
+        const jwtReader = newJWTLib({
+            issuer: 'mctest',
+            signingKey: 'foo',
+            expirationDurationS: 1000,
+        })
+
+        const userID = 'bar'
+
+        const token = jwtWriter.createValidJWT(userID)
+
+        const decodedID = jwtReader.userIDFromToken(token.key)
+
+        expect(decodedID).toBeInstanceOf(Error)
+    })
+
+    it('errors with bad expiration', () => {
+        const jwtWriter = newJWTLib({
+            issuer: 'mctest',
+            signingKey: 'foo',
+            expirationDurationS: 0,
+        })
+
+        const jwtReader = newJWTLib({
+            issuer: 'mctest',
+            signingKey: 'foo',
+            expirationDurationS: 1000,
+        })
+
+        const userID = 'bar'
+
+        const token = jwtWriter.createValidJWT(userID)
+
+        const decodedID = jwtReader.userIDFromToken(token.key)
+
+        expect(decodedID).toBeInstanceOf(Error)
+    })
+
+    it('errors with bad secret', () => {
+        const jwtWriter = newJWTLib({
+            issuer: 'mctest',
+            signingKey: 'wrong',
+            expirationDurationS: 1000,
+        })
+
+        const jwtReader = newJWTLib({
+            issuer: 'mctest',
+            signingKey: 'foo',
+            expirationDurationS: 1000,
+        })
+
+        const userID = 'bar'
+
+        const token = jwtWriter.createValidJWT(userID)
+
+        const decodedID = jwtReader.userIDFromToken(token.key)
+
+        expect(decodedID).toBeInstanceOf(Error)
+    })
+
+    it('errors with bogus JWT', () => {
+        const jwtReader = newJWTLib({
+            issuer: 'mctest',
+            signingKey: 'foo',
+            expirationDurationS: 1000,
+        })
+
+        const decodedID = jwtReader.userIDFromToken('blerg')
+
+        expect(decodedID).toBeInstanceOf(Error)
+    })
+})

--- a/services/app-api/src/jwt/jwt.ts
+++ b/services/app-api/src/jwt/jwt.ts
@@ -1,0 +1,55 @@
+import type { APIKeyType } from '../domain-models'
+import { curry } from 'purify-ts/Function'
+import { sign, verify } from 'jsonwebtoken'
+
+interface JWTConfig {
+    issuer: string
+    signingKey: string
+    expirationDurationS: number
+}
+
+function createValidJWT(config: JWTConfig, userID: string): APIKeyType {
+    const token = sign({}, config.signingKey, {
+        subject: userID,
+        issuer: config.issuer,
+        expiresIn: config.expirationDurationS,
+    })
+
+    return {
+        key: token,
+        expiresAt: new Date(Date.now() + config.expirationDurationS),
+    }
+}
+
+function userIDFromToken(config: JWTConfig, token: string): string | Error {
+    try {
+        const decoded = verify(token, config.signingKey, {
+            issuer: config.issuer,
+        })
+
+        if (!decoded.sub || typeof decoded === 'string') {
+            return new Error('No subject included in otherwise valid JWT')
+        }
+
+        return decoded.sub
+    } catch (err) {
+        console.info('Error decoding JWT', err)
+        return err
+    }
+}
+
+interface JWTLib {
+    createValidJWT(userID: string): APIKeyType
+    userIDFromToken(token: string): string | Error
+}
+
+function newJWTLib(config: JWTConfig): JWTLib {
+    return {
+        createValidJWT: curry(createValidJWT)(config),
+        userIDFromToken: curry(userIDFromToken)(config),
+    }
+}
+
+export type { JWTLib }
+
+export { newJWTLib }

--- a/services/app-api/src/resolvers/APIKey/createAPIKey.test.ts
+++ b/services/app-api/src/resolvers/APIKey/createAPIKey.test.ts
@@ -1,0 +1,33 @@
+import { constructTestPostgresServer } from '../../testHelpers/gqlHelpers'
+import CREATE_API_KEY from '../../../../app-graphql/src/mutations/createAPIKey.graphql'
+import { newJWTLib } from '../../jwt'
+import { testCMSUser } from '../../testHelpers/userHelpers'
+
+describe('createAPIKey', () => {
+    it('creates a new API key', async () => {
+        const jwt = newJWTLib({
+            issuer: 'mctestiss',
+            signingKey: 'foo',
+            expirationDurationS: 1000,
+        })
+
+        const user = testCMSUser()
+
+        const server = await constructTestPostgresServer({
+            jwt,
+            context: { user },
+        })
+
+        const result = await server.executeOperation({
+            query: CREATE_API_KEY,
+        })
+
+        const keyResult = result.data?.createAPIKey
+
+        const token = keyResult.key
+
+        const userID = jwt.userIDFromToken(token)
+
+        expect(userID).toBe(user.id)
+    })
+})

--- a/services/app-api/src/resolvers/APIKey/createAPIKey.ts
+++ b/services/app-api/src/resolvers/APIKey/createAPIKey.ts
@@ -1,0 +1,12 @@
+import type { MutationResolvers } from '../../gen/gqlServer'
+import type { JWTLib } from '../../jwt'
+
+function createAPIKeyResolver(jwt: JWTLib): MutationResolvers['createAPIKey'] {
+    return async (_parent, _input, context) => {
+        const { user } = context
+
+        return jwt.createValidJWT(user.id)
+    }
+}
+
+export { createAPIKeyResolver }

--- a/services/app-api/src/resolvers/APIKey/index.ts
+++ b/services/app-api/src/resolvers/APIKey/index.ts
@@ -1,0 +1,1 @@
+export { createAPIKeyResolver } from './createAPIKey'

--- a/services/app-api/src/resolvers/configureResolvers.ts
+++ b/services/app-api/src/resolvers/configureResolvers.ts
@@ -25,17 +25,20 @@ import {
 } from './user'
 import type { EmailParameterStore } from '../parameterStore'
 import type { LDService } from '../launchDarkly/launchDarkly'
+import type { JWTLib } from '../jwt'
 import { fetchEmailSettingsResolver } from './email/fetchEmailSettings'
 import { indexRatesResolver } from './contractAndRates/indexRates'
 import { rateResolver } from './contractAndRates/rateResolver'
 import { fetchRateResolver } from './contractAndRates/fetchRate'
 import { updateContract } from './contract/updateContract'
+import { createAPIKeyResolver } from './APIKey'
 
 export function configureResolvers(
     store: Store,
     emailer: Emailer,
     emailParameterStore: EmailParameterStore,
-    launchDarkly: LDService
+    launchDarkly: LDService,
+    jwt: JWTLib
 ): Resolvers {
     const resolvers: Resolvers = {
         Date: GraphQLDate,
@@ -84,6 +87,7 @@ export function configureResolvers(
                 emailer,
                 emailParameterStore
             ),
+            createAPIKey: createAPIKeyResolver(jwt),
         },
         User: {
             // resolveType is required to differentiate Unions

--- a/services/app-graphql/src/mutations/createAPIKey.graphql
+++ b/services/app-graphql/src/mutations/createAPIKey.graphql
@@ -1,0 +1,6 @@
+mutation createAPIKey {
+    createAPIKey {
+        key
+        expiresAt
+    }
+}

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -269,6 +269,13 @@ type Mutation {
     createQuestionResponse(
         input: CreateQuestionResponseInput!
     ): CreateQuestionResponsePayload!
+
+
+    """
+    createAPIKey creates a valid API key for the logged in user, valid for 90 days
+    """
+    createAPIKey: CreateAPIKeyPayload!
+
 }
 
 input CreateHealthPlanPackageInput {
@@ -462,6 +469,11 @@ input UpdateContractInput {
 
 type UpdateContractPayload {
     pkg: HealthPlanPackage!
+}
+
+type CreateAPIKeyPayload {
+    key: String!
+    expiresAt: DateTime!
 }
 
 "Date is a CalendarDate representing a day without time information"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16309,6 +16309,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
+"@types/json-schema@7.0.12":
+  version "7.0.12"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"
+  integrity sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==
+
 "@types/json-stable-stringify@^1.0.32":
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/@types/json-stable-stringify/-/json-stable-stringify-1.0.34.tgz#c0fb25e4d957e0ee2e497c1f553d7f8bb668fd75"
@@ -31312,6 +31317,13 @@ pure-rand@^6.0.0:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.0.2.tgz#a9c2ddcae9b68d736a8163036f088a2781c8b306"
   integrity sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==
+
+purify-ts@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/purify-ts/-/purify-ts-2.0.1.tgz#1317af1791f1d45727f496309d215145f32594bc"
+  integrity sha512-g17AdcyNtXyUuLgMfQN8bS2xPiTrxxkebe5Ssy234NX8ZpE2Nbk6bIXO5MNapFVb77jcv7a4Xt9NfPtuCLGiBQ==
+  dependencies:
+    "@types/json-schema" "7.0.12"
 
 pvtsutils@^1.3.2:
   version "1.3.2"


### PR DESCRIPTION
## Summary

This is step one for adding a new page that can generate JWTs. 

I created a new GraphQL mutation for creating a new API Token. 

I created a new service module called `jwt` that wraps what seemed like overwhelmingly the most popular JWT JS library. 

@pearl-truss I think you will want to use the JWTLib I added here to do the validation of the JWT coming in to the lambda authorizer. Feel free to modify it at will, I made the API just return a user ID from the token, that might not be all we need? I think it's got what I need for the creation page is what I was focused on. 

#### Related issues

https://qmacbis.atlassian.net/browse/MCR-3833