### PR TITLE
MCR-3813: Made rate summary route available to state user

### DIFF
--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -92,7 +92,6 @@ const StateUserRoutes = ({
                     path={RoutesRecord.DASHBOARD_SUBMISSIONS}
                     element={<StateDashboard />}
                 />
-
                 <Route
                     path={RoutesRecord.SUBMISSIONS}
                     element={<StateDashboard />}
@@ -100,6 +99,10 @@ const StateUserRoutes = ({
                 <Route
                     path={RoutesRecord.SUBMISSIONS_NEW}
                     element={<NewStateSubmissionForm />}
+                />
+                <Route
+                    path={RoutesRecord.RATES_SUMMARY}
+                    element={<RateSummary />}
                 />
                 <Route element={<SubmissionSideNav />}>
                     {showQuestionResponse && (

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -38,6 +38,7 @@ import {
 } from '../QuestionResponse'
 import { GraphQLExplorer } from '../GraphQLExplorer/GraphQLExplorer'
 import { RateSummary } from '../SubmissionSummary/RateSummary'
+import { User } from '../../gen/gqlClient'
 
 function componentForAuthMode(
     authMode: AuthModeType
@@ -67,11 +68,13 @@ const StateUserRoutes = ({
     setAlert,
     showQuestionResponse,
     stageName,
+    loggedInUser,
 }: {
     authMode: AuthModeType
     setAlert?: React.Dispatch<React.ReactElement>
     showQuestionResponse: boolean
     stageName?: string
+    loggedInUser: User
 }): React.ReactElement => {
     // feature flag
     const ldClient = useLDClient()
@@ -109,7 +112,7 @@ const StateUserRoutes = ({
                 {showRateSummaryPage && (
                     <Route
                         path={RoutesRecord.RATES_SUMMARY}
-                        element={<RateSummary />}
+                        element={<RateSummary loggedInUser={loggedInUser}/>}
                     />
                 )}
                 <Route element={<SubmissionSideNav />}>
@@ -158,11 +161,13 @@ const CMSUserRoutes = ({
     setAlert,
     showQuestionResponse,
     stageName,
+    loggedInUser
 }: {
     authMode: AuthModeType
     setAlert?: React.Dispatch<React.ReactElement>
     showQuestionResponse: boolean
     stageName?: string
+    loggedInUser: User
 }): React.ReactElement => {
     return (
         <AuthenticatedRouteWrapper authMode={authMode} setAlert={setAlert}>
@@ -213,7 +218,7 @@ const CMSUserRoutes = ({
 
                 <Route
                     path={RoutesRecord.RATES_SUMMARY}
-                    element={<RateSummary />}
+                    element={<RateSummary loggedInUser={loggedInUser}/>}
                 />
 
                 <Route
@@ -383,6 +388,7 @@ export const AppRoutes = ({
                 setAlert={setAlert}
                 showQuestionResponse={showQuestionResponse}
                 stageName={stageName}
+                loggedInUser={loggedInUser}
             />
         )
     } else {
@@ -392,6 +398,7 @@ export const AppRoutes = ({
                 setAlert={setAlert}
                 showQuestionResponse={showQuestionResponse}
                 stageName={stageName}
+                loggedInUser={loggedInUser}
             />
         )
     }

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -73,6 +73,12 @@ const StateUserRoutes = ({
     showQuestionResponse: boolean
     stageName?: string
 }): React.ReactElement => {
+    // feature flag
+    const ldClient = useLDClient()
+    const showRateSummaryPage: boolean = ldClient?.variation(
+        featureFlags.RATE_EDIT_UNLOCK.flag,
+        featureFlags.RATE_EDIT_UNLOCK.defaultValue
+    )
     return (
         <AuthenticatedRouteWrapper setAlert={setAlert} authMode={authMode}>
             <Routes>
@@ -100,10 +106,12 @@ const StateUserRoutes = ({
                     path={RoutesRecord.SUBMISSIONS_NEW}
                     element={<NewStateSubmissionForm />}
                 />
-                <Route
-                    path={RoutesRecord.RATES_SUMMARY}
-                    element={<RateSummary />}
-                />
+                {showRateSummaryPage && (
+                    <Route
+                        path={RoutesRecord.RATES_SUMMARY}
+                        element={<RateSummary />}
+                    />
+                )}
                 <Route element={<SubmissionSideNav />}>
                     {showQuestionResponse && (
                         <>

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -38,7 +38,6 @@ import {
 } from '../QuestionResponse'
 import { GraphQLExplorer } from '../GraphQLExplorer/GraphQLExplorer'
 import { RateSummary } from '../SubmissionSummary/RateSummary'
-import { User } from '../../gen/gqlClient'
 
 function componentForAuthMode(
     authMode: AuthModeType
@@ -68,13 +67,11 @@ const StateUserRoutes = ({
     setAlert,
     showQuestionResponse,
     stageName,
-    loggedInUser,
 }: {
     authMode: AuthModeType
     setAlert?: React.Dispatch<React.ReactElement>
     showQuestionResponse: boolean
     stageName?: string
-    loggedInUser: User
 }): React.ReactElement => {
     // feature flag
     const ldClient = useLDClient()
@@ -112,7 +109,7 @@ const StateUserRoutes = ({
                 {showRateSummaryPage && (
                     <Route
                         path={RoutesRecord.RATES_SUMMARY}
-                        element={<RateSummary loggedInUser={loggedInUser}/>}
+                        element={<RateSummary />}
                     />
                 )}
                 <Route element={<SubmissionSideNav />}>
@@ -161,13 +158,11 @@ const CMSUserRoutes = ({
     setAlert,
     showQuestionResponse,
     stageName,
-    loggedInUser
 }: {
     authMode: AuthModeType
     setAlert?: React.Dispatch<React.ReactElement>
     showQuestionResponse: boolean
     stageName?: string
-    loggedInUser: User
 }): React.ReactElement => {
     return (
         <AuthenticatedRouteWrapper authMode={authMode} setAlert={setAlert}>
@@ -218,7 +213,7 @@ const CMSUserRoutes = ({
 
                 <Route
                     path={RoutesRecord.RATES_SUMMARY}
-                    element={<RateSummary loggedInUser={loggedInUser}/>}
+                    element={<RateSummary />}
                 />
 
                 <Route
@@ -388,7 +383,6 @@ export const AppRoutes = ({
                 setAlert={setAlert}
                 showQuestionResponse={showQuestionResponse}
                 stageName={stageName}
-                loggedInUser={loggedInUser}
             />
         )
     } else {
@@ -398,7 +392,6 @@ export const AppRoutes = ({
                 setAlert={setAlert}
                 showQuestionResponse={showQuestionResponse}
                 stageName={stageName}
-                loggedInUser={loggedInUser}
             />
         )
     }

--- a/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.test.tsx
@@ -24,7 +24,7 @@ describe('RateSummary', () => {
 
     describe('Viewing RateSummary as a CMS user', () => {
         it('renders without errors', async () => {
-            renderWithProviders(wrapInRoutes(<RateSummary />), {
+            renderWithProviders(wrapInRoutes(<RateSummary loggedInUser={mockValidCMSUser()}/>), {
                 apolloProvider: {
                     mocks: [
                         fetchCurrentUserMock({
@@ -58,7 +58,7 @@ describe('RateSummary', () => {
                     return new Error('Error: getBulkDlURL encountered an error')
                 },
             }
-            renderWithProviders(wrapInRoutes(<RateSummary />), {
+            renderWithProviders(wrapInRoutes(<RateSummary loggedInUser={mockValidCMSUser()}/>), {
                 apolloProvider: {
                     mocks: [
                         fetchCurrentUserMock({
@@ -87,7 +87,7 @@ describe('RateSummary', () => {
         })
 
         it('renders back to dashboard link for CMS users', async () => {
-            renderWithProviders(wrapInRoutes(<RateSummary />), {
+            renderWithProviders(wrapInRoutes(<RateSummary loggedInUser={mockValidCMSUser()}/>), {
                 apolloProvider: {
                     mocks: [
                         fetchCurrentUserMock({
@@ -117,7 +117,7 @@ describe('RateSummary', () => {
         })
 
         it('renders without errors', async () => {
-            renderWithProviders(wrapInRoutes(<RateSummary />), {
+            renderWithProviders(wrapInRoutes(<RateSummary loggedInUser={mockValidStateUser()}/>), {
                 apolloProvider: {
                     mocks: [
                         fetchCurrentUserMock({
@@ -142,7 +142,7 @@ describe('RateSummary', () => {
         })
 
         it('renders expected error page when rate ID is invalid', async () => {
-            renderWithProviders(wrapInRoutes(<RateSummary />), {
+            renderWithProviders(wrapInRoutes(<RateSummary loggedInUser={mockValidStateUser()}/>), {
                 apolloProvider: {
                     mocks: [
                         fetchCurrentUserMock({

--- a/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.test.tsx
@@ -24,7 +24,7 @@ describe('RateSummary', () => {
 
     describe('Viewing RateSummary as a CMS user', () => {
         it('renders without errors', async () => {
-            renderWithProviders(wrapInRoutes(<RateSummary loggedInUser={mockValidCMSUser()}/>), {
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
                 apolloProvider: {
                     mocks: [
                         fetchCurrentUserMock({
@@ -58,7 +58,7 @@ describe('RateSummary', () => {
                     return new Error('Error: getBulkDlURL encountered an error')
                 },
             }
-            renderWithProviders(wrapInRoutes(<RateSummary loggedInUser={mockValidCMSUser()}/>), {
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
                 apolloProvider: {
                     mocks: [
                         fetchCurrentUserMock({
@@ -87,7 +87,7 @@ describe('RateSummary', () => {
         })
 
         it('renders back to dashboard link for CMS users', async () => {
-            renderWithProviders(wrapInRoutes(<RateSummary loggedInUser={mockValidCMSUser()}/>), {
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
                 apolloProvider: {
                     mocks: [
                         fetchCurrentUserMock({
@@ -117,7 +117,7 @@ describe('RateSummary', () => {
         })
 
         it('renders without errors', async () => {
-            renderWithProviders(wrapInRoutes(<RateSummary loggedInUser={mockValidStateUser()}/>), {
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
                 apolloProvider: {
                     mocks: [
                         fetchCurrentUserMock({
@@ -142,7 +142,7 @@ describe('RateSummary', () => {
         })
 
         it('renders expected error page when rate ID is invalid', async () => {
-            renderWithProviders(wrapInRoutes(<RateSummary loggedInUser={mockValidStateUser()}/>), {
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
                 apolloProvider: {
                     mocks: [
                         fetchCurrentUserMock({
@@ -164,7 +164,7 @@ describe('RateSummary', () => {
         })
 
         it('renders back to dashboard link for state users', async () => {
-            renderWithProviders(wrapInRoutes(<RateSummary loggedInUser={mockValidStateUser()}/>), {
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
                 apolloProvider: {
                     mocks: [
                         fetchCurrentUserMock({

--- a/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.test.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import { renderWithProviders, testS3Client } from '../../../testHelpers'
+import { renderWithProviders, testS3Client, ldUseClientSpy } from '../../../testHelpers'
 import {
     fetchCurrentUserMock,
     fetchRateMockSuccess,
@@ -112,6 +112,10 @@ describe('RateSummary', () => {
     })
 
     describe('Viewing RateSummary as a State user', () => {
+        beforeEach(() => {
+            ldUseClientSpy({'rate-edit-unlock': true})
+        })
+
         it('renders without errors', async () => {
             renderWithProviders(wrapInRoutes(<RateSummary />), {
                 apolloProvider: {
@@ -126,6 +130,10 @@ describe('RateSummary', () => {
                 routerProvider: {
                     route: '/rates/1337'
                 },
+            })
+
+            await waitFor(() => {
+                expect(screen.queryByTestId('rate-summary')).toBeInTheDocument()
             })
 
             expect(

--- a/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.test.tsx
@@ -4,6 +4,7 @@ import {
     fetchCurrentUserMock,
     fetchRateMockSuccess,
     mockValidCMSUser,
+    mockValidStateUser,
 } from '../../../testHelpers/apolloMocks'
 import { RateSummary } from './RateSummary'
 import { RoutesRecord } from '../../../constants'
@@ -20,90 +21,138 @@ const wrapInRoutes = (children: React.ReactNode) => {
 
 describe('RateSummary', () => {
     afterAll(() => jest.clearAllMocks())
-    it('renders without errors', async () => {
-        renderWithProviders(wrapInRoutes(<RateSummary />), {
-            apolloProvider: {
-                mocks: [
-                    fetchCurrentUserMock({
-                        user: mockValidCMSUser(),
-                        statusCode: 200,
-                    }),
-                    fetchRateMockSuccess({ rate: { id: '7a' } }),
-                ],
-            },
-            routerProvider: {
-                route: '/rates/7a',
-            },
+
+    describe('Viewing RateSummary as a CMS user', () => {
+        it('renders without errors', async () => {
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchRateMockSuccess({ rate: { id: '7a' } }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/rates/7a',
+                },
+            })
+    
+            expect(
+                await screen.findByText('Programs this rate certification covers')
+            ).toBeInTheDocument()
         })
 
-        expect(
-            await screen.findByText('Programs this rate certification covers')
-        ).toBeInTheDocument()
+        it('renders document download warning banner when download fails', async () => {
+            const error = jest.spyOn(console, 'error').mockImplementation(() => {
+                // mock expected console error to keep test output clear
+            })
+    
+            const s3Provider = {
+                ...testS3Client(),
+                getBulkDlURL: async (
+                    keys: string[],
+                    fileName: string
+                ): Promise<string | Error> => {
+                    return new Error('Error: getBulkDlURL encountered an error')
+                },
+            }
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchRateMockSuccess({ rate: { id: '7a' } }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/rates/7a',
+                },
+                s3Provider,
+            })
+    
+            await waitFor(() => {
+                expect(screen.getByTestId('warning-alert')).toBeInTheDocument()
+                expect(screen.getByTestId('warning-alert')).toHaveClass(
+                    'usa-alert--warning'
+                )
+                expect(screen.getByTestId('warning-alert')).toHaveTextContent(
+                    'Document download unavailable'
+                )
+                expect(error).toHaveBeenCalled()
+            })
+        })
+
+        it('renders back to dashboard link for CMS users', async () => {
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchRateMockSuccess({ rate: { id: '7a' } }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/rates/7a',
+                },
+            })
+    
+            const backLink = await screen.findByRole('link', {
+                name: /Back to dashboard/,
+            })
+            expect(backLink).toBeInTheDocument()
+    
+            expect(backLink).toHaveAttribute('href', '/dashboard/rate-reviews')
+        })
     })
 
-    it('renders document download warning banner when download fails', async () => {
-        const error = jest.spyOn(console, 'error').mockImplementation(() => {
-            // mock expected console error to keep test output clear
+    describe('Viewing RateSummary as a State user', () => {
+        it('renders without errors', async () => {
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidStateUser(),
+                            statusCode: 200,
+                        }),
+                        fetchRateMockSuccess({ rate: { id: '1337' } }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/rates/1337'
+                },
+            })
+
+            expect(
+                await screen.findByText('Programs this rate certification covers')
+            ).toBeInTheDocument()
         })
 
-        const s3Provider = {
-            ...testS3Client(),
-            getBulkDlURL: async (
-                keys: string[],
-                fileName: string
-            ): Promise<string | Error> => {
-                return new Error('Error: getBulkDlURL encountered an error')
-            },
-        }
-        renderWithProviders(wrapInRoutes(<RateSummary />), {
-            apolloProvider: {
-                mocks: [
-                    fetchCurrentUserMock({
-                        user: mockValidCMSUser(),
-                        statusCode: 200,
-                    }),
-                    fetchRateMockSuccess({ rate: { id: '7a' } }),
-                ],
-            },
-            routerProvider: {
-                route: '/rates/7a',
-            },
-            s3Provider,
-        })
+        it('renders expected error page when rate ID is invalid', async () => {
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidStateUser(),
+                            statusCode: 200,
+                        }),
+                        fetchRateMockSuccess({ rate: { id: '1337' } }),
+                    ],
+                },
+                //purposefully attaching invalid id to url here
+                routerProvider: {
+                    route: '/rates/133'
+                },
+            })
 
-        await waitFor(() => {
-            expect(screen.getByTestId('warning-alert')).toBeInTheDocument()
-            expect(screen.getByTestId('warning-alert')).toHaveClass(
-                'usa-alert--warning'
-            )
-            expect(screen.getByTestId('warning-alert')).toHaveTextContent(
-                'Document download unavailable'
-            )
-            expect(error).toHaveBeenCalled()
+            expect(
+                await screen.findByText('System error')
+            ).toBeInTheDocument()
         })
-    })
-
-    it('renders back to dashboard link for CMS users', async () => {
-        renderWithProviders(wrapInRoutes(<RateSummary />), {
-            apolloProvider: {
-                mocks: [
-                    fetchCurrentUserMock({
-                        user: mockValidCMSUser(),
-                        statusCode: 200,
-                    }),
-                    fetchRateMockSuccess({ rate: { id: '7a' } }),
-                ],
-            },
-            routerProvider: {
-                route: '/rates/7a',
-            },
-        })
-
-        const backLink = await screen.findByRole('link', {
-            name: /Back to dashboard/,
-        })
-        expect(backLink).toBeInTheDocument()
-
-        expect(backLink).toHaveAttribute('href', '/dashboard/rate-reviews')
     })
 })

--- a/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.test.tsx
@@ -162,5 +162,29 @@ describe('RateSummary', () => {
                 await screen.findByText('System error')
             ).toBeInTheDocument()
         })
+
+        it('renders back to dashboard link for state users', async () => {
+            renderWithProviders(wrapInRoutes(<RateSummary loggedInUser={mockValidStateUser()}/>), {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidStateUser(),
+                            statusCode: 200,
+                        }),
+                        fetchRateMockSuccess({ rate: { id: '7a' } }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/rates/7a',
+                },
+            })
+    
+            const backLink = await screen.findByRole('link', {
+                name: /Back to dashboard/,
+            })
+            expect(backLink).toBeInTheDocument()
+    
+            expect(backLink).toHaveAttribute('href', '/dashboard')
+        })
     })
 })

--- a/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.tsx
@@ -4,18 +4,20 @@ import { NavLink, useParams } from 'react-router-dom'
 
 import { Loading } from '../../../components'
 import { usePage } from '../../../contexts/PageContext'
-import { User, useFetchRateQuery } from '../../../gen/gqlClient'
+import { useFetchRateQuery } from '../../../gen/gqlClient'
 import styles from '../SubmissionSummary.module.scss'
 import { GenericErrorPage } from '../../Errors/GenericErrorPage'
 import { RoutesRecord } from '../../../constants'
 import { SingleRateSummarySection } from '../../../components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection'
+import { useAuth } from '../../../contexts/AuthContext'
 
 type RouteParams = {
     id: string
 }
 
-export const RateSummary = ({loggedInUser}: {loggedInUser: User}): React.ReactElement => {
+export const RateSummary = (): React.ReactElement => {
     // Page level state
+    const { loggedInUser } = useAuth()
     const { updateHeading } = usePage()
     const [rateName, setRateName] = useState<string | undefined>(undefined)
     const { id } = useParams<keyof RouteParams>()
@@ -69,7 +71,7 @@ export const RateSummary = ({loggedInUser}: {loggedInUser: User}): React.ReactEl
                         //TODO: Will have to remove this conditional along with associated loggedInUser prop once the rate dashboard
                         //is made available to state users
                         to={{
-                            pathname: loggedInUser.__typename === 'StateUser' ? RoutesRecord.DASHBOARD : RoutesRecord.DASHBOARD_RATES,
+                            pathname: loggedInUser?.__typename === 'StateUser' ? RoutesRecord.DASHBOARD : RoutesRecord.DASHBOARD_RATES,
                         }}
                     >
                         <Icon.ArrowBack />

--- a/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.tsx
@@ -4,7 +4,7 @@ import { NavLink, useParams } from 'react-router-dom'
 
 import { Loading } from '../../../components'
 import { usePage } from '../../../contexts/PageContext'
-import { useFetchRateQuery } from '../../../gen/gqlClient'
+import { User, useFetchRateQuery } from '../../../gen/gqlClient'
 import styles from '../SubmissionSummary.module.scss'
 import { GenericErrorPage } from '../../Errors/GenericErrorPage'
 import { RoutesRecord } from '../../../constants'
@@ -14,7 +14,7 @@ type RouteParams = {
     id: string
 }
 
-export const RateSummary = (): React.ReactElement => {
+export const RateSummary = ({loggedInUser}: {loggedInUser: User}): React.ReactElement => {
     // Page level state
     const { updateHeading } = usePage()
     const [rateName, setRateName] = useState<string | undefined>(undefined)
@@ -66,8 +66,10 @@ export const RateSummary = (): React.ReactElement => {
                 <div>
                     <Link
                         asCustom={NavLink}
+                        //TODO: Will have to remove this conditional along with associated loggedInUser prop once the rate dashboard
+                        //is made available to state users
                         to={{
-                            pathname: RoutesRecord.DASHBOARD_RATES,
+                            pathname: loggedInUser.__typename === 'StateUser' ? RoutesRecord.DASHBOARD : RoutesRecord.DASHBOARD_RATES,
                         }}
                     >
                         <Icon.ArrowBack />


### PR DESCRIPTION
## Summary
Added a new route for state users to be able to view rate summary's when accessing the `/rates/:id` url, the dashboard link has also been changed to route to the standard dashboard for state users but still routes to the rates dashboard for CMS users.

#### Related issues
[MCR-3813](https://qmacbis.atlassian.net/browse/MCR-3813)

#### Screenshots
![image](https://github.com/Enterprise-CMCS/managed-care-review/assets/111928238/9afc3040-36ac-4d03-b972-607c024d699b)

#### Test cases covered

Wrote two unit tests:

- State user has access to `/rates/:id`
- Expected error page is rendered when rate ID is invalid

## QA guidance

visit the `/rates/:id` url as a state user using a valid rate id