### PR TITLE
Send utag.view tag data on initial app load

### DIFF
--- a/services/app-web/src/hooks/useTealium.ts
+++ b/services/app-web/src/hooks/useTealium.ts
@@ -90,6 +90,19 @@ const useTealium = (): {
 
         document.body.appendChild(loadTagsSnippet)
 
+        const tagData: TealiumViewDataObject = {
+            content_language: 'en',
+            content_type: `${CONTENT_TYPE_BY_ROUTE[currentRoute]}`,
+            page_name: tealiumPageName,
+            page_path: pathname,
+            site_domain: 'cms.gov',
+            site_environment: `${process.env.REACT_APP_STAGE_NAME}`,
+            site_section: `${currentRoute}`,
+            logged_in: `${Boolean(loggedInUser) ?? false}`,
+        }
+        window.utag.view(tagData)
+        console.log('RAN IT')
+
         return () => {
             // document.body.removeChild(loadTagsSnippet)
             document.head.removeChild(initializeTagManagerSnippet)

--- a/services/app-web/src/hooks/useTealium.ts
+++ b/services/app-web/src/hooks/useTealium.ts
@@ -101,12 +101,14 @@ const useTealium = (): {
             logged_in: `${Boolean(loggedInUser) ?? false}`,
         }
         window.utag.view(tagData)
-        console.log('RAN IT')
 
         return () => {
             // document.body.removeChild(loadTagsSnippet)
             document.head.removeChild(initializeTagManagerSnippet)
         }
+
+    // NOTE: Run effect once on component mount, we recheck dependencies if effect is updated in the subsequent page view effect
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     // Add page view


### PR DESCRIPTION
## Summary
It was pointed out in adding event tracking analytics that we aren't running `utag.view` in initial app load, only when we switch pages. This PR addresses that by adding a call to register tags on the initial load `useEffect`.

#### Related issues
https://qmacbis.atlassian.net/browse/MCR-3891
https://jira.cms.gov/browse/BLSTANALYT-7038 

## QA guidance
This could be tested with breakpoints - checking that appropriate effect fires when expected when launching the SPA