### PR TITLE
Revert "Send utag.view tag data on initial app load"

### DIFF
--- a/services/app-web/src/hooks/useTealium.ts
+++ b/services/app-web/src/hooks/useTealium.ts
@@ -90,25 +90,10 @@ const useTealium = (): {
 
         document.body.appendChild(loadTagsSnippet)
 
-        const tagData: TealiumViewDataObject = {
-            content_language: 'en',
-            content_type: `${CONTENT_TYPE_BY_ROUTE[currentRoute]}`,
-            page_name: tealiumPageName,
-            page_path: pathname,
-            site_domain: 'cms.gov',
-            site_environment: `${process.env.REACT_APP_STAGE_NAME}`,
-            site_section: `${currentRoute}`,
-            logged_in: `${Boolean(loggedInUser) ?? false}`,
-        }
-        window.utag.view(tagData)
-
         return () => {
             // document.body.removeChild(loadTagsSnippet)
             document.head.removeChild(initializeTagManagerSnippet)
         }
-
-    // NOTE: Run effect once on component mount, we recheck dependencies if effect is updated in the subsequent page view effect
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     // Add page view


### PR DESCRIPTION
Reverts Enterprise-CMCS/managed-care-review#2215

This is failing in higher environments due to `utag.view` not loading in the page yet. Prepping this PR in case we decide to revert. See failed promote https://github.com/Enterprise-CMCS/managed-care-review/actions/runs/7749469528.