### PR TITLE
MCR-3767 CMS has unlock rate button

### DIFF
--- a/services/app-api/src/resolvers/configureResolvers.ts
+++ b/services/app-api/src/resolvers/configureResolvers.ts
@@ -32,6 +32,7 @@ import { rateResolver } from './rate/rateResolver'
 import { fetchRateResolver } from './rate/fetchRate'
 import { updateContract } from './contract/updateContract'
 import { createAPIKeyResolver } from './APIKey'
+import { unlockRate } from './rate/unlockRate'
 
 export function configureResolvers(
     store: Store,
@@ -88,6 +89,7 @@ export function configureResolvers(
                 emailParameterStore
             ),
             createAPIKey: createAPIKeyResolver(jwt),
+            unlockRate: unlockRate(store),
         },
         User: {
             // resolveType is required to differentiate Unions

--- a/services/app-api/src/resolvers/rate/unlockRate.test.ts
+++ b/services/app-api/src/resolvers/rate/unlockRate.test.ts
@@ -1,0 +1,39 @@
+import {
+    constructTestPostgresServer,
+    createAndSubmitTestHealthPlanPackage,
+} from '../../testHelpers/gqlHelpers'
+import UNLOCK_RATE from '../../../../app-graphql/src/mutations/unlockRate.graphql'
+import { testCMSUser } from '../../testHelpers/userHelpers'
+import { latestFormData } from '../../testHelpers/healthPlanPackageHelpers'
+
+describe(`unlockRate`, () => {
+    const cmsUser = testCMSUser()
+
+    it('returns a new rate with unlock info assigned', async () => {
+        const stateServer = await constructTestPostgresServer()
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+        })
+
+        // First, create a new package with rates
+        const submission =
+            await createAndSubmitTestHealthPlanPackage(stateServer)
+        const attachedRate = latestFormData(submission).rateInfos[0]
+        expect(attachedRate.id).toBeDefined()
+
+        // Unlock a rate
+        const unlockResult = await cmsServer.executeOperation({
+            query: UNLOCK_RATE,
+            variables: {
+                input: {
+                    rateID: attachedRate.id,
+                    unlockedReason: 'Super duper good reason.',
+                },
+            },
+        })
+
+        expect(unlockResult.errors).toBeUndefined()
+    })
+})

