### PR TITLE
MCR-3940 Change RateDetails page to call fetchContract

### DIFF
--- a/services/app-web/src/components/FileUpload/FileUpload.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.tsx
@@ -71,6 +71,7 @@ export const FileUpload = ({
     const inputRequired = inputProps['aria-required'] || inputProps.required
 
     React.useEffect(() => {
+        console.info('effect1')
         if (JSON.stringify(fileItems) !== JSON.stringify(previousFileItems)) {
             onFileItemsUpdate({ fileItems })
         }
@@ -78,6 +79,7 @@ export const FileUpload = ({
 
     //Pass input ref to parent when innerInputRef prop exists.
     React.useEffect(() => {
+        console.info('effect2')
         if (innerInputRef && fileInputRef?.current?.input) {
             innerInputRef(fileInputRef.current.input)
         }

--- a/services/app-web/src/components/FileUpload/FileUpload.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.tsx
@@ -116,6 +116,7 @@ export const FileUpload = ({
 
             items.push(newItem)
         }
+        console.log(items)
 
         return items
     }

--- a/services/app-web/src/components/FileUpload/FileUpload.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.tsx
@@ -37,7 +37,6 @@ export type FileUploadProps = {
     scanFile?: (key: string) => Promise<void | Error> // optional function to be called after uploading (used for scanning)
     deleteFile: (key: string) => Promise<void>
     onFileItemsUpdate: ({ fileItems }: { fileItems: FileItemT[] }) => void
-    innerInputRef?: (el: HTMLInputElement) => void
 } & JSX.IntrinsicElements['input']
 
 /*
@@ -60,7 +59,6 @@ export const FileUpload = ({
     deleteFile,
     onFileItemsUpdate,
     allowMultipleUploads = true,
-    innerInputRef,
     ...inputProps
 }: FileUploadProps): React.ReactElement => {
     const [fileItems, setFileItems] = useState<FileItemT[]>(initialItems || [])
@@ -71,19 +69,10 @@ export const FileUpload = ({
     const inputRequired = inputProps['aria-required'] || inputProps.required
 
     React.useEffect(() => {
-        console.info('effect1')
         if (JSON.stringify(fileItems) !== JSON.stringify(previousFileItems)) {
             onFileItemsUpdate({ fileItems })
         }
     }, [fileItems, previousFileItems, onFileItemsUpdate])
-
-    //Pass input ref to parent when innerInputRef prop exists.
-    React.useEffect(() => {
-        console.info('effect2')
-        if (innerInputRef && fileInputRef?.current?.input) {
-            innerInputRef(fileInputRef.current.input)
-        }
-    }, [fileInputRef, innerInputRef])
 
     const isDuplicateItem = (
         existingList: FileItemT[],

--- a/services/app-web/src/components/FileUpload/FileUpload.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.tsx
@@ -116,7 +116,6 @@ export const FileUpload = ({
 
             items.push(newItem)
         }
-        console.log(items)
 
         return items
     }

--- a/services/app-web/src/pages/RateEdit/RateEdit.test.tsx
+++ b/services/app-web/src/pages/RateEdit/RateEdit.test.tsx
@@ -32,7 +32,8 @@ describe('RateEdit', () => {
                             statusCode: 200,
                         }),
                         fetchRateMockSuccess({
-                            rate: { id: '1337', status: 'UNLOCKED' },
+                            id: '1337',
+                            status: 'UNLOCKED',
                         }),
                     ],
                 },

--- a/services/app-web/src/pages/RateEdit/RateEdit.tsx
+++ b/services/app-web/src/pages/RateEdit/RateEdit.tsx
@@ -113,11 +113,7 @@ export const RateEdit = (): React.ReactElement => {
                 unlockedInfo={unlockedInfo}
                 showPageErrorMessage={Boolean(fetchError || submitError)}
             />
-            <RateDetailsV2
-                type="SINGLE"
-                rates={[rate]}
-                submitRate={submitRateHandler}
-            />
+            <RateDetailsV2 type="SINGLE" submitRate={submitRateHandler} />
         </div>
     )
 }

--- a/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
@@ -30,7 +30,7 @@ describe('RateSummary', () => {
                             user: mockValidCMSUser(),
                             statusCode: 200,
                         }),
-                        fetchRateMockSuccess({ rate: { id: '7a' } }),
+                        fetchRateMockSuccess({ id: '7a' }),
                     ],
                 },
                 routerProvider: {
@@ -68,7 +68,7 @@ describe('RateSummary', () => {
                             user: mockValidCMSUser(),
                             statusCode: 200,
                         }),
-                        fetchRateMockSuccess({ rate: { id: '7a' } }),
+                        fetchRateMockSuccess({ id: '7a' }),
                     ],
                 },
                 routerProvider: {
@@ -97,7 +97,7 @@ describe('RateSummary', () => {
                             user: mockValidCMSUser(),
                             statusCode: 200,
                         }),
-                        fetchRateMockSuccess({ rate: { id: '7a' } }),
+                        fetchRateMockSuccess({ id: '7a' }),
                     ],
                 },
                 routerProvider: {
@@ -123,7 +123,7 @@ describe('RateSummary', () => {
                             user: mockValidStateUser(),
                             statusCode: 200,
                         }),
-                        fetchRateMockSuccess({ rate: { id: '1337' } }),
+                        fetchRateMockSuccess({ id: '1337' }),
                     ],
                 },
                 routerProvider: {
@@ -163,7 +163,8 @@ describe('RateSummary', () => {
                                 statusCode: 200,
                             }),
                             fetchRateMockSuccess({
-                                rate: { id: '1337', status: 'UNLOCKED' },
+                                id: '1337',
+                                status: 'UNLOCKED',
                             }),
                         ],
                     },
@@ -195,7 +196,7 @@ describe('RateSummary', () => {
                             user: mockValidStateUser(),
                             statusCode: 200,
                         }),
-                        fetchRateMockSuccess({ rate: { id: '1337' } }),
+                        fetchRateMockSuccess({ id: '1337' }),
                     ],
                 },
                 //purposefully attaching invalid id to url here
@@ -216,7 +217,7 @@ describe('RateSummary', () => {
                             user: mockValidStateUser(),
                             statusCode: 200,
                         }),
-                        fetchRateMockSuccess({ rate: { id: '7a' } }),
+                        fetchRateMockSuccess({ id: '7a' }),
                     ],
                 },
                 routerProvider: {

--- a/services/app-web/src/pages/StateSubmission/Contacts/ActuaryContactFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/ActuaryContactFields.tsx
@@ -6,6 +6,12 @@ import { PoliteErrorMessage } from '../../../components/PoliteErrorMessage'
 import { RateCertFormType } from '../RateDetails/SingleRateCert'
 import styles from '../StateSubmissionForm.module.scss'
 
+/**
+ * This component renders actuary contact related form fields with their labels and error messages
+ *
+ * It relies on useFormikContext hook to work inside of a Formik form with matching field name values
+ */
+
 type FormError =
     FormikErrors<RateCertFormType>[keyof FormikErrors<RateCertFormType>]
 

--- a/services/app-web/src/pages/StateSubmission/Contacts/ActuaryContactFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/ActuaryContactFields.tsx
@@ -1,19 +1,15 @@
 import React from 'react'
-import { ActuaryContact } from '../../../common-code/healthPlanFormDataType'
-import { Field, FormikErrors, FormikValues, getIn } from 'formik'
+import { Field, FormikErrors, getIn, useFormikContext } from 'formik'
 import { Fieldset, FormGroup } from '@trussworks/react-uswds'
 import { FieldRadio, FieldTextInput } from '../../../components/Form'
 import { PoliteErrorMessage } from '../../../components/PoliteErrorMessage'
 import { RateCertFormType } from '../RateDetails/SingleRateCert'
 import styles from '../StateSubmissionForm.module.scss'
-import { ActuaryContact as ActuaryContactGQL } from '../../../gen/gqlClient'
 
 type FormError =
     FormikErrors<RateCertFormType>[keyof FormikErrors<RateCertFormType>]
 
 type ActuaryFormPropType = {
-    actuaryContact: ActuaryContact | ActuaryContactGQL // GQl type for v2 API
-    errors: FormikErrors<FormikValues>
     shouldValidate: boolean
     fieldNamePrefix: string
     fieldSetLegend?: string
@@ -21,19 +17,14 @@ type ActuaryFormPropType = {
 }
 
 export const ActuaryContactFields = ({
-    actuaryContact,
-    errors,
     shouldValidate,
     fieldNamePrefix,
     fieldSetLegend = 'Actuary Contact',
     inputRef,
 }: ActuaryFormPropType) => {
+    const { values, errors } = useFormikContext()
     const showFieldErrors = (error?: FormError) =>
         shouldValidate && Boolean(error)
-
-    if (!actuaryContact) {
-        return null
-    }
 
     return (
         <Fieldset legend={fieldSetLegend}>
@@ -143,7 +134,8 @@ export const ActuaryContactFields = ({
                     aria-required
                 />
 
-                {actuaryContact.actuarialFirm === 'OTHER' && (
+                {getIn(values, `${fieldNamePrefix}.actuarialFirm`) ===
+                    'OTHER' && (
                     <FormGroup
                         error={showFieldErrors(
                             getIn(

--- a/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
@@ -149,7 +149,7 @@ const flattenErrors = (
     return flattened
 }
 
-export const Contacts = ({
+const Contacts = ({
     showValidations = false,
 }: HealthPlanFormPageProps): React.ReactElement => {
     const [shouldValidate, setShouldValidate] = React.useState(showValidations)
@@ -692,3 +692,4 @@ export const Contacts = ({
         </>
     )
 }
+export { Contacts }

--- a/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import * as Yup from 'yup'
 import {
     Form as UswdsForm,
@@ -539,12 +539,6 @@ export const Contacts = ({
                                                                             data-testid="actuary-contact"
                                                                         >
                                                                             <ActuaryContactFields
-                                                                                actuaryContact={
-                                                                                    _actuaryContact
-                                                                                }
-                                                                                errors={
-                                                                                    errors
-                                                                                }
                                                                                 shouldValidate={
                                                                                     shouldValidate
                                                                                 }

--- a/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import * as Yup from 'yup'
 import {
     Form as UswdsForm,
@@ -49,6 +49,7 @@ import {
 import { useAuth } from '../../../contexts/AuthContext'
 import { ErrorOrLoadingPage } from '../ErrorOrLoadingPage'
 import { PageBannerAlerts } from '../PageBannerAlerts'
+import { useErrorSummary } from '../../../hooks/useErrorSummary'
 
 export interface ContactsFormValues {
     stateContacts: StateContact[]
@@ -147,6 +148,7 @@ const flattenErrors = (
 
     return flattened
 }
+
 export const Contacts = ({
     showValidations = false,
 }: HealthPlanFormPageProps): React.ReactElement => {
@@ -154,6 +156,8 @@ export const Contacts = ({
     const [focusNewContact, setFocusNewContact] = React.useState(false)
     const [focusNewActuaryContact, setFocusNewActuaryContact] =
         React.useState(false)
+    const { setFocusErrorSummaryHeading, errorSummaryHeadingRef } =
+        useErrorSummary()
 
     // set up API handling and HPP data
     const { loggedInUser } = useAuth()
@@ -177,15 +181,11 @@ export const Contacts = ({
 
     const navigate = useNavigate()
 
-    const errorSummaryHeadingRef = React.useRef<HTMLHeadingElement>(null)
-    const [focusErrorSummaryHeading, setFocusErrorSummaryHeading] =
-        React.useState(false)
-
     /*
      Set focus to contact name field when adding new contacts.
      Clears ref and focusNewContact component state immediately after. The reset allows additional contacts to be added and preserves expected focus behavior.
     */
-    React.useEffect(() => {
+    useEffect(() => {
         if (focusNewContact) {
             newStateContactNameRef.current &&
                 newStateContactNameRef.current.focus()
@@ -199,15 +199,6 @@ export const Contacts = ({
             newActuaryContactNameRef.current = null
         }
     }, [focusNewContact, focusNewActuaryContact])
-
-    useEffect(() => {
-        // Focus the error summary heading only if we are displaying
-        // validation errors and the heading element exists
-        if (focusErrorSummaryHeading && errorSummaryHeadingRef.current) {
-            errorSummaryHeadingRef.current.focus()
-        }
-        setFocusErrorSummaryHeading(false)
-    }, [focusErrorSummaryHeading])
 
     // TODO: refactor this into reusable component that is more understandable
     const showFieldErrors = (error?: FormError): boolean | undefined =>

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import dayjs from 'dayjs'
 import {
     Form as UswdsForm,
@@ -83,6 +83,7 @@ import {
 import { useAuth } from '../../../contexts/AuthContext'
 import { ErrorOrLoadingPage } from '../ErrorOrLoadingPage'
 import { PageBannerAlerts } from '../PageBannerAlerts'
+import { useErrorSummary } from '../../../hooks/useErrorSummary'
 
 function formattedDatePlusOneDay(initialValue: string): string {
     const dayjsValue = dayjs(initialValue)
@@ -146,6 +147,8 @@ export const ContractDetails = ({
     const [shouldValidate, setShouldValidate] = React.useState(showValidations)
     const navigate = useNavigate()
     const ldClient = useLDClient()
+    const { setFocusErrorSummaryHeading, errorSummaryHeadingRef } =
+        useErrorSummary()
 
     // set up API handling and HPP data
     const { loggedInUser } = useAuth()
@@ -185,20 +188,6 @@ export const ContractDetails = ({
                 : undefined
     const documentsErrorKey =
         fileItems.length === 0 ? 'documents' : '#file-items-list'
-
-    // Error summary state management
-    const errorSummaryHeadingRef = React.useRef<HTMLHeadingElement>(null)
-    const [focusErrorSummaryHeading, setFocusErrorSummaryHeading] =
-        React.useState(false)
-
-    useEffect(() => {
-        // Focus the error summary heading only if we are displaying
-        // validation errors and the heading element exists
-        if (focusErrorSummaryHeading && errorSummaryHeadingRef.current) {
-            errorSummaryHeadingRef.current.focus()
-        }
-        setFocusErrorSummaryHeading(false)
-    }, [focusErrorSummaryHeading])
 
     if (interimState || !draftSubmission)
         return <ErrorOrLoadingPage state={interimState || 'GENERIC_ERROR'} />

--- a/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
+++ b/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
@@ -28,10 +28,13 @@ import {
 import { ErrorOrLoadingPage } from '../ErrorOrLoadingPage'
 import { DynamicStepIndicator } from '../../../components'
 import { PageBannerAlerts } from '../PageBannerAlerts'
+import { useErrorSummary } from '../../../hooks/useErrorSummary'
 
 export const Documents = (): React.ReactElement => {
     const [shouldValidate, setShouldValidate] = useState(false)
     const navigate = useNavigate()
+    const { setFocusErrorSummaryHeading, errorSummaryHeadingRef } =
+        useErrorSummary()
 
     // set up API handling and HPP data
     const { loggedInUser } = useAuth()
@@ -83,20 +86,6 @@ export const Documents = (): React.ReactElement => {
             : showFileUploadError && !hasValidFiles
               ? 'You must remove all documents with error messages before continuing'
               : undefined
-
-    // Error summary state management
-    const errorSummaryHeadingRef = React.useRef<HTMLHeadingElement>(null)
-    const [focusErrorSummaryHeading, setFocusErrorSummaryHeading] =
-        React.useState(false)
-
-    React.useEffect(() => {
-        // Focus the error summary heading only if we are displaying
-        // validation errors and the heading element exists
-        if (focusErrorSummaryHeading && errorSummaryHeadingRef.current) {
-            errorSummaryHeadingRef.current.focus()
-        }
-        setFocusErrorSummaryHeading(false)
-    }, [focusErrorSummaryHeading])
 
     if (interimState || !draftSubmission || !updateDraft)
         return <ErrorOrLoadingPage state={interimState || 'GENERIC_ERROR'} />

--- a/services/app-web/src/pages/StateSubmission/ErrorOrLoadingPage.tsx
+++ b/services/app-web/src/pages/StateSubmission/ErrorOrLoadingPage.tsx
@@ -4,12 +4,30 @@ import { GridContainer } from '@trussworks/react-uswds'
 import { Loading } from '../../components'
 import { ErrorInvalidSubmissionStatus } from '../Errors/ErrorInvalidSubmissionStatusPage'
 import { Error404 } from '../Errors/Error404Page'
+import { handleApolloError } from '../../gqlHelpers/apolloErrors'
+import { ApolloError } from '@apollo/client'
+import { ErrorForbiddenPage } from '../Errors/ErrorForbiddenPage'
 
-type InterimState = 'LOADING' | 'GENERIC_ERROR' | 'NOT_FOUND' | 'INVALID_STATUS'
+type InterimState =
+    | 'LOADING'
+    | 'GENERIC_ERROR'
+    | 'NOT_FOUND'
+    | 'INVALID_STATUS'
+    | 'FORBIDDEN'
 type ErrorOrLoadingPageProps = {
-    state: 'LOADING' | 'GENERIC_ERROR' | 'NOT_FOUND' | 'INVALID_STATUS'
+    state?: InterimState
 }
 
+const handleAndReturnErrorState = (error: ApolloError): InterimState => {
+    handleApolloError(error, true)
+    if (error.graphQLErrors[0]?.extensions?.code === 'NOT_FOUND') {
+        return 'NOT_FOUND'
+    } else if (error.graphQLErrors[0]?.extensions?.code === 'FORBIDDEN_ERROR') {
+        return 'FORBIDDEN'
+    } else {
+        return 'GENERIC_ERROR'
+    }
+}
 const ErrorOrLoadingPage = ({
     state,
 }: ErrorOrLoadingPageProps): React.ReactElement => {
@@ -24,6 +42,8 @@ const ErrorOrLoadingPage = ({
             return <GenericErrorPage />
         case 'NOT_FOUND':
             return <Error404 />
+        case 'FORBIDDEN':
+            return <ErrorForbiddenPage />
         case 'INVALID_STATUS':
             return <ErrorInvalidSubmissionStatus />
         default:
@@ -31,5 +51,5 @@ const ErrorOrLoadingPage = ({
     }
 }
 
-export { ErrorOrLoadingPage }
+export { ErrorOrLoadingPage, handleAndReturnErrorState }
 export type { InterimState, ErrorOrLoadingPageProps }

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -126,7 +126,7 @@ export const RateDetails = ({
     } = useHealthPlanPackageForm(id)
     const { setFocusErrorSummaryHeading, errorSummaryHeadingRef } =
         useErrorSummary()
-
+    console.info('original rate details page')
     const [shouldValidate, setShouldValidate] = React.useState(showValidations)
 
     // multi-rates state management

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { Form as UswdsForm } from '@trussworks/react-uswds'
 import { FieldArray, FieldArrayRenderProps, Formik, FormikErrors } from 'formik'
 import { useNavigate } from 'react-router-dom'
@@ -39,6 +39,7 @@ import { FormContainer } from '../FormContainer'
 import { useAuth } from '../../../contexts/AuthContext'
 import { ErrorOrLoadingPage } from '../ErrorOrLoadingPage'
 import { PageBannerAlerts } from '../PageBannerAlerts'
+import { useErrorSummary } from '../../../hooks/useErrorSummary'
 
 // This function is used to get initial form values as well return empty form values when we add a new rate or delete a rate
 // We need to include the getKey function in params because there are no guarantees currently file is in s3 even if when we load data from API
@@ -123,21 +124,10 @@ export const RateDetails = ({
         showPageErrorMessage,
         unlockInfo,
     } = useHealthPlanPackageForm(id)
+    const { setFocusErrorSummaryHeading, errorSummaryHeadingRef } =
+        useErrorSummary()
 
-    // form validation state management
-    const [focusErrorSummaryHeading, setFocusErrorSummaryHeading] =
-        React.useState(false)
-    const errorSummaryHeadingRef = React.useRef<HTMLHeadingElement>(null)
     const [shouldValidate, setShouldValidate] = React.useState(showValidations)
-
-    useEffect(() => {
-        // Focus the error summary heading only if we are displaying
-        // validation errors and the heading element exists
-        if (focusErrorSummaryHeading && errorSummaryHeadingRef.current) {
-            errorSummaryHeadingRef.current.focus()
-        }
-        setFocusErrorSummaryHeading(false)
-    }, [focusErrorSummaryHeading])
 
     // multi-rates state management
     const [focusNewRate, setFocusNewRate] = React.useState(false)

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -126,7 +126,6 @@ export const RateDetails = ({
     } = useHealthPlanPackageForm(id)
     const { setFocusErrorSummaryHeading, errorSummaryHeadingRef } =
         useErrorSummary()
-    console.info('original rate details page')
     const [shouldValidate, setShouldValidate] = React.useState(showValidations)
 
     // multi-rates state management

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
@@ -13,8 +13,8 @@ const SingleRateCertSchema = (_activeFeatureFlags: FeatureFlagSettings) =>
     Yup.object().shape({
         rateDocuments: validateFileItemsListSingleUpload({ required: true }),
         supportingDocuments: validateFileItemsList({ required: false }),
-        hasSharedRateCert:  _activeFeatureFlags['rate-edit-unlock']?  Yup.string(): Yup.string().defined('You must select yes or no'),
-        packagesWithSharedRateCerts: _activeFeatureFlags['rate-edit-unlock']? Yup.array().optional():  Yup.array()
+        hasSharedRateCert:  _activeFeatureFlags['rate-edit-unlock'] || _activeFeatureFlags['link-rates']?  Yup.string(): Yup.string().defined('You must select yes or no'),
+        packagesWithSharedRateCerts: _activeFeatureFlags['rate-edit-unlock'] || _activeFeatureFlags['link-rates']? Yup.array().optional():  Yup.array()
         .when('hasSharedRateCert', {
             is: 'YES',
             then: Yup.array().min(

--- a/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateCert.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateCert.tsx
@@ -556,7 +556,7 @@ export const SingleRateCert = ({
                         type="button"
                         unstyled
                         className={styles.removeContactBtn}
-                        onClick={() => multiRatesConfig.removeSelf}
+                        onClick={multiRatesConfig.removeSelf}
                     >
                         Remove rate certification
                     </Button>

--- a/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateCert.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateCert.tsx
@@ -188,7 +188,6 @@ export const SingleRateCert = ({
                                 previousDocuments
                             )
                         }
-                        innerInputRef={multiRatesConfig?.reassignNewRateRef}
                         onFileItemsUpdate={({ fileItems }) =>
                             setFieldValue(
                                 `${fieldNamePrefix}.rateDocuments`,

--- a/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateCert.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateCert.tsx
@@ -547,8 +547,6 @@ export const SingleRateCert = ({
 
                 <FormGroup>
                     <ActuaryContactFields
-                        actuaryContact={rateInfo.actuaryContacts[0]}
-                        errors={errors}
                         shouldValidate={shouldValidate}
                         fieldNamePrefix={`${fieldNamePrefix}.actuaryContacts.0`}
                         fieldSetLegend="Certifying Actuary"
@@ -559,7 +557,7 @@ export const SingleRateCert = ({
                         type="button"
                         unstyled
                         className={styles.removeContactBtn}
-                        onClick={multiRatesConfig.removeSelf}
+                        onClick={() => multiRatesConfig.removeSelf}
                     >
                         Remove rate certification
                     </Button>

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.test.tsx
@@ -15,6 +15,7 @@ import { RoutesRecord } from '../../../../constants'
 import userEvent from '@testing-library/user-event'
 import { rateRevisionDataMock } from '../../../../testHelpers/apolloMocks/rateDataMock'
 import { fetchDraftRateMockSuccess } from '../../../../testHelpers/apolloMocks/rateGQLMocks'
+import { clickAddNewRate, fillOutFirstRate, rateCertifications } from '../../../../testHelpers/jestRateHelpers'
 
 describe('RateDetails', () => {
     describe('handles edit  of a single rate', () => {
@@ -112,8 +113,8 @@ describe('RateDetails', () => {
                     expect(submitButton).not.toHaveAttribute('aria-disabled')
                 })
             })
-            //eslint-disable-next-line jest/no-disabled-tests
-            it.skip('disabled with alert if previously submitted with more than one rate cert file', async () => {
+
+            it('disabled with alert if previously submitted with more than one rate cert file', async () => {
                 const rateID = 'abc-123'
                 renderWithProviders(
                     <Routes>
@@ -209,32 +210,65 @@ describe('RateDetails', () => {
 
     describe('handles editing multiple rates', () => {
         it.todo('handles multiple rates')
-        it.todo(
-            'renders add another rate button, which adds another set of rate certification fields to the form'
+        it(
+            'add rate button will increase number of rate certification fields on the', async () => {
+                const rateID = '123-dfg'
+                renderWithProviders(
+                    <Routes>
+                        <Route
+                            path={RoutesRecord.SUBMISSIONS_RATE_DETAILS}
+                            element={<RateDetailsV2 type="MULTI" />}
+                        />
+                    </Routes>,
+                    {
+                        apolloProvider: {
+                            mocks: [
+                                fetchCurrentUserMock({ statusCode: 200 }),
+                                // fetchContractMockSuccess({ id: rateID }),
+                            ],
+                        },
+                        routerProvider: {
+                            route: `/submissions/${rateID}/edit`,
+                        },
+                    }
+                )
+
+                const rateCertsOnLoad = rateCertifications(screen)
+                expect(rateCertsOnLoad).toHaveLength(1)
+
+                await fillOutFirstRate(screen)
+
+                await clickAddNewRate(screen)
+
+                await waitFor(() => {
+                    const rateCertsAfterAddAnother = rateCertifications(screen)
+                    expect(rateCertsAfterAddAnother).toHaveLength(2)
+                })
+            }
         )
-        //eslint-disable-next-line jest/no-disabled-tests
-        it.skip('disabled with alert after first attempt to continue with invalid duplicate files', async () => {
-            const rateID = '123-dfg'
-            renderWithProviders(
-                <Routes>
-                    <Route
-                        path={RoutesRecord.SUBMISSIONS_RATE_DETAILS}
-                        element={<RateDetailsV2 type="MULTI" />}
-                    />
-                </Routes>,
-                {
-                    apolloProvider: {
-                        mocks: [
-                            fetchCurrentUserMock({ statusCode: 200 }),
-                            // fetchContractMockSuccess({ id: rateID }),
-                        ],
-                    },
-                    routerProvider: {
-                        route: `/submissions/${rateID}/edit`,
-                    },
-                }
-            )
-            await screen.findByText('Rate certification type')
+
+        it('disabled with alert after first attempt to continue with invalid duplicate files', async () => {
+                const rateID = '123-dfg'
+                renderWithProviders(
+                    <Routes>
+                        <Route
+                            path={RoutesRecord.SUBMISSIONS_RATE_DETAILS}
+                            element={<RateDetailsV2 type="MULTI" />}
+                        />
+                    </Routes>,
+                    {
+                        apolloProvider: {
+                            mocks: [
+                                fetchCurrentUserMock({ statusCode: 200 }),
+                                // fetchContractMockSuccess({ id: rateID }),
+                            ],
+                        },
+                        routerProvider: {
+                            route: `/submissions/${rateID}/edit`,
+                        },
+                    }
+                )
+                await screen.findByText('Rate certification type')
             const input = screen.getByLabelText(
                 'Upload one rate certification document'
             )
@@ -262,3 +296,5 @@ describe('RateDetails', () => {
         it.todo('cannot continue with partially filled out second rate')
     })
 })
+
+

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.test.tsx
@@ -3,16 +3,16 @@ import { RateDetailsV2 } from './RateDetailsV2'
 import { renderWithProviders } from '../../../../testHelpers'
 import {
     fetchCurrentUserMock,
-    rateDataMock,
+    fetchRateMockSuccess,
 } from '../../../../testHelpers/apolloMocks'
 import { Route, Routes } from 'react-router-dom'
 import { RoutesRecord } from '../../../../constants'
 
 describe('RateDetails', () => {
-    describe('handles a single rate', () => {
+    describe('handles editing a single rate', () => {
         it('renders without errors', async () => {
             const mockSubmit = jest.fn()
-            const rate = rateDataMock()
+            const rateID = 'test-abc-123'
             renderWithProviders(
                 <Routes>
                     <Route
@@ -27,10 +27,13 @@ describe('RateDetails', () => {
                 </Routes>,
                 {
                     apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                        mocks: [
+                            fetchCurrentUserMock({ statusCode: 200 }),
+                            fetchRateMockSuccess({ id: rateID }),
+                        ],
                     },
                     routerProvider: {
-                        route: `/rates/${rate.id}/edit`,
+                        route: `/rates/${rateID}/edit`,
                     },
                 }
             )

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.test.tsx
@@ -20,7 +20,6 @@ describe('RateDetails', () => {
                         element={
                             <RateDetailsV2
                                 type="SINGLE"
-                                rates={[rate]}
                                 submitRate={mockSubmit}
                             />
                         }

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.test.tsx
@@ -113,7 +113,7 @@ describe('RateDetails', () => {
                 })
             })
             //eslint-disable-next-line jest/no-disabled-tests
-            it('disabled with alert if previously submitted with more than one rate cert file', async () => {
+            it.skip('disabled with alert if previously submitted with more than one rate cert file', async () => {
                 const rateID = 'abc-123'
                 renderWithProviders(
                     <Routes>

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.test.tsx
@@ -1,15 +1,23 @@
 import { screen, waitFor } from '@testing-library/react'
 import { RateDetailsV2 } from './RateDetailsV2'
-import { renderWithProviders } from '../../../../testHelpers'
+import {
+    TEST_DOC_FILE,
+    TEST_PNG_FILE,
+    dragAndDrop,
+    renderWithProviders,
+} from '../../../../testHelpers'
 import {
     fetchCurrentUserMock,
     fetchRateMockSuccess,
 } from '../../../../testHelpers/apolloMocks'
 import { Route, Routes } from 'react-router-dom'
 import { RoutesRecord } from '../../../../constants'
+import userEvent from '@testing-library/user-event'
+import { rateRevisionDataMock } from '../../../../testHelpers/apolloMocks/rateDataMock'
+import { fetchDraftRateMockSuccess } from '../../../../testHelpers/apolloMocks/rateGQLMocks'
 
 describe('RateDetails', () => {
-    describe('handles editing a single rate', () => {
+    describe('handles edit  of a single rate', () => {
         it('renders without errors', async () => {
             const mockSubmit = jest.fn()
             const rateID = 'test-abc-123'
@@ -48,110 +56,209 @@ describe('RateDetails', () => {
             expect(
                 screen.getByRole('button', { name: 'Submit' })
             ).not.toHaveAttribute('aria-disabled')
+            const requiredLabels = await screen.findAllByText('Required')
+            expect(requiredLabels).toHaveLength(6)
+            const optionalLabels = screen.queryAllByText('Optional')
+            expect(optionalLabels).toHaveLength(1)
         })
 
-        it.todo('displays correct form guidance')
-        it.todo('loads with empty rate type and document upload fields visible')
-        it.todo('cannot continue without selecting rate type')
+        describe('submit', () => {
+            it('enabled on initial load but disabled with alert if valid rate cert file replaced with invalid file', async () => {
+                const rateID = 'abc-123'
+                renderWithProviders(
+                    <Routes>
+                        <Route
+                            path={RoutesRecord.RATE_EDIT}
+                            element={
+                                <RateDetailsV2
+                                    type="SINGLE"
+                                    submitRate={jest.fn()}
+                                />
+                            }
+                        />
+                    </Routes>,
+                    {
+                        apolloProvider: {
+                            mocks: [
+                                fetchCurrentUserMock({ statusCode: 200 }),
+                                fetchRateMockSuccess({ id: rateID }),
+                            ],
+                        },
+                        routerProvider: {
+                            route: `/rates/${rateID}/edit`,
+                        },
+                    }
+                )
 
-        it.todo('cannot continue without selecting rate capitation type')
+                await screen.findByText('Rate certification type')
 
-        it.todo('cannot continue if no documents are added')
-        it.todo('progressively disclose new rate form fields as expected')
-        it.todo('displays program options based on current user state')
+                const input = screen.getByLabelText(
+                    'Upload one rate certification document'
+                )
+                const targetEl = screen.getAllByTestId(
+                    'file-input-droptarget'
+                )[0]
 
-        describe('handles documents and file upload', () => {
-            it.todo('renders file upload')
-            it.todo('accepts documents on new rate')
-            it.todo('accepts a single file for rate cert')
+                await userEvent.upload(input, [TEST_DOC_FILE])
+                dragAndDrop(targetEl, [TEST_PNG_FILE])
+
+                await waitFor(() => {
+                    const submitButton = screen.getByRole('button', {
+                        name: 'Submit',
+                    })
+                    expect(
+                        screen.getByText('This is not a valid file type.')
+                    ).toBeInTheDocument()
+                    expect(submitButton).not.toHaveAttribute('aria-disabled')
+                })
+            })
+            //eslint-disable-next-line jest/no-disabled-tests
+            it('disabled with alert if previously submitted with more than one rate cert file', async () => {
+                const rateID = 'abc-123'
+                renderWithProviders(
+                    <Routes>
+                        <Route
+                            path={RoutesRecord.RATE_EDIT}
+                            element={
+                                <RateDetailsV2
+                                    type="SINGLE"
+                                    submitRate={jest.fn()}
+                                />
+                            }
+                        />
+                    </Routes>,
+                    {
+                        apolloProvider: {
+                            mocks: [
+                                fetchCurrentUserMock({ statusCode: 200 }),
+                                fetchDraftRateMockSuccess({
+                                    id: rateID,
+                                    draftRevision: {
+                                        ...rateRevisionDataMock(),
+                                        formData: {
+                                            ...rateRevisionDataMock().formData,
+                                            rateDocuments: [
+                                                {
+                                                    s3URL: 's3://bucketname/one-one/one-one.png',
+                                                    name: 'one one',
+                                                    sha256: 'fakeSha1',
+                                                },
+                                                {
+                                                    s3URL: 's3://bucketname/one-two/one-two.png',
+                                                    name: 'one two',
+                                                    sha256: 'fakeSha2',
+                                                },
+                                                {
+                                                    s3URL: 's3://bucketname/one-three/one-three.png',
+                                                    name: 'one three',
+                                                    sha256: 'fakeSha3',
+                                                },
+                                            ],
+                                        },
+                                    },
+                                }),
+                            ],
+                        },
+                        routerProvider: {
+                            route: `/rates/${rateID}/edit`,
+                        },
+                    }
+                )
+                await screen.findByText('Rate certification type')
+                const submitButton = screen.getByRole('button', {
+                    name: 'Submit',
+                })
+                expect(submitButton).not.toHaveAttribute('aria-disabled')
+
+                submitButton.click()
+
+                await waitFor(() => {
+                    expect(
+                        screen.getAllByText(
+                            'Only one document is allowed for a rate certification. You must remove documents before continuing.'
+                        )
+                    ).toHaveLength(2)
+
+                    expect(submitButton).toHaveAttribute(
+                        'aria-disabled',
+                        'true'
+                    )
+                })
+            })
 
             it.todo(
-                'accepts multiple pdf, word, excel documents for supporting documents'
+                'disabled with alert after first attempt to continue with invalid rate doc file'
             )
-            it.todo('handles multiple rates')
-            it.todo(
-                'renders add another rate button, which adds another set of rate certification fields to the form'
-            )
-            it.todo(
-                'renders remove rate certification button, which removes set of rate certification fields from the form'
-            )
-            it.todo('accepts documents on second rate')
-            it.todo(
-                'cannot continue without selecting rate type for a second rate'
-            )
-            it.todo(
-                'cannot continue if no documents are added to the second rate'
-            )
-        })
-
-        describe('handles rates across submissions', () => {
-            it.todo(
-                'correctly checks shared rate certification radios and selects shared package'
-            )
-            it.todo('cannot continue when shared rate radio is unchecked')
-            it.todo(
-                'cannot continue when shared rate radio is checked and no package is selected'
-            )
-        })
-
-        describe('Continue button', () => {
-            it.todo('enabled when valid files are present')
-
-            it.todo(
-                'enabled when invalid files have been dropped but valid files are present'
-            )
-
-            it.todo(
-                'disabled with alert after first attempt to continue with zero files'
-            )
-            it.todo(
-                'disabled with alert if previously submitted with more than one rate cert file'
-            )
-
-            it.todo(
-                'disabled with alert after first attempt to continue with invalid duplicate files'
-            )
-
-            it.todo(
-                'disabled with alert after first attempt to continue with invalid files'
-            )
-            // eslint-disable-next-line jest/no-disabled-tests
             it.todo(
                 'disabled with alert when trying to continue while a file is still uploading'
             )
         })
 
         describe('Save as draft button', () => {
-            it.todo('enabled when valid files are present')
-
-            it.todo(
-                'enabled when invalid files have been dropped but valid files are present'
-            )
-            it.todo(
-                'when zero files present, does not trigger missing documents alert on click but still saves the in progress draft'
-            )
-            it.todo(
-                'when existing file is removed, does not trigger missing documents alert on click but still saves the in progress draft'
-            )
-            it.todo(
-                'when duplicate files present, triggers error alert on click'
-            )
+            it.todo('saves documents that were uploaded')
+            it.todo('does not trigger form validations')
+            it.todo('trigger duplicate file validations')
         })
 
         describe('Back button', () => {
-            it.todo('enabled when valid files are present')
-
-            it.todo(
-                'enabled when invalid files have been dropped but valid files are present'
-            )
-
-            it.todo(
-                'when zero files present, does not trigger missing documents alert on click'
-            )
-
-            it.todo(
-                'when duplicate files present, does not trigger duplicate documents alert on click and silently updates rate and supporting documents lists without duplicates'
-            )
+            it.todo('saves documents that were uploaded')
+            it.todo('does not trigger form validations')
+            it.todo('does not trigger duplicate file validations')
         })
+    })
+
+    describe('handles editing multiple rates', () => {
+        it.todo('handles multiple rates')
+        it.todo(
+            'renders add another rate button, which adds another set of rate certification fields to the form'
+        )
+        //eslint-disable-next-line jest/no-disabled-tests
+        it.skip('disabled with alert after first attempt to continue with invalid duplicate files', async () => {
+            const rateID = '123-dfg'
+            renderWithProviders(
+                <Routes>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_RATE_DETAILS}
+                        element={<RateDetailsV2 type="MULTI" />}
+                    />
+                </Routes>,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({ statusCode: 200 }),
+                            // fetchContractMockSuccess({ id: rateID }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: `/submissions/${rateID}/edit`,
+                    },
+                }
+            )
+            await screen.findByText('Rate certification type')
+            const input = screen.getByLabelText(
+                'Upload one rate certification document'
+            )
+            const submitButton = screen.getByRole('button', {
+                name: 'Submit',
+            })
+
+            await userEvent.upload(input, TEST_DOC_FILE)
+            await userEvent.upload(input, [])
+            await userEvent.upload(input, TEST_DOC_FILE)
+            expect(submitButton).not.toHaveAttribute('aria-disabled')
+
+            submitButton.click()
+
+            await screen.findAllByText(
+                'You must remove all documents with error messages before continuing'
+            )
+            expect(submitButton).toHaveAttribute('aria-disabled', 'true')
+        })
+
+        it.todo(
+            'renders remove rate certification button, which removes set of rate certification fields from the form'
+        )
+        it.todo('accepts documents on second rate')
+        it.todo('cannot continue with partially filled out second rate')
     })
 })

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.test.tsx
@@ -15,7 +15,11 @@ import { RoutesRecord } from '../../../../constants'
 import userEvent from '@testing-library/user-event'
 import { rateRevisionDataMock } from '../../../../testHelpers/apolloMocks/rateDataMock'
 import { fetchDraftRateMockSuccess } from '../../../../testHelpers/apolloMocks/rateGQLMocks'
-import { clickAddNewRate, fillOutFirstRate, rateCertifications } from '../../../../testHelpers/jestRateHelpers'
+import {
+    clickAddNewRate,
+    fillOutFirstRate,
+    rateCertifications,
+} from '../../../../testHelpers/jestRateHelpers'
 
 describe('RateDetails', () => {
     describe('handles edit  of a single rate', () => {
@@ -113,8 +117,8 @@ describe('RateDetails', () => {
                     expect(submitButton).not.toHaveAttribute('aria-disabled')
                 })
             })
-
-            it('disabled with alert if previously submitted with more than one rate cert file', async () => {
+            // eslint-disable-next-line
+            it.skip('disabled with alert if previously submitted with more than one rate cert file', async () => {
                 const rateID = 'abc-123'
                 renderWithProviders(
                     <Routes>
@@ -165,6 +169,7 @@ describe('RateDetails', () => {
                         },
                     }
                 )
+
                 await screen.findByText('Rate certification type')
                 const submitButton = screen.getByRole('button', {
                     name: 'Submit',
@@ -210,65 +215,64 @@ describe('RateDetails', () => {
 
     describe('handles editing multiple rates', () => {
         it.todo('handles multiple rates')
-        it(
-            'add rate button will increase number of rate certification fields on the', async () => {
-                const rateID = '123-dfg'
-                renderWithProviders(
-                    <Routes>
-                        <Route
-                            path={RoutesRecord.SUBMISSIONS_RATE_DETAILS}
-                            element={<RateDetailsV2 type="MULTI" />}
-                        />
-                    </Routes>,
-                    {
-                        apolloProvider: {
-                            mocks: [
-                                fetchCurrentUserMock({ statusCode: 200 }),
-                                // fetchContractMockSuccess({ id: rateID }),
-                            ],
-                        },
-                        routerProvider: {
-                            route: `/submissions/${rateID}/edit`,
-                        },
-                    }
-                )
+        //eslint-disable-next-line
+        it.skip('add rate button will increase number of rate certification fields on the', async () => {
+            const rateID = '123-dfg'
+            renderWithProviders(
+                <Routes>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_RATE_DETAILS}
+                        element={<RateDetailsV2 type="MULTI" />}
+                    />
+                </Routes>,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({ statusCode: 200 }),
+                            // fetchContractMockSuccess({ id: rateID }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: `/submissions/${rateID}/edit`,
+                    },
+                }
+            )
 
-                const rateCertsOnLoad = rateCertifications(screen)
-                expect(rateCertsOnLoad).toHaveLength(1)
+            const rateCertsOnLoad = rateCertifications(screen)
+            expect(rateCertsOnLoad).toHaveLength(1)
 
-                await fillOutFirstRate(screen)
+            await fillOutFirstRate(screen)
 
-                await clickAddNewRate(screen)
+            await clickAddNewRate(screen)
 
-                await waitFor(() => {
-                    const rateCertsAfterAddAnother = rateCertifications(screen)
-                    expect(rateCertsAfterAddAnother).toHaveLength(2)
-                })
-            }
-        )
-
-        it('disabled with alert after first attempt to continue with invalid duplicate files', async () => {
-                const rateID = '123-dfg'
-                renderWithProviders(
-                    <Routes>
-                        <Route
-                            path={RoutesRecord.SUBMISSIONS_RATE_DETAILS}
-                            element={<RateDetailsV2 type="MULTI" />}
-                        />
-                    </Routes>,
-                    {
-                        apolloProvider: {
-                            mocks: [
-                                fetchCurrentUserMock({ statusCode: 200 }),
-                                // fetchContractMockSuccess({ id: rateID }),
-                            ],
-                        },
-                        routerProvider: {
-                            route: `/submissions/${rateID}/edit`,
-                        },
-                    }
-                )
-                await screen.findByText('Rate certification type')
+            await waitFor(() => {
+                const rateCertsAfterAddAnother = rateCertifications(screen)
+                expect(rateCertsAfterAddAnother).toHaveLength(2)
+            })
+        })
+        //eslint-disable-next-line
+        it.skip('disabled with alert after first attempt to continue with invalid duplicate files', async () => {
+            const rateID = '123-dfg'
+            renderWithProviders(
+                <Routes>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_RATE_DETAILS}
+                        element={<RateDetailsV2 type="MULTI" />}
+                    />
+                </Routes>,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({ statusCode: 200 }),
+                            // fetchContractMockSuccess({ id: rateID }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: `/submissions/${rateID}/edit`,
+                    },
+                }
+            )
+            await screen.findByText('Rate certification type')
             const input = screen.getByLabelText(
                 'Upload one rate certification document'
             )
@@ -296,5 +300,3 @@ describe('RateDetails', () => {
         it.todo('cannot continue with partially filled out second rate')
     })
 })
-
-

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -37,7 +37,7 @@ import {
     useFetchContractQuery,
     useFetchRateQuery,
 } from '../../../../gen/gqlClient'
-import { SingleRateCertV2 } from './SingleRateCertV2'
+import { SingleRateFormFields } from './SingleRateFormFields'
 import type { SubmitRateHandler } from '../../../RateEdit/RateEdit'
 import { useFocus, useRouteParams } from '../../../../hooks'
 import { useErrorSummary } from '../../../../hooks/useErrorSummary'
@@ -436,7 +436,7 @@ const RateDetailsV2 = ({
                                                             <Fieldset
                                                                 data-testid={`rate-certification-form`}
                                                             >
-                                                                <SingleRateCertV2
+                                                                <SingleRateFormFields
                                                                     rateForm={
                                                                         rate
                                                                     }

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -47,6 +47,8 @@ import {
     ErrorOrLoadingPage,
     handleAndReturnErrorState,
 } from '../../ErrorOrLoadingPage'
+import { featureFlags } from '../../../../common-code/featureFlags'
+import { useLDClient } from 'launchdarkly-react-client-sdk'
 
 export type RateDetailFormValues = {
     id?: string // no id if its a new rate
@@ -134,11 +136,21 @@ const RateDetailsV2 = ({
     const { getKey } = useS3()
     const displayAsStandaloneRate = type === 'SINGLE'
     const { loggedInUser } = useAuth()
+    const ldClient = useLDClient()
+    const useLinkedRates = ldClient?.variation(
+        featureFlags.LINK_RATES.flag,
+        featureFlags.LINK_RATES.defaultValue
+    )
+
+    const useEditUnlockRate = ldClient?.variation(
+        featureFlags.RATE_EDIT_UNLOCK.flag,
+        featureFlags.RATE_EDIT_UNLOCK.defaultValue
+    )
     // Form validation
     const [shouldValidate, setShouldValidate] = React.useState(showValidations)
     const rateDetailsFormSchema = RateDetailsFormSchema({
-        'rate-edit-unlock': true,
-        // Add linked rates logic
+        'rate-edit-unlock': useEditUnlockRate,
+        'link-rates': useLinkedRates,
     })
     const { setFocusErrorSummaryHeading, errorSummaryHeadingRef } =
         useErrorSummary()

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -188,7 +188,7 @@ const RateDetailsV2 = ({
         skip: !displayAsStandaloneRate,
     })
     const ratesFromContract =
-        fetchContractData?.fetchContract.contract.draftRates
+        fetchContractData?.fetchContract.contract.draftRates // TODO WHEN WE IMPLEMENT UDPATE API, THIS SHOULD ALSO LOAD FROM ANY LINKED RATES
     const initialRequestLoading = fetchContractLoading || fetchRateLoading
     const initialRequestError = fetchContractError || fetchRateError
     const previousDocuments: string[] = []
@@ -249,6 +249,8 @@ const RateDetailsV2 = ({
             redirectPath: RouteT
         }
     ) => {
+        console.log(setSubmitting)
+        console.log('THIS', options.type, rates[0].rateDocuments)
         if (options.type === 'CONTINUE') {
             const fileErrorsNeedAttention = rates.some((rateForm) =>
                 isLoadingOrHasFileErrors(
@@ -298,9 +300,9 @@ const RateDetailsV2 = ({
 
         const { id, ...formData } = gqlFormDatas[0] // only grab the first rate in the array because multi-rates functionality not added yet. This will be part of Link Rates epic
 
-        if (options.type === 'CONTINUE' && id && submitRate) {
+        if (options.type === 'CONTINUE' && id && displayAsStandaloneRate && submitRate) {
             await submitRate(id, formData, setSubmitting, 'DASHBOARD')
-        } else if (options.type === 'CONTINUE' && !id) {
+        } else if (options.type === 'CONTINUE' && !displayAsStandaloneRate) {
             throw new Error(
                 'Rate create and update for a new rate is not yet implemented. This will be part of Link Rates epic.'
             )
@@ -372,9 +374,9 @@ const RateDetailsV2 = ({
                         loggedInUser={loggedInUser}
                         unlockedInfo={
                             fetchContractData?.fetchContract.contract
-                                .draftRevision?.unlockInfo
+                                .draftRevision?.unlockInfo || fetchRateData?.fetchRate.rate.draftRevision?.unlockInfo
                         }
-                        showPageErrorMessage={false} // TODO FIGURE OUT ERROR BANNER FOR BOTH MULTI AND STANDALONE USE CASE
+                        showPageErrorMessage={false} // TODO WHEN WE IMPLEMENT UDPATE API -  FIGURE OUT ERROR BANNER FOR BOTH MULTI AND STANDALONE USE CASE
                     />
                 )}
             </div>
@@ -386,7 +388,7 @@ const RateDetailsV2 = ({
                         setSubmitting,
                         {
                             type: 'CONTINUE',
-                            redirectPath: 'DASHBOARD_SUBMISSIONS',
+                            redirectPath: displayAsStandaloneRate?  'DASHBOARD_SUBMISSIONS':  'SUBMISSIONS_CONTACTS',
                         }
                     )
                 }}

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/SingleRateCertV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/SingleRateCertV2.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import {
-    Button,
     DatePicker,
     DateRangePicker,
     Fieldset,
@@ -11,19 +10,18 @@ import {
 import classnames from 'classnames'
 import {
     FieldRadio,
-    // FileUpload,
+    FileUpload,
     PoliteErrorMessage,
     ProgramSelect,
-    SectionCard,
 } from '../../../../components'
 
 import styles from '../../StateSubmissionForm.module.scss'
 import { formatUserInputDate, isDateRangeEmpty } from '../../../../formHelpers'
-// import {
-//     ACCEPTED_RATE_SUPPORTING_DOCS_FILE_TYPES,
-//     ACCEPTED_RATE_CERTIFICATION_FILE_TYPES,
-// } from '../../../../components/FileUpload'
-// import { useS3 } from '../../../../contexts/S3Context'
+import {
+    ACCEPTED_RATE_SUPPORTING_DOCS_FILE_TYPES,
+    ACCEPTED_RATE_CERTIFICATION_FILE_TYPES,
+} from '../../../../components/FileUpload'
+import { useS3 } from '../../../../contexts/S3Context'
 
 import { FormikErrors, getIn, useFormikContext } from 'formik'
 import { ActuaryContactFields } from '../../Contacts'
@@ -37,17 +35,11 @@ const isRateTypeAmendment = (rateForm: RateDetailFormValues): boolean =>
 export type SingleRateFormError =
     FormikErrors<RateDetailFormConfig>[keyof FormikErrors<RateDetailFormConfig>]
 
-type MultiRatesConfig = {
-    reassignNewRateRef: ((el: HTMLInputElement) => void) | undefined
-    removeSelf: () => void // callback to Formik FieldArray to imperatively remove this rate from overall list and refocus on add new rate button
-}
-
 type SingleRateCertV2Props = {
     rateForm: RateDetailFormValues
     shouldValidate: boolean
     index: number // defaults to 0
-    previousDocuments: string[] // this only passed in to ensure S3 deleteFile doesn't remove valid files for previous revisions
-    multiRatesConfig?: MultiRatesConfig // this is for use with multi-rates UI
+    previousDocuments: string[] // this only passed in to ensure S3 deleteFile doesn't remove valid files for previous revision
 }
 
 const RateDatesErrorMessage = ({
@@ -79,16 +71,12 @@ const RateDatesErrorMessage = ({
 export const SingleRateCertV2 = ({
     rateForm,
     shouldValidate,
-    multiRatesConfig,
     index = 0,
-    // previousDocuments,
+    previousDocuments,
 }: SingleRateCertV2Props): React.ReactElement => {
     // page level setup
-    // const { handleDeleteFile, handleUploadFile, handleScanFile } = useS3()
-    const key = rateForm.id
-    const displayAsStandaloneRate = multiRatesConfig === undefined
+    const { handleDeleteFile, handleUploadFile, handleScanFile } = useS3()
     const fieldNamePrefix = `rates.${index}`
-    const rateCertNumber = index + 1
     const { errors, setFieldValue } = useFormikContext<RateDetailFormConfig>()
 
     const showFieldErrors = (
@@ -99,428 +87,383 @@ export const SingleRateCertV2 = ({
     }
 
     return (
-        <SectionCard>
-            <h3 className={styles.rateName}>
-                {displayAsStandaloneRate
-                    ? `Rate certification`
-                    : `Rate certification ${rateCertNumber}`}
-            </h3>
-            <Fieldset
-                data-testid={`rate-certification-form`}
-                key={key}
-                id={`${fieldNamePrefix}.container.${rateForm.id}`}
-            >
-                {/* <FormGroup error={Boolean(showFieldErrors('rateDocuments'))}>
-                    <FileUpload
-                        id={`${fieldNamePrefix}.rateDocuments`}
-                        name={`${fieldNamePrefix}.rateDocuments`}
-                        label="Upload one rate certification document"
-                        aria-required
-                        allowMultipleUploads={false}
-                        error={showFieldErrors('rateDocuments')}
-                        hint={
-                            <span className={styles.guidanceTextBlockNoPadding}>
-                                <Link
-                                    aria-label="Document definitions and requirements (opens in new window)"
-                                    href={'/help#key-documents'}
-                                    variant="external"
-                                    target="_blank"
-                                >
-                                    Document definitions and requirements
-                                </Link>
-                                <span className="padding-top-2">
-                                    {`Upload only one rate certification document. Additional rates can be added later.`}
-                                </span>
-
-                                <span className="padding-top-1">
-                                    This input only accepts one file in PDF,
-                                    DOC, or DOCX format.
-                                </span>
+        <>
+            <FormGroup error={Boolean(showFieldErrors('rateDocuments'))}>
+                <FileUpload
+                    id={`${fieldNamePrefix}.rateDocuments`}
+                    name={`${fieldNamePrefix}.rateDocuments`}
+                    label="Upload one rate certification document"
+                    aria-required
+                    allowMultipleUploads={false}
+                    error={showFieldErrors('rateDocuments')}
+                    hint={
+                        <span className={styles.guidanceTextBlockNoPadding}>
+                            <Link
+                                aria-label="Document definitions and requirements (opens in new window)"
+                                href={'/help#key-documents'}
+                                variant="external"
+                                target="_blank"
+                            >
+                                Document definitions and requirements
+                            </Link>
+                            <span className="padding-top-2">
+                                {`Upload only one rate certification document. Additional rates can be added later.`}
                             </span>
-                        }
-                        accept={ACCEPTED_RATE_CERTIFICATION_FILE_TYPES}
-                        initialItems={rateForm.rateDocuments}
-                        uploadFile={(file) =>
-                            handleUploadFile(file, 'HEALTH_PLAN_DOCS')
-                        }
-                        scanFile={(key) =>
-                            handleScanFile(key, 'HEALTH_PLAN_DOCS')
-                        }
-                        deleteFile={(key) =>
-                            handleDeleteFile(
-                                key,
-                                'HEALTH_PLAN_DOCS',
-                                previousDocuments
-                            )
-                        }
-                        innerInputRef={multiRatesConfig?.reassignNewRateRef}
-                        onFileItemsUpdate={({ fileItems }) =>
-                            setFieldValue(
-                                `${fieldNamePrefix}.rateDocuments`,
-                                fileItems
-                            )
-                        }
-                    />
-                </FormGroup> */}
 
-                {/* <FormGroup
-                    error={Boolean(showFieldErrors('supportingDocuments'))}
+                            <span className="padding-top-1">
+                                This input only accepts one file in PDF, DOC, or
+                                DOCX format.
+                            </span>
+                        </span>
+                    }
+                    accept={ACCEPTED_RATE_CERTIFICATION_FILE_TYPES}
+                    initialItems={rateForm.rateDocuments}
+                    uploadFile={(file) =>
+                        handleUploadFile(file, 'HEALTH_PLAN_DOCS')
+                    }
+                    scanFile={(key) => handleScanFile(key, 'HEALTH_PLAN_DOCS')}
+                    deleteFile={(key) =>
+                        handleDeleteFile(
+                            key,
+                            'HEALTH_PLAN_DOCS',
+                            previousDocuments
+                        )
+                    }
+                    onFileItemsUpdate={({ fileItems }) =>
+                        setFieldValue(
+                            `${fieldNamePrefix}.rateDocuments`,
+                            fileItems
+                        )
+                    }
+                />
+            </FormGroup>
+
+            <FormGroup error={Boolean(showFieldErrors('supportingDocuments'))}>
+                <FileUpload
+                    id={`${fieldNamePrefix}.supportingDocuments`}
+                    name={`${fieldNamePrefix}.supportingDocuments`}
+                    label="Upload supporting documents"
+                    aria-required={false}
+                    error={showFieldErrors('supportingDocuments')}
+                    hint={
+                        <span className={styles.guidanceTextBlockNoPadding}>
+                            <Link
+                                aria-label="Document definitions and requirements (opens in new window)"
+                                href={'/help#key-documents'}
+                                variant="external"
+                                target="_blank"
+                            >
+                                Document definitions and requirements
+                            </Link>
+                            <span className="padding-top-1">
+                                {`Upload any supporting documents for Rate certification ${index + 1}`}
+                            </span>
+                            <span>Additional rates can be added later.</span>
+
+                            <span className="padding-top-1">
+                                This input only accepts PDF, CSV, DOC, DOCX,
+                                XLS, XLSX files.
+                            </span>
+                        </span>
+                    }
+                    accept={ACCEPTED_RATE_SUPPORTING_DOCS_FILE_TYPES}
+                    initialItems={rateForm.supportingDocuments}
+                    uploadFile={(file) =>
+                        handleUploadFile(file, 'HEALTH_PLAN_DOCS')
+                    }
+                    scanFile={(key) => handleScanFile(key, 'HEALTH_PLAN_DOCS')}
+                    deleteFile={(key) =>
+                        handleDeleteFile(
+                            key,
+                            'HEALTH_PLAN_DOCS',
+                            previousDocuments
+                        )
+                    }
+                    onFileItemsUpdate={({ fileItems }) =>
+                        setFieldValue(
+                            `${fieldNamePrefix}.supportingDocuments`,
+                            fileItems
+                        )
+                    }
+                />
+            </FormGroup>
+            <FormGroup error={Boolean(showFieldErrors('rateProgramIDs'))}>
+                <Label htmlFor={`${fieldNamePrefix}.rateProgramIDs`}>
+                    Programs this rate certification covers
+                </Label>
+                <span className={styles.requiredOptionalText}>Required</span>
+                <PoliteErrorMessage>
+                    {showFieldErrors('rateProgramIDs')}
+                </PoliteErrorMessage>
+                <ProgramSelect
+                    name={`${fieldNamePrefix}.rateProgramIDs`}
+                    inputId={`${fieldNamePrefix}.rateProgramIDs`}
+                    programIDs={rateForm.rateProgramIDs}
+                    aria-label="programs (required)"
+                />
+            </FormGroup>
+
+            <FormGroup error={Boolean(showFieldErrors('rateType'))}>
+                <Fieldset
+                    className={styles.radioGroup}
+                    legend="Rate certification type"
+                    role="radiogroup"
+                    aria-required
                 >
-                    <FileUpload
-                        id={`${fieldNamePrefix}.supportingDocuments`}
-                        name={`${fieldNamePrefix}.supportingDocuments`}
-                        label="Upload supporting documents"
-                        aria-required={false}
-                        error={showFieldErrors('supportingDocuments')}
-                        hint={
-                            <span className={styles.guidanceTextBlockNoPadding}>
-                                <Link
-                                    aria-label="Document definitions and requirements (opens in new window)"
-                                    href={'/help#key-documents'}
-                                    variant="external"
-                                    target="_blank"
-                                >
-                                    Document definitions and requirements
-                                </Link>
-                                <span className="padding-top-1">
-                                    {`Upload any supporting documents for Rate certification ${rateCertNumber}`}
-                                </span>
-                                <span>
-                                    Additional rates can be added later.
-                                </span>
-
-                                <span className="padding-top-1">
-                                    This input only accepts PDF, CSV, DOC, DOCX,
-                                    XLS, XLSX files.
-                                </span>
-                            </span>
-                        }
-                        accept={ACCEPTED_RATE_SUPPORTING_DOCS_FILE_TYPES}
-                        initialItems={rateForm.supportingDocuments}
-                        uploadFile={(file) =>
-                            handleUploadFile(file, 'HEALTH_PLAN_DOCS')
-                        }
-                        scanFile={(key) =>
-                            handleScanFile(key, 'HEALTH_PLAN_DOCS')
-                        }
-                        deleteFile={(key) =>
-                            handleDeleteFile(
-                                key,
-                                'HEALTH_PLAN_DOCS',
-                                previousDocuments
-                            )
-                        }
-                        onFileItemsUpdate={({ fileItems }) =>
-                            setFieldValue(
-                                `${fieldNamePrefix}.supportingDocuments`,
-                                fileItems
-                            )
-                        }
-                    />
-                </FormGroup> */}
-                <FormGroup error={Boolean(showFieldErrors('rateProgramIDs'))}>
-                    <Label htmlFor={`${fieldNamePrefix}.rateProgramIDs`}>
-                        Programs this rate certification covers
-                    </Label>
                     <span className={styles.requiredOptionalText}>
                         Required
                     </span>
                     <PoliteErrorMessage>
-                        {showFieldErrors('rateProgramIDs')}
+                        {showFieldErrors('rateType')}
                     </PoliteErrorMessage>
-                    <ProgramSelect
-                        name={`${fieldNamePrefix}.rateProgramIDs`}
-                        inputId={`${fieldNamePrefix}.rateProgramIDs`}
-                        programIDs={rateForm.rateProgramIDs}
-                        aria-label="programs (required)"
+
+                    <Link
+                        aria-label="Rate certification type definitions (opens in new window)"
+                        href={'/help#rate-cert-type-definitions'}
+                        variant="external"
+                        target="_blank"
+                    >
+                        Rate certification type definitions
+                    </Link>
+                    <FieldRadio
+                        id={`newRate-${index}`}
+                        name={`${fieldNamePrefix}.rateType`}
+                        label="New rate certification"
+                        value={'NEW'}
                     />
-                </FormGroup>
+                    <FieldRadio
+                        id={`amendmentRate-${index}`}
+                        name={`${fieldNamePrefix}.rateType`}
+                        label="Amendment to prior rate certification"
+                        value={'AMENDMENT'}
+                    />
+                </Fieldset>
+            </FormGroup>
 
-                <FormGroup error={Boolean(showFieldErrors('rateType'))}>
-                    <Fieldset
-                        className={styles.radioGroup}
-                        legend="Rate certification type"
-                        role="radiogroup"
-                        aria-required
-                    >
-                        <span className={styles.requiredOptionalText}>
-                            Required
-                        </span>
-                        <PoliteErrorMessage>
-                            {showFieldErrors('rateType')}
-                        </PoliteErrorMessage>
-
-                        <Link
-                            aria-label="Rate certification type definitions (opens in new window)"
-                            href={'/help#rate-cert-type-definitions'}
-                            variant="external"
-                            target="_blank"
-                        >
-                            Rate certification type definitions
-                        </Link>
-                        <FieldRadio
-                            id={`newRate-${index}`}
-                            name={`${fieldNamePrefix}.rateType`}
-                            label="New rate certification"
-                            value={'NEW'}
-                        />
-                        <FieldRadio
-                            id={`amendmentRate-${index}`}
-                            name={`${fieldNamePrefix}.rateType`}
-                            label="Amendment to prior rate certification"
-                            value={'AMENDMENT'}
-                        />
-                    </Fieldset>
-                </FormGroup>
-
-                <FormGroup
-                    error={Boolean(showFieldErrors('rateCapitationType'))}
+            <FormGroup error={Boolean(showFieldErrors('rateCapitationType'))}>
+                <Fieldset
+                    className={styles.radioGroup}
+                    legend={
+                        <div className={styles.capitationLegend}>
+                            <p className="margin-bottom-0">
+                                Does the actuary certify capitation rates
+                                specific to each rate cell or a rate range?
+                            </p>
+                            <span
+                                className={classnames(
+                                    styles.legendSubHeader,
+                                    styles.requiredOptionalText
+                                )}
+                            >
+                                Required
+                            </span>
+                            <p
+                                className={classnames(
+                                    'margin-bottom-0',
+                                    styles.legendSubHeader
+                                )}
+                            >
+                                See 42 CFR §§ 438.4(b) and 438.4(c)
+                            </p>
+                        </div>
+                    }
+                    role="radiogroup"
+                    aria-required
                 >
-                    <Fieldset
-                        className={styles.radioGroup}
-                        legend={
-                            <div className={styles.capitationLegend}>
-                                <p className="margin-bottom-0">
-                                    Does the actuary certify capitation rates
-                                    specific to each rate cell or a rate range?
-                                </p>
-                                <span
-                                    className={classnames(
-                                        styles.legendSubHeader,
-                                        styles.requiredOptionalText
-                                    )}
-                                >
-                                    Required
-                                </span>
-                                <p
-                                    className={classnames(
-                                        'margin-bottom-0',
-                                        styles.legendSubHeader
-                                    )}
-                                >
-                                    See 42 CFR §§ 438.4(b) and 438.4(c)
-                                </p>
-                            </div>
-                        }
-                        role="radiogroup"
-                        aria-required
-                    >
-                        <PoliteErrorMessage>
-                            {showFieldErrors('rateCapitationType')}
-                        </PoliteErrorMessage>
-                        <FieldRadio
-                            id={`rateCell-${index}`}
-                            name={`${fieldNamePrefix}.rateCapitationType`}
-                            label="Certification of capitation rates specific to each rate cell"
-                            value={'RATE_CELL'}
-                        />
-                        <FieldRadio
-                            id={`rateRange-${index}`}
-                            name={`${fieldNamePrefix}.rateCapitationType`}
-                            label="Certification of rate ranges of capitation rates per rate cell"
-                            value={'RATE_RANGE'}
-                        />
-                    </Fieldset>
-                </FormGroup>
+                    <PoliteErrorMessage>
+                        {showFieldErrors('rateCapitationType')}
+                    </PoliteErrorMessage>
+                    <FieldRadio
+                        id={`rateCell-${index}`}
+                        name={`${fieldNamePrefix}.rateCapitationType`}
+                        label="Certification of capitation rates specific to each rate cell"
+                        value={'RATE_CELL'}
+                    />
+                    <FieldRadio
+                        id={`rateRange-${index}`}
+                        name={`${fieldNamePrefix}.rateCapitationType`}
+                        label="Certification of rate ranges of capitation rates per rate cell"
+                        value={'RATE_RANGE'}
+                    />
+                </Fieldset>
+            </FormGroup>
 
-                {!isRateTypeEmpty(rateForm) && (
-                    <>
-                        <FormGroup
-                            error={Boolean(
-                                showFieldErrors('rateDateStart') ??
-                                    showFieldErrors('rateDateEnd')
-                            )}
-                        >
-                            <Fieldset
-                                aria-required
-                                legend={
-                                    isRateTypeAmendment(rateForm)
-                                        ? 'Rating period of original rate certification'
-                                        : 'Rating period'
-                                }
-                            >
-                                <span className={styles.requiredOptionalText}>
-                                    Required
-                                </span>
-                                <RateDatesErrorMessage
-                                    startDate={rateForm.rateDateStart}
-                                    endDate={rateForm.rateDateEnd}
-                                    startDateError={showFieldErrors(
-                                        'rateDateStart'
-                                    )}
-                                    endDateError={showFieldErrors(
-                                        'rateDateEnd'
-                                    )}
-                                    shouldValidate={shouldValidate}
-                                />
-
-                                <DateRangePicker
-                                    className={styles.dateRangePicker}
-                                    startDateHint="mm/dd/yyyy"
-                                    startDateLabel="Start date"
-                                    startDatePickerProps={{
-                                        disabled: false,
-                                        id: `${fieldNamePrefix}.rateDateStart`,
-                                        name: `${fieldNamePrefix}.rateDateStart`,
-                                        'aria-required': true,
-                                        defaultValue: rateForm.rateDateStart,
-                                        onChange: (val) =>
-                                            setFieldValue(
-                                                `${fieldNamePrefix}.rateDateStart`,
-                                                formatUserInputDate(val)
-                                            ),
-                                    }}
-                                    endDateHint="mm/dd/yyyy"
-                                    endDateLabel="End date"
-                                    endDatePickerProps={{
-                                        disabled: false,
-                                        id: `${fieldNamePrefix}.rateDateEnd`,
-                                        name: `${fieldNamePrefix}.rateDateEnd`,
-                                        'aria-required': true,
-                                        defaultValue: rateForm.rateDateEnd,
-                                        onChange: (val) =>
-                                            setFieldValue(
-                                                `${fieldNamePrefix}.rateDateEnd`,
-                                                formatUserInputDate(val)
-                                            ),
-                                    }}
-                                />
-                            </Fieldset>
-                        </FormGroup>
-
-                        {isRateTypeAmendment(rateForm) && (
-                            <>
-                                <FormGroup
-                                    error={Boolean(
-                                        showFieldErrors('effectiveDateStart') ??
-                                            showFieldErrors('effectiveDateEnd')
-                                    )}
-                                >
-                                    <Fieldset
-                                        aria-required
-                                        legend="Effective dates of rate amendment"
-                                    >
-                                        <span
-                                            className={
-                                                styles.requiredOptionalText
-                                            }
-                                        >
-                                            Required
-                                        </span>
-                                        <RateDatesErrorMessage
-                                            startDate={
-                                                rateForm.effectiveDateStart
-                                            }
-                                            endDate={rateForm.effectiveDateEnd}
-                                            startDateError={showFieldErrors(
-                                                'effectiveDateStart'
-                                            )}
-                                            endDateError={showFieldErrors(
-                                                'effectiveDateEnd'
-                                            )}
-                                            shouldValidate={shouldValidate}
-                                        />
-
-                                        <DateRangePicker
-                                            className={styles.dateRangePicker}
-                                            startDateHint="mm/dd/yyyy"
-                                            startDateLabel="Start date"
-                                            startDatePickerProps={{
-                                                disabled: false,
-                                                id: `${fieldNamePrefix}.effectiveDateStart`,
-                                                name: `${fieldNamePrefix}.effectiveDateStart`,
-                                                'aria-required': true,
-                                                defaultValue:
-                                                    rateForm.effectiveDateStart,
-                                                onChange: (val) =>
-                                                    setFieldValue(
-                                                        `${fieldNamePrefix}.effectiveDateStart`,
-                                                        formatUserInputDate(val)
-                                                    ),
-                                            }}
-                                            endDateHint="mm/dd/yyyy"
-                                            endDateLabel="End date"
-                                            endDatePickerProps={{
-                                                disabled: false,
-                                                id: `${fieldNamePrefix}.effectiveDateEnd`,
-                                                name: `${fieldNamePrefix}.effectiveDateEnd`,
-                                                'aria-required': true,
-                                                defaultValue:
-                                                    rateForm.effectiveDateEnd,
-                                                onChange: (val) =>
-                                                    setFieldValue(
-                                                        `${fieldNamePrefix}.effectiveDateEnd`,
-                                                        formatUserInputDate(val)
-                                                    ),
-                                            }}
-                                        />
-                                    </Fieldset>
-                                </FormGroup>
-                            </>
+            {!isRateTypeEmpty(rateForm) && (
+                <>
+                    <FormGroup
+                        error={Boolean(
+                            showFieldErrors('rateDateStart') ??
+                                showFieldErrors('rateDateEnd')
                         )}
-                        <FormGroup
-                            error={Boolean(
-                                showFieldErrors('rateDateCertified')
-                            )}
+                    >
+                        <Fieldset
+                            aria-required
+                            legend={
+                                isRateTypeAmendment(rateForm)
+                                    ? 'Rating period of original rate certification'
+                                    : 'Rating period'
+                            }
                         >
-                            <Label
-                                htmlFor={`${fieldNamePrefix}.rateDateCertified`}
-                                id={`rateDateCertifiedLabel.${index}`}
-                            >
-                                {isRateTypeAmendment(rateForm)
-                                    ? 'Date certified for rate amendment'
-                                    : 'Date certified'}
-                            </Label>
                             <span className={styles.requiredOptionalText}>
                                 Required
                             </span>
-                            <div
-                                className="usa-hint"
-                                id={`rateDateCertifiedHint.${index}`}
-                            >
-                                mm/dd/yyyy
-                            </div>
-                            <PoliteErrorMessage>
-                                {showFieldErrors('rateDateCertified')}
-                            </PoliteErrorMessage>
-
-                            <DatePicker
-                                aria-required
-                                aria-describedby={`rateDateCertifiedLabel.${index} rateDateCertifiedHint.${index}`}
-                                id={`${fieldNamePrefix}.rateDateCertified`}
-                                name={`${fieldNamePrefix}.rateDateCertified`}
-                                defaultValue={rateForm.rateDateCertified}
-                                onChange={(val) =>
-                                    setFieldValue(
-                                        `${fieldNamePrefix}.rateDateCertified`,
-                                        formatUserInputDate(val)
-                                    )
-                                }
+                            <RateDatesErrorMessage
+                                startDate={rateForm.rateDateStart}
+                                endDate={rateForm.rateDateEnd}
+                                startDateError={showFieldErrors(
+                                    'rateDateStart'
+                                )}
+                                endDateError={showFieldErrors('rateDateEnd')}
+                                shouldValidate={shouldValidate}
                             />
-                        </FormGroup>
-                    </>
-                )}
 
-                <FormGroup>
-                    <ActuaryContactFields
-                        actuaryContact={rateForm.actuaryContacts[0]}
-                        errors={errors}
-                        shouldValidate={shouldValidate}
-                        fieldNamePrefix={`${fieldNamePrefix}.actuaryContacts.0`}
-                        fieldSetLegend="Certifying Actuary"
-                    />
-                </FormGroup>
-                {index >= 1 && multiRatesConfig && (
-                    <Button
-                        type="button"
-                        unstyled
-                        className={styles.removeContactBtn}
-                        onClick={multiRatesConfig.removeSelf}
+                            <DateRangePicker
+                                className={styles.dateRangePicker}
+                                startDateHint="mm/dd/yyyy"
+                                startDateLabel="Start date"
+                                startDatePickerProps={{
+                                    disabled: false,
+                                    id: `${fieldNamePrefix}.rateDateStart`,
+                                    name: `${fieldNamePrefix}.rateDateStart`,
+                                    'aria-required': true,
+                                    defaultValue: rateForm.rateDateStart,
+                                    onChange: (val) =>
+                                        setFieldValue(
+                                            `${fieldNamePrefix}.rateDateStart`,
+                                            formatUserInputDate(val)
+                                        ),
+                                }}
+                                endDateHint="mm/dd/yyyy"
+                                endDateLabel="End date"
+                                endDatePickerProps={{
+                                    disabled: false,
+                                    id: `${fieldNamePrefix}.rateDateEnd`,
+                                    name: `${fieldNamePrefix}.rateDateEnd`,
+                                    'aria-required': true,
+                                    defaultValue: rateForm.rateDateEnd,
+                                    onChange: (val) =>
+                                        setFieldValue(
+                                            `${fieldNamePrefix}.rateDateEnd`,
+                                            formatUserInputDate(val)
+                                        ),
+                                }}
+                            />
+                        </Fieldset>
+                    </FormGroup>
+
+                    {isRateTypeAmendment(rateForm) && (
+                        <>
+                            <FormGroup
+                                error={Boolean(
+                                    showFieldErrors('effectiveDateStart') ??
+                                        showFieldErrors('effectiveDateEnd')
+                                )}
+                            >
+                                <Fieldset
+                                    aria-required
+                                    legend="Effective dates of rate amendment"
+                                >
+                                    <span
+                                        className={styles.requiredOptionalText}
+                                    >
+                                        Required
+                                    </span>
+                                    <RateDatesErrorMessage
+                                        startDate={rateForm.effectiveDateStart}
+                                        endDate={rateForm.effectiveDateEnd}
+                                        startDateError={showFieldErrors(
+                                            'effectiveDateStart'
+                                        )}
+                                        endDateError={showFieldErrors(
+                                            'effectiveDateEnd'
+                                        )}
+                                        shouldValidate={shouldValidate}
+                                    />
+
+                                    <DateRangePicker
+                                        className={styles.dateRangePicker}
+                                        startDateHint="mm/dd/yyyy"
+                                        startDateLabel="Start date"
+                                        startDatePickerProps={{
+                                            disabled: false,
+                                            id: `${fieldNamePrefix}.effectiveDateStart`,
+                                            name: `${fieldNamePrefix}.effectiveDateStart`,
+                                            'aria-required': true,
+                                            defaultValue:
+                                                rateForm.effectiveDateStart,
+                                            onChange: (val) =>
+                                                setFieldValue(
+                                                    `${fieldNamePrefix}.effectiveDateStart`,
+                                                    formatUserInputDate(val)
+                                                ),
+                                        }}
+                                        endDateHint="mm/dd/yyyy"
+                                        endDateLabel="End date"
+                                        endDatePickerProps={{
+                                            disabled: false,
+                                            id: `${fieldNamePrefix}.effectiveDateEnd`,
+                                            name: `${fieldNamePrefix}.effectiveDateEnd`,
+                                            'aria-required': true,
+                                            defaultValue:
+                                                rateForm.effectiveDateEnd,
+                                            onChange: (val) =>
+                                                setFieldValue(
+                                                    `${fieldNamePrefix}.effectiveDateEnd`,
+                                                    formatUserInputDate(val)
+                                                ),
+                                        }}
+                                    />
+                                </Fieldset>
+                            </FormGroup>
+                        </>
+                    )}
+                    <FormGroup
+                        error={Boolean(showFieldErrors('rateDateCertified'))}
                     >
-                        Remove rate certification
-                    </Button>
-                )}
-            </Fieldset>
-        </SectionCard>
+                        <Label
+                            htmlFor={`${fieldNamePrefix}.rateDateCertified`}
+                            id={`rateDateCertifiedLabel.${index}`}
+                        >
+                            {isRateTypeAmendment(rateForm)
+                                ? 'Date certified for rate amendment'
+                                : 'Date certified'}
+                        </Label>
+                        <span className={styles.requiredOptionalText}>
+                            Required
+                        </span>
+                        <div
+                            className="usa-hint"
+                            id={`rateDateCertifiedHint.${index}`}
+                        >
+                            mm/dd/yyyy
+                        </div>
+                        <PoliteErrorMessage>
+                            {showFieldErrors('rateDateCertified')}
+                        </PoliteErrorMessage>
+
+                        <DatePicker
+                            aria-required
+                            aria-describedby={`rateDateCertifiedLabel.${index} rateDateCertifiedHint.${index}`}
+                            id={`${fieldNamePrefix}.rateDateCertified`}
+                            name={`${fieldNamePrefix}.rateDateCertified`}
+                            defaultValue={rateForm.rateDateCertified}
+                            onChange={(val) =>
+                                setFieldValue(
+                                    `${fieldNamePrefix}.rateDateCertified`,
+                                    formatUserInputDate(val)
+                                )
+                            }
+                        />
+                    </FormGroup>
+                </>
+            )}
+            <FormGroup>
+                <ActuaryContactFields
+                    shouldValidate={shouldValidate}
+                    fieldNamePrefix={`${fieldNamePrefix}.actuaryContacts.0`}
+                    fieldSetLegend="Certifying Actuary"
+                />
+            </FormGroup>
+        </>
     )
 }

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/SingleRateCertV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/SingleRateCertV2.tsx
@@ -11,7 +11,7 @@ import {
 import classnames from 'classnames'
 import {
     FieldRadio,
-    FileUpload,
+    // FileUpload,
     PoliteErrorMessage,
     ProgramSelect,
     SectionCard,
@@ -19,11 +19,11 @@ import {
 
 import styles from '../../StateSubmissionForm.module.scss'
 import { formatUserInputDate, isDateRangeEmpty } from '../../../../formHelpers'
-import {
-    ACCEPTED_RATE_SUPPORTING_DOCS_FILE_TYPES,
-    ACCEPTED_RATE_CERTIFICATION_FILE_TYPES,
-} from '../../../../components/FileUpload'
-import { useS3 } from '../../../../contexts/S3Context'
+// import {
+//     ACCEPTED_RATE_SUPPORTING_DOCS_FILE_TYPES,
+//     ACCEPTED_RATE_CERTIFICATION_FILE_TYPES,
+// } from '../../../../components/FileUpload'
+// import { useS3 } from '../../../../contexts/S3Context'
 
 import { FormikErrors, getIn, useFormikContext } from 'formik'
 import { ActuaryContactFields } from '../../Contacts'
@@ -47,7 +47,7 @@ type SingleRateCertV2Props = {
     shouldValidate: boolean
     index: number // defaults to 0
     previousDocuments: string[] // this only passed in to ensure S3 deleteFile doesn't remove valid files for previous revisions
-    multiRatesConfig?: MultiRatesConfig //t his is for use with Linked Rates and multi-rates UI
+    multiRatesConfig?: MultiRatesConfig // this is for use with multi-rates UI
 }
 
 const RateDatesErrorMessage = ({
@@ -81,10 +81,10 @@ export const SingleRateCertV2 = ({
     shouldValidate,
     multiRatesConfig,
     index = 0,
-    previousDocuments,
+    // previousDocuments,
 }: SingleRateCertV2Props): React.ReactElement => {
     // page level setup
-    const { handleDeleteFile, handleUploadFile, handleScanFile } = useS3()
+    // const { handleDeleteFile, handleUploadFile, handleScanFile } = useS3()
     const key = rateForm.id
     const displayAsStandaloneRate = multiRatesConfig === undefined
     const fieldNamePrefix = `rates.${index}`
@@ -110,7 +110,7 @@ export const SingleRateCertV2 = ({
                 key={key}
                 id={`${fieldNamePrefix}.container.${rateForm.id}`}
             >
-                <FormGroup error={Boolean(showFieldErrors('rateDocuments'))}>
+                {/* <FormGroup error={Boolean(showFieldErrors('rateDocuments'))}>
                     <FileUpload
                         id={`${fieldNamePrefix}.rateDocuments`}
                         name={`${fieldNamePrefix}.rateDocuments`}
@@ -161,9 +161,9 @@ export const SingleRateCertV2 = ({
                             )
                         }
                     />
-                </FormGroup>
+                </FormGroup> */}
 
-                <FormGroup
+                {/* <FormGroup
                     error={Boolean(showFieldErrors('supportingDocuments'))}
                 >
                     <FileUpload
@@ -217,7 +217,7 @@ export const SingleRateCertV2 = ({
                             )
                         }
                     />
-                </FormGroup>
+                </FormGroup> */}
                 <FormGroup error={Boolean(showFieldErrors('rateProgramIDs'))}>
                     <Label htmlFor={`${fieldNamePrefix}.rateProgramIDs`}>
                         Programs this rate certification covers

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/SingleRateFormFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/SingleRateFormFields.tsx
@@ -91,6 +91,9 @@ export const SingleRateFormFields = ({
         if (!shouldValidate) return undefined
         return getIn(errors, `${fieldNamePrefix}.${fieldName}`)
     }
+    if (rateForm.status === 'SUBMITTED' || rateForm.status === 'RESUBMITTED') {
+        return <div>This is a Linked Rate. UI forthcoming</div>
+    }
 
     return (
         <>

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/SingleRateFormFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/SingleRateFormFields.tsx
@@ -32,10 +32,16 @@ const isRateTypeEmpty = (rateForm: RateDetailFormValues): boolean =>
 const isRateTypeAmendment = (rateForm: RateDetailFormValues): boolean =>
     rateForm.rateType === 'AMENDMENT'
 
+/**
+ * This component renders rate certification related form fields with their labels and error messages
+ *
+ * It relies on useFormikContext hook to work inside of a Formik form with matching field name values
+ */
+
 export type SingleRateFormError =
     FormikErrors<RateDetailFormConfig>[keyof FormikErrors<RateDetailFormConfig>]
 
-type SingleRateCertV2Props = {
+type SingleRateFormFieldsProps = {
     rateForm: RateDetailFormValues
     shouldValidate: boolean
     index: number // defaults to 0
@@ -68,12 +74,12 @@ const RateDatesErrorMessage = ({
     return <PoliteErrorMessage>{validationErrorMessage}</PoliteErrorMessage>
 }
 
-export const SingleRateCertV2 = ({
+export const SingleRateFormFields = ({
     rateForm,
     shouldValidate,
     index = 0,
     previousDocuments,
-}: SingleRateCertV2Props): React.ReactElement => {
+}: SingleRateFormFieldsProps): React.ReactElement => {
     // page level setup
     const { handleDeleteFile, handleUploadFile, handleScanFile } = useS3()
     const fieldNamePrefix = `rates.${index}`

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
@@ -50,7 +50,7 @@ export const StateSubmissionForm = (): React.ReactElement => {
                     )}
                     element={
                         useLinkedRates ? (
-                            <RateDetailsV2 type="MULTI" rates={[]} />
+                            <RateDetailsV2 type="MULTI" />
                         ) : (
                             <RateDetails />
                         )

--- a/services/app-web/src/testHelpers/apolloMocks/rateDataMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/rateDataMock.ts
@@ -160,6 +160,30 @@ const rateRevisionDataMock = (data?: Partial<RateRevision>): RateRevision => {
     }
 }
 
+const draftRateDataMock =  (
+    rate?: Partial<Rate>,
+    draftRevision?: Partial<RateRevision>
+): Rate => {
+    const rateID = rate?.id ?? uuidv4()
+    return {
+        __typename: 'Rate',
+        createdAt: '2023-10-16T19:01:21.389Z',
+        updatedAt: '2023-10-16T19:01:21.389Z',
+        stateCode: 'MN',
+        stateNumber: 10,
+        state: mockMNState(),
+        status: 'DRAFT',
+        initiallySubmittedAt: '2023-10-16',
+        draftRevision: {
+           ...rateRevisionDataMock({submitInfo: null,  ...draftRevision}),
+        },
+        revisions: [],
+        ...rate,
+        id: rateID,
+
+    }
+}
+
 const rateDataMock = (
     revision?: Partial<RateRevision>,
     rate?: Partial<Rate>
@@ -214,4 +238,4 @@ const rateDataMock = (
     }
 }
 
-export { rateDataMock, rateRevisionDataMock }
+export { rateDataMock, rateRevisionDataMock,draftRateDataMock,   }

--- a/services/app-web/src/testHelpers/apolloMocks/rateGQLMocks.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/rateGQLMocks.ts
@@ -10,13 +10,10 @@ import { MockedResponse } from '@apollo/client/testing'
 import { rateDataMock } from './rateDataMock'
 import { GraphQLError } from 'graphql/index'
 
-const fetchRateMockSuccess = ({
-    revision,
-    rate,
-}: {
+const fetchRateMockSuccess = (
+    rate?: Partial<Rate>,
     revision?: Partial<RateRevision>
-    rate?: Partial<Rate>
-}): MockedResponse<FetchRateQuery> => {
+): MockedResponse<FetchRateQuery> => {
     const rateData = rateDataMock(revision, rate)
 
     return {

--- a/services/app-web/src/testHelpers/apolloMocks/rateGQLMocks.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/rateGQLMocks.ts
@@ -7,7 +7,7 @@ import {
     RateRevision,
 } from '../../gen/gqlClient'
 import { MockedResponse } from '@apollo/client/testing'
-import { rateDataMock } from './rateDataMock'
+import { draftRateDataMock, rateDataMock } from './rateDataMock'
 import { GraphQLError } from 'graphql/index'
 
 const fetchRateMockSuccess = (
@@ -15,6 +15,28 @@ const fetchRateMockSuccess = (
     revision?: Partial<RateRevision>
 ): MockedResponse<FetchRateQuery> => {
     const rateData = rateDataMock(revision, rate)
+
+    return {
+        request: {
+            query: FetchRateDocument,
+            variables: { input: { rateID: rateData.id } },
+        },
+        result: {
+            data: {
+                fetchRate: {
+                    rate: {
+                        ...rateData,
+                    },
+                },
+            },
+        },
+    }
+}
+const fetchDraftRateMockSuccess = (
+    rate?: Partial<Rate>,
+    revision?: Partial<RateRevision>
+): MockedResponse<FetchRateQuery> => {
+    const rateData = draftRateDataMock(rate, revision)
 
     return {
         request: {
@@ -78,4 +100,4 @@ const indexRatesMockFailure = (): MockedResponse<IndexRatesQuery> => {
     }
 }
 
-export { fetchRateMockSuccess, indexRatesMockSuccess, indexRatesMockFailure }
+export { fetchRateMockSuccess, indexRatesMockSuccess, indexRatesMockFailure, fetchDraftRateMockSuccess }

--- a/services/app-web/src/testHelpers/jestRateHelpers.tsx
+++ b/services/app-web/src/testHelpers/jestRateHelpers.tsx
@@ -1,0 +1,196 @@
+import {
+    waitFor,
+    within,
+    fireEvent,
+    type Screen,
+} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import selectEvent from 'react-select-event'
+import {
+    TEST_PDF_FILE,
+    updateDateRange,
+} from '../testHelpers'
+
+const fillOutIndexRate = async (screen: Screen, index: number) => {
+    const targetRateCert = rateCertifications(screen)[index]
+    expect(targetRateCert).toBeDefined()
+    const withinTargetRateCert = within(targetRateCert)
+
+    // assert proper initial fields are present
+    expect(
+        withinTargetRateCert.getByText('Upload one rate certification document')
+    ).toBeInTheDocument()
+    expect(
+        withinTargetRateCert.getByText(
+            'Programs this rate certification covers'
+        )
+    ).toBeInTheDocument()
+    expect(
+        withinTargetRateCert.getByText('Rate certification type')
+    ).toBeInTheDocument()
+    expect(
+        withinTargetRateCert.getByText(
+            'Does the actuary certify capitation rates specific to each rate cell or a rate range?'
+        )
+    ).toBeInTheDocument()
+
+    //Rates across submission
+    const sharedRates = withinTargetRateCert.queryByText(
+        /Was this rate certification uploaded to any other submissions/
+    )
+    //if rates across submission UI exists then fill out section
+    if (sharedRates) {
+        expect(sharedRates).toBeInTheDocument()
+        withinTargetRateCert.getByLabelText('No').click()
+    }
+
+    // add 1 doc
+    const input = withinTargetRateCert.getByLabelText(
+        'Upload one rate certification document'
+    )
+    await userEvent.upload(input, [TEST_PDF_FILE])
+
+    // add programs
+    const combobox = await withinTargetRateCert.findByRole('combobox')
+    selectEvent.openMenu(combobox)
+    await selectEvent.select(combobox, 'SNBC')
+    selectEvent.openMenu(combobox)
+    await selectEvent.select(combobox, 'PMAP')
+    expect(
+        withinTargetRateCert.getByLabelText('Remove SNBC')
+    ).toBeInTheDocument()
+    expect(
+        withinTargetRateCert.getByLabelText('Remove PMAP')
+    ).toBeInTheDocument()
+
+    //  add types and answer captitation rates question
+    withinTargetRateCert.getByLabelText('New rate certification').click()
+
+    withinTargetRateCert
+        .getByLabelText(
+            'Certification of capitation rates specific to each rate cell'
+        )
+        .click()
+
+    // check that now we can see dates, since that is triggered after selecting type
+    await waitFor(() => {
+        expect(
+            withinTargetRateCert.queryByText('Start date')
+        ).toBeInTheDocument()
+        expect(withinTargetRateCert.queryByText('End date')).toBeInTheDocument()
+        expect(
+            withinTargetRateCert.queryByText('Date certified')
+        ).toBeInTheDocument()
+        expect(withinTargetRateCert.queryByText('Name')).toBeInTheDocument()
+        expect(
+            withinTargetRateCert.queryByText('Title/Role')
+        ).toBeInTheDocument()
+        expect(withinTargetRateCert.queryByText('Email')).toBeInTheDocument()
+    })
+
+    const startDateInputs = withinTargetRateCert.getAllByLabelText('Start date')
+    const endDateInputs = withinTargetRateCert.getAllByLabelText('End date')
+    await updateDateRange({
+        start: { elements: startDateInputs, date: '01/01/2022' },
+        end: { elements: endDateInputs, date: '12/31/2022' },
+    })
+
+    withinTargetRateCert.getAllByLabelText('Date certified')[0].focus()
+    await userEvent.paste('12/01/2021')
+
+    // fill out actuary contact
+    withinTargetRateCert.getByLabelText('Name').focus()
+    await userEvent.paste(`Actuary Contact Person ${index}`)
+
+    withinTargetRateCert.getByLabelText('Title/Role').focus()
+    await userEvent.paste(`Actuary Contact Title ${index}`)
+
+    withinTargetRateCert.getByLabelText('Email').focus()
+    await userEvent.paste(`actuarycontact${index}@test.com`)
+
+    await userEvent.click(withinTargetRateCert.getByLabelText('Mercer'))
+}
+
+const rateCertifications = (screen: Screen) => {
+    return screen.getAllByTestId('rate-certification-form')
+}
+
+const lastRateCertificationFromList = (screen: Screen) => {
+    return rateCertifications(screen).pop()
+}
+
+
+const fillOutFirstRate = async (screen: Screen) => {
+    // trigger errors (used later to confirm we filled out every field)
+    fireEvent.click(
+        screen.getByRole('button', {
+            name: 'Continue',
+        })
+    )
+
+    await fillOutIndexRate(screen, 0)
+}
+
+const clickAddNewRate = async (screen: Screen) => {
+    const rateCertsBeforeAddingNewRate = rateCertifications(screen)
+
+    const addAnotherButton = screen.getByRole('button', {
+        name: /Add another rate/,
+    })
+
+    expect(addAnotherButton).toBeInTheDocument()
+    fireEvent.click(addAnotherButton)
+    return await waitFor(() =>
+        expect(rateCertifications(screen)).toHaveLength(
+            rateCertsBeforeAddingNewRate.length + 1
+        )
+    )
+}
+
+const clickRemoveIndexRate = async (
+    screen: Screen,
+    indexOfRateCertToRemove: number
+) => {
+    // Remember, user cannot never remove the first rate certification -- MR-2231
+    const rateCertsBeforeRemoving = rateCertifications(screen)
+    // Confirm there is a rate to remove
+    expect(rateCertsBeforeRemoving.length).toBeGreaterThanOrEqual(2)
+
+    // Confirm there is one less rate removal button than rate certs
+    const removeRateButtonsBeforeClick = screen.getAllByRole('button', {
+        name: /Remove rate certification/,
+    })
+    expect(removeRateButtonsBeforeClick.length).toBeGreaterThanOrEqual(1)
+    expect(removeRateButtonsBeforeClick).toHaveLength(
+        rateCertsBeforeRemoving.length - 1
+    )
+
+    // Remove rate cert
+    const removeRateButton =
+        removeRateButtonsBeforeClick[indexOfRateCertToRemove - 1]
+
+    expect(removeRateButton).toBeInTheDocument()
+    fireEvent.click(removeRateButton)
+
+    await waitFor(() => {
+        // Confirm that there is one less rate certification on the page
+        expect(rateCertifications(screen)).toHaveLength(
+            rateCertsBeforeRemoving.length - 1
+        )
+        // Confirm that there is one less rate removal button (might even be zero buttons on page if all additional rates removed)
+        expect(
+            screen.getAllByRole('button', {
+                name: /Remove rate certification/,
+            })
+        ).toHaveLength(removeRateButtonsBeforeClick.length - 1)
+    })
+}
+
+export{
+    clickAddNewRate,
+    clickRemoveIndexRate,
+    fillOutFirstRate,
+    fillOutIndexRate,
+    rateCertifications,
+    lastRateCertificationFromList,
+}


### PR DESCRIPTION
## Summary
Main work completed:
- Implement  `MULTI` RateDetails workflow
   - I saw some rendering issues after adding additional `useQuery` calls for the new APIs. I spent the most time on trying to investigate what is going on with re-renders.
- Change the API that is called to be conditional -  contract API if we are in MULTI, rate API if we are in SINGLE 

Other notes:
- noticed there's still something odd going on with `ProgramSelect` in terms of that UI triggering additional re-renders. However, addressing that seemed out of scope + needs more investigation. It is an existing issue.

#### Related issues
https://jiraent.cms.gov/browse/MCR-3940

#### Screenshots

UI with linked rate flag off (red box shows the packages with shared rates UI is present) 
![Screenshot 2024-03-04 at 5 52 02 PM](https://github.com/Enterprise-CMCS/managed-care-review/assets/10750442/e9da789e-3289-488c-ae99-761bbd40ecdd)

UI with linked rate flag on (no red box - these fields are not visible and we should not validate on them)
![Screenshot 2024-03-04 at 5 52 53 PM](https://github.com/Enterprise-CMCS/managed-care-review/assets/10750442/81a0e637-eece-4f81-8e8a-78f3af9718eb)


#### Test cases covered
- I'm starting to write Jest tests. Will keep incrementally committing these.  Let's not hold up on the PR on tests though -   this is still featured flagged (in use on rate edit page and on new linked rate workflow). 
- Cypress must pass, that helps ensure I didn't change flag off behavior

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
- **Open Network tab** - you should see `/graphql` request to fetch contract when the linked rates feature flag is on. 
- **Look at the UI** - There is no `PackagesWithSharedRates` UI shown when linked rates feature flag is on. Validations still work (e.g. no validation error for "You must select at least one submission" when you continue with no changes)
-  **Cypress** - Existing cypress tests for linked rates flag OFF still pass

<!---These are developer instructions on how to test or validate the work -->
