### PR TITLE
Bump python lambda runtime on secrets manager rotator

### DIFF
--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -11,7 +11,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: python3.7
+  runtime: python3.12
   region: us-east-1
   iam:
     role:
@@ -85,7 +85,7 @@ package:
 
 functions:
   rotator:
-    runtime: python3.7
+    runtime: python3.12
     handler: lambda_function.lambda_handler
     description: Conducts an AWS SecretsManager secret rotation for RDS PostgreSQL using single user rotation scheme
     timeout: 30


### PR DESCRIPTION
## Summary

Amazon has removed the python runtime that we had originally set up our lambda secrets manager rotator with, which caused CI to fail in deploys of the `postgres` service. This PR bumps the runtime to the latest python runtime available in AWS for lambdas.

#### Related issues
https://jiraent.cms.gov/browse/MCR-3951
