### PR TITLE
Use single DNS name for clamav

### DIFF
--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -480,7 +480,7 @@ resources:
       Type: AWS::Route53::HostedZone
       Condition: IsDevValProd
       Properties:
-        Name: mc-review-${sls:stage}.local
+        Name: mc-review.local
         VPCs:
           - VPCId: ${self:custom.vpcId}
             VPCRegion: !Ref AWS::Region

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -491,7 +491,7 @@ resources:
       DependsOn: ClamAVInstance
       Properties:
         HostedZoneId: !Ref MCRInternalZone
-        Name: clamav.mc-review-${sls:stage}.local
+        Name: clamav.mc-review.local
         Type: A
         ResourceRecords:
           - !GetAtt ClamAVInstance.PrivateIp

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -177,6 +177,7 @@ resources:
       - !Equals ['${sls:stage}', 'main']
       - !Equals ['${sls:stage}', 'val']
       - !Equals ['${sls:stage}', 'prod']
+      - !Equals ['${sls:stage}', 'mtfixavdns']
 
   Resources:
     DocumentUploadsBucket:

--- a/services/uploads/src/avLayer/clamd.conf
+++ b/services/uploads/src/avLayer/clamd.conf
@@ -1,5 +1,5 @@
 # hostname and port of the remote ClamAV daemon
-TCPAddr HOSTNAME
+TCPAddr clamav.mc-review.local
 TCPSocket  3310
 
 # Enable verbose logging

--- a/services/uploads/src/avLayer/clamd.conf
+++ b/services/uploads/src/avLayer/clamd.conf
@@ -10,3 +10,6 @@ LogFile /var/log/clamd.log
 
 # Set the maximum number of concurrent threads for scanning
 MaxThreads  10
+
+# Set the max file size for the clamd stream
+StreamMaxLength 50M

--- a/services/uploads/webpack.config.js
+++ b/services/uploads/webpack.config.js
@@ -68,6 +68,9 @@ module.exports = {
                             );
                     },
                 },
+                {
+                    from: path.resolve(__dirname, 'src/avLayer/clamd.conf'),
+                },
             ],
         }),
     ],

--- a/services/uploads/webpack.config.js
+++ b/services/uploads/webpack.config.js
@@ -68,21 +68,6 @@ module.exports = {
                             );
                     },
                 },
-                {
-                    from: path.resolve(__dirname, 'src/avLayer/clamd.conf'),
-                    transform(content) {
-                        const stage = slsw.lib.options.stage;
-                        const stageHostname = ['main', 'val', 'prod'].includes(
-                            stage
-                        )
-                            ? `clamav.mc-review-${stage}.local`
-                            : 'clamav.mc-review-main.local';
-
-                        return content
-                            .toString()
-                            .replace('HOSTNAME', stageHostname);
-                    },
-                },
             ],
         }),
     ],


### PR DESCRIPTION
## Summary

It turns out the reason why DNS wasn't resolving properly in val and prod for `clamav.mc-review.local` in PR #2256 was because when CMS provisioned our VPCs, hostname resolution wasn't turned on in higher environments. Now that it's turned on, we should be fine going back to the simpler version here of using the same hostname across environments.

#### Related issues
https://jiraent.cms.gov/browse/MCR-3960
