### PR TITLE
MCR-3813 Restricting rate access to each respective state

### DIFF
--- a/services/app-web/src/pages/Errors/ErrorForbiddenPage.tsx
+++ b/services/app-web/src/pages/Errors/ErrorForbiddenPage.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import styles from './Errors.module.scss'
+import { GridContainer } from '@trussworks/react-uswds'
+import { PageHeading } from '../../components'
+
+interface ForbiddenErrorPageProps {
+    errorMsg?: string
+}
+
+export const ErrorForbiddenPage = ({
+    errorMsg,
+}: ForbiddenErrorPageProps): React.ReactElement => {
+    return (
+        <section className={styles.errorsContainer}>
+            <GridContainer>
+                <PageHeading>Forbidden</PageHeading>
+                {errorMsg ? (
+                    <p>{errorMsg}</p>
+                ) : (
+                    <p>
+                        You do not have permission to view the requested file or
+                        resource.
+                    </p>
+                )}
+            </GridContainer>
+        </section>
+    )
+}

--- a/services/app-web/src/pages/RateEdit/RateEdit.tsx
+++ b/services/app-web/src/pages/RateEdit/RateEdit.tsx
@@ -5,6 +5,7 @@ import { GridContainer } from '@trussworks/react-uswds'
 import { Loading } from '../../components'
 import { GenericErrorPage } from '../Errors/GenericErrorPage'
 import { ErrorForbiddenPage } from '../Errors/ErrorForbiddenPage'
