### PR TITLE
MCR-3758: Update launch darkly and fix testing

### DIFF
--- a/docs/technical-design/launch-darkly-testing-approach.md
+++ b/docs/technical-design/launch-darkly-testing-approach.md
@@ -28,7 +28,7 @@ Client side unit testing utilizes the `LDProvider`, from `launchdarkly-react-cli
 We use this method for testing because the official documented [unit testing](https://docs.launchdarkly.com/guides/sdk/unit-tests/?q=unit+test) method by LaunchDarkly does not work with our LaunchDarkly implementation. Our implementation follow exactly the documentation, so it could be how we are setting up our unit tests. Previously we had used `jest.spyOn` to intercept `useLDClient` and mock the `useLDClient.variation()` function with our defined feature flag values. With `launchdarkly-react-client-sdk@3.0.10` that method did not work anymore.
 
 #### Configuration
-When using the `LDProvider` we need to pass in a mocked `ldClient` in the configuration. This allows us to initialize `ldClient` outside of the provider, which would have required the provider to perform an API call to LaunchDarkly. Now tha this API call does not happen it isolates our unit tests from the feature flag values on the LaunchDarkly server and only use the values we define in each test.
+When using the `LDProvider` we need to pass in a mocked `ldClient` in the configuration. This allows us to initialize `ldClient` outside of the provider, which would have required the provider to perform an API call to LaunchDarkly. Now that this API call does not happen it isolates our unit tests from the feature flag values on the LaunchDarkly server and only use the values we define in each test.
 
 The configuration below, in `renderWithProviders`, the `ldClient` field is how we initialize `ldClient` with our defined flag values. We are using the `ldClientMock()` function to generate a mock that matches the type this field requires. 
 
@@ -38,6 +38,7 @@ You will also see that, compared to our configuration in [app-web/src/index.tsx]
 const ldProviderConfig: ProviderConfig = {
   clientSideID: 'test-url',
   options: {
+    bootstrap: flags,
     baseUrl: 'test-url',
     streamUrl: 'test-url',
     eventsUrl: 'test-url',
@@ -96,6 +97,7 @@ const flags = {
 const ldProviderConfig: ProviderConfig = {
   clientSideID: 'test-url',
   options: {
+    bootstrap: flags,
     baseUrl: 'test-url',
     streamUrl: 'test-url',
     eventsUrl: 'test-url',
@@ -108,7 +110,7 @@ const ldProviderConfig: ProviderConfig = {
 
 Using this method in our unit tests is simple and similar to how we configure the other providers. When calling `renderWithProdivers` we need to supply the second argument `options` with the `featureFlag` field. 
 
-In the example below we set `featureFlag` with an object that contains two feature flags and their values. When this test is run, the component will be supplied with these two flag values we supplied along with default flag values for feature flags we did not define in the argument. Take note that the `featureFlag` field is type `FeatureFlagSettings` so you will only be allowed to define flags that exists in [flags.ts](../../services/app-web/src/common-code/featureFlags/flags.ts).
+In the example below we set `featureFlag` with an object that contains two feature flags and their values. When this test is run, the component will be supplied with these two flag values along with the other default flag values from [flags.ts](../../services/app-web/src/common-code/featureFlags/flags.ts). Take note that the `featureFlag` field is type `FeatureFlagSettings` so you will only be allowed to define flags that exists in [flags.ts](../../services/app-web/src/common-code/featureFlags/flags.ts).
 
 ```javascript
 renderWithProviders(

--- a/docs/technical-design/launch-darkly-testing-approach.md
+++ b/docs/technical-design/launch-darkly-testing-approach.md
@@ -52,28 +52,13 @@ The two important functions in the `ldCientMock` are `variation` and `allFlags`.
 ```javascript
 const ldClientMock = (featureFlags: FeatureFlagSettings): LDClient => ({
   ... other functions,
-  variation: jest.fn((
-          flag: FeatureFlagLDConstant,
-          defaultValue: FlagValue | undefined
-  ) => {
-    if (
-            featureFlags[flag] === undefined &&
-            defaultValue === undefined
-    ) {
-      //ldClient.variation doesn't require a default value, throwing error here if a defaultValue was not provided.
-      throw new Error(
-              'ldUseClientSpy returned an invalid value of undefined'
-      )
-    }
-    return featureFlags[flag] === undefined
-            ? defaultValue
-            : featureFlags[flag]
-  }),
-  allFlags: jest.fn(() => {
-    const defaultFeatureFlags = getDefaultFeatureFlags()
-    Object.assign(defaultFeatureFlags, featureFlags)
-    return defaultFeatureFlags
-  }),
+  variation: jest.fn(
+    (
+      flag: FeatureFlagLDConstant,
+      defaultValue: FlagValue | undefined
+    ) => featureFlags[flag] ?? defaultValue
+  ),
+  allFlags: jest.fn(() => featureFlags),
 })
 ```
 

--- a/services/app-web/package.json
+++ b/services/app-web/package.json
@@ -105,7 +105,7 @@
         "graphql": "^16.2.0",
         "jotai": "^2.2.1",
         "jotai-location": "^0.5.1",
-        "launchdarkly-react-client-sdk": "^3.0.1",
+        "launchdarkly-react-client-sdk": "^3.0.10",
         "path-browserify": "^1.0.1",
         "qs": "^6.11.0",
         "react": "^18.2.0",

--- a/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/ContactsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/ContactsSummarySection.tsx
@@ -51,6 +51,7 @@ export const ContactsSummarySection = ({
                             submission.stateContacts.map(
                                 (stateContact, index) => (
                                     <DataDetail
+                                        key={'statecontact_' + index}
                                         id={'statecontact_' + index}
                                         label={`Contact ${index + 1}`}
                                         children={

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
@@ -1,8 +1,5 @@
 import { screen, waitFor, within } from '@testing-library/react'
-import {
-    ldUseClientSpy,
-    renderWithProviders,
-} from '../../../testHelpers/jestHelpers'
+import { renderWithProviders } from '../../../testHelpers/jestHelpers'
 import { ContractDetailsSummarySection } from './ContractDetailsSummarySection'
 import {
     fetchCurrentUserMock,
@@ -17,9 +14,6 @@ import {
 } from '../../../constants/statutoryRegulatoryAttestation'
 
 describe('ContractDetailsSummarySection', () => {
-    afterEach(() => {
-        jest.restoreAllMocks()
-    })
     const defaultApolloMocks = {
         mocks: [fetchCurrentUserMock({ statusCode: 200 })],
     }
@@ -110,8 +104,7 @@ describe('ContractDetailsSummarySection', () => {
         })
     })
 
-    it('can render all contract details fields', () => {
-        ldUseClientSpy({ '438-attestation': true })
+    it('can render all contract details fields', async () => {
         const submission = mockContractAndRatesDraft({
             statutoryRegulatoryAttestation: true,
         })
@@ -124,14 +117,18 @@ describe('ContractDetailsSummarySection', () => {
             />,
             {
                 apolloProvider: defaultApolloMocks,
+                featureFlags: { '438-attestation': true },
             }
         )
 
-        expect(
-            screen.getByRole('definition', {
-                name: StatutoryRegulatoryAttestationQuestion,
-            })
-        ).toBeInTheDocument()
+        await waitFor(() => {
+            expect(
+                screen.getByRole('definition', {
+                    name: StatutoryRegulatoryAttestationQuestion,
+                })
+            ).toBeInTheDocument()
+        })
+
         expect(
             screen.getByRole('definition', { name: 'Contract status' })
         ).toBeInTheDocument()
@@ -161,7 +158,6 @@ describe('ContractDetailsSummarySection', () => {
     })
 
     it('displays correct contract 438 attestation yes and no text and description', async () => {
-        ldUseClientSpy({ '438-attestation': true })
         const submission = mockContractAndRatesDraft({
             statutoryRegulatoryAttestation: false,
             statutoryRegulatoryAttestationDescription: 'No compliance',
@@ -175,14 +171,18 @@ describe('ContractDetailsSummarySection', () => {
             />,
             {
                 apolloProvider: defaultApolloMocks,
+                featureFlags: { '438-attestation': true },
             }
         )
 
-        expect(
-            screen.getByRole('definition', {
-                name: StatutoryRegulatoryAttestationQuestion,
-            })
-        ).toBeInTheDocument()
+        await waitFor(() => {
+            expect(
+                screen.getByRole('definition', {
+                    name: StatutoryRegulatoryAttestationQuestion,
+                })
+            ).toBeInTheDocument()
+        })
+
         expect(
             screen.getByRole('definition', {
                 name: 'Non-compliance description',

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
@@ -1,7 +1,4 @@
-import {
-    ldUseClientSpy,
-    renderWithProviders,
-} from '../../../testHelpers/jestHelpers'
+import { renderWithProviders } from '../../../testHelpers/jestHelpers'
 import { SingleRateSummarySection } from './SingleRateSummarySection'
 import {
     fetchCurrentUserMock,
@@ -14,13 +11,6 @@ import { packageName } from '../../../common-code/healthPlanFormDataType'
 import { RateRevision } from '../../../gen/gqlClient'
 
 describe('SingleRateSummarySection', () => {
-    beforeEach(() => {
-        ldUseClientSpy({ 'rate-edit-unlock': true })
-    })
-    afterEach(() => {
-        jest.resetAllMocks()
-    })
-
     it('can render rate details without errors', async () => {
         const rateData = rateDataMock()
         await waitFor(() => {
@@ -39,6 +29,7 @@ describe('SingleRateSummarySection', () => {
                             }),
                         ],
                     },
+                    featureFlags: { 'rate-edit-unlock': true },
                 }
             )
         })
@@ -134,6 +125,7 @@ describe('SingleRateSummarySection', () => {
                             }),
                         ],
                     },
+                    featureFlags: { 'rate-edit-unlock': true },
                 }
             )
         })
@@ -234,6 +226,7 @@ describe('SingleRateSummarySection', () => {
                         }),
                     ],
                 },
+                featureFlags: { 'rate-edit-unlock': true },
             }
         )
 
@@ -273,6 +266,7 @@ describe('SingleRateSummarySection', () => {
                         }),
                     ],
                 },
+                featureFlags: { 'rate-edit-unlock': true },
             }
         )
 
@@ -313,6 +307,7 @@ describe('SingleRateSummarySection', () => {
                             }),
                         ],
                     },
+                    featureFlags: { 'rate-edit-unlock': true },
                 }
             )
             expect(
@@ -345,6 +340,7 @@ describe('SingleRateSummarySection', () => {
                             }),
                         ],
                     },
+                    featureFlags: { 'rate-edit-unlock': true },
                 }
             )
             await waitFor(() => {
@@ -379,6 +375,7 @@ describe('SingleRateSummarySection', () => {
                             }),
                         ],
                     },
