### PR TITLE
Add always-on ClamAV server 

### DIFF
--- a/services/uploads/README.md
+++ b/services/uploads/README.md
@@ -16,6 +16,32 @@ In addition to live scanning all uploaded files, we also have a pair of lambdas 
 
 The avAuditUploads lambda pulls a list of every file in the uploads bucket and then invokes avAuditFiles for each of them in chunks of 20 or so. For any files that are found to be INFECTED, it then grabs the current s3 tags for them and verifies that they are tagged accordingly. If not, it will re-tag the file to be INFECTED, preventing further download.
 
+## ClamAV Daemon
+
+We have an ec2 instance that is created in dev, val, and prod that is configured with an always on ClamAV instance that accepts incoming virus scan requests on port 3310. The motivation here is that we are working towards having our av scanning lambdas use the always on ClamAV daemon rather than rely on just the lambda, as there is a high startup cost for ClamAV of around 29 seconds in our testing. This means that all virus scans take at least 29 seconds for the user. By using an always on instance we can reduce that to closer to the actual time of the virus scan (usually < 1s).
+
+The server is restricted to only have access from connections in the default security group as well as anything else that is placed in the ClamAV security group. This allows for our AV scanning lambds to call out to the instance while restricting all other traffic. However, all of our engineers have ssh pub keys on the instance in case they need access to the machine via ssh for any reason.
+
+### Accessing the VM
+
+Similar to the [Postgres jumpbox](../postgres/README.md), we use the `authorized_keys` file to give access to this VM and you'll need to add your IP to the VM's security group:
+
+1. Determine your public facing IP address. An easy way to do this is to `curl https://ifconfig.me/`
+2. Locate the EC2 instance in the AWS console. Click and go into Security > Security groups.
+3. There should be two security groups attached to the instance, the default and the ClamAV one. Select the ClamAV security group.
+4. On the `Inbound rules` tab select `Edit inbound rules`
+5. Add a rule for `ssh` with the `source` set to your local IP address with `/32` appended to it (e.g. `1.2.3.4/32`)
+6. Save the rule
+
+#### SSH to the instances
+
+You should now be able to ssh to the jump box.
+
+1. Locate the Public IPv4 address of the instance. This can be found by clicking into the VM on the `Instances` section of the EC2 console.
+2. ssh ubuntu@public-ip
+
+You should be using public key auth to ssh. If you need to point to your private key, use `ssh -i ~/.ssh/${yourkeyfile} ubuntu@public-ip`
+
 ## Significant dependencies
 
 -   serverless-s3-upload

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -429,7 +429,7 @@ resources:
           - AssociatePublicIpAddress: true
             DeviceIndex: '0'
             GroupSet:
-              - !Ref ClamAvSecurityGroup
+              - !Ref ClamAVSecurityGroup
               - ${self:custom.sgId}
             SubnetId: !Sub ${self:custom.publicSubnetA}
         Tags:

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -187,7 +187,6 @@ resources:
       - !Equals ['${sls:stage}', 'main']
       - !Equals ['${sls:stage}', 'val']
       - !Equals ['${sls:stage}', 'prod']
-      - !Equals ['${sls:stage}', 'mtbuildclamavserver']
 
   Resources:
     DocumentUploadsBucket:
@@ -432,7 +431,6 @@ resources:
         InstanceType: t3.medium
         ImageId: ami-0c7217cdde317cfec # Ubuntu 22.04 LTS
         IamInstanceProfile: !Ref ClamAVInstanceProfile
-        KeyName: mojo # for testing
         NetworkInterfaces:
           - AssociatePublicIpAddress: true
             DeviceIndex: '0'

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -428,9 +428,10 @@ resources:
       Type: AWS::EC2::Instance
       Condition: IsDevValProd
       Properties:
-        InstanceType: t2.micro
+        InstanceType: t3.medium
         ImageId: ami-05bfc1ab11bfbf484
         IamInstanceProfile: !Ref ClamAVInstanceProfile
