### PR TITLE
Tweak tealium more - get it loading on page launch

### DIFF
--- a/services/app-web/src/hooks/useTealium.ts
+++ b/services/app-web/src/hooks/useTealium.ts
@@ -45,7 +45,7 @@ const useTealium = (): {
         }
 
         const tealiumEnv = getTealiumEnv(
-          'main'
+            process.env.REACT_APP_STAGE_NAME || 'main'
         )
         const tealiumProfile = 'cms-mcreview'
         if (!tealiumEnv || !tealiumProfile) {


### PR DESCRIPTION
## Summary
I think my last fix  #2215 still didn't fully resolve this - let's try this. Moving the tealium call to be in the `.then` 

How to test: This can be tested in review apps by removing the environment specific guard clause (see below) and then putting a breakpoint or console logging where we call utag.view  

```// Do not add tealium for local dev or review apps
        if (process.env.REACT_APP_AUTH_MODE !== 'IDM') {
```