--- a/services/app-api/src/resolvers/rate/unlockRate.test.ts
+++ b/services/app-api/src/resolvers/rate/unlockRate.test.ts
@@ -5,11 +5,12 @@ import {
 import UNLOCK_RATE from '../../../../app-graphql/src/mutations/unlockRate.graphql'
 import { testCMSUser } from '../../testHelpers/userHelpers'
 import { latestFormData } from '../../testHelpers/healthPlanPackageHelpers'
+import { expectToBeDefined } from '../../testHelpers/assertionHelpers'
 
 describe(`unlockRate`, () => {
     const cmsUser = testCMSUser()
 
-    it('returns a new rate with unlock info assigned', async () => {
+    it('changes rate status to UNLOCKED and creates a new draft revision with unlock info', async () => {
         const stateServer = await constructTestPostgresServer()
         const cmsServer = await constructTestPostgresServer({
             context: {
@@ -17,23 +18,105 @@ describe(`unlockRate`, () => {
             },
         })
 
-        // First, create a new package with rates
+        // Create a rate
         const submission =
             await createAndSubmitTestHealthPlanPackage(stateServer)
-        const attachedRate = latestFormData(submission).rateInfos[0]
-        expect(attachedRate.id).toBeDefined()
+        const initialSubmitFormData = latestFormData(submission)
+        const rateID = initialSubmitFormData.rateInfos[0].id
+        expect(rateID).toBeDefined()
 
-        // Unlock a rate
+        // unlock rate
+        const unlockedReason = 'Super duper good reason.'
         const unlockResult = await cmsServer.executeOperation({
             query: UNLOCK_RATE,
             variables: {
                 input: {
-                    rateID: attachedRate.id,
-                    unlockedReason: 'Super duper good reason.',
+                    rateID,
+                    unlockedReason,
                 },
             },
         })
 
         expect(unlockResult.errors).toBeUndefined()
+
+        const updatedRate = unlockResult.data?.unlockRate.rate
+
+        console.info(updatedRate)
+        expect(updatedRate.status).toBe('UNLOCKED')
+        expect(updatedRate.draftRevision).toBeDefined()
+        expect(updatedRate.draftRevision.unlockInfo.updatedReason).toEqual(
+            unlockedReason
+        )
+    })
+
+    it('returns status error if rate is actively being edited in draft', async () => {
+        const stateServer = await constructTestPostgresServer()
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+        })
+
+        // Create a rate
+        const submission =
+            await createAndSubmitTestHealthPlanPackage(stateServer)
+        const initialSubmitFormData = latestFormData(submission)
+        const targetRateBeforeUnlock = initialSubmitFormData.rateInfos[0]
+        expectToBeDefined(targetRateBeforeUnlock.id)
+
+        // Unlock the rate once
+        const unlockResult1 = await cmsServer.executeOperation({
+            query: UNLOCK_RATE,
+            variables: {
+                input: {
+                    rateID: targetRateBeforeUnlock.id,
+                    unlockedReason: 'Super duper good reason.',
+                },
+            },
+        })
+
+        expect(unlockResult1.errors).toBeUndefined()
+
+        // Try to unlock the rate again
+        const unlockResult2 = await cmsServer.executeOperation({
+            query: UNLOCK_RATE,
+            variables: {
+                input: {
+                    rateID: targetRateBeforeUnlock.id,
+                    unlockedReason: 'Super duper good reason.',
+                },
+            },
+        })
+
+        expectToBeDefined(unlockResult2.errors)
+        expect(unlockResult2.errors[0].message).toBe(
+            'Attempted to unlock rate with wrong status'
+        )
+    })
+
+    it('returns unauthorized error for state user', async () => {
+        const stateServer = await constructTestPostgresServer()
+        // Create a rate
+        const submission =
+            await createAndSubmitTestHealthPlanPackage(stateServer)
+        const initialSubmitFormData = latestFormData(submission)
+        const targetRateBeforeUnlock = initialSubmitFormData.rateInfos[0]
+        expect(targetRateBeforeUnlock.id).toBeDefined()
+
+        // Unlock the rate
+        const unlockResult = await stateServer.executeOperation({
+            query: UNLOCK_RATE,
+            variables: {
+                input: {
+                    rateID: targetRateBeforeUnlock.id,
+                    unlockedReason: 'Super duper good reason.',
+                },
+            },
+        })
+
+        expectToBeDefined(unlockResult.errors)
+        expect(unlockResult.errors[0].message).toBe(
+            'user not authorized to unlock rate'
+        )
     })
 })

--- a/services/app-api/src/resolvers/rate/unlockRate.ts
+++ b/services/app-api/src/resolvers/rate/unlockRate.ts
@@ -1,0 +1,90 @@
+import { ForbiddenError, UserInputError } from 'apollo-server-lambda'
+import type { RateType } from '../../domain-models'
+import { isCMSUser } from '../../domain-models'
+import type { MutationResolvers } from '../../gen/gqlServer'
+import { logError, logSuccess } from '../../logger'
+import { NotFoundError } from '../../postgres'
+import type { Store } from '../../postgres'
+import {
+    setErrorAttributesOnActiveSpan,
+    setResolverDetailsOnActiveSpan,
+    setSuccessAttributesOnActiveSpan,
+} from '../attributeHelper'
+import { GraphQLError } from 'graphql'
+
+export function unlockRate(store: Store): MutationResolvers['unlockRate'] {
+    return async (_parent, { input }, context) => {
+        const { user, span } = context
+        const { unlockedReason, rateID } = input
+        setResolverDetailsOnActiveSpan('unlockRate', user, span)
+        span?.setAttribute('mcreview.rate_id', rateID)
+
+        // This resolver is only callable by CMS users
+        if (!isCMSUser(user)) {
+            logError('unlockRate', 'user not authorized to unlock rate')
+            setErrorAttributesOnActiveSpan(
+                'user not authorized to unlock rate',
+                span
+            )
+            throw new ForbiddenError('user not authorized to unlock rate')
+        }
+
+        const initialRateResult = await store.findRateWithHistory(rateID)
+
+        if (initialRateResult instanceof Error) {
+            if (initialRateResult instanceof NotFoundError) {
+                const errMessage = `A rate must exist to be unlocked: ${rateID}`
+                logError('unlockRate', errMessage)
+                setErrorAttributesOnActiveSpan(errMessage, span)
+                throw new UserInputError(errMessage, {
+                    argumentName: 'rateID',
+                })
+            }
+
+            const errMessage = `Issue finding a rate. Message: ${initialRateResult.message}`
+            logError('unlockRate', errMessage)
+            setErrorAttributesOnActiveSpan(errMessage, span)
+            throw new GraphQLError(errMessage, {
+                extensions: {
+                    code: 'INTERNAL_SERVER_ERROR',
+                    cause: 'DB_ERROR',
+                },
+            })
+        }
+
+        const rate: RateType = initialRateResult
+
+        if (rate.draftRevision) {
+            const errMessage = `Attempted to unlock rate with wrong status`
+            logError('unlockRate', errMessage)
+            setErrorAttributesOnActiveSpan(errMessage, span)
+            throw new UserInputError(errMessage, {
+                argumentName: 'pkgID',
+                cause: 'INVALID_PACKAGE_STATUS',
+            })
+        }
+
+        const unlockRateResult = await store.unlockRate({
+            rateID: rate.id,
+            unlockReason: unlockedReason,
+            unlockedByUserID: user.id,
+        })
+
+        if (unlockRateResult instanceof Error) {
+            const errMessage = `Failed to unlock rate revision with ID: ${rate.id}; ${unlockRateResult.message}`
+            logError('unlockRate', errMessage)
+            setErrorAttributesOnActiveSpan(errMessage, span)
+            throw new GraphQLError(errMessage, {
+                extensions: {
+                    code: 'INTERNAL_SERVER_ERROR',
+                    cause: 'DB_ERROR',
+                },
+            })
+        }
+
+        logSuccess('unlockRate')
+        setSuccessAttributesOnActiveSpan(span)
+
+        return { rate: unlockRateResult }
+    }
+}

--- a/services/app-api/src/resolvers/rate/unlockRate.ts
+++ b/services/app-api/src/resolvers/rate/unlockRate.ts
@@ -59,7 +59,7 @@ export function unlockRate(store: Store): MutationResolvers['unlockRate'] {
             logError('unlockRate', errMessage)
             setErrorAttributesOnActiveSpan(errMessage, span)
             throw new UserInputError(errMessage, {
-                argumentName: 'pkgID',
+                argumentName: 'rateID',
                 cause: 'INVALID_PACKAGE_STATUS',
             })
         }

--- a/services/app-api/src/testHelpers/assertionHelpers.ts
+++ b/services/app-api/src/testHelpers/assertionHelpers.ts
@@ -1,0 +1,17 @@
+// Functions that assists with type narrow in jest tests
+
+// must -  interrupts test flow to through an error
+function must<T>(maybeErr: T | Error): T {
+    if (maybeErr instanceof Error) {
+        throw maybeErr
+    }
+    return maybeErr
+}
+
+// expectToBeDefined - properly  type narrows the results of toBeDefined
+// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/41179 would eventually address this but is not implemented
+function expectToBeDefined<T>(arg: T): asserts arg is NonNullable<T> {
+    expect(arg).toBeDefined()
+}
+
+export { must, expectToBeDefined }

--- a/services/app-api/src/testHelpers/contractAndRates/contractHelpers.ts
+++ b/services/app-api/src/testHelpers/contractAndRates/contractHelpers.ts
@@ -7,7 +7,7 @@ import type {
 import type { StateCodeType } from '../../../../app-web/src/common-code/healthPlanFormDataType'
 import type { ContractFormDataType } from '../../domain-models/contractAndRates'
 import { findStatePrograms } from '../../postgres'
-import { must } from '../errorHelpers'
+import { must } from '../assertionHelpers'
 
 const defaultContractData = () => ({
     id: uuidv4(),

--- a/services/app-api/src/testHelpers/contractAndRates/rateHelpers.ts
+++ b/services/app-api/src/testHelpers/contractAndRates/rateHelpers.ts
@@ -6,7 +6,7 @@ import type {
 } from '../../postgres/contractAndRates/prismaSubmittedRateHelpers'
 import type { StateCodeType } from '../../../../app-web/src/common-code/healthPlanFormDataType'
 import { findStatePrograms } from '../../postgres'
-import { must } from '../errorHelpers'
+import { must } from '../assertionHelpers'
 
 const defaultRateData = () => ({
     id: '24fb2a5f-6d0d-4e26-9906-4de28927c882',

--- a/services/app-api/src/testHelpers/errorHelpers.ts
+++ b/services/app-api/src/testHelpers/errorHelpers.ts
@@ -1,9 +1,0 @@
-// For use in TESTS only. Throws a returned error
-function must<T>(maybeErr: T | Error): T {
-    if (maybeErr instanceof Error) {
-        throw maybeErr
-    }
-    return maybeErr
-}
-
-export { must }

--- a/services/app-api/src/testHelpers/gqlHelpers.ts
+++ b/services/app-api/src/testHelpers/gqlHelpers.ts
@@ -42,7 +42,7 @@ import type { LDService } from '../launchDarkly/launchDarkly'
 import { insertUserToLocalAurora } from '../authn'
 import { testStateUser } from './userHelpers'
 import { findStatePrograms } from '../postgres'
-import { must } from './errorHelpers'
+import { must } from './assertionHelpers'
 import { newJWTLib } from '../jwt'
 import type { JWTLib } from '../jwt'
 

--- a/services/app-api/src/testHelpers/index.ts
+++ b/services/app-api/src/testHelpers/index.ts
@@ -4,7 +4,7 @@ export {
     assertAnErrorCode,
 } from './gqlAssertions'
 
-export { must } from './errorHelpers'
+export { must } from './assertionHelpers'
 
 export {
     createInsertContractData,

--- a/services/app-api/src/testHelpers/stateHelpers.ts
+++ b/services/app-api/src/testHelpers/stateHelpers.ts
@@ -1,5 +1,5 @@
 import type { PrismaClient, State } from '@prisma/client'
-import { must } from './errorHelpers'
+import { must } from './assertionHelpers'
 
 async function getStateRecord(
     client: PrismaClient,

--- a/services/app-graphql/src/mutations/unlockRate.graphql
+++ b/services/app-graphql/src/mutations/unlockRate.graphql
@@ -1,0 +1,152 @@
+fragment rateRevisionFragment on RateRevision {
+    id
+    createdAt
+    updatedAt
+    unlockInfo {
+        updatedAt
+        updatedBy
+        updatedReason
+    }
+    submitInfo {
+        updatedAt
+        updatedBy
+        updatedReason
+    }
+    formData {
+        rateType,
+        rateCapitationType,
+        rateDocuments {
+            name
+            s3URL
+            sha256
+        },
+        supportingDocuments {
+            name
+            s3URL
+            sha256
+        },
+        rateDateStart,
+        rateDateEnd,
+        rateDateCertified,
+        amendmentEffectiveDateStart,
+        amendmentEffectiveDateEnd,
+        rateProgramIDs,
+        rateCertificationName,
+        certifyingActuaryContacts {
+            name
+            titleRole
+            email
+            actuarialFirm
+            actuarialFirmOther
+        },
+        addtlActuaryContacts {
+            name
+            titleRole
+            email
+            actuarialFirm
+            actuarialFirmOther
+        },
+        actuaryCommunicationPreference
+        packagesWithSharedRateCerts {
+            packageName
+            packageId
+            packageStatus
+        }
+    }
+    contractRevisions {
+        id
+        contract {
+            id
+            stateCode
+            stateNumber
+        }
+        createdAt
+        updatedAt
+        submitInfo {
+            updatedAt
+            updatedBy
+            updatedReason
+        }
+        unlockInfo {
+            updatedAt
+            updatedBy
+            updatedReason
+        }
+        formData {
+            programIDs
+            populationCovered
+            submissionType
+            riskBasedContract
+            submissionDescription
+            stateContacts {
+                name,
+                title
+                email
+            }
+            supportingDocuments {
+                name
+                s3URL
+                sha256
+            }
+            contractType
+            contractExecutionStatus
+            contractDocuments {
+                name
+                s3URL
+                sha256
+            }
+            contractDateStart
+            contractDateEnd
+            managedCareEntities
+            federalAuthorities
+            inLieuServicesAndSettings
+            modifiedBenefitsProvided
+            modifiedGeoAreaServed
+            modifiedMedicaidBeneficiaries
+            modifiedRiskSharingStrategy
+            modifiedIncentiveArrangements
+            modifiedWitholdAgreements
+            modifiedStateDirectedPayments
+            modifiedPassThroughPayments
+            modifiedPaymentsForMentalDiseaseInstitutions
+            modifiedMedicalLossRatioStandards
+            modifiedOtherFinancialPaymentIncentive
+            modifiedEnrollmentProcess
+            modifiedGrevienceAndAppeal
+            modifiedNetworkAdequacyStandards
+            modifiedLengthOfContract
+            modifiedNonRiskPaymentArrangements
+        }
+    }
+}
+
+mutation unlockRate($input: UnlockRateInput!) {
+    unlockRate(input: $input) {
+        rate {
+            id
+            createdAt
+            updatedAt
+            stateCode
+            stateNumber
+            state {
+                code
+                name
+                programs {
+                    id
+                    name
+                    fullName
+                }
+            }
+            status
+            initiallySubmittedAt
+
+            draftRevision {
+                ...rateRevisionFragment
+            }
+
+            revisions {
+                ...rateRevisionFragment
+            }
+        }
+    }
+}

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -67,7 +67,7 @@ type Query {
 
     Errors:
     - ForbiddenError: User must be a CMS or Admin type user
-    - NotFoundError: No rates with at least one submitted revision were found 
+    - NotFoundError: No rates with at least one submitted revision were found
     """
     indexRates: IndexRatesPayload!
     """
@@ -275,6 +275,32 @@ type Mutation {
     createAPIKey creates a valid API key for the logged in user, valid for 90 days
     """
     createAPIKey: CreateAPIKeyPayload!
+
+
+ """
+    unlockRate returns a submitted package to the state for additional edits.
+
+    This can only be called by a CMSUser.
+    The rate must be in the SUBMITTED or RESUBMITTED state to be unlocked.
+    Email notifications will be sent to all the relevant parties
+
+    Errors:
+    - ForbiddenError:
+        - A non CMSuser called this
+    - UserInputError
+        - A rate cannot be found with the given `rateID`
+    - INTERNAL_SERVER_ERROR
+        - DB_ERROR
+            - Postgres returns error when attempting to finding rate
+            - Postgres returns error when attempting to update rate
+        - INVALID_PACKAGE_STATUS
+            - Attempted to unlock a rate in the DRAFT or UNLOCKED state
+        - EMAIL_ERROR
+            - Sending state or CMS email failed.
+    """
+    unlockRate(
+        input: UnlockRateInput!
+    ): UnlockRatePayload!
 
 }
 
@@ -776,7 +802,7 @@ enum ManagedCareEntity {
 }
 
 """
-The state plan and/or waiver authorities that allow the 
+The state plan and/or waiver authorities that allow the
 state to run its managed care programs
 """
 enum FederalAuthority {
@@ -815,7 +841,7 @@ type ContractFormData {
     submissionType: SubmissionType!
     """
     Whether or not this contract is risk based
-    Risk-based contracts have specific requirements that 
+    Risk-based contracts have specific requirements that
     non-risk based contracts do not have
     """
     riskBasedContract: Boolean
@@ -838,7 +864,7 @@ type ContractFormData {
     """
     contractType: ContractType
     """
-    Execution status for a contract. 
+    Execution status for a contract.
     Contracts are fully executed or unexecuted by some or all parties
     Status can be either EXECUTED or UNEXECUTED
     """
@@ -863,7 +889,7 @@ type ContractFormData {
     """
     federalAuthorities: [FederalAuthority!]!
     """
-    If contract is in Lieu-of Services and Settings (ILOSs) 
+    If contract is in Lieu-of Services and Settings (ILOSs)
     in accordance with 42 CFR § 438.3(e)(2)
     """
     inLieuServicesAndSettings: Boolean,
@@ -887,7 +913,7 @@ type ContractFormData {
     "If contract includes modifications to the pass-through payments"
     modifiedPassThroughPayments: Boolean,
     """
-    If contract includes modifications to payments to MCOs and PIHPs for enrollees that 
+    If contract includes modifications to payments to MCOs and PIHPs for enrollees that
     are a patient in an institution for mental disease
     """
     modifiedPaymentsForMentalDiseaseInstitutions: Boolean,
@@ -928,7 +954,7 @@ enum RateCapitationType {
 
 """
 State's communication preference for contacting their actuaries. Either:
-- wants CMS to reach out to their actuaries directly or 
+- wants CMS to reach out to their actuaries directly or
 - go through them
 """
 enum ActuaryCommunication {
@@ -957,7 +983,7 @@ type ActuaryContact  {
 }
 
 """
-A package in the system 
+A package in the system
 that shares a rate with another package.
 It's used as a part of RateFormData
 """
@@ -980,11 +1006,11 @@ type RateFormData {
     rateType: RateType
     """
     Can be 'RATE_CELL' or 'RATE_RANGE'
-    These values represent on what basis the capitation rate is actuarially sound 
+    These values represent on what basis the capitation rate is actuarially sound
     """
     rateCapitationType: RateCapitationType
     """
-    Signed certification documents the state uploads 
+    Signed certification documents the state uploads
     Files can be PDF, DOC, or DOCX format
     """
     rateDocuments: [GenericDocument!]!
@@ -994,21 +1020,21 @@ type RateFormData {
     """
     supportingDocuments: [GenericDocument!]!
     """
-    If the rateType is NEW this is the start date of the 
+    If the rateType is NEW this is the start date of the
     rating period for a new certification.
     If the rateType is AMENDMENT this is the start date of the
     rating period for the original rate certification
     """
     rateDateStart: Date
     """
-    If the rateType is NEW this is the end date of the 
+    If the rateType is NEW this is the end date of the
     rating period for a new certification.
     If the rateType is AMENDMENT this is the end date of the
     rating period for the original rate certification
     """
     rateDateEnd: Date
     """
-    The date the rate certification was 
+    The date the rate certification was
     certified/signed by the state's actuary
     """
     rateDateCertified: Date
@@ -1027,31 +1053,31 @@ type RateFormData {
     """
     rateProgramIDs: [String!]!
     """
-    Represents the name of the rate. 
+    Represents the name of the rate.
     This value is auto generated based on rate, package and state program details
     """
     rateCertificationName: String
     """
     An array of ActuaryContacts
-    Each element includes the the name, title/role and email 
+    Each element includes the the name, title/role and email
     of the actuaries who certified the rate
     """
     certifyingActuaryContacts: [ActuaryContact!]!
     """
     An array of additional ActuaryContacts
-    Each element includes the the name, title/role and email 
+    Each element includes the the name, title/role and email
     """
     addtlActuaryContacts: [ActuaryContact!]!
     """
     Is either OACT_TO_ACTUARY or OACT_TO_STATE
-    It specifies whether the state wants CMS to reach out to their actuaries 
+    It specifies whether the state wants CMS to reach out to their actuaries
     directly or go through them
     """
     actuaryCommunicationPreference: ActuaryCommunication
     """
-    An array of PackageWithSameRate elements 
+    An array of PackageWithSameRate elements
     which contain the packageName, packageId, and packageStatus
-    These elements represent other packages in the system 
+    These elements represent other packages in the system
     that are using this rate
     """
     packagesWithSharedRateCerts: [PackageWithSameRate!]!
@@ -1131,6 +1157,13 @@ type Rate {
     This value is used to generate the rateName
     """
     stateNumber: Int!
+     """
+    Information about who, when, and why this revision was unlocked.
+    Will be blank on the initial revision.
+    """
+    unlockInfo: UpdateInformation
+    "Information on who, when, and why this revision was submitted."
+    submitInfo: UpdateInformation
     "The currently modifiable revision if the rate is DRAFT or UNLOCKED"
     draftRevision: RateRevision
     """
@@ -1162,4 +1195,14 @@ type FetchRatePayload {
 
 input FetchRateInput{
     rateID: ID!
+}
+
+type UnlockRatePayload {
+    rate: Rate!
+}
+
+input UnlockRateInput{
+    rateID: ID!
+    "User given reason this rate was unlocked"
+    unlockedReason: String!
 }

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -1157,13 +1157,6 @@ type Rate {
     This value is used to generate the rateName
     """
     stateNumber: Int!
-     """
-    Information about who, when, and why this revision was unlocked.
-    Will be blank on the initial revision.
-    """
-    unlockInfo: UpdateInformation
-    "Information on who, when, and why this revision was submitted."
-    submitInfo: UpdateInformation
     "The currently modifiable revision if the rate is DRAFT or UNLOCKED"
     draftRevision: RateRevision
     """

--- a/services/app-web/src/components/SectionHeader/SectionHeader.module.scss
+++ b/services/app-web/src/components/SectionHeader/SectionHeader.module.scss
@@ -1,10 +1,9 @@
 @use '../../styles/custom.scss' as custom;
 @use '../../styles/uswdsImports.scss' as uswds;
 
-.summarySectionWrapper {
-    max-width: 50rem;
+.primaryDiv {
+    flex-basis: 73%;
 }
-
 
 .summarySectionHeader {
     display: flex;
@@ -20,23 +19,12 @@
             margin-top: 17.5px;
         }
     }
-
 }
 
 .summarySectionHeaderBorder {
     border-bottom: 1px solid custom.$mcr-gray-lighter;
     margin-bottom: uswds.units(2);
 }
-
-.summarySectionSubHeader {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin: uswds.units(4) 0;
-    padding-top: uswds.units(4);
-    border-top: 1px solid custom.$mcr-gray-lighter;
-}
-
 
 @media print {
     .summarySectionHeader a {

--- a/services/app-web/src/components/SectionHeader/SectionHeader.test.tsx
+++ b/services/app-web/src/components/SectionHeader/SectionHeader.test.tsx
@@ -41,6 +41,7 @@ describe('SectionHeader', () => {
             screen.getByRole('link', { name: 'Edit Page 2' })
         ).toHaveAttribute('href', '/some-edit-path')
     })
+
     it('respects the hideBorder prop', () => {
         renderWithProviders(
             <SectionHeader header="This is a section" hideBorder />
@@ -50,5 +51,13 @@ describe('SectionHeader', () => {
                 .getByRole('heading', { name: 'This is a section' })
                 .closest('div')
         ).not.toHaveClass('summarySectionHeaderBorder')
+    })
+
+    it('does not render invisible zero-width space character in accesible name', () => {
+        renderWithProviders(<SectionHeader header="THIS-IS-123-456-67-RATE" />)
+
+        expect(
+            screen.getByRole('heading', { name: 'THIS-IS-123-456-67-RATE' })
+        ).toHaveAccessibleName('THIS-IS-123-456-67-RATE')
     })
 })

--- a/services/app-web/src/components/SectionHeader/SectionHeader.test.tsx
+++ b/services/app-web/src/components/SectionHeader/SectionHeader.test.tsx
@@ -41,7 +41,6 @@ describe('SectionHeader', () => {
             screen.getByRole('link', { name: 'Edit Page 2' })
         ).toHaveAttribute('href', '/some-edit-path')
     })
-
     it('respects the hideBorder prop', () => {
         renderWithProviders(
             <SectionHeader header="This is a section" hideBorder />
@@ -51,13 +50,5 @@ describe('SectionHeader', () => {
                 .getByRole('heading', { name: 'This is a section' })
                 .closest('div')
         ).not.toHaveClass('summarySectionHeaderBorder')
-    })
-
-    it('does not render invisible zero-width space character in accesible name', () => {
-        renderWithProviders(<SectionHeader header="THIS-IS-123-456-67-RATE" />)
-
-        expect(
-            screen.getByRole('heading', { name: 'THIS-IS-123-456-67-RATE' })
-        ).toHaveAccessibleName('THIS-IS-123-456-67-RATE')
     })
 })

--- a/services/app-web/src/components/SectionHeader/SectionHeader.tsx
+++ b/services/app-web/src/components/SectionHeader/SectionHeader.tsx
@@ -12,24 +12,6 @@ export type SectionHeaderProps = {
     headerId?: string
     hideBorder?: boolean
 }
-/*
-    Handle word breaks with complex strings by adding zero-wdith space character after each hyphen
-    @param {header} section title, submission name or rate name depending on page
-
-    This is for use with rate names which combine letters, numbers, hypens.
-    CSS break-word and overflow-wrap do not work as expected here.
-*/
-const headerWithReasonableBreaks = (header: string): React.ReactElement => {
-    const characters = header.split('')
-
-    return (
-        <>
-            {characters.map((char) => {
-                return char === '-' ? <>{char}&#8203;</> : char
-            })}
-        </>
-    )
-}
 
 export const SectionHeader = ({
     header,
@@ -48,13 +30,7 @@ export const SectionHeader = ({
     return (
         <div className={classes} id={sectionId}>
             <div className={styles.primaryDiv}>
-                <h2
-                    id={headerId}
-                    aria-label={header}
-                    style={{ wordWrap: 'break-word' }}
-                >
-                    {headerWithReasonableBreaks(header)}
-                </h2>
+                <h2 id={headerId}>{header}</h2>
                 {subHeaderComponent}
             </div>
             <div>

--- a/services/app-web/src/components/SectionHeader/SectionHeader.tsx
+++ b/services/app-web/src/components/SectionHeader/SectionHeader.tsx
@@ -29,7 +29,7 @@ export const SectionHeader = ({
     })
     return (
         <div className={classes} id={sectionId}>
-            <div>
+            <div className={styles.primaryDiv}>
                 <h2 id={headerId}>{header}</h2>
                 {subHeaderComponent}
             </div>

--- a/services/app-web/src/components/SectionHeader/SectionHeader.tsx
+++ b/services/app-web/src/components/SectionHeader/SectionHeader.tsx
@@ -12,6 +12,24 @@ export type SectionHeaderProps = {
     headerId?: string
     hideBorder?: boolean
 }
+/*
+    Handle word breaks with complex strings by adding zero-wdith space character after each hyphen
+    @param {header} section title, submission name or rate name depending on page
+
+    This is for use with rate names which combine letters, numbers, hypens.
+    CSS break-word and overflow-wrap do not work as expected here.
+*/
+const headerWithReasonableBreaks = (header: string): React.ReactElement => {
+    const characters = header.split('')
+
+    return (
+        <>
+            {characters.map((char) => {
+                return char === '-' ? <>{char}&#8203;</> : char
+            })}
+        </>
+    )
+}
 
 export const SectionHeader = ({
     header,
@@ -30,7 +48,13 @@ export const SectionHeader = ({
     return (
         <div className={classes} id={sectionId}>
             <div className={styles.primaryDiv}>
-                <h2 id={headerId}>{header}</h2>
+                <h2
+                    id={headerId}
+                    aria-label={header}
+                    style={{ wordWrap: 'break-word' }}
+                >
+                    {headerWithReasonableBreaks(header)}
+                </h2>
                 {subHeaderComponent}
             </div>
             <div>

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
@@ -1,4 +1,7 @@
-import { renderWithProviders } from '../../../testHelpers/jestHelpers'
+import {
+    ldUseClientSpy,
+    renderWithProviders,
+} from '../../../testHelpers/jestHelpers'
 import { SingleRateSummarySection } from './SingleRateSummarySection'
 import {
     fetchCurrentUserMock,
@@ -11,6 +14,13 @@ import { packageName } from '../../../common-code/healthPlanFormDataType'
 import { RateRevision } from '../../../gen/gqlClient'
 
 describe('SingleRateSummarySection', () => {
+    beforeEach(() => {
+        ldUseClientSpy({ 'rate-edit-unlock': true })
+    })
+    afterEach(() => {
+        jest.resetAllMocks()
+    })
+
     it('can render rate details without errors', async () => {
         const rateData = rateDataMock()
         await waitFor(() => {

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
@@ -278,4 +278,104 @@ describe('SingleRateSummarySection', () => {
             await screen.findAllByText(/You must provide this information/)
         ).toHaveLength(2)
     })
+
+    describe('Unlock rate', () => {
+        it('renders the unlock button to CMS users', async () => {
+            const rateData = rateDataMock(
+                {
+                    rateType: undefined,
+                    rateDateCertified: undefined,
+                } as unknown as Partial<RateRevision>,
+                { status: 'UNLOCKED' }
+            )
+            renderWithProviders(
+                <SingleRateSummarySection
+                    rate={rateData}
+                    isSubmitted={false}
+                    statePrograms={rateData.state.programs}
+                />,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                statusCode: 200,
+                                user: mockValidCMSUser(),
+                            }),
+                        ],
+                    },
+                }
+            )
+            expect(
+                await screen.findByRole('button', {
+                    name: 'Unlock rate',
+                })
+            ).toBeInTheDocument()
+        })
+
+        it('disables the unlock button for CMS users when rate already unlocked', async () => {
+            const rateData = rateDataMock(
+                {
+                    rateType: undefined,
+                    rateDateCertified: undefined,
+                } as unknown as Partial<RateRevision>,
+                { status: 'UNLOCKED' }
+            )
+            renderWithProviders(
+                <SingleRateSummarySection
+                    rate={rateData}
+                    isSubmitted={false}
+                    statePrograms={rateData.state.programs}
+                />,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                statusCode: 200,
+                                user: mockValidCMSUser(),
+                            }),
+                        ],
+                    },
+                }
+            )
+            await waitFor(() => {
+                expect(
+                    screen.getByRole('button', {
+                        name: 'Unlock rate',
+                    })
+                ).toHaveAttribute('aria-disabled', 'true')
+            })
+        })
+
+        it('does not render the unlock button to state users', async () => {
+            const rateData = rateDataMock(
+                {
+                    rateType: undefined,
+                    rateDateCertified: undefined,
+                } as unknown as Partial<RateRevision>,
+                { status: 'UNLOCKED' }
+            )
+            renderWithProviders(
+                <SingleRateSummarySection
+                    rate={rateData}
+                    isSubmitted={false}
+                    statePrograms={rateData.state.programs}
+                />,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                statusCode: 200,
+                                user: mockValidStateUser(),
+                            }),
+                        ],
+                    },
+                }
+            )
+            expect(
+                await screen.queryByRole('button', {
+                    name: 'Unlock rate',
+                })
+            ).toBeNull()
+        })
+    })
 })

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -211,7 +211,7 @@ export const SingleRateSummarySection = ({
             })
 
             if (data?.unlockRate.rate) {
-                // navigate('') TODO
+                // don't do anything, eventually this entire function will be in the modal
             } else {
                 recordJSException(
                     `[UNEXPECTED]: Error attempting to unlock rate, no data present.`

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -232,26 +232,25 @@ export const SingleRateSummarySection = ({
                 id={`"rate-details-${rate.id}`}
                 className={styles.summarySection}
             >
+                <SectionHeader
+                    header={
+                        rate.revisions[0].formData.rateCertificationName ||
+                        'Unknown rate name'
+                    }
+                >
+                    {showRateUnlock && isCMSUser ? (
+                        <UnlockRateButton
+                            disabled={isUnlocked || unlockLoading}
+                            onClick={handleUnlockRate}
+                        >
+                            Unlock rate
+                        </UnlockRateButton>
+                    ) : null}
+                </SectionHeader>
+                {documentError && (
+                    <DocumentWarningBanner className={styles.banner} />
+                )}
                 <dl>
-                    <SectionHeader
-                        header={
-                            rate.revisions[0].formData.rateCertificationName ||
-                            'Unknown rate name'
-                        }
-                    >
-                        {showRateUnlock && isCMSUser ? (
-                            <UnlockRateButton
-                                disabled={isUnlocked || unlockLoading}
-                                onClick={handleUnlockRate}
-                            >
-                                Unlock rate
-                            </UnlockRateButton>
-                        ) : null}
-                    </SectionHeader>
-                    {documentError && (
-                        <DocumentWarningBanner className={styles.banner} />
-                    )}
-
                     <DoubleColumnGrid>
                         {ratePrograms && (
                             <DataDetail

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -32,6 +32,8 @@ import { SectionCard } from '../../SectionCard'
 import { UnlockRateButton } from './UnlockRateButton'
 import { ERROR_MESSAGES } from '../../../constants'
 import { handleApolloErrorsAndAddUserFacingMessages } from '../../../gqlHelpers/mutationWrappersForUserFriendlyErrors'
+import { useLDClient } from 'launchdarkly-react-client-sdk'
+import { featureFlags } from '../../../common-code/featureFlags'
 
 // This rate summary pages assumes we are using contract and rates API.
 // Eventually RateDetailsSummarySection should share code with this code
@@ -136,6 +138,13 @@ export const SingleRateSummarySection = ({
         !isSubmitted && loggedInUser?.role === 'STATE_USER'
     const isCMSUser = loggedInUser?.role === 'CMS_USER'
 
+    // feature flags
+    const ldClient = useLDClient()
+    const showRateUnlock: boolean = ldClient?.variation(
+        featureFlags.RATE_EDIT_UNLOCK.flag,
+        featureFlags.RATE_EDIT_UNLOCK.defaultValue
+    )
+
     // TODO BULK DOWNLOAD
     // needs to be wrap in a standalone hook
     const { getKey, getBulkDlURL } = useS3()
@@ -230,7 +239,7 @@ export const SingleRateSummarySection = ({
                             'Unknown rate name'
                         }
                     >
-                        {isCMSUser ? (
+                        {showRateUnlock && isCMSUser ? (
                             <UnlockRateButton
                                 disabled={isUnlocked || unlockLoading}
                                 onClick={handleUnlockRate}

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -235,8 +235,7 @@ export const SingleRateSummarySection = ({
                                 disabled={isUnlocked || unlockLoading}
                                 onClick={handleUnlockRate}
                             >
-                                {' '}
-                                Unlock Rate{' '}
+                                Unlock rate
                             </UnlockRateButton>
                         ) : null}
                     </SectionHeader>

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/UnlockRateButton.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/UnlockRateButton.tsx
@@ -1,6 +1,6 @@
 import { ActionButton } from '../../ActionButton'
 
-// Eventually ActionButton will be entirely swapped out for ModalToggleButton - part of TICKET NUMBER when modal is hooked into unlockRate
+// Eventually ActionButton will be entirely swapped out for ModalToggleButton - part MCR-3782 when unlock reason modal is added
 type UnlockRateButtonProps = JSX.IntrinsicElements['button']
 
 export const UnlockRateButton = ({

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/UnlockRateButton.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/UnlockRateButton.tsx
@@ -1,22 +1,23 @@
-import { ModalRef, ModalToggleButton } from '@trussworks/react-uswds'
-import styles from '../SubmissionSummarySection.module.scss'
+import { ActionButton } from '../../ActionButton'
+
+// Eventually ActionButton will be entirely swapped out for ModalToggleButton - part of TICKET NUMBER when modal is hooked into unlockRate
+type UnlockRateButtonProps = JSX.IntrinsicElements['button']
 
 export const UnlockRateButton = ({
+    onClick,
     disabled,
-    modalRef,
-}: {
-    disabled: boolean
-    modalRef: React.RefObject<ModalRef>
-}): React.ReactElement => {
+    children,
+    ...props
+}: UnlockRateButtonProps): React.ReactElement => {
     return (
-        <ModalToggleButton
-            modalRef={modalRef}
-            className={styles.submitButton}
+        <ActionButton
+            {...props}
+            type="button"
+            variant="outline"
             disabled={disabled}
-            outline
-            opener
+            onClick={onClick}
         >
-            Unlock rate
-        </ModalToggleButton>
+            {children}
+        </ActionButton>
     )
 }

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/UnlockRateButton.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/UnlockRateButton.tsx
@@ -1,0 +1,22 @@
+import { ModalRef, ModalToggleButton } from '@trussworks/react-uswds'
+import styles from '../SubmissionSummarySection.module.scss'
+
+export const UnlockRateButton = ({
+    disabled,
+    modalRef,
+}: {
+    disabled: boolean
+    modalRef: React.RefObject<ModalRef>
+}): React.ReactElement => {
+    return (
+        <ModalToggleButton
+            modalRef={modalRef}
+            className={styles.submitButton}
+            disabled={disabled}
+            outline
+            opener
+        >
+            Unlock rate
+        </ModalToggleButton>
+    )
+}

--- a/services/app-web/src/gqlHelpers/mutationWrappersForUserFriendlyErrors.ts
+++ b/services/app-web/src/gqlHelpers/mutationWrappersForUserFriendlyErrors.ts
@@ -29,6 +29,7 @@ type MutationType =
     | 'SUBMIT_HEALTH_PLAN_PACKAGE'
     | 'UNLOCK_HEALTH_PLAN_PACKAGE'
     | 'CREATE_QUESTION'
+    | 'UNLOCK_RATE'
 
 type IndexQuestionDivisions =
     | 'DMCOQuestions'
@@ -40,7 +41,8 @@ const divisionToIndexQuestionDivision = (
 ): IndexQuestionDivisions =>
     `${division.toUpperCase()}Questions` as IndexQuestionDivisions
 
-const handleApolloErrorsAndAddUserFacingMessages = (
+
+export const handleApolloErrorsAndAddUserFacingMessages = (
     apolloError: ApolloError,
     mutation: MutationType
 ) => {


### PR DESCRIPTION
## Summary
Add rate unlock button

Reminder: no banners, no modal yet. All that happens is that when CMS user clicks the button, we hit the `unlockRate`. The button starts showing up disabled while the rate is unlocked.

#### Related issues
https://qmacbis.atlassian.net/browse/MCR-3767

#### Screenshots
<img width="819" alt="Screenshot 2024-01-11 at 8 07 20 PM" src="https://github.com/Enterprise-CMCS/managed-care-review/assets/10750442/4515df47-d9f3-46b1-ab92-7a0cb2e1d661">

- **(from design review)**  We talked about how the rate name was was not breaking properly. There's empty space to the right of the first line. Looks like css `break-word` or overflow does not work as expected because our name also includes numbers. I found a solution using HTML entities in [cf47ef1](https://github.com/Enterprise-CMCS/managed-care-review/pull/2166/commits/cf47ef17c6ffcc513d7a7a805bc10c4d103f59b4) but pulled it off this PR to refine it more and ship as it's own work. FYI @kelseylistrom still working on this. 

#### Test cases covered
`app-web`
- renders the unlock button to CMS users
- disables the unlock button for CMS users when rate already unlocked
- does not render the unlock button to state users

`app-api`
- changes rate status to UNLOCKED and creates a new draft revision with unlock info
- returns status error if rate is actively being edited in draft
- 'returns unauthorized error for state user

## QA guidance
- Confirm feature flag on/off state
- Rate should unlock properly
