### PR TITLE
Add dev IPs to jump box security group

### DIFF
--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -103,6 +103,7 @@ resources:
       - !Equals ['${sls:stage}', 'main']
       - !Equals ['${sls:stage}', 'val']
       - !Equals ['${sls:stage}', 'prod']
+      - !Equals ['${sls:stage}', 'mtsechubsg']
 
   Resources:
     # VPC endpoint for rotation lambda

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -103,7 +103,6 @@ resources:
       - !Equals ['${sls:stage}', 'main']
       - !Equals ['${sls:stage}', 'val']
       - !Equals ['${sls:stage}', 'prod']
-      - !Equals ['${sls:stage}', 'mtsechubsg']
 
   Resources:
     # VPC endpoint for rotation lambda

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -178,6 +178,7 @@ resources:
           - AssociatePublicIpAddress: true
             DeviceIndex: '0'
             GroupSet:
+              - !Ref PostgresVmSg
               - ${self:custom.sgId}
             SubnetId: !Sub ${self:custom.publicSubnetA}
         UserData:
@@ -268,6 +269,42 @@ resources:
         Path: '/delegatedadmin/developer/'
         Roles:
           - !Ref PgVMIAMRole
+
+    PostgresVmSg:
+      Type: 'AWS::EC2::SecurityGroup'
+      Condition: IsDevValProd
+      Properties:
+        GroupDescription: Enable SSH access via port 22
+        VpcId: !Sub ${self:custom.vpcId}
+        SecurityGroupIngress:
+          - IpProtocol: tcp
+            FromPort: 22
+            ToPort: 22
+            CidrIp: 34.196.35.156/32
+          - IpProtocol: tcp
+            FromPort: 22
+            ToPort: 22
+            CidrIp: 73.170.112.247/32
+          - IpProtocol: tcp
+            FromPort: 22
+            ToPort: 22
+            CidrIp: 172.58.0.0/16
+          - IpProtocol: tcp
+            FromPort: 22
+            ToPort: 22
+            CidrIp: 162.218.226.179/32
+          - IpProtocol: tcp
+            FromPort: 22
+            ToPort: 22
+            CidrIp: 66.108.108.206/32
+          - IpProtocol: tcp
+            FromPort: 22
+            ToPort: 22
+            CidrIp: 207.153.23.192/32
+          - IpProtocol: tcp
+            FromPort: 22
+            ToPort: 22
+            CidrIpv6: 2601:483:5300:22cf:e1a1:88e9:46b7:2c49/128
 
     PostgresSubnetGroup:
       Type: AWS::RDS::DBSubnetGroup

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -178,7 +178,6 @@ resources:
           - AssociatePublicIpAddress: true
             DeviceIndex: '0'
             GroupSet:
-              - !Ref PostgresVmSg
               - ${self:custom.sgId}
             SubnetId: !Sub ${self:custom.publicSubnetA}
         UserData:
@@ -269,18 +268,6 @@ resources:
         Path: '/delegatedadmin/developer/'
         Roles:
           - !Ref PgVMIAMRole
-
-    PostgresVmSg:
-      Type: 'AWS::EC2::SecurityGroup'
-      Condition: IsDevValProd
-      Properties:
-        GroupDescription: Enable SSH access via port 22
-        VpcId: !Sub ${self:custom.vpcId}
-        SecurityGroupIngress:
-          - IpProtocol: tcp
-            FromPort: 22
-            ToPort: 22
-            CidrIp: 0.0.0.0/0
 
     PostgresSubnetGroup:
       Type: AWS::RDS::DBSubnetGroup


### PR DESCRIPTION
## Summary

We received a security alert from CMS cloud that the security group rule that allows access on `0.0.0.0/0` for ssh (protected by pub key auth) is disallowed. That rule was automatically reverted by their scanning and we've been adding dev IPs to an allowlist for ssh. They've asked us to also remove that open rule from our automation, which is what this is.

This adds the dev IPs that were manually added to the security group to our cloud formation template for that security group.

#### Related issues
https://qmacbis.atlassian.net/browse/MCR-3825