+                    featureFlags: { 'rate-edit-unlock': true },
                 }
             )
             expect(

--- a/services/app-web/src/pages/App/AppBody.test.tsx
+++ b/services/app-web/src/pages/App/AppBody.test.tsx
@@ -1,7 +1,6 @@
 import { screen } from '@testing-library/react'
 
 import {
-    ldUseClientSpy,
     renderWithProviders,
     userClickSignIn,
 } from '../../testHelpers/jestHelpers'
@@ -26,16 +25,18 @@ describe('AppBody', () => {
     })
 
     it('App renders without errors', () => {
-        ldUseClientSpy({ 'session-expiring-modal': false })
-        renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />)
+        renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
+            featureFlags: { 'session-expiring-modal': false },
+        })
         const mainElement = screen.getByRole('main')
         expect(mainElement).toBeInTheDocument()
     })
 
     describe('Sign In buttton click', () => {
         it('displays local login heading when expected', async () => {
-            ldUseClientSpy({})
-            renderWithProviders(<AppBody authMode={'LOCAL'} />)
+            renderWithProviders(<AppBody authMode={'LOCAL'} />, {
+                featureFlags: { 'session-expiring-modal': false },
+            })
 
             await userClickSignIn(screen)
 
@@ -48,8 +49,9 @@ describe('AppBody', () => {
         })
 
         it('displays Cognito login page when expected', async () => {
-            ldUseClientSpy({ 'session-expiring-modal': false })
-            renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />)
+            renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
+                featureFlags: { 'session-expiring-modal': false },
+            })
             await userClickSignIn(screen)
 
             expect(
@@ -58,8 +60,9 @@ describe('AppBody', () => {
         })
 
         it('displays Cognito signup page when expected', async () => {
-            ldUseClientSpy({ 'session-expiring-modal': false })
-            renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />)
+            renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
+                featureFlags: { 'session-expiring-modal': false },
+            })
             await userClickSignIn(screen)
 
             expect(
@@ -88,7 +91,6 @@ describe('AppBody', () => {
 
         it('shows test environment banner in val', () => {
             process.env.REACT_APP_STAGE_NAME = 'val'
-            ldUseClientSpy({ 'session-expiring-modal': false })
             renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
                 apolloProvider: {
                     mocks: [
@@ -96,6 +98,7 @@ describe('AppBody', () => {
                         indexHealthPlanPackagesMockSuccess(),
                     ],
                 },
+                featureFlags: { 'session-expiring-modal': false },
             })
 
             expect(
@@ -105,7 +108,6 @@ describe('AppBody', () => {
 
         it('does not show test environment banner in prod', () => {
             process.env.REACT_APP_STAGE_NAME = 'prod'
-            ldUseClientSpy({ 'session-expiring-modal': false })
             renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
                 apolloProvider: {
                     mocks: [
@@ -113,6 +115,7 @@ describe('AppBody', () => {
                         indexHealthPlanPackagesMockSuccess(),
                     ],
                 },
+                featureFlags: { 'session-expiring-modal': false },
             })
 
             expect(screen.queryByText('THIS IS A TEST ENVIRONMENT')).toBeNull()
@@ -121,16 +124,16 @@ describe('AppBody', () => {
 
     describe('Site under maintenance banner', () => {
         it('displays maintenance banner when feature flag is on', async () => {
-            ldUseClientSpy({
-                'site-under-maintenance-banner': 'UNSCHEDULED',
-                'session-expiring-modal': false,
-            })
             renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
                 apolloProvider: {
                     mocks: [
                         fetchCurrentUserMock({ statusCode: 200 }),
                         indexHealthPlanPackagesMockSuccess(),
                     ],
+                },
+                featureFlags: {
+                    'site-under-maintenance-banner': 'UNSCHEDULED',
+                    'session-expiring-modal': false,
                 },
             })
             expect(
@@ -144,7 +147,6 @@ describe('AppBody', () => {
         })
 
         it('does not display maintenance banner when flag is off', async () => {
-            ldUseClientSpy({ 'session-expiring-modal': false })
             renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
                 apolloProvider: {
                     mocks: [
@@ -152,6 +154,7 @@ describe('AppBody', () => {
                         indexHealthPlanPackagesMockSuccess(),
                     ],
                 },
+                featureFlags: { 'session-expiring-modal': false },
             })
             expect(
                 screen.queryByRole('heading', { name: 'Site Unavailable' })
@@ -166,7 +169,6 @@ describe('AppBody', () => {
 
     describe('Page scrolling', () => {
         it('scroll top on page load', async () => {
-            ldUseClientSpy({})
             renderWithProviders(<AppBody authMode={'LOCAL'} />)
             await userClickSignIn(screen)
             expect(window.scrollTo).toHaveBeenCalledWith(0, 0)

--- a/services/app-web/src/pages/App/AppRoutes.test.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.test.tsx
@@ -1,9 +1,6 @@
 import { screen, waitFor } from '@testing-library/react'
 
-import {
-    ldUseClientSpy,
-    renderWithProviders,
-} from '../../testHelpers/jestHelpers'
+import { renderWithProviders } from '../../testHelpers/jestHelpers'
 import { AppRoutes } from './AppRoutes'
 import {
     fetchCurrentUserMock,
@@ -22,7 +19,6 @@ describe('AppRoutes', () => {
     })
     describe('/[root]', () => {
         it('state dashboard when state user logged in', async () => {
-            ldUseClientSpy({ 'session-expiring-modal': false })
             renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
                 apolloProvider: {
                     mocks: [
@@ -30,6 +26,7 @@ describe('AppRoutes', () => {
                         indexHealthPlanPackagesMockSuccess(),
                     ],
                 },
+                featureFlags: { 'session-expiring-modal': false },
             })
 
             await waitFor(() => {
@@ -46,7 +43,6 @@ describe('AppRoutes', () => {
         })
 
         it('cms dashboard when cms user logged in', async () => {
-            ldUseClientSpy({ 'session-expiring-modal': false })
             renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
                 apolloProvider: {
                     mocks: [
@@ -57,6 +53,7 @@ describe('AppRoutes', () => {
                         indexHealthPlanPackagesMockSuccess(),
                     ],
                 },
+                featureFlags: { 'session-expiring-modal': false },
             })
 
             await waitFor(() => {
@@ -73,7 +70,6 @@ describe('AppRoutes', () => {
         })
 
         it('landing page when no user', async () => {
-            ldUseClientSpy({ 'session-expiring-modal': false })
             renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
                 apolloProvider: {
                     mocks: [
@@ -82,6 +78,7 @@ describe('AppRoutes', () => {
                         }),
                     ],
                 },
+                featureFlags: { 'session-expiring-modal': false },
             })
             await waitFor(() => {
                 expect(
@@ -102,7 +99,6 @@ describe('AppRoutes', () => {
 
     describe('/auth', () => {
         it('auth header is displayed', async () => {
-            ldUseClientSpy({ 'session-expiring-modal': false })
             renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
                 routerProvider: { route: '/auth' },
                 apolloProvider: {
@@ -112,6 +108,7 @@ describe('AppRoutes', () => {
                         }),
                     ],
                 },
+                featureFlags: { 'session-expiring-modal': false },
             })
 
             await waitFor(() => {
@@ -136,8 +133,13 @@ describe('AppRoutes', () => {
             renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
                 routerProvider: { route: '/help' },
                 apolloProvider: {
-                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                    mocks: [
+                        fetchCurrentUserMock({
+                            statusCode: 200,
+                        }),
+                    ],
                 },
+                featureFlags: { 'session-expiring-modal': false },
             })
 
             await screen.findByTestId('help-authenticated')
@@ -162,6 +164,7 @@ describe('AppRoutes', () => {
                         }),
                     ],
                 },
+                featureFlags: { 'session-expiring-modal': false },
             })
             await screen.findByTestId('help-authenticated')
             await waitFor(() => {
@@ -200,7 +203,6 @@ describe('AppRoutes', () => {
 
     describe('invalid routes', () => {
         it('redirect to landing page when no user', async () => {
-            ldUseClientSpy({ 'session-expiring-modal': false })
             renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
                 routerProvider: { route: '/not-a-real-place' },
                 apolloProvider: {
@@ -210,6 +212,7 @@ describe('AppRoutes', () => {
                         }),
                     ],
                 },
+                featureFlags: { 'session-expiring-modal': false },
             })
 
             await waitFor(() => {
@@ -223,12 +226,12 @@ describe('AppRoutes', () => {
         })
 
         it('redirect to 404 error page when user is logged in', async () => {
-            ldUseClientSpy({ 'session-expiring-modal': false })
             renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
                 apolloProvider: {
                     mocks: [fetchCurrentUserMock({ statusCode: 200 })],
                 },
                 routerProvider: { route: '/not-a-real-place' },
+                featureFlags: { 'session-expiring-modal': false },
             })
 
             await waitFor(() =>

--- a/services/app-web/src/pages/Landing/Landing.test.tsx
+++ b/services/app-web/src/pages/Landing/Landing.test.tsx
@@ -1,17 +1,16 @@
 import { screen } from '@testing-library/react'
-import {
-    ldUseClientSpy,
-    renderWithProviders,
-} from '../../testHelpers/jestHelpers'
+import { renderWithProviders } from '../../testHelpers/jestHelpers'
 import { Landing } from './Landing'
 
 describe('Landing', () => {
     afterAll(() => jest.clearAllMocks())
 
     it('displays session expired when query parameter included', async () => {
-        ldUseClientSpy({ 'site-under-maintenance-banner': false })
         renderWithProviders(<Landing />, {
             routerProvider: { route: '/?session-timeout' },
+            featureFlags: {
+                'site-under-maintenance-banner': false,
+            },
         })
         expect(
             screen.queryByRole('heading', { name: 'Session expired' })
@@ -21,9 +20,11 @@ describe('Landing', () => {
         ).toBeNull()
     })
     it('does not display session expired by default', async () => {
-        ldUseClientSpy({ 'site-under-maintenance-banner': false })
         renderWithProviders(<Landing />, {
             routerProvider: { route: '/' },
+            featureFlags: {
+                'site-under-maintenance-banner': false,
+            },
         })
         expect(
             screen.queryByRole('heading', {

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponse.test.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponse.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor, within } from '@testing-library/react'
 import { Route, Routes } from 'react-router-dom'
 import { SubmissionSideNav } from '../SubmissionSideNav'
 import { QuestionResponse } from './QuestionResponse'
-import { ldUseClientSpy, renderWithProviders } from '../../testHelpers'
+import { renderWithProviders } from '../../testHelpers'
 import { RoutesRecord } from '../../constants/routes'
 
 import {
@@ -15,13 +15,6 @@ import {
 import { IndexQuestionsPayload } from '../../gen/gqlClient'
 
 describe('QuestionResponse', () => {
-    beforeEach(() => {
-        ldUseClientSpy({ 'cms-questions': true })
-    })
-    afterEach(() => {
-        jest.resetAllMocks()
-    })
-
     it('renders expected questions correctly with rounds', async () => {
         const mockQuestions = mockQuestionsPayload('15')
 
@@ -49,6 +42,9 @@ describe('QuestionResponse', () => {
                 },
                 routerProvider: {
                     route: '/submissions/15/question-and-answers',
+                },
+                featureFlags: {
+                    'cms-questions': true,
                 },
             }
         )
@@ -177,6 +173,9 @@ describe('QuestionResponse', () => {
                 routerProvider: {
                     route: '/submissions/15/question-and-answers',
                 },
+                featureFlags: {
+                    'cms-questions': true,
+                },
             }
         )
 
@@ -230,6 +229,9 @@ describe('QuestionResponse', () => {
                 },
                 routerProvider: {
                     route: '/submissions/15/question-and-answers',
+                },
+                featureFlags: {
+                    'cms-questions': true,
                 },
             }
         )
@@ -291,6 +293,9 @@ describe('QuestionResponse', () => {
                 routerProvider: {
                     route: '/submissions/15/question-and-answers',
                 },
+                featureFlags: {
+                    'cms-questions': true,
+                },
             }
         )
 
@@ -338,6 +343,9 @@ describe('QuestionResponse', () => {
                 routerProvider: {
                     route: '/submissions/15/question-and-answers?submit=question',
                 },
+                featureFlags: {
+                    'cms-questions': true,
+                },
             }
         )
 
@@ -372,6 +380,9 @@ describe('QuestionResponse', () => {
                 routerProvider: {
                     route: '/submissions/15/question-and-answers?submit=response',
                 },
+                featureFlags: {
+                    'cms-questions': true,
+                },
             }
         )
 
@@ -403,6 +414,9 @@ describe('QuestionResponse', () => {
                 },
                 routerProvider: {
                     route: '/submissions/15/question-and-answers',
+                },
+                featureFlags: {
+                    'cms-questions': true,
                 },
             }
         )
@@ -437,6 +451,9 @@ describe('QuestionResponse', () => {
                 },
                 routerProvider: {
                     route: '/submissions/15/question-and-answers',
+                },
+                featureFlags: {
+                    'cms-questions': true,
                 },
             }
         )

--- a/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadQuestions.test.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadQuestions.test.tsx
@@ -4,7 +4,6 @@ import { Route, Routes } from 'react-router-dom'
 import { UploadQuestions } from '../../QuestionResponse'
 import {
     dragAndDrop,
-    ldUseClientSpy,
     renderWithProviders,
     TEST_DOC_FILE,
     TEST_PDF_FILE,
@@ -26,13 +25,6 @@ import { SubmissionSideNav } from '../../SubmissionSideNav'
 import { Location } from 'react-router-dom'
 
 describe('UploadQuestions', () => {
-    beforeEach(() => {
-        ldUseClientSpy({ 'cms-questions': true })
-    })
-    afterEach(() => {
-        jest.resetAllMocks()
-    })
-
     it('displays file upload for correct cms division', async () => {
         const division = 'testDivision'
         renderWithProviders(
@@ -58,6 +50,9 @@ describe('UploadQuestions', () => {
                 },
                 routerProvider: {
                     route: `/submissions/15/question-and-answers/${division}/upload-questions`,
+                },
+                featureFlags: {
+                    'cms-questions': true,
                 },
             }
         )
@@ -103,6 +98,9 @@ describe('UploadQuestions', () => {
                 },
                 routerProvider: {
                     route: `/submissions/15/question-and-answers/dmco/upload-questions`,
+                },
+                featureFlags: {
+                    'cms-questions': true,
                 },
             }
         )
@@ -165,6 +163,9 @@ describe('UploadQuestions', () => {
                     route: `/submissions/15/question-and-answers/dmco/upload-questions`,
                 },
                 location: (location) => (testLocation = location),
+                featureFlags: {
+                    'cms-questions': true,
+                },
             }
         )
 
@@ -220,6 +221,9 @@ describe('UploadQuestions', () => {
                         }),
                     ],
                 },
+                featureFlags: {
+                    'cms-questions': true,
+                },
             }
         )
         await screen.findByRole('heading', {
@@ -264,6 +268,9 @@ describe('UploadQuestions', () => {
                             id: '15',
                         }),
                     ],
+                },
+                featureFlags: {
+                    'cms-questions': true,
                 },
             }
         )
@@ -314,6 +321,9 @@ describe('UploadQuestions', () => {
                             id: '15',
                         }),
                     ],
+                },
+                featureFlags: {
+                    'cms-questions': true,
                 },
             }
         )
@@ -384,6 +394,9 @@ describe('UploadQuestions', () => {
                             ],
                         }),
                     ],
+                },
+                featureFlags: {
+                    'cms-questions': true,
                 },
             }
         )

--- a/services/app-web/src/pages/QuestionResponse/UploadResponse/UploadResponse.test.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadResponse/UploadResponse.test.tsx
@@ -4,7 +4,6 @@ import { Route, Routes } from 'react-router-dom'
 import { UploadResponse } from './UploadResponse'
 import {
     dragAndDrop,
-    ldUseClientSpy,
     renderWithProviders,
     TEST_DOC_FILE,
     TEST_PDF_FILE,
@@ -24,13 +23,6 @@ import {
 import { SubmissionSideNav } from '../../SubmissionSideNav'
 
 describe('UploadResponse', () => {
-    beforeEach(() => {
-        ldUseClientSpy({ 'cms-questions': true })
-    })
-    afterEach(() => {
-        jest.resetAllMocks()
-    })
-
     const division = 'testDivision'
     const questionID = 'testQuestion'
 
@@ -58,6 +50,9 @@ describe('UploadResponse', () => {
                 },
                 routerProvider: {
                     route: `/submissions/15/question-and-answers/${division}/${questionID}/upload-response`,
+                },
+                featureFlags: {
+                    'cms-questions': true,
                 },
             }
         )
@@ -97,6 +92,9 @@ describe('UploadResponse', () => {
                 },
                 routerProvider: {
                     route: `/submissions/15/question-and-answers/dmco/${questionID}/upload-response`,
+                },
+                featureFlags: {
+                    'cms-questions': true,
                 },
             }
         )
@@ -145,6 +143,9 @@ describe('UploadResponse', () => {
                 routerProvider: {
                     route: `/submissions/15/question-and-answers/dmco/${questionID}/upload-response`,
                 },
+                featureFlags: {
+                    'cms-questions': true,
+                },
             }
         )
 
@@ -190,6 +191,9 @@ describe('UploadResponse', () => {
                 },
                 routerProvider: {
                     route: `/submissions/15/question-and-answers/dmco/${questionID}/upload-response`,
+                },
+                featureFlags: {
+                    'cms-questions': true,
                 },
             }
         )
@@ -240,6 +244,9 @@ describe('UploadResponse', () => {
                 },
                 routerProvider: {
                     route: `/submissions/15/question-and-answers/dmco/${questionID}/upload-response`,
+                },
+                featureFlags: {
+                    'cms-questions': true,
                 },
             }
         )
@@ -302,6 +309,9 @@ describe('UploadResponse', () => {
                 },
                 routerProvider: {
                     route: `/submissions/15/question-and-answers/dmco/${questionID}/upload-response`,
+                },
+                featureFlags: {
+                    'cms-questions': true,
                 },
             }
         )

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
@@ -17,7 +17,6 @@ import {
     TEST_PNG_FILE,
     dragAndDrop,
     selectYesNoRadio,
-    ldUseClientSpy,
 } from '../../../testHelpers/jestHelpers'
 import { ACCEPTED_SUBMISSION_FILE_TYPES } from '../../../components/FileUpload'
 import { ContractDetails } from './'
@@ -38,10 +37,6 @@ const scrollIntoViewMock = jest.fn()
 HTMLElement.prototype.scrollIntoView = scrollIntoViewMock
 
 describe('ContractDetails', () => {
-    afterEach(() => {
-        jest.clearAllMocks()
-    })
-
     const emptyContractDetailsDraft = {
         ...mockDraft(),
     }
@@ -1028,7 +1023,6 @@ describe('ContractDetails', () => {
 
     describe('Contract 438 attestation', () => {
         it('renders 438 attestation question without errors', async () => {
-            ldUseClientSpy({ '438-attestation': true })
             const draft = mockBaseContract({
                 statutoryRegulatoryAttestation: true,
             })
@@ -1041,14 +1035,17 @@ describe('ContractDetails', () => {
                     />,
                     {
                         apolloProvider: defaultApolloProvider,
+                        featureFlags: { '438-attestation': true },
                     }
                 )
             })
 
             // expect 438 attestation question to be on the page
-            expect(
-                screen.getByText(StatutoryRegulatoryAttestationQuestion)
-            ).toBeInTheDocument()
+            await waitFor(() => {
+                expect(
+                    screen.getByText(StatutoryRegulatoryAttestationQuestion)
+                ).toBeInTheDocument()
+            })
 
             const yesRadio = screen.getByRole('radio', {
                 name: StatutoryRegulatoryAttestation.YES,
@@ -1073,7 +1070,6 @@ describe('ContractDetails', () => {
             })
         })
         it('errors when continuing without answering 438 attestation question', async () => {
-            ldUseClientSpy({ '438-attestation': true })
             const draft = mockContractAndRatesDraft({
                 contractDateStart: new Date('11-12-2023'),
                 contractDateEnd: new Date('11-12-2024'),
@@ -1090,14 +1086,17 @@ describe('ContractDetails', () => {
                     />,
                     {
                         apolloProvider: defaultApolloProvider,
+                        featureFlags: { '438-attestation': true },
                     }
                 )
             })
 
             // expect 438 attestation question to be on the page
-            expect(
-                screen.getByText(StatutoryRegulatoryAttestationQuestion)
-            ).toBeInTheDocument()
+            await waitFor(() => {
+                expect(
+                    screen.getByText(StatutoryRegulatoryAttestationQuestion)
+                ).toBeInTheDocument()
+            })
 
             const yesRadio = screen.getByRole('radio', {
                 name: StatutoryRegulatoryAttestation.YES,
@@ -1140,7 +1139,6 @@ describe('ContractDetails', () => {
             })
         })
         it('errors when continuing without description for 438 non-compliance', async () => {
-            ldUseClientSpy({ '438-attestation': true })
             const draft = mockContractAndRatesDraft({
                 contractDateStart: new Date('11-12-2023'),
                 contractDateEnd: new Date('11-12-2024'),
@@ -1157,14 +1155,17 @@ describe('ContractDetails', () => {
                     />,
                     {
                         apolloProvider: defaultApolloProvider,
+                        featureFlags: { '438-attestation': true },
                     }
                 )
             })
 
             // expect 438 attestation question to be on the page
-            expect(
-                screen.getByText(StatutoryRegulatoryAttestationQuestion)
-            ).toBeInTheDocument()
+            await waitFor(() => {
+                expect(
+                    screen.getByText(StatutoryRegulatoryAttestationQuestion)
+                ).toBeInTheDocument()
+            })
 
             const continueButton = screen.getByRole('button', {
                 name: 'Continue',

--- a/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.test.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.test.tsx
@@ -17,15 +17,8 @@ import {
     mockUnlockedHealthPlanPackage,
     mockValidCMSUser,
 } from '../../testHelpers/apolloMocks'
-import { ldUseClientSpy } from '../../testHelpers'
 
 describe('SubmissionSideNav', () => {
-    beforeEach(() => {
-        ldUseClientSpy({ 'cms-questions': true })
-    })
-    afterEach(() => {
-        jest.resetAllMocks()
-    })
     it('loads sidebar nav with expected links', async () => {
         renderWithProviders(
             <Routes>
@@ -55,6 +48,7 @@ describe('SubmissionSideNav', () => {
                 routerProvider: {
                     route: '/submissions/15',
                 },
+                featureFlags: { 'cms-questions': true },
             }
         )
 
@@ -124,6 +118,7 @@ describe('SubmissionSideNav', () => {
                     route: '/submissions/15',
                 },
                 location: (location) => (testLocation = location),
+                featureFlags: { 'cms-questions': true },
             }
         )
 
@@ -230,6 +225,7 @@ describe('SubmissionSideNav', () => {
                 routerProvider: {
                     route: '/submissions/15',
                 },
+                featureFlags: { 'cms-questions': true },
             }
         )
         expect(
@@ -266,6 +262,7 @@ describe('SubmissionSideNav', () => {
                 routerProvider: {
                     route: '/submissions/15',
                 },
+                featureFlags: { 'cms-questions': true },
             }
         )
 
@@ -313,6 +310,7 @@ describe('SubmissionSideNav', () => {
                     routerProvider: {
                         route: '/submissions/15',
                     },
+                    featureFlags: { 'cms-questions': true },
                 }
             )
 
@@ -355,6 +353,7 @@ describe('SubmissionSideNav', () => {
                     routerProvider: {
                         route: '/submissions/15',
                     },
+                    featureFlags: { 'cms-questions': true },
                 }
             )
 
@@ -398,6 +397,7 @@ describe('SubmissionSideNav', () => {
                         route: '/submissions/15',
                     },
                     location: (location) => (testLocation = location),
+                    featureFlags: { 'cms-questions': true },
                 }
             )
 
@@ -443,6 +443,7 @@ describe('SubmissionSideNav', () => {
                         route: '/submissions/15',
                     },
                     location: (location) => (testLocation = location),
+                    featureFlags: { 'cms-questions': true },
                 }
             )
 
@@ -487,6 +488,7 @@ describe('SubmissionSideNav', () => {
                     routerProvider: {
                         route: '/submissions/15',
                     },
+                    featureFlags: { 'cms-questions': true },
                 }
             )
 
@@ -521,6 +523,7 @@ describe('SubmissionSideNav', () => {
                         ],
                     },
                     routerProvider: { route: '/submissions/404' },
+                    featureFlags: { 'cms-questions': true },
                 }
             )
 
@@ -559,6 +562,7 @@ describe('SubmissionSideNav', () => {
                     routerProvider: {
                         route: '/submissions/15/question-and-answers',
                     },
+                    featureFlags: { 'cms-questions': true },
                 }
             )
 

--- a/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.test.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import { renderWithProviders, testS3Client, ldUseClientSpy } from '../../../testHelpers'
+import { renderWithProviders, testS3Client } from '../../../testHelpers'
 import {
     fetchCurrentUserMock,
     fetchRateMockSuccess,
@@ -20,8 +20,6 @@ const wrapInRoutes = (children: React.ReactNode) => {
 }
 
 describe('RateSummary', () => {
-    afterAll(() => jest.clearAllMocks())
-
     describe('Viewing RateSummary as a CMS user', () => {
         it('renders without errors', async () => {
             renderWithProviders(wrapInRoutes(<RateSummary />), {
@@ -38,17 +36,21 @@ describe('RateSummary', () => {
                     route: '/rates/7a',
                 },
             })
-    
+
             expect(
-                await screen.findByText('Programs this rate certification covers')
+                await screen.findByText(
+                    'Programs this rate certification covers'
+                )
             ).toBeInTheDocument()
         })
 
         it('renders document download warning banner when download fails', async () => {
-            const error = jest.spyOn(console, 'error').mockImplementation(() => {
-                // mock expected console error to keep test output clear
-            })
-    
+            const error = jest
+                .spyOn(console, 'error')
+                .mockImplementation(() => {
+                    // mock expected console error to keep test output clear
+                })
+
             const s3Provider = {
                 ...testS3Client(),
                 getBulkDlURL: async (
@@ -73,7 +75,7 @@ describe('RateSummary', () => {
                 },
                 s3Provider,
             })
-    
+
             await waitFor(() => {
                 expect(screen.getByTestId('warning-alert')).toBeInTheDocument()
                 expect(screen.getByTestId('warning-alert')).toHaveClass(
@@ -101,21 +103,17 @@ describe('RateSummary', () => {
                     route: '/rates/7a',
                 },
             })
-    
+
             const backLink = await screen.findByRole('link', {
                 name: /Back to dashboard/,
             })
             expect(backLink).toBeInTheDocument()
-    
+
             expect(backLink).toHaveAttribute('href', '/dashboard/rate-reviews')
         })
     })
 
     describe('Viewing RateSummary as a State user', () => {
-        beforeEach(() => {
-            ldUseClientSpy({'rate-edit-unlock': true})
-        })
-
         it('renders without errors', async () => {
             renderWithProviders(wrapInRoutes(<RateSummary />), {
                 apolloProvider: {
@@ -128,8 +126,9 @@ describe('RateSummary', () => {
                     ],
                 },
                 routerProvider: {
-                    route: '/rates/1337'
+                    route: '/rates/1337',
                 },
+                featureFlags: { 'rate-edit-unlock': true },
             })
 
             await waitFor(() => {
@@ -137,7 +136,9 @@ describe('RateSummary', () => {
             })
 
             expect(
-                await screen.findByText('Programs this rate certification covers')
+                await screen.findByText(
+                    'Programs this rate certification covers'
+                )
             ).toBeInTheDocument()
         })
 
@@ -154,13 +155,12 @@ describe('RateSummary', () => {
                 },
                 //purposefully attaching invalid id to url here
                 routerProvider: {
-                    route: '/rates/133'
+                    route: '/rates/133',
                 },
+                featureFlags: { 'rate-edit-unlock': true },
             })
 
-            expect(
-                await screen.findByText('System error')
-            ).toBeInTheDocument()
+            expect(await screen.findByText('System error')).toBeInTheDocument()
         })
 
         it('renders back to dashboard link for state users', async () => {
@@ -177,13 +177,14 @@ describe('RateSummary', () => {
                 routerProvider: {
                     route: '/rates/7a',
                 },
+                featureFlags: { 'rate-edit-unlock': true },
             })
-    
+
             const backLink = await screen.findByRole('link', {
                 name: /Back to dashboard/,
             })
             expect(backLink).toBeInTheDocument()
-    
+
             expect(backLink).toHaveAttribute('href', '/dashboard')
         })
     })

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -16,21 +16,12 @@ import {
     mockStateSubmission,
     mockSubmittedHealthPlanPackage,
 } from '../../testHelpers/apolloMocks'
-import {
-    ldUseClientSpy,
-    renderWithProviders,
-} from '../../testHelpers/jestHelpers'
+import { renderWithProviders } from '../../testHelpers/jestHelpers'
 import { SubmissionSummary } from './SubmissionSummary'
 import { SubmissionSideNav } from '../SubmissionSideNav'
 import { testS3Client } from '../../testHelpers/s3Helpers'
 
 describe('SubmissionSummary', () => {
-    beforeEach(() => {
-        ldUseClientSpy({ 'cms-questions': false })
-    })
-    afterEach(() => {
-        jest.resetAllMocks()
-    })
     it('renders without errors', async () => {
         renderWithProviders(
             <Routes>

--- a/services/app-web/src/testHelpers/index.ts
+++ b/services/app-web/src/testHelpers/index.ts
@@ -11,7 +11,6 @@ export {
     userClickByRole,
     userClickByTestId,
     userClickSignIn,
-    ldUseClientSpy,
     TEST_DOC_FILE,
     TEST_DOCX_FILE,
     TEST_PDF_FILE,

--- a/services/app-web/src/testHelpers/jestHelpers.tsx
+++ b/services/app-web/src/testHelpers/jestHelpers.tsx
@@ -49,26 +49,9 @@ function ldClientMock(featureFlags: FeatureFlagSettings): LDClient {
             (
                 flag: FeatureFlagLDConstant,
                 defaultValue: FlagValue | undefined
-            ) => {
-                if (
-                    featureFlags[flag] === undefined &&
-                    defaultValue === undefined
-                ) {
-                    //ldClient.variation doesn't require a default value, throwing error here if a defaultValue was not provided.
-                    throw new Error(
-                        'ldUseClientSpy returned an invalid value of undefined'
-                    )
-                }
-                return featureFlags[flag] === undefined
-                    ? defaultValue
-                    : featureFlags[flag]
-            }
+            ) => featureFlags[flag] ?? defaultValue
         ),
-        allFlags: jest.fn(() => {
-            const defaultFeatureFlags = getDefaultFeatureFlags()
-            Object.assign(defaultFeatureFlags, featureFlags)
-            return defaultFeatureFlags
-        }),
+        allFlags: jest.fn(() => featureFlags),
     }
 }
 
@@ -106,6 +89,7 @@ const renderWithProviders = (
     const ldProviderConfig: ProviderConfig = {
         clientSideID: 'test-url',
         options: {
+            bootstrap: flags,
             baseUrl: 'test-url',
             streamUrl: 'test-url',
             eventsUrl: 'test-url',

--- a/yarn.lock
+++ b/yarn.lock
@@ -22813,10 +22813,10 @@ launchdarkly-eventsource@2.0.0:
   resolved "https://registry.yarnpkg.com/launchdarkly-eventsource/-/launchdarkly-eventsource-2.0.0.tgz#2832e73fa8bc0c103a7f8c6dbc3b1b53d22f9acc"
   integrity sha512-fxZ4IN46juAc3s8/geiutRPbI8cvUBz0Lcsayh3wfd97edYWLIsnaThw2esQ3zc6vgZ1v5IjTbdumNgoT3iRnw==
 
-launchdarkly-js-client-sdk@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-3.1.3.tgz#e046439f0e4f0bfd6d38b9eaa4420a6e40ffc0c7"
-  integrity sha512-/JR/ri8z3bEj9RFTTKDjd+con4F1MsWUea1MmBDtFj4gDA0l9NDm1KzhMKiIeoBdmB2rSaeFYe4CaYOEp8IryA==
+launchdarkly-js-client-sdk@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-3.1.4.tgz#e613cb53412533c07ccf140ae570fc994c59758d"
+  integrity sha512-yq0FeklpVuHMSRz7jfUAfyM7I/659RvGztqJ0Y9G5eN/ZrG1o2W61ZU0Nrv/gqZCtLXjarh/u1otxSFFBjTpHw==
   dependencies:
     escape-string-regexp "^4.0.0"
     launchdarkly-js-sdk-common "5.0.3"
@@ -22830,13 +22830,13 @@ launchdarkly-js-sdk-common@5.0.3:
     fast-deep-equal "^2.0.1"
     uuid "^8.0.0"
 
-launchdarkly-react-client-sdk@^3.0.1:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/launchdarkly-react-client-sdk/-/launchdarkly-react-client-sdk-3.0.6.tgz#5c694a4a013757d2afb5213efd28d9c16af1595e"
-  integrity sha512-r7gSshScugjnJB4lJ6mAOMKpV4Pj/wUks3tsRHdfeXgER9jPdxmZOAkm0besMjK0S7lfQdjxJ2KIXrh+Mn1sQA==
+launchdarkly-react-client-sdk@^3.0.10:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/launchdarkly-react-client-sdk/-/launchdarkly-react-client-sdk-3.0.10.tgz#33816d939d9bd18b0723c0fd30b4772f2429f3de"
+  integrity sha512-ssb3KWe9z42+q8X2u32OrlDntGLsv0NP/p4E2Hx4O9RU0OeFm9v6omOlIk9SMsYEQD4QzLSXAp5L3cSN2ssLlA==
   dependencies:
     hoist-non-react-statics "^3.3.2"
-    launchdarkly-js-client-sdk "^3.1.3"
+    launchdarkly-js-client-sdk "^3.1.4"
     lodash.camelcase "^4.3.0"
 
 lazy-ass@^1.6.0:
@@ -28458,7 +28458,6 @@ serverless-plugin-scripts@^1.0.2:
 
 serverless-s3-bucket-helper@CMSgov/serverless-s3-bucket-helper:
   version "1.0.0"
-  uid "3e519d15676de237ec8ede3ff9ae26abf3f3ef0a"
   resolved "https://codeload.github.com/CMSgov/serverless-s3-bucket-helper/tar.gz/3e519d15676de237ec8ede3ff9ae26abf3f3ef0a"
 
 serverless-s3-local@^0.7.1:


### PR DESCRIPTION
## Summary
[MCR-3758](https://qmacbis.atlassian.net/browse/MCR-3758)

- Replace `ldUseClientSpy` with `LDProvider` to configure feature flags for unit testing.
   - Using `LDProvider` to initialize our tests because `jest.spyOn` used in `ldUseClientSpy` is not working with `launchdarkly-react-client-sdk` versions 3.0.9 and above. I'm not exactly sure why it stopped working. I've tried to fully construct a `useLDClient` `mockImplemenation` in `ldUseClientSpy` with no success.
   - With `LDProvider`, we are initializing a mocked `ldClient` for our unit tests when using `renderWithProviders`. Since we are initializing the `ldClient` outside of `LDProvider,` it does not do it internally, which requires an API call to LaunchDarkly; we are isolating tests from flag values in LaunchDarkly.
   - With using `LDProvider,` follows the pattern we set in `renderWithProviders`, so I'm happy with that.
 - Updated the docs on the new method for unit testing.
 - Updated all tests with feature flags.
 - Fixed a React error.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

It's a pretty simple implementation, so I'm not sure what QA tests can be done here. There should be no side effects to the UI.

<!---These are developer instructions on how to test or validate the work -->
