### PR TITLE
Force SSL on the New Relic datahose bucket

### DIFF
--- a/services/infra-api/serverless.yml
+++ b/services/infra-api/serverless.yml
@@ -130,6 +130,26 @@ resources:
             - ServerSideEncryptionByDefault:
                 SSEAlgorithm: AES256
 
+    S3FirehoseEventsBucketPolicy:
+      Type: 'AWS::S3::BucketPolicy'
+      Properties:
+        Bucket: !Ref S3FirehoseEventsBucket
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Sid: 'AllowSSLRequestOnly'
+              Effect: Deny
+              Principal: '*'
+              Action: 's3:*'
+              Resource:
+                - !Join [
+                    '',
+                    ['arn:aws:s3:::', !Ref S3FirehoseEventsBucket, '/*'],
+                  ]
+              Condition:
+                Bool:
+                  'aws:SecureTransport': false
+
     FirehoseStreamToNewRelic:
       Type: AWS::KinesisFirehose::DeliveryStream
       Condition: CreateNRInfraMonitoring

--- a/services/infra-api/serverless.yml
+++ b/services/infra-api/serverless.yml
@@ -146,6 +146,7 @@ resources:
                   'aws:SecureTransport': false
               Resource:
                 - !Sub ${S3FirehoseEventsBucket.Arn}
+                - !Sub ${S3FirehoseEventsBucket.Arn}/*
               Sid: DenyUnencryptedConnections
 
     FirehoseStreamToNewRelic:

--- a/services/infra-api/serverless.yml
+++ b/services/infra-api/serverless.yml
@@ -131,24 +131,22 @@ resources:
                 SSEAlgorithm: AES256
 
     S3FirehoseEventsBucketPolicy:
-      Type: 'AWS::S3::BucketPolicy'
+      Type: AWS::S3::BucketPolicy
+      Condition: CreateNRInfraMonitoring
       Properties:
         Bucket: !Ref S3FirehoseEventsBucket
         PolicyDocument:
           Version: '2012-10-17'
           Statement:
-            - Sid: 'AllowSSLRequestOnly'
-              Effect: Deny
-              Principal: '*'
+            - Effect: Deny
               Action: 's3:*'
-              Resource:
-                - !Join [
-                    '',
-                    ['arn:aws:s3:::', !Ref S3FirehoseEventsBucket, '/*'],
-                  ]
+              Principal: '*'
               Condition:
                 Bool:
                   'aws:SecureTransport': false
+              Resource:
+                - !Sub ${S3FirehoseEventsBucket.Arn}
+              Sid: DenyUnencryptedConnections
 
     FirehoseStreamToNewRelic:
       Type: AWS::KinesisFirehose::DeliveryStream


### PR DESCRIPTION
## Summary

We got a security hub alert about needing to force SSL on buckets, and the New Relic data hose bucket is the only one that we don't have an explicit SSL deny on. This adds the policy to that bucket to close out that alert.

#### Related issues
https://qmacbis.atlassian.net/browse/MCR-2246
