### PR TITLE
bugfix: make sure utag.view exists

### DIFF
--- a/services/app-web/src/hooks/useTealium.ts
+++ b/services/app-web/src/hooks/useTealium.ts
@@ -43,11 +43,6 @@ const useTealium = (): {
             return
         }
 
-        const waitForUtag = async () => {
-            return new Promise(resolve => setTimeout(resolve, 1000));
-        }
-
-
         const tealiumEnv = getTealiumEnv(
             process.env.REACT_APP_STAGE_NAME || 'main'
         )
@@ -95,44 +90,31 @@ const useTealium = (): {
 
         document.body.appendChild(loadTagsSnippet)
 
-        waitForUtag()
-
-        if(window.utag) {
-            const tagData: TealiumViewDataObject = {
-                content_language: 'en',
-                content_type: `${CONTENT_TYPE_BY_ROUTE[currentRoute]}`,
-                page_name: tealiumPageName,
-                page_path: pathname,
-                site_domain: 'cms.gov',
-                site_environment: `${process.env.REACT_APP_STAGE_NAME}`,
-                site_section: `${currentRoute}`,
-                logged_in: `${Boolean(loggedInUser) ?? false}`,
-            }
-            window.utag.view(tagData)
-        }
-
-
         return () => {
             // document.body.removeChild(loadTagsSnippet)
             document.head.removeChild(initializeTagManagerSnippet)
         }
-
-    // NOTE: Run effect once on component mount, we recheck dependencies if effect is updated in the subsequent page view effect
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     // Add page view
     // this effect should fire on each page view or if something changes about logged in user
     useEffect(() => {
+
         // Do not add tealium for local dev or review apps
         if (process.env.REACT_APP_AUTH_MODE !== 'IDM') {
-            // console.info(`mock tealium page view: ${tealiumPageName}`)
             return
         }
 
-        // Guardrail - protect against trying to call utag before its loaded.
+        const waitForUtag = async () => {
+           return new Promise(resolve => setTimeout(resolve, 1000));
+        }
+
+
         if (!window.utag) {
-            return
+            waitForUtag().catch(() => { /* All of this is a guardrail - protect against trying to call utag before its loaded*/ })
+            if (!window.utag) {
+                return
+            }
         }
 
         // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/services/app-web/src/hooks/useTealium.ts
+++ b/services/app-web/src/hooks/useTealium.ts
@@ -43,6 +43,11 @@ const useTealium = (): {
             return
         }
 
+        const waitForUtag = async () => {
+            return new Promise(resolve => setTimeout(resolve, 1000));
+        }
+
+
         const tealiumEnv = getTealiumEnv(
             process.env.REACT_APP_STAGE_NAME || 'main'
         )
@@ -90,17 +95,22 @@ const useTealium = (): {
 
         document.body.appendChild(loadTagsSnippet)
 
-        const tagData: TealiumViewDataObject = {
-            content_language: 'en',
-            content_type: `${CONTENT_TYPE_BY_ROUTE[currentRoute]}`,
-            page_name: tealiumPageName,
-            page_path: pathname,
-            site_domain: 'cms.gov',
-            site_environment: `${process.env.REACT_APP_STAGE_NAME}`,
-            site_section: `${currentRoute}`,
-            logged_in: `${Boolean(loggedInUser) ?? false}`,
+        waitForUtag()
+
+        if(window.utag) {
+            const tagData: TealiumViewDataObject = {
+                content_language: 'en',
+                content_type: `${CONTENT_TYPE_BY_ROUTE[currentRoute]}`,
+                page_name: tealiumPageName,
+                page_path: pathname,
+                site_domain: 'cms.gov',
+                site_environment: `${process.env.REACT_APP_STAGE_NAME}`,
+                site_section: `${currentRoute}`,
+                logged_in: `${Boolean(loggedInUser) ?? false}`,
+            }
+            window.utag.view(tagData)
         }
-        window.utag.view(tagData)
+
 
         return () => {
             // document.body.removeChild(loadTagsSnippet)


### PR DESCRIPTION
## Summary
This should address the issue the cause the failed promote referenced in #2229. Please take a look though, let me know your thoughts. This adds a second to the initial app load before tealium called. From what I can tell from those tags usually take around 35 ms to load. 

Also added guard clause so this won't break app compile when window.utag is not set yet. 

#### Related issues
#2215 