+import { Error404 } from '../Errors/Error404Page'
 
 type RouteParams = {
     id: string
@@ -37,13 +38,15 @@ export const RateEdit = (): React.ReactElement => {
         )
     } else if (error || !rate) {
         //error handling for a state user that tries to access rates for a different state
-        if (error?.graphQLErrors[0].extensions.code === 'FORBIDDEN') {
+        if (error?.graphQLErrors[0]?.extensions?.code === 'FORBIDDEN') {
             return (
                 <ErrorForbiddenPage errorMsg={error.graphQLErrors[0].message} />
             )
+        } else if (error?.graphQLErrors[0]?.extensions?.code === 'NOT_FOUND') {
+            return <Error404 />
+        } else {
+            return <GenericErrorPage />
         }
-
-        return <GenericErrorPage />
     }
 
     if (rate.status !== 'UNLOCKED') {

--- a/services/app-web/src/pages/RateEdit/RateEdit.tsx
+++ b/services/app-web/src/pages/RateEdit/RateEdit.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { useFetchRateQuery } from '../../gen/gqlClient'
+import { StateUser, useFetchRateQuery } from '../../gen/gqlClient'
 import { GridContainer } from '@trussworks/react-uswds'
 import { Loading } from '../../components'
 import { GenericErrorPage } from '../Errors/GenericErrorPage'
+import { useAuth } from '../../contexts/AuthContext'
 
 type RouteParams = {
     id: string
@@ -11,6 +12,8 @@ type RouteParams = {
 
 export const RateEdit = (): React.ReactElement => {
     const navigate = useNavigate()
+    const { loggedInUser } = useAuth()
+    let user: StateUser
     const { id } = useParams<keyof RouteParams>()
     if (!id) {
         throw new Error(
@@ -36,6 +39,15 @@ export const RateEdit = (): React.ReactElement => {
         )
     } else if (error || !rate) {
         return <GenericErrorPage />
+    }
+
+    if (loggedInUser && loggedInUser.__typename === 'StateUser') {
+        user = loggedInUser
+
+        //Will render a error component if the state user is attempting to access a rate not belonging to their state
+        if (user.state.code !== rate.stateCode) {
+            return <GenericErrorPage />
+        }
     }
 
     if (rate.status !== 'UNLOCKED') {

--- a/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.tsx
@@ -4,7 +4,7 @@ import { NavLink, useNavigate, useParams } from 'react-router-dom'
 
 import { Loading } from '../../../components'
 import { usePage } from '../../../contexts/PageContext'
-import { useFetchRateQuery } from '../../../gen/gqlClient'
+import { StateUser, useFetchRateQuery } from '../../../gen/gqlClient'
 import styles from '../SubmissionSummary.module.scss'
 import { GenericErrorPage } from '../../Errors/GenericErrorPage'
 import { RoutesRecord } from '../../../constants'
@@ -18,6 +18,7 @@ type RouteParams = {
 export const RateSummary = (): React.ReactElement => {
     // Page level state
     const { loggedInUser } = useAuth()
+    let user: StateUser
     const { updateHeading } = usePage()
     const navigate = useNavigate()
     const [rateName, setRateName] = useState<string | undefined>(undefined)
@@ -53,9 +54,18 @@ export const RateSummary = (): React.ReactElement => {
         return <GenericErrorPage />
     }
 
-    //Redirecting a state user to the edit page if rate is unlocked
-    if (loggedInUser?.role === 'STATE_USER' && rate.status === 'UNLOCKED') {
-        navigate(`/rates/${id}/edit`)
+    if (loggedInUser && loggedInUser.__typename === 'StateUser') {
+        user = loggedInUser
+
+        //Will render a error component if the state user is attempting to access a rate not belonging to their state
+        if (user.state.code !== rate.stateCode) {
+            return <GenericErrorPage />
+        }
+
+        //Redirecting a state user to the edit page if rate is unlocked
+        if (user.role === 'STATE_USER' && rate.status === 'UNLOCKED') {
+            navigate(`/rates/${id}/edit`)
+        }
     }
 
     if (

--- a/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.tsx
@@ -53,7 +53,7 @@ export const RateSummary = (): React.ReactElement => {
         )
     } else if (error || !rate || !currentRateRev?.formData) {
         //error handling for a state user that tries to access rates for a different state
-        if (error?.graphQLErrors[0].extensions.code === 'FORBIDDEN') {
+        if (error?.graphQLErrors[0]?.extensions?.code === 'FORBIDDEN') {
             return (
                 <ErrorForbiddenPage errorMsg={error.graphQLErrors[0].message} />
             )

--- a/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/RateSummary/RateSummary.tsx
@@ -11,6 +11,7 @@ import { RoutesRecord } from '../../../constants'
 import { SingleRateSummarySection } from '../../../components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection'
 import { useAuth } from '../../../contexts/AuthContext'
 import { ErrorForbiddenPage } from '../../Errors/ErrorForbiddenPage'
+import { Error404 } from '../../Errors/Error404Page'
 
 type RouteParams = {
     id: string
@@ -56,9 +57,11 @@ export const RateSummary = (): React.ReactElement => {
             return (
                 <ErrorForbiddenPage errorMsg={error.graphQLErrors[0].message} />
             )
+        } else if (error?.graphQLErrors[0]?.extensions?.code === 'NOT_FOUND') {
+            return <Error404 />
+        } else {
+            return <GenericErrorPage />
         }
-
-        return <GenericErrorPage />
     }
 
     //Redirecting a state user to the edit page if rate is unlocked


### PR DESCRIPTION
…tate code

## Summary
A continuation to MCR-3793, the purpose of this PR is to deny access to rates from unrelated states (i.e. Minnesota should not be able to access Virginia's rates)

#### Related issues
[MCR-3813](https://jiraent.cms.gov/browse/MCR-3813)
#### Screenshots
Will display custom error message if provided:
![image](https://github.com/Enterprise-CMCS/managed-care-review/assets/111928238/d73211c3-0a02-46ea-a2d7-795071476307)

Standard forbidden error message if no error message is provided:
![image](https://github.com/Enterprise-CMCS/managed-care-review/assets/111928238/5cbcc515-2daa-4424-8c06-9f14d0520c3f)

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

1. Grab a rate id of your choice
2. Log in as a state user that differs from the state attached to the rate
3. When visiting `/rates/:id` and `rates/:id/edit` you should be met with the Forbidden error page