### PR TITLE
MCR-3849 Fix: check auth for session expiration after a failed file upload

### DIFF
--- a/docs/technical-design/feature-brief-session-expiration.md
+++ b/docs/technical-design/feature-brief-session-expiration.md
@@ -2,33 +2,37 @@
 
 ## Introduction
 
-We use a third-party authentication provider ([IDM](https://confluenceent.cms.gov/display/IDM/IDM+Trainings+and+Guides)) which automatically logs out sessions due to inactivity after about 30 minutes. We don't have direct access to their timekeeping, but we know this is about how long they allow a session to be inactive. Thus, we manually track sessions internally for the same time period.
+We use a third-party authentication provider ([IDM](https://confluenceent.cms.gov/display/IDM/IDM+Trainings+and+Guides)) that automatically logs out sessions due to inactivity after about 30 minutes. Although sessions are handled by AWS Amplify/Cognito after login, we follow the same rules. We currently don't access Cognito to check if our session is active. Instead, we manually track sessions internally in React (`AuthContext.tsx`) for the same time period.
 
-Importantly this featured is permanently feature-flagged since we have different requirements between production/staging and lower environments. More details about feature flags [below](#implementation-details).
+Importantly this behavior permanently feature-flagged, with different requirements between production/staging and lower environments. More details about feature flags [below](#implementation-details).
 
 ## Expected behavior
+
  Two minutes before the session will expire due to inactivity we show a warning modal. The modal displays a live countdown and has CTA buttons with 1. the ability to log out immediately 2. the ability to extend the session. This helps us fulfill accessibility requirements around [WCAG 2.2.1 Timing Adjustable](https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable.html).
 
 ![session expiration modal](../../.images/session-expiring.png)
 
-### Possible outcomes after the session expiration modal is displayed:
+### Possible outcomes after the session expiration coutntdown modal is displayed:
+
 1. If the user chooses to logout, we redirect to landing page.
 2. If the user extends the session, we refresh their tokens and restart our counter for the session.
-3. If the user takes no action and the browser is still active, the 2 minute countdown will complete and the user will be automatically logged out and a error banner will appear on the landing page notifying them what happened.
+3. If the user takes no action and the browser is still active, the countdown completes and the user is automatically logged out and redirected to landing page. A session expired banner notifies them what happened.
 
 ![session expired banner - relevant for outcome 3](../../.images/session-expired-banner.png)
 
-This auto logout behavior will happen even if the browser tab is in the background. Either way we are keep track of time and the session expiration flow will work as expected.
+This auto logout behavior will happen even if that specific browser tab is inactive and in background. Either way we are keep track of time and the session expiration flow will work as expected.
 
 ## Known edge cases
-These are edge cases we decided not to address. Documenting for visibility.
 
-- The user puts computer to sleep while logged in (before session expiration modal is visible) and comes back after the session has expired.
-    - In this case, the session expiration modal will not display. The user will still  appear to be logged in when they relaunch their computer. However, as soon as the user takes an action that hits the API and we get a 403, we will follow the code path for outcome #3 above - automatically log the user and show the session expired error banner.
-- The user has MC-Review open in multiple tabs and then logs out of only one tab manually before session expiration.
+These are edge cases. Documenting for visibility.
+
+- The user puts computer entirely sleep while logged in (before session expiration modal is visible) and comes back after the session has expired.
+    - In this case, the session expiration modal will not display. The user will still appear logged in when they relaunch their computer and browser. However, as soon as the user takes an action that hits the graphql API or tries to upload a file to S3, we will follow the code path for outcome #3 above -  logout the user, redirect to landing page, show session expired error banner.
+- The user has MC-Review open in multiple tabs and logs out of one tab manually prior to session expiration.
     - This is not an ideal user experience. This is why we recommend users navigate the application in one tab at time. If the user logs out then goes to another tab that is still open and starts using the application, they will be able to make some requests with the cached user but at a certain point the requests will error (this may or may not be auth errors, sometimes the API may fail first with 400s and thus the generic failed request banner will show)
 
 ##  Implementation details
+
 - There are two evergreen feature flags (`SESSION_EXPIRING_MODAL` and `MINUTES_UNTIL_SESSION_EXPIRES`) associated with this feature.
     -  `SESSION_EXPIRING_MODAL` allows turning this feature off on dev and review apps since it can disrupt Cypress.  Expect that VAL and PROD have this flag turned on permanently.
     - `MINUTES_UNTIL_SESSION_EXPIRES` allows us shorten the session expiration time to turn on modal quickly and test functionality. Expect that VAL and PROD the default 30 min is used.

--- a/services/app-web/src/components/FileUpload/FileUpload.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.tsx
@@ -180,8 +180,8 @@ export const FileUpload = ({
     }
     // Upload to S3 and update file items in component state with the async loading status
     // This includes moving from pending/loading UI to display success or errors
-    const asyncS3Upload = (files: File[] | File) => {
-        const upload = async (file: File) => {
+    const handleS3Upload = (files: File[] | File) => {
+        const asyncUploadAndScan = async (file: File) => {
             const sha = (await calculateSHA256(file)) || ''
             uploadFile(file)
                 .then((data) => {
@@ -291,10 +291,10 @@ export const FileUpload = ({
 
         if (!(files instanceof File)) {
             files.forEach((file) => {
-                upload(file).catch((e) => console.error(e))
+                asyncUploadAndScan(file).catch((e) => console.error(e))
             })
         } else {
-            upload(files).catch((e) => console.error(e))
+            asyncUploadAndScan(files).catch((e) => console.error(e))
         }
     }
 
@@ -318,7 +318,7 @@ export const FileUpload = ({
             })
         })
 
-        asyncS3Upload(item.file)
+        handleS3Upload(item.file)
     }
 
     const addFilesAndUpdateList = (files: File[]) => {
@@ -334,7 +334,7 @@ export const FileUpload = ({
                 })
             })
         setFileItems((array) => [...array, ...items])
-        asyncS3Upload(files)
+        handleS3Upload(files)
 
         // reset input immediately to prepare for next interaction
         fileInputRef.current?.clearFiles()

--- a/services/app-web/src/components/Header/Header.test.tsx
+++ b/services/app-web/src/components/Header/Header.test.tsx
@@ -141,36 +141,5 @@ describe('Header', () => {
 
             await waitFor(() => expect(spy).toHaveBeenCalledTimes(1))
         })
-
-        it('calls setAlert when logout is unsuccessful', async () => {
-            const spy = jest
-                .spyOn(CognitoAuthApi, 'signOut')
-                .mockRejectedValue('This logout failed!')
-            const mockAlert = jest.fn()
-
-            renderWithProviders(
-                <Header authMode={'AWS_COGNITO'} setAlert={mockAlert} />,
-                {
-                    apolloProvider: {
-                        mocks: [
-                            fetchCurrentUserMock({ statusCode: 200 }),
-                            fetchCurrentUserMock({ statusCode: 403 }),
-                        ],
-                    },
-                }
-            )
-
-            await waitFor(() => {
-                const signOutButton = screen.getByRole('button', {
-                    name: /Sign out/i,
-                })
-
-                expect(signOutButton).toBeInTheDocument()
-                void userEvent.click(signOutButton)
-            })
-
-            await waitFor(() => expect(spy).toHaveBeenCalledTimes(1))
-            await waitFor(() => expect(mockAlert).toHaveBeenCalled())
-        })
     })
 })

--- a/services/app-web/src/components/Header/Header.tsx
+++ b/services/app-web/src/components/Header/Header.tsx
@@ -10,12 +10,9 @@ import { Logo } from '../Logo'
 import styles from './Header.module.scss'
 import { PageHeadingRow } from './PageHeadingRow/PageHeadingRow'
 import { UserLoginInfo } from './UserLoginInfo/UserLoginInfo'
-import { recordJSException } from '../../otelHelpers'
-import { ErrorAlertSignIn } from '../ErrorAlert'
 
 export type HeaderProps = {
     authMode: AuthModeType
-    setAlert?: React.Dispatch<React.ReactElement>
     disableLogin?: boolean
 }
 
@@ -24,25 +21,16 @@ export type HeaderProps = {
  */
 export const Header = ({
     authMode,
-    setAlert,
     disableLogin = false,
 }: HeaderProps): React.ReactElement => {
     const { logout, loggedInUser, loginStatus } = useAuth()
     const { heading } = usePage()
     const { currentRoute: route } = useCurrentRoute()
 
-    const handleLogout = (
+    const handleLogout = async (
         e: React.MouseEvent<HTMLButtonElement, MouseEvent>
     ) => {
-        if (!logout) {
-            console.info('Something went wrong ', e)
-            return
-        }
-
-        logout({ sessionTimeout: false }).catch((e) => {
-            recordJSException(`Error with logout: ${e}`)
-            setAlert && setAlert(<ErrorAlertSignIn />)
-        })
+        await logout({ sessionTimeout: false })
     }
 
     return (

--- a/services/app-web/src/contexts/AuthContext.tsx
+++ b/services/app-web/src/contexts/AuthContext.tsx
@@ -254,7 +254,7 @@ function AuthProvider({
         try {
             await realLogout()
             if (sessionTimeout) {
-                window.location.href = `${redirectPath}?session-timeout=true'`
+                window.location.href = `${redirectPath}?session-timeout=true`
             } else {
                 window.location.href = redirectPath
             }

--- a/services/app-web/src/pages/App/AppBody.tsx
+++ b/services/app-web/src/pages/App/AppBody.tsx
@@ -49,11 +49,7 @@ export function AppBody({
                 </div>
             )}
 
-            <Header
-                authMode={authMode}
-                setAlert={setGlobalAlert}
-                disableLogin={siteUnderMaintenance}
-            />
+            <Header authMode={authMode} disableLogin={siteUnderMaintenance} />
             <main id="main-content" className={styles.mainContent} role="main">
                 {globalAlert && globalAlert}
                 {siteUnderMaintenance ? (

--- a/services/app-web/src/pages/Auth/Auth.test.tsx
+++ b/services/app-web/src/pages/Auth/Auth.test.tsx
@@ -13,7 +13,7 @@ import {
 import { CognitoLogin } from './CognitoLogin'
 import { LocalLogin } from '../../localAuth'
 import { fetchCurrentUserMock } from '../../testHelpers/apolloMocks'
-/*  
+/*
 This file should only have basic user flows for auth. Form and implementation details are tested at the component level.
 */
 
@@ -243,7 +243,7 @@ describe('Auth', () => {
             })
         })
 
-        it('when login fails, stay on page and display error alert', async () => {
+        it('when login fails, kick back to landing page', async () => {
             let testLocation: Location
 
             renderWithProviders(
@@ -266,7 +266,7 @@ describe('Auth', () => {
 
             await userClickByTestId(screen, 'TophButton')
             await waitFor(() => {
-                expect(testLocation.pathname).toBe('/auth')
+                expect(testLocation.pathname).toBe('/')
             })
         })
     })

--- a/services/app-web/src/pages/Auth/CognitoLogin.tsx
+++ b/services/app-web/src/pages/Auth/CognitoLogin.tsx
@@ -4,8 +4,14 @@ import { Button, GridContainer, Grid } from '@trussworks/react-uswds'
 import { Signup } from './Signup'
 import { ConfirmSignUp } from './ConfirmSignUp'
 import { Login } from './Login'
+import { ErrorAlertSessionExpired } from '../../components'
+import { useLocation } from 'react-router-dom'
 
 export const CognitoLogin = (): React.ReactElement => {
+    const location = useLocation()
+    const redirectFromSessionTimeout = new URLSearchParams(location.search).get(
+        'session-timeout'
+    )
     const [showConfirmation, setShowConfirmation] = useState(false)
     const [showLogin, setShowLogin] = useState(false)
     const [enteredEmail, setEnteredEmail] = useState('')
@@ -18,6 +24,7 @@ export const CognitoLogin = (): React.ReactElement => {
 
     return showForms ? (
         <GridContainer>
+            {redirectFromSessionTimeout && <ErrorAlertSessionExpired />}
             <h2>Auth Page</h2>
             <Grid row>
                 {!showLogin && (

--- a/services/app-web/src/pages/Auth/Login.tsx
+++ b/services/app-web/src/pages/Auth/Login.tsx
@@ -58,17 +58,19 @@ export function Login({ defaultEmail }: Props): React.ReactElement {
                 setShowFormAlert(true)
                 console.info('Error', result.message)
             } else {
-                try {
-                    await checkAuth()
-                } catch (e) {
-                    console.info('UNEXPECTED NOT LOGGED IN AFTER LOGGIN', e)
+                const result = await checkAuth('/auth')
+                if (result instanceof Error) {
+                    console.error(
+                        'UNEXPECTED -  NOT AUTHENTICATED BUT COGNITO PASSWORD LOGIN HAS RESOLVED WITHOUT ERROR',
+                        result
+                    )
                     setShowFormAlert(true)
                 }
-
                 navigate('/')
             }
         } catch (err) {
-            console.info('Unexpected error signing in:', err)
+            setShowFormAlert(true)
+            console.info('Sign in error:', err)
         }
     }
 

--- a/services/app-web/src/pages/Landing/Landing.test.tsx
+++ b/services/app-web/src/pages/Landing/Landing.test.tsx
@@ -34,4 +34,26 @@ describe('Landing', () => {
             screen.queryByText(/You have been logged out due to inactivity/)
         ).toBeNull()
     })
+
+    it('displays sign in error when query parameter included', async () => {
+        ldUseClientSpy({ 'site-under-maintenance-banner': false })
+        renderWithProviders(<Landing />, {
+            routerProvider: { route: '/?auth-error' },
+        })
+        expect(
+            screen.queryByRole('heading', { name: 'Sign in error' })
+        ).toBeNull()
+    })
+
+    it('does not display sign in error by default', async () => {
+        ldUseClientSpy({ 'site-under-maintenance-banner': false })
+        renderWithProviders(<Landing />, {
+            routerProvider: { route: '/' },
+        })
+        expect(
+            screen.queryByRole('heading', {
+                name: 'Sign in error',
+            })
+        ).toBeNull()
+    })
 })

--- a/services/app-web/src/pages/Landing/Landing.tsx
+++ b/services/app-web/src/pages/Landing/Landing.tsx
@@ -8,9 +8,12 @@ import {
     ErrorAlertSiteUnavailable,
     ErrorAlertSessionExpired,
     ErrorAlertScheduledMaintenance,
+    ErrorAlertSignIn,
 } from '../../components'
 
-function maintenanceBannerForVariation(flag: string): React.ReactNode {
+function maintenanceBannerForVariation(
+    flag: string
+): React.ReactElement | undefined {
     if (flag === 'UNSCHEDULED') {
         return <ErrorAlertSiteUnavailable />
     } else if (flag === 'SCHEDULED') {
@@ -27,7 +30,7 @@ export const Landing = (): React.ReactElement => {
         featureFlags.SITE_UNDER_MAINTENANCE_BANNER.defaultValue
     )
 
-    const maybeMaintenaceBanner = maintenanceBannerForVariation(
+    const maintainenceBanner = maintenanceBannerForVariation(
         siteUnderMaintenanceBannerFlag
     )
 
@@ -35,13 +38,20 @@ export const Landing = (): React.ReactElement => {
         'session-timeout'
     )
 
+    const redirectFromAuthError = new URLSearchParams(location.search).get(
+        'auth-error'
+    )
+
     return (
         <>
             <section className={styles.detailsSection}>
                 <GridContainer className={styles.detailsSectionContent}>
-                    {maybeMaintenaceBanner}
-                    {redirectFromSessionTimeout && !maybeMaintenaceBanner && (
+                    {maintainenceBanner}
+                    {redirectFromSessionTimeout && !maintainenceBanner && (
                         <ErrorAlertSessionExpired />
+                    )}
+                    {redirectFromAuthError && !maintainenceBanner && (
+                        <ErrorAlertSignIn />
                     )}
                     <Grid row gap className="margin-top-2">
                         <Grid tablet={{ col: 6 }}>

--- a/services/app-web/src/pages/Wrapper/AuthenticatedRouteWrapper.tsx
+++ b/services/app-web/src/pages/Wrapper/AuthenticatedRouteWrapper.tsx
@@ -36,15 +36,12 @@ export const AuthenticatedRouteWrapper = ({
 
     const logoutSession = useCallback(
         (forcedSessionSignout: boolean) => {
-            updateSessionExpirationState(false)
-            if (logout) {
-                logout({ sessionTimeout: forcedSessionSignout }).catch((e) => {
-                    recordJSException(`Error with logout: ${e}`)
-                    setAlert && setAlert(<ErrorAlertSignIn />)
-                })
-            }
+            logout({ sessionTimeout: forcedSessionSignout }).catch((e) => {
+                recordJSException(`Error with logout: ${e}`)
+                setAlert && setAlert(<ErrorAlertSignIn />)
+            })
         },
-        [logout, setAlert, updateSessionExpirationState]
+        [logout, setAlert]
     )
 
     const resetSessionTimeout = () => {


### PR DESCRIPTION
## Summary
Automatic logout when file upload fails due to session expiration

#### Related issues
https://qmacbis.atlassian.net/browse/MCR-3849

#### Screenshots

#### Test cases covered

This requires manual testing right now.

## QA guidance

**Steps to Reproduce**
- Sign into MC-Review _with the Toph CMS user_ 
- Leave the tab open on a form page with file upload. 
- Let tab and browser go inactive for 45 min
- Return to the MC-Review tab
- Immediately try to add a file on that same page 
- File upload fails
- App logs out and kicks you back to homepage (or auth page if its a review app) with session alert telling you what happened

**Other things to test**
- make sure logout is still working in general and session expiration modal still shows when app is active