+        KeyName: mojo # for testing
         NetworkInterfaces:
           - AssociatePublicIpAddress: true
             DeviceIndex: '0'

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -447,8 +447,20 @@ resources:
         UserData:
           Fn::Base64: !Sub |
             #!/bin/bash
-            sudo apt-get update
-            sudo apt-get install -y clamav clamav-daemon
+            apt-get update
+            apt-get install -y clamav clamav-daemon
+
+            # Install clamav 1.0.4
+            wget https://www.clamav.net/downloads/production/clamav-1.0.4.linux.x86_64.deb
+            dpkg -i clamav-1.0.4.linux.x86_64.deb
+            apt-get install -f
+
+            # Write the freshclam.conf
+            echo "DatabaseMirror database.clamav.net" > /usr/local/etc/freshclam.conf
+            echo "CompressLocalDatabase yes" >> /usr/local/etc/freshclam.conf
+            chmod  644 /usr/local/etc/freshclam.conf
+            chown clamav:clamav /usr/local/etc/freshclam.conf
+
             sudo systemctl enable clamav-freshclam
             sudo systemctl start clamav-freshclam
             sudo systemctl enable clamav-daemon

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -52,6 +52,7 @@ provider:
 custom:
   region: ${aws:region}
   reactAppOtelCollectorUrl: ${env:REACT_APP_OTEL_COLLECTOR_URL, ssm:/configuration/react_app_otel_collector_url}
+  authorizedKeys: ${file(../postgres/scripts/authorized_keys)}
   webpack:
     webpackConfig: webpack.config.js
     packager: yarn
@@ -449,6 +450,10 @@ resources:
             #!/bin/bash
             apt-get update
             apt-get install -y clamav clamav-daemon
+
+            echo '${self:custom.authorizedKeys}' > /home/ubuntu/.ssh/authorized_keys
+            chown ubuntu:ubuntu /home/ubuntu/.ssh/authorized_keys
+            chmod 600 /home/ubuntu/.ssh/authorized_keys
 
             # Install clamav 1.0.4
             wget https://www.clamav.net/downloads/production/clamav-1.0.4.linux.x86_64.deb

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -425,6 +425,13 @@ resources:
         SecurityGroups:
           - !Ref ClamAVSecurityGroup
         IamInstanceProfile: !Ref ClamAVInstanceProfile
+        NetworkInterfaces:
+          - AssociatePublicIpAddress: true
+            DeviceIndex: '0'
+            GroupSet:
+              - !Ref ClamAvSecurityGroup
+              - ${self:custom.sgId}
+            SubnetId: !Sub ${self:custom.publicSubnetA}
         Tags:
           - Key: mcr-vmuse
             Value: clamavd

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -66,6 +66,13 @@ custom:
       deploy:finalize: |
         rm lambda_layer.zip
         serverless invoke --stage ${sls:stage} --function avDownloadDefinitions -t Event
+  vpcId: ${ssm:/configuration/${sls:stage}/vpc/id, ssm:/configuration/default/vpc/id}
+  sgId: ${ssm:/configuration/${sls:stage}/vpc/sg/id, ssm:/configuration/default/vpc/sg/id}
+  privateSubnets:
+    - ${ssm:/configuration/${sls:stage}/vpc/subnets/private/a/id, ssm:/configuration/default/vpc/subnets/private/a/id}
+    - ${ssm:/configuration/${sls:stage}/vpc/subnets/private/b/id, ssm:/configuration/default/vpc/subnets/private/b/id}
+    - ${ssm:/configuration/${sls:stage}/vpc/subnets/private/c/id, ssm:/configuration/default/vpc/subnets/private/c/id}
+  publicSubnetA: ${ssm:/configuration/${sls:stage}/vpc/subnets/public/a/id, ssm:/configuration/default/vpc/subnets/public/a/id}
   serverless-offline-ssm:
     stages:
       - local
@@ -109,6 +116,9 @@ functions:
     layers:
       - !Ref ClamAvLambdaLayer
       - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:1
+    vpc:
+      securityGroupIds: ${self:custom.sgId}
+      subnetIds: ${self:custom.privateSubnets}
     environment:
       stage: ${sls:stage}
       CLAMAV_BUCKET_NAME: !Ref ClamDefsBucket
@@ -363,6 +373,67 @@ resources:
                 - !Sub ${QAUploadsBucket.Arn}
                 - !Sub ${QAUploadsBucket.Arn}/*
               Sid: DenyUnencryptedConnections
+
+    ClamAVSecurityGroup:
+      Type: AWS::EC2::SecurityGroup
+      Properties:
+        GroupDescription: Security group for ClamAV daemon
+        SecurityGroupIngress:
+          - IpProtocol: tcp
+            FromPort: 3310
+            ToPort: 3310
+            SourceSecurityGroupId: ${self:custom.sgId}
+
+    ClamAVInstanceProfile:
+      Type: AWS::IAM::InstanceProfile
+      Properties:
+        Path: /
+        Roles:
+          - !Ref ClamAVInstanceRole
+
+    ClamAVInstanceRole:
+      Type: AWS::IAM::Role
+      Properties:
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service: lambda.amazonaws.com
+              Action: sts:AssumeRole
+        Policies:
+          - PolicyName: ClamAVInstancePolicy
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - logs:CreateLogGroup
+                    - logs:CreateLogStream
+                    - logs:PutLogEvents
+                  Resource: '*'
+
+    ClamAVInstance:
+      Type: AWS::EC2::Instance
+      Properties:
+        InstanceType: t2.micro
+        ImageId: ami-05bfc1ab11bfbf484
+        KeyName: my-key-pair # Replace with your key pair name
+        SecurityGroups:
+          - !Ref ClamAVSecurityGroup
+        IamInstanceProfile: !Ref ClamAVInstanceProfile
+        Tags:
+          - Key: mcr-vmuse
+            Value: clamavd
+        UserData:
+          Fn::Base64: !Sub |
+            #!/bin/bash
+            sudo apt-get update
+            sudo apt-get install -y clamav clamav-daemon
+            sudo systemctl enable clamav-freshclam
+            sudo systemctl start clamav-freshclam
+            sudo systemctl enable clamav-daemon
+            sudo systemctl start clamav-daemon
 
   Outputs:
     DocumentUploadsBucketName:

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -378,6 +378,7 @@ resources:
       Type: AWS::EC2::SecurityGroup
       Properties:
         GroupDescription: Security group for ClamAV daemon
+        VpcId: ${self:custom.vpcId}
         SecurityGroupIngress:
           - IpProtocol: tcp
             FromPort: 3310
@@ -418,7 +419,6 @@ resources:
       Properties:
         InstanceType: t2.micro
         ImageId: ami-05bfc1ab11bfbf484
-        KeyName: my-key-pair # Replace with your key pair name
         SecurityGroups:
           - !Ref ClamAVSecurityGroup
         IamInstanceProfile: !Ref ClamAVInstanceProfile

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -395,6 +395,9 @@ resources:
     ClamAVInstanceRole:
       Type: AWS::IAM::Role
       Properties:
+        Path: '/delegatedadmin/developer/'
+        PermissionsBoundary: !Sub 'arn:aws:iam::${AWS::AccountId}:policy/cms-cloud-admin/ct-ado-poweruser-permissions-boundary-policy'
+        RoleName: !Sub 'clamavdVm-${sls:stage}-ServiceRole'
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
           Statement:

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -422,8 +422,6 @@ resources:
       Properties:
         InstanceType: t2.micro
         ImageId: ami-05bfc1ab11bfbf484
-        SecurityGroups:
-          - !Ref ClamAVSecurityGroup
         IamInstanceProfile: !Ref ClamAVInstanceProfile
         NetworkInterfaces:
           - AssociatePublicIpAddress: true
@@ -433,6 +431,8 @@ resources:
               - ${self:custom.sgId}
             SubnetId: !Sub ${self:custom.publicSubnetA}
         Tags:
+          - Key: Name
+            Value: clamavd-${sls:stage}
           - Key: mcr-vmuse
             Value: clamavd
         UserData:

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -455,16 +455,15 @@ resources:
             dpkg -i clamav-1.0.4.linux.x86_64.deb
             apt-get install -f
 
-            # Write the freshclam.conf
-            echo "DatabaseMirror database.clamav.net" > /usr/local/etc/freshclam.conf
-            echo "CompressLocalDatabase yes" >> /usr/local/etc/freshclam.conf
-            chmod  644 /usr/local/etc/freshclam.conf
-            chown clamav:clamav /usr/local/etc/freshclam.conf
+            # Write to the clamd.conf
+            echo "TCPSocket 3310" >> /etc/clamav/clamd.conf
+            echo "TCPAddr 0.0.0.0" >> /etc/clamav/clamd.conf 
 
-            sudo systemctl enable clamav-freshclam
-            sudo systemctl start clamav-freshclam
-            sudo systemctl enable clamav-daemon
-            sudo systemctl start clamav-daemon
+            # Start clamd and get defs
+            systemctl enable clamav-freshclam
+            systemctl start clamav-freshclam
+            systemctl enable clamav-daemon
+            systemctl start clamav-daemon
 
   Outputs:
     DocumentUploadsBucketName:

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -429,7 +429,7 @@ resources:
       Condition: IsDevValProd
       Properties:
         InstanceType: t3.medium
-        ImageId: ami-05bfc1ab11bfbf484
+        ImageId: ami-0c7217cdde317cfec # Ubuntu 22.04 LTS
         IamInstanceProfile: !Ref ClamAVInstanceProfile
         KeyName: mojo # for testing
         NetworkInterfaces:

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -388,7 +388,7 @@ resources:
     ClamAVInstanceProfile:
       Type: AWS::IAM::InstanceProfile
       Properties:
-        Path: /
+        Path: '/delegatedadmin/developer/'
         Roles:
           - !Ref ClamAVInstanceRole
 
@@ -403,7 +403,7 @@ resources:
           Statement:
             - Effect: Allow
               Principal:
-                Service: lambda.amazonaws.com
+                Service: ec2.amazonaws.com
               Action: sts:AssumeRole
         Policies:
           - PolicyName: ClamAVInstancePolicy

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -181,6 +181,13 @@ functions:
       REACT_APP_OTEL_COLLECTOR_URL: ${self:custom.reactAppOtelCollectorUrl}
 
 resources:
+  Conditions:
+    IsDevValProd: !Or
+      - !Equals ['${sls:stage}', 'main']
+      - !Equals ['${sls:stage}', 'val']
+      - !Equals ['${sls:stage}', 'prod']
+      - !Equals ['${sls:stage}', 'mtbuildclamavserver']
+
   Resources:
     DocumentUploadsBucket:
       Type: AWS::S3::Bucket
@@ -419,6 +426,7 @@ resources:
 
     ClamAVInstance:
       Type: AWS::EC2::Instance
+      Condition: IsDevValProd
       Properties:
         InstanceType: t2.micro
         ImageId: ami-05bfc1ab11bfbf484


### PR DESCRIPTION
## Summary

This adds a server that runs `clamavd` and `freshclam` with a configuration that allows it to accept incoming `clamdscan` requests from connections coming from within it's security group. This sets us up to allow our lambda antivirus scanning function to call an always-on `clamavd` instance that will return results without incurring the startup cost that we've been living with in the lambda only version.

#### Related issues
https://jiraent.cms.gov/browse/MCR-3820
