### PR TITLE
MCR-3944 - titleRole grapqhl fix

### DIFF
--- a/services/app-api/src/domain-models/contractAndRates/contractTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/contractTypes.ts
@@ -12,8 +12,6 @@ const contractSchema = z.object({
     createdAt: z.date(),
     updatedAt: z.date(),
     status: statusSchema,
-    createdAt: z.date(),
-    updatedAt: z.date(),
     stateCode: z.string(),
     mccrsID: z.string().optional(),
     stateNumber: z.number().min(1),

--- a/services/app-graphql/src/mutations/updateDraftContractRates.graphql
+++ b/services/app-graphql/src/mutations/updateDraftContractRates.graphql
@@ -33,7 +33,7 @@ mutation updateDraftContractRates($input: UpdateDraftContractRatesInput!) {
                     riskBasedContract
                     stateContacts {
                         name
-                        title
+                        titleRole
                         email
                     }
                     contractDocuments {


### PR DESCRIPTION
## Summary

A previous PR updated `stateContact` graphql types to have a `titleRole` instead of `title` field. This PR switches over a lingering `title` field that caused issues on promote 

## QA guidance

`./dev generate` runs without graphql errors 