### PR TITLE
[MCR-3889] State user sees expanded rate info in dropdown

### DIFF
--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
@@ -34,7 +34,7 @@ export const LinkRateSelect = ({
     data?.indexRates.edges
         .map((edge) => edge.node)
         .forEach((rate) => {
-            if (rate.revisions.length > 0.5) {
+            if (rate.revisions.length > 0) {
                 rate.revisions.forEach((revision) => {
                     if (revision.formData.rateCertificationName) {
                         rateNames.push({

--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
@@ -123,7 +123,6 @@ export const LinkRateSelect = ({
     return (
         <>
             <Select
-                menuIsOpen={true}
                 value={defaultValues}
                 className={styles.multiSelect}
                 options={error || loading ? undefined : rateNames}

--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
@@ -46,7 +46,7 @@ export const LinkRateSelect = ({
                     </p>
                     <p>
                         Rating period:
-                        {formatCalendarDate(revision.formData.rateDateStart)} -{' '}
+                        {formatCalendarDate(revision.formData.rateDateStart)} -
                         {formatCalendarDate(revision.formData.rateDateEnd)}
                     </p>
                     <p>

--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
@@ -30,53 +30,35 @@ export const LinkRateSelect = ({
     const user = loggedInUser as StateUser
     const statePrograms = user.state.programs
 
-    const rateNames: LinkRateOptionType[] = []
-    data?.indexRates.edges
-        .map((edge) => edge.node)
-        .forEach((rate) => {
-            if (rate.revisions.length > 0) {
-                rate.revisions.forEach((revision) => {
-                    if (revision.formData.rateCertificationName) {
-                        rateNames.push({
-                            value: revision.id,
-                            label: (
-                                <div style={{ lineHeight: '50%' }}>
-                                    <h4>
-                                        {
-                                            revision.formData
-                                                .rateCertificationName
-                                        }
-                                    </h4>
-                                    <p>
-                                        Programs:{' '}
-                                        {programNames(
-                                            statePrograms,
-                                            revision.formData.rateProgramIDs
-                                        ).join(', ')}
-                                    </p>
-                                    <p>
-                                        Rating period:{' '}
-                                        {formatCalendarDate(
-                                            revision.formData.rateDateStart
-                                        )}{' '}
-                                        -{' '}
-                                        {formatCalendarDate(
-                                            revision.formData.rateDateEnd
-                                        )}
-                                    </p>
-                                    <p>
-                                        Certification date:{' '}
-                                        {formatCalendarDate(
-                                            revision.formData.rateDateCertified
-                                        )}
-                                    </p>
-                                </div>
-                            ),
-                        })
-                    }
-                })
-            }
-        })
+    const rateNames = data?.indexRates.edges.map((edge) => {
+        const revision = edge.node.revisions[0]
+        return {
+            value: revision.id,
+            label: (
+                <div style={{ lineHeight: '50%' }}>
+                    <h4>{revision.formData.rateCertificationName}</h4>
+                    <p>
+                        Programs:
+                        {programNames(
+                            statePrograms,
+                            revision.formData.rateProgramIDs
+                        ).join(', ')}
+                    </p>
+                    <p>
+                        Rating period:
+                        {formatCalendarDate(revision.formData.rateDateStart)} -{' '}
+                        {formatCalendarDate(revision.formData.rateDateEnd)}
+                    </p>
+                    <p>
+                        Certification date:
+                        {formatCalendarDate(
+                            revision.formData.rateDateCertified
+                        )}
+                    </p>
+                </div>
+            ),
+        }
+    })
 
     const onFocus: AriaOnFocus<LinkRateOptionType> = ({
         focused,
@@ -88,9 +70,9 @@ export const LinkRateSelect = ({
     }
 
     const defaultValues =
-        initialValues.length && rateNames.length
+        initialValues.length && rateNames?.length
             ? initialValues.map((rateId) => {
-                  const rateName = rateNames.find(
+                  const rateName = rateNames?.find(
                       (names) => names.value === rateId
                   )?.label.props.children[0].props.children
 

--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
@@ -38,19 +38,19 @@ export const LinkRateSelect = ({
                 <div style={{ lineHeight: '50%' }}>
                     <h4>{revision.formData.rateCertificationName}</h4>
                     <p>
-                        Programs:
+                        Programs:{' '}
                         {programNames(
                             statePrograms,
                             revision.formData.rateProgramIDs
                         ).join(', ')}
                     </p>
                     <p>
-                        Rating period:
-                        {formatCalendarDate(revision.formData.rateDateStart)} -
+                        Rating period:{' '}
+                        {formatCalendarDate(revision.formData.rateDateStart)} -{' '}
                         {formatCalendarDate(revision.formData.rateDateEnd)}
                     </p>
                     <p>
-                        Certification date:
+                        Certification date:{' '}
                         {formatCalendarDate(
                             revision.formData.rateDateCertified
                         )}

--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
@@ -1,12 +1,15 @@
 import React from 'react'
 import Select, { AriaOnFocus, Props } from 'react-select'
 import styles from '../../components/Select/Select.module.scss'
-import { useIndexRatesQuery } from '../../gen/gqlClient'
+import { StateUser, useIndexRatesQuery } from '../../gen/gqlClient'
 import { useField } from 'formik'
+import { useAuth } from '../../contexts/AuthContext'
+import { programNames } from '../../common-code/healthPlanFormDataType'
+import { formatCalendarDate } from '../../common-code/dateHelpers'
 
 export interface LinkRateOptionType {
     readonly value: string
-    readonly label: string
+    readonly label: React.ReactElement
     readonly isFixed?: boolean
     readonly isDisabled?: boolean
 }
@@ -23,17 +26,52 @@ export const LinkRateSelect = ({
 }: LinkRateSelectPropType & Props<LinkRateOptionType, true>) => {
     const [_field, _meta, helpers] = useField({ name })
     const { data, loading, error } = useIndexRatesQuery()
+    const { loggedInUser } = useAuth()
+    const user = loggedInUser as StateUser
+    const statePrograms = user.state.programs
 
     const rateNames: LinkRateOptionType[] = []
     data?.indexRates.edges
         .map((edge) => edge.node)
         .forEach((rate) => {
-            if (rate.revisions.length > 0) {
+            if (rate.revisions.length > 0.5) {
                 rate.revisions.forEach((revision) => {
                     if (revision.formData.rateCertificationName) {
                         rateNames.push({
                             value: revision.id,
-                            label: revision.formData.rateCertificationName,
+                            label: (
+                                <div style={{ lineHeight: '50%' }}>
+                                    <h4>
+                                        {
+                                            revision.formData
+                                                .rateCertificationName
+                                        }
+                                    </h4>
+                                    <p>
+                                        Programs:{' '}
+                                        {programNames(
+                                            statePrograms,
+                                            revision.formData.rateProgramIDs
+                                        ).join(', ')}
+                                    </p>
+                                    <p>
+                                        Rating period:{' '}
+                                        {formatCalendarDate(
+                                            revision.formData.rateDateStart
+                                        )}{' '}
+                                        -{' '}
+                                        {formatCalendarDate(
+                                            revision.formData.rateDateEnd
+                                        )}
+                                    </p>
+                                    <p>
+                                        Certification date:{' '}
+                                        {formatCalendarDate(
+                                            revision.formData.rateDateCertified
+                                        )}
+                                    </p>
+                                </div>
+                            ),
                         })
                     }
                 })
@@ -54,7 +92,7 @@ export const LinkRateSelect = ({
             ? initialValues.map((rateId) => {
                   const rateName = rateNames.find(
                       (names) => names.value === rateId
-                  )?.label
+                  )?.label.props.children[0].props.children
 
                   if (!rateName) {
                       return {
@@ -85,6 +123,7 @@ export const LinkRateSelect = ({
     return (
         <>
             <Select
+                menuIsOpen={true}
                 value={defaultValues}
                 className={styles.multiSelect}
                 options={error || loading ? undefined : rateNames}

--- a/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
@@ -69,7 +69,9 @@ export const LinkYourRates = ({
                                     (item: LinkRateOptionType) => {
                                         return {
                                             rateId: item.value,
-                                            rateName: item.label,
+                                            rateName:
+                                                item.label.props.children[0]
+                                                    .props.children,
                                         }
                                     }
                                 )


### PR DESCRIPTION
## Summary
This PR adds expanded rate info to the link your rates dropdown options

#### Screenshots
![image](https://github.com/Enterprise-CMCS/managed-care-review/assets/111928238/a6fdfb78-7ce6-4d7e-9a8d-b16458ac0861)

## QA guidance

Navigate to the rate details page of the form, select `Yes, this rate certification is part of another submission`, and scroll the dropdown