### PR TITLE
MCR-3835: Attach lambda authorizer to api gateway endpoint

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -197,18 +197,6 @@ functions:
           method: get
           cors: true
           authorizer: aws_iam
-    timeout: 60 # aurora cold start can be long
-    vpc:
-      securityGroupIds:
-        - ${self:custom.sgId}
-      subnetIds: ${self:custom.privateSubnets}
-    layers:
-      - !Ref PrismaClientEngineLambdaLayer
-      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:1
-
-  graphql_external:
-    handler: src/handlers/apollo_gql.graphqlHandler
-    events:
       - http:
           path: v1/graphql/external
           method: post
@@ -230,7 +218,8 @@ functions:
       subnetIds: ${self:custom.privateSubnets}
     layers:
       - !Ref PrismaClientEngineLambdaLayer
-      
+      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:1
+
   migrate:
     handler: src/handlers/postgres_migrate.main
     timeout: 60

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -175,18 +175,7 @@ functions:
 
   third_party_api_authorizer:
     handler: src/handlers/third_party_API_authorizer.main
-
-  jwthealth:
-      handler: src/handlers/health_check.main
-      events:
-        - http:
-            path: jwt_health_check
-            method: get
-            cors: true
-            authorizer:
-              name: third_party_api_authorizer
-              identitySource: method.request.header.Authorization 
-              
+         
   otel:
     handler: src/handlers/otel_proxy.main
     events:
@@ -217,6 +206,24 @@ functions:
       - !Ref PrismaClientEngineLambdaLayer
       - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:1
 
+  graphql_external:
+    handler: src/handlers/apollo_gql.graphqlHandler
+    events:
+      - http:
+          path: v1/graphql/external
+          method: get
+          cors: true
+          authorizer:
+              name: third_party_api_authorizer
+              identitySource: method.request.header.Authorization
+    timeout: 60 # aurora cold start can be long
+    vpc:
+      securityGroupIds:
+        - ${self:custom.sgId}
+      subnetIds: ${self:custom.privateSubnets}
+    layers:
+      - !Ref PrismaClientEngineLambdaLayer
+      
   migrate:
     handler: src/handlers/postgres_migrate.main
     timeout: 60

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -211,6 +211,13 @@ functions:
     events:
       - http:
           path: v1/graphql/external
+          method: post
+          cors: true
+          authorizer:
+              name: third_party_api_authorizer
+              identitySource: method.request.header.Authorization
+      - http:
+          path: v1/graphql/external
           method: get
           cors: true
           authorizer:


### PR DESCRIPTION
## Summary

New `graphql_external` endpoint created. This is a copy of the `graphql` endpoint with the following changes:
- ~~Only has a get method. I believe we said we would limit 3rd parties to queries for now.~~ I added in the post method because of the language in https://qmacbis.atlassian.net/browse/MCR-3836 seems like it's something we will eventually implement
- URL path to invoke is `v1/graphql/external` per eng notes on the ticket
- 3rd party authorizer is attached

#### Related issues
https://qmacbis.atlassian.net/browse/MCR-3835


## QA guidance

I tested locally with curl

```
curl \
  --request GET \
  --header "Accept: text/javascript" \
  --header "Authorization: Bearer {token}" \
  --data '{"query": "query { indexHealthPlanPackage { totalCount edges{} } }"}' \
http://127.0.0.1:3030/local/v1/graphql/external
```

**With a valid token an apollo error is returned**

`Context creation failed: Log: placing user in gql context failed","    at ApolloServer.context`. 

I believe this error will resolve after https://qmacbis.atlassian.net/browse/MCR-3836 is completed

**With an invalid token a permission error is returned**

`"error":"Forbidden","message":"No principalId set on the Response"`


