### PR TITLE
Removing FE cacheing from application

### DIFF
--- a/services/app-web/src/components/Modal/UnlockSubmitModal.tsx
+++ b/services/app-web/src/components/Modal/UnlockSubmitModal.tsx
@@ -4,7 +4,6 @@ import { FormGroup, ModalRef, Textarea } from '@trussworks/react-uswds'
 import { useNavigate } from 'react-router-dom'
 import {
     FetchHealthPlanPackageWithQuestionsDocument,
-    FetchHealthPlanPackageDocument,
     HealthPlanPackage,
     useSubmitHealthPlanPackageMutation,
     useUnlockHealthPlanPackageMutation,
@@ -18,7 +17,6 @@ import * as Yup from 'yup'
 import styles from './UnlockSubmitModal.module.scss'
 import { GenericApiErrorProps } from '../Banner/GenericApiErrorBanner/GenericApiErrorBanner'
 import { ERROR_MESSAGES } from '../../constants/errors'
-import { useAuth } from '../../contexts/AuthContext'
 
 type ModalType = 'SUBMIT' | 'RESUBMIT' | 'UNLOCK'
 
@@ -79,7 +77,6 @@ export const UnlockSubmitModal = ({
         GenericApiErrorProps | undefined
     >(undefined) // when api errors error
     const navigate = useNavigate()
-    const { loggedInUser } = useAuth()
     const modalValues: ModalValueType = modalValueDictionary[modalType]
 
     const modalFormInitialValues = {
@@ -139,73 +136,11 @@ export const UnlockSubmitModal = ({
         if (result instanceof Error && result.cause === 'EMAIL_ERROR') {
             modalRef.current?.toggleModal(undefined, false)
 
-            // We cannot update cache and re-fetch query inside the mutation because it returns an apollo
-            // error on failing emails. We have to manually update cache depending on unlock or submit
             if (modalType !== 'UNLOCK' && submissionName) {
-                // Updating the package status here so when redirected to the dashboard the status will be up-to-date
-                // without having to wait for the refetch.
-                client.cache.updateQuery(
-                    {
-                        query: FetchHealthPlanPackageDocument,
-                        variables: {
-                            input: {
-                                pkgID: healthPlanPackage.id,
-                            },
-                        },
-                    },
-                    (data) => {
-                        const pkg = data?.fetchHealthPlanPackage?.pkg
-
-                        if (pkg) {
-                            return {
-                                fetchHealthPlanPackage: {
-                                    __typename: 'FetchHealthPlanPackagePayload',
-                                    pkg: {
-                                        ...pkg,
-                                        status: 'SUBMITTED',
-                                    },
-                                },
-                            }
-                        }
-                    }
-                )
                 navigate(
                     `/dashboard/submissions?justSubmitted=${submissionName}`
                 )
             } else {
-                // Updating the cache here with unlockInfo before manually re-fetching query.
-                // This will prevent the loading animation to happen and have up-to-date unlock banner.
-                const pkg = healthPlanPackage as HealthPlanPackage
-                client.cache.writeQuery({
-                    query: FetchHealthPlanPackageWithQuestionsDocument,
-                    data: {
-                        fetchHealthPlanPackage: {
-                            pkg: {
-                                ...pkg,
-                                status: 'UNLOCKED',
-                                revisions: [
-                                    {
-                                        __typename: 'HealthPlanRevisionEdge',
-                                        node: {
-                                            ...pkg.revisions[
-                                                pkg.revisions.length - 1
-                                            ].node,
-                                            unlockInfo: {
-                                                updatedAt: new Date(),
-                                                updatedBy: loggedInUser?.email,
-                                                updatedReason:
-                                                    unlockSubmitModalInput,
-                                            },
-                                            submitInfo: null,
-                                            id: null,
-                                        },
-                                    },
-                                    ...pkg.revisions,
-                                ],
-                            },
-                        },
-                    },
-                })
                 await client.refetchQueries({
                     include: [FetchHealthPlanPackageWithQuestionsDocument],
                 })

--- a/services/app-web/src/gqlHelpers/fetchHealthPlanPackageWrapper.ts
+++ b/services/app-web/src/gqlHelpers/fetchHealthPlanPackageWrapper.ts
@@ -157,7 +157,7 @@ function useFetchHealthPlanPackageWithQuestionsWrapper(
                 },
             },
             onCompleted,
-            fetchPolicy: 'cache-and-network',
+            fetchPolicy: 'network-only',
         })
     )
     const result = results.result

--- a/services/app-web/src/gqlHelpers/mutationWrappersForUserFriendlyErrors.ts
+++ b/services/app-web/src/gqlHelpers/mutationWrappersForUserFriendlyErrors.ts
@@ -3,13 +3,9 @@ import {
     HealthPlanPackage,
     SubmitHealthPlanPackageMutationFn,
     UnlockHealthPlanPackageMutationFn,
-    FetchHealthPlanPackageWithQuestionsQuery,
-    FetchHealthPlanPackageWithQuestionsDocument,
-    IndexQuestionsPayload,
     CreateQuestionMutation,
     CreateQuestionResponseMutationFn,
     CreateQuestionResponseMutation,
-    Question,
     Division,
     CreateQuestionInput,
     CreateQuestionResponseInput,
@@ -154,80 +150,13 @@ export const submitMutationWrapper = async (
     }
 }
 
-/**
- * Manually updating the cache for Q&A mutations because the Q&A page is in a layout route that is not unmounted during the Q&A
- * workflow. So, when calling Q&A mutations the Q&A page will not refetch the data. The alternative would be to use
- * cache.evict() to force a refetch, but would then cause the loading UI to show.
- **/
 export const createQuestionWrapper = async (
     createQuestion: CreateQuestionMutationFn,
     input: CreateQuestionInput
 ): Promise<CreateQuestionMutation | GraphQLErrors | Error> => {
     try {
         const result = await createQuestion({
-            variables: { input },
-            update(cache, { data }) {
-                if (data) {
-                    const newQuestion = data.createQuestion.question as Question
-                    const result =
-                        cache.readQuery<FetchHealthPlanPackageWithQuestionsQuery>(
-                            {
-                                query: FetchHealthPlanPackageWithQuestionsDocument,
-                                variables: {
-                                    input: {
-                                        pkgID: newQuestion.contractID,
-                                    },
-                                },
-                            }
-                        )
-
-                    const pkg = result?.fetchHealthPlanPackage.pkg
-
-                    if (pkg) {
-                        const indexQuestionDivision =
-                            divisionToIndexQuestionDivision(
-                                newQuestion.division
-                            )
-                        const questions = pkg.questions as IndexQuestionsPayload
-                        const divisionQuestions =
-                            questions[indexQuestionDivision]
-
-                        cache.writeQuery({
-                            query: FetchHealthPlanPackageWithQuestionsDocument,
-                            data: {
-                                fetchHealthPlanPackage: {
-                                    pkg: {
-                                        ...pkg,
-                                        questions: {
-                                            ...pkg.questions,
-                                            [indexQuestionDivision]: {
-                                                totalCount:
-                                                    divisionQuestions.totalCount
-                                                        ? divisionQuestions.totalCount +
-                                                          1
-                                                        : 1,
-                                                edges: [
-                                                    {
-                                                        __typename:
-                                                            'QuestionEdge',
-                                                        node: {
-                                                            ...newQuestion,
-                                                            responses: [],
-                                                        },
-                                                    },
-                                                    ...divisionQuestions.edges,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        })
-                    }
-                }
-            },
-            onQueryUpdated: () => true,
-        })
+            variables: { input }})
 
         if (result.data?.createQuestion) {
             return result.data
@@ -250,74 +179,7 @@ export const createResponseWrapper = async (
 ): Promise<CreateQuestionResponseMutation | GraphQLErrors | Error> => {
     try {
         const result = await createResponse({
-            variables: { input },
-            update(cache, { data }) {
-                if (data) {
-                    const newResponse =
-                        data.createQuestionResponse.question.responses[0]
-                    const result =
-                        cache.readQuery<FetchHealthPlanPackageWithQuestionsQuery>(
-                            {
-                                query: FetchHealthPlanPackageWithQuestionsDocument,
-                                variables: {
-                                    input: {
-                                        pkgID: pkgID,
-                                    },
-                                },
-                            }
-                        )
-                    const pkg = result?.fetchHealthPlanPackage.pkg
-
-                    if (pkg) {
-                        const questions = pkg.questions as IndexQuestionsPayload
-                        const indexQuestionDivision =
-                            divisionToIndexQuestionDivision(division)
-                        const divisionQuestions =
-                            questions[indexQuestionDivision]
-
-                        const updatedPkg = {
-                            ...pkg,
-                            questions: {
-                                ...pkg.questions,
-                                [indexQuestionDivision]: {
-                                    ...divisionQuestions,
-                                    edges: divisionQuestions.edges.map(
-                                        (edge) => {
-                                            if (
-                                                edge.node.id ===
-                                                newResponse.questionID
-                                            ) {
-                                                return {
-                                                    __typename: 'QuestionEdge',
-                                                    node: {
-                                                        ...edge.node,
-                                                        responses: [
-                                                            newResponse,
-                                                            ...edge.node
-                                                                .responses,
-                                                        ],
-                                                    },
-                                                }
-                                            }
-                                            return edge
-                                        }
-                                    ),
-                                },
-                            },
-                        }
-
-                        cache.writeQuery({
-                            query: FetchHealthPlanPackageWithQuestionsDocument,
-                            data: {
-                                fetchHealthPlanPackage: {
-                                    pkg: updatedPkg,
-                                },
-                            },
-                        })
-                    }
-                }
-            },
-            onQueryUpdated: () => true,
+            variables: { input }
         })
 
         if (result.data?.createQuestionResponse) {

--- a/services/app-web/src/pages/StateDashboard/StateDashboard.tsx
+++ b/services/app-web/src/pages/StateDashboard/StateDashboard.tsx
@@ -18,8 +18,6 @@ import {
     Loading,
 } from '../../components'
 import { getCurrentRevisionFromHealthPlanPackage } from '../../gqlHelpers'
-import { useLDClient } from 'launchdarkly-react-client-sdk'
-import { featureFlags } from '../../common-code/featureFlags'
 
 /**
  * We only pull a subset of data out of the submission and revisions for display in Dashboard
@@ -30,17 +28,8 @@ export const StateDashboard = (): React.ReactElement => {
     const { loginStatus, loggedInUser } = useAuth()
     const location = useLocation()
 
-    // Force use network until we have all the APIs in use and we can reimplement cacheing
-    const ldClient = useLDClient()
-    const useContractAndRatesAPI: boolean = ldClient?.variation(
-        featureFlags.RATE_EDIT_UNLOCK.flag,
-        featureFlags.RATE_EDIT_UNLOCK.defaultValue
-    )
-
     const { loading, data, error } = useIndexHealthPlanPackagesQuery({
-        fetchPolicy: useContractAndRatesAPI
-            ? 'network-only'
-            : 'cache-and-network',
+        fetchPolicy: 'network-only',
     })
 
     if (error) {

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
@@ -32,8 +32,6 @@ import {
     SubmissionType as SubmissionTypeT,
     useCreateHealthPlanPackageMutation,
     CreateHealthPlanPackageInput,
-    IndexHealthPlanPackagesDocument,
-    IndexHealthPlanPackagesQuery,
 } from '../../../gen/gqlClient'
 import { PageActions } from '../PageActions'
 import styles from '../StateSubmissionForm.module.scss'
@@ -79,45 +77,7 @@ export const SubmissionType = ({
     const isNewSubmission = location.pathname === '/submissions/new'
 
     const [createHealthPlanPackage, { error }] =
-        useCreateHealthPlanPackageMutation({
-            // This function updates the Apollo Client Cache after we create a new DraftSubmission
-            // Without it, we wouldn't show this newly created submission on the dashboard page
-            // without a refresh. Anytime a mutation does more than "modify an existing object"
-            // you'll need to handle the cache.
-            update(cache, { data }) {
-                const pkg = data?.createHealthPlanPackage.pkg
-                if (pkg) {
-                    const result =
-                        cache.readQuery<IndexHealthPlanPackagesQuery>({
-                            query: IndexHealthPlanPackagesDocument,
-                        })
-
-                    const indexHealthPlanPackages = {
-                        totalCount:
-                            result?.indexHealthPlanPackages.totalCount || 0,
-                        edges: result?.indexHealthPlanPackages.edges || [],
-                    }
-
-                    cache.writeQuery({
-                        query: IndexHealthPlanPackagesDocument,
-                        data: {
-                            indexHealthPlanPackages: {
-                                __typename: 'IndexHealthPlanPackagesPayload',
-                                totalCount:
-                                    indexHealthPlanPackages.totalCount + 1,
-                                edges: [
-                                    {
-                                        __typename: 'HealthPlanPackageEdge',
-                                        node: pkg,
-                                    },
-                                    ...indexHealthPlanPackages.edges,
-                                ],
-                            },
-                        },
-                    })
-                }
-            },
-        })
+        useCreateHealthPlanPackageMutation()
 
     useEffect(() => {
         // Focus the error summary heading only if we are displaying


### PR DESCRIPTION
## Summary
Remove caching on state submission form as per refactor plan for Contract & Rates Types. To recap...

_Benefits:_
-  prep for multiple APIs in use on frontend (HPP on some pages, contract and rates on other pages)
- reduce chance for regressions while we refactor page by page and also have feature flags in use (Linked Rates)
- ensure submission form, summary pages, dashboard and Q&A all fetch their own correct data

_Drawbacks:_
- During this interim period, we will have the loading indicator displaying more often when users change pages. 
- Cypress could get a little more flaky and times for cypress go up slightly

We can reduce the time period we have no caching by having a clear timeline to fully implement refactor 

#### Related issues
None, this is prep for Linked Rates and having two versions of Rate Details and Review/Submit in use in the form

#### Test cases covered
Tests should pass as normal

## QA guidance
- Manual checks that new or edited submissions appear at the top of the dashboard list with proper information
- Manual checks that going between submission form and Q&A pages behave as expected