### PR TITLE
Revert "Force SSL on the New Relic datahose bucket"

### DIFF
--- a/services/infra-api/serverless.yml
+++ b/services/infra-api/serverless.yml
@@ -130,25 +130,6 @@ resources:
             - ServerSideEncryptionByDefault:
                 SSEAlgorithm: AES256
 
-    S3FirehoseEventsBucketPolicy:
-      Type: AWS::S3::BucketPolicy
-      Condition: CreateNRInfraMonitoring
-      Properties:
-        Bucket: !Ref S3FirehoseEventsBucket
-        PolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-            - Effect: Deny
-              Action: 's3:*'
-              Principal: '*'
-              Condition:
-                Bool:
-                  'aws:SecureTransport': false
-              Resource:
-                - !Sub ${S3FirehoseEventsBucket.Arn}
-                - !Sub ${S3FirehoseEventsBucket.Arn}/*
-              Sid: DenyUnencryptedConnections
-
     FirehoseStreamToNewRelic:
       Type: AWS::KinesisFirehose::DeliveryStream
       Condition: CreateNRInfraMonitoring


### PR DESCRIPTION
This policy seems to already exist in `main`, reverting it while I figure out why it's conflicting with already deployed resources to unblock promotes.


Reverts Enterprise-CMCS/managed-care-review#2180