### PR TITLE
State can select from a list of previously submitted rates on rate details page

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.ts
@@ -11,7 +11,8 @@ type RateOrErrorType = {
 type RateOrErrorArrayType = RateOrErrorType[]
 
 async function findAllRatesWithHistoryBySubmitInfo(
-    client: PrismaTransactionType
+    client: PrismaTransactionType,
+    stateCode?: string
 ): Promise<RateOrErrorArrayType | Error> {
     try {
         const rates = await client.rateTable.findMany({
@@ -23,9 +24,13 @@ async function findAllRatesWithHistoryBySubmitInfo(
                         },
                     },
                 },
-                stateCode: {
-                    not: 'AS', // exclude test state as per ADR 019
-                },
+                stateCode: stateCode
+                    ? {
+                          equals: stateCode,
+                      }
+                    : {
+                          not: 'AS', // exclude test state as per ADR 019
+                      },
             },
             include: {
                 ...includeFullRate,

--- a/services/app-api/src/postgres/postgresStore.ts
+++ b/services/app-api/src/postgres/postgresStore.ts
@@ -123,9 +123,9 @@ type Store = {
     findAllContractsWithHistoryBySubmitInfo: () => Promise<
         ContractOrErrorArrayType | Error
     >
-    findAllRatesWithHistoryBySubmitInfo: () => Promise<
-        RateOrErrorArrayType | Error
-    >
+    findAllRatesWithHistoryBySubmitInfo: (
+        stateCode?: string
+    ) => Promise<RateOrErrorArrayType | Error>
 
     submitContract: (
         args: SubmitContractArgsType

--- a/services/app-api/src/resolvers/rate/indexRates.ts
+++ b/services/app-api/src/resolvers/rate/indexRates.ts
@@ -54,8 +54,16 @@ export function indexRatesResolver(store: Store): QueryResolvers['indexRates'] {
         const stateUser = isStateUser(user)
 
         if (adminPermissions || cmsUser || stateUser) {
-            const ratesWithHistory =
-                await store.findAllRatesWithHistoryBySubmitInfo()
+            let ratesWithHistory
+            if (stateUser) {
+                ratesWithHistory =
+                    await store.findAllRatesWithHistoryBySubmitInfo(
+                        user.stateCode
+                    )
+            } else {
+                ratesWithHistory =
+                    await store.findAllRatesWithHistoryBySubmitInfo()
+            }
             if (ratesWithHistory instanceof Error) {
                 const errMessage = `Issue finding rates with history Message: ${ratesWithHistory.message}`
                 setErrorAttributesOnActiveSpan(errMessage, span)

--- a/services/app-graphql/src/queries/indexRates.graphql
+++ b/services/app-graphql/src/queries/indexRates.graphql
@@ -75,6 +75,71 @@ query indexRates {
                             packageStatus
                         }
                     }
+                                     contractRevisions {
+                        id
+                        contract {
+                            id
+                            stateCode
+                            stateNumber
+                        }
+                        createdAt
+                        updatedAt
+                        submitInfo {
+                            updatedAt
+                            updatedBy
+                            updatedReason
+                        }
+                        unlockInfo {
+                            updatedAt
+                            updatedBy
+                            updatedReason
+                        }
+                        formData {
+                            programIDs
+                            populationCovered
+                            submissionType
+                            riskBasedContract
+                            submissionDescription
+                            stateContacts {
+                                name,
+                                titleRole
+                                email
+                            }
+                            supportingDocuments {
+                                name
+                                s3URL
+                                sha256
+                            }
+                            contractType
+                            contractExecutionStatus
+                            contractDocuments {
+                                name
+                                s3URL
+                                sha256
+                            }
+                            contractDateStart
+                            contractDateEnd
+                            managedCareEntities
+                            federalAuthorities
+                            inLieuServicesAndSettings
+                            modifiedBenefitsProvided
+                            modifiedGeoAreaServed
+                            modifiedMedicaidBeneficiaries
+                            modifiedRiskSharingStrategy
+                            modifiedIncentiveArrangements
+                            modifiedWitholdAgreements
+                            modifiedStateDirectedPayments
+                            modifiedPassThroughPayments
+                            modifiedPaymentsForMentalDiseaseInstitutions
+                            modifiedMedicalLossRatioStandards
+                            modifiedOtherFinancialPaymentIncentive
+                            modifiedEnrollmentProcess
+                            modifiedGrevienceAndAppeal
+                            modifiedNetworkAdequacyStandards
+                            modifiedLengthOfContract
+                            modifiedNonRiskPaymentArrangements
+                        }
+                    }
                 }
 
                 revisions {

--- a/services/app-graphql/src/queries/indexRates.graphql
+++ b/services/app-graphql/src/queries/indexRates.graphql
@@ -138,6 +138,8 @@ query indexRates {
                             modifiedNetworkAdequacyStandards
                             modifiedLengthOfContract
                             modifiedNonRiskPaymentArrangements
+                            statutoryRegulatoryAttestation
+                            statutoryRegulatoryAttestationDescription
                         }
                     }
                 }

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
@@ -17,7 +17,7 @@ export type UploadedDocumentsTableProps = {
     documents: SubmissionDocument[] | GenericDocument[]
     caption: string | null
     packagesWithSharedRateCerts?: SharedRateCertDisplay[] // revisit field after rates refactor
-    documentDateLookupTable: DocumentDateLookupTableType
+    documentDateLookupTable?: DocumentDateLookupTableType
     isSupportingDocuments?: boolean // delete after rates refactor
     multipleDocumentsAllowed?: boolean
     documentCategory?: string // if this prop is not included, do not show category column - delete after rates refactor
@@ -52,7 +52,11 @@ export const UploadedDocumentsTable = ({
     // dates will be undefined in lookup table we are dealing with a new initial submission
     const canDisplayDateAddedForDocument = (doc: DocumentWithS3Data) => {
         const documentLookupKey = doc.sha256
-        return documentLookupKey && documentDateLookupTable[documentLookupKey]
+        return (
+            documentLookupKey &&
+            documentDateLookupTable &&
+            documentDateLookupTable[documentLookupKey]
+        )
     }
 
     const shouldHaveNewTag = (doc: DocumentWithS3Data) => {
@@ -190,7 +194,8 @@ export const UploadedDocumentsTable = ({
                                 </td>
                             )}
                             <td>
-                                {canDisplayDateAddedForDocument(doc) ? (
+                                {canDisplayDateAddedForDocument(doc) &&
+                                documentDateLookupTable ? (
                                     dayjs(
                                         documentDateLookupTable[doc.sha256]
                                     ).format('M/D/YY')

--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
@@ -39,7 +39,7 @@ export const LinkRateSelect = ({
     const rateNames = rates.map((rate) => {
         const revision = rate.revisions[0]
         return {
-            value: revision.id,
+            value: rate.id,
             label: (
                 <>
                     <h4>{revision.formData.rateCertificationName}</h4>
@@ -119,7 +119,7 @@ export const LinkRateSelect = ({
         if (action === 'select-option') {
             const linkedRateID = newValue.value
             // const linkedRateName = newValue.label
-            const linkedRate = rates?.find((rate) => rate.id === linkedRateID)
+            const linkedRate = rates.find((rate) => rate.id === linkedRateID)
             const linkedRateForm: FormikRateForm = convertGQLRateToRateForm(
                 getKey,
                 linkedRate

--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
@@ -18,13 +18,13 @@ export interface LinkRateOptionType {
 
 export type LinkRateSelectPropType = {
     name: string
-    initialValues: string[]
+    initialValue: string | undefined
     autofill: (rateForm: FormikRateForm) => void // used for multi-rates, when called will FieldArray replace the existing form fields with new data
 }
 
 export const LinkRateSelect = ({
     name,
-    initialValues,
+    initialValue,
     autofill,
     ...selectProps
 }: LinkRateSelectPropType & Props<LinkRateOptionType, true>) => {
@@ -36,7 +36,7 @@ export const LinkRateSelect = ({
 
     const rates = data?.indexRates.edges.map((e) => e.node) || []
 
-    const rateNames = rates.map((rate) => {
+    const rateNames: LinkRateOptionType[] = rates.map((rate) => {
         const revision = rate.revisions[0]
         return {
             value: rate.id,
@@ -79,26 +79,9 @@ export const LinkRateSelect = ({
         }`
     }
 
-    const defaultValues =
-        initialValues.length && rateNames?.length
-            ? initialValues.map((rateId) => {
-                  const rateName = rateNames?.find(
-                      (names) => names.value === rateId
-                  )?.label.props.children[0].props.children
-
-                  if (!rateName) {
-                      return {
-                          value: rateId,
-                          label: 'Unknown rate',
-                      }
-                  }
-
-                  return {
-                      value: rateId,
-                      label: rateName,
-                  }
-              })
-            : []
+    const defaultValue: LinkRateOptionType | undefined = rateNames.find(
+        (rateOption) => rateOption.value === initialValue
+    )
 
     const noOptionsMessage = () => {
         if (loading) {
@@ -126,12 +109,6 @@ export const LinkRateSelect = ({
             )
             // put already selected fields back in place
             linkedRateForm.ratePreviouslySubmitted = 'YES'
-            linkedRateForm.linkedRates = [
-                {
-                    rateId: linkedRateID,
-                    rateName: 'LOOK_FOR_ME', // linkedRateName,
-                },
-            ]
 
             autofill(linkedRateForm)
         } else if (action === 'clear') {
@@ -147,7 +124,7 @@ export const LinkRateSelect = ({
     return (
         <>
             <Select
-                value={defaultValues}
+                value={defaultValue}
                 className={styles.multiSelect}
                 options={error || loading ? undefined : rateNames}
                 isSearchable

--- a/services/app-web/src/pages/LinkYourRates/LinkYourRates.stories.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkYourRates.stories.tsx
@@ -13,7 +13,13 @@ export const LinkRates = (): React.ReactElement => {
             onSubmit={(values) => console.info('submitted', values)}
         >
             <form>
-                <LinkYourRates fieldNamePrefix="rateForms.1" index={1} />
+                <LinkYourRates
+                    fieldNamePrefix="rateForms.1"
+                    index={1}
+                    autofill={() => {
+                        console.info('autofill rate')
+                    }}
+                />
             </form>
         </Formik>
     )

--- a/services/app-web/src/pages/LinkYourRates/LinkYourRates.test.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkYourRates.test.tsx
@@ -16,7 +16,11 @@ describe('LinkYourRates', () => {
                 onSubmit={(values) => console.info('submitted', values)}
             >
                 <form>
-                    <LinkYourRates fieldNamePrefix="rateForms.1" index={1} />
+                    <LinkYourRates
+                        fieldNamePrefix="rateForms.1"
+                        index={1}
+                        autofill={jest.fn()}
+                    />
                 </form>
             </Formik>,
             {
@@ -48,7 +52,11 @@ describe('LinkYourRates', () => {
                 onSubmit={(values) => console.info('submitted', values)}
             >
                 <form>
-                    <LinkYourRates fieldNamePrefix="rateForms.1" index={1} />
+                    <LinkYourRates
+                        fieldNamePrefix="rateForms.1"
+                        index={1}
+                        autofill={jest.fn()}
+                    />
                 </form>
             </Formik>,
             {
@@ -83,7 +91,11 @@ describe('LinkYourRates', () => {
                 onSubmit={(values) => console.info('submitted', values)}
             >
                 <form>
-                    <LinkYourRates fieldNamePrefix="rateForms.1" index={1} />
+                    <LinkYourRates
+                        fieldNamePrefix="rateForms.1"
+                        index={1}
+                        autofill={jest.fn()}
+                    />
                 </form>
             </Formik>,
             {

--- a/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
@@ -6,15 +6,18 @@ import styles from '../StateSubmission/StateSubmissionForm.module.scss'
 import { FieldRadio } from '../../components'
 import { getIn, useFormikContext } from 'formik'
 import { LinkRateOptionType, LinkRateSelect } from './LinkRateSelect'
+import { FormikRateForm } from '../StateSubmission/RateDetails/V2/RateDetailsV2'
 
 export type LinkYourRatesProps = {
     fieldNamePrefix: string
     index: number
+    autofill: (rateForm: FormikRateForm) => void // used for multi-rates, when called will FieldArray replace the existing form fields with new data
 }
 
 export const LinkYourRates = ({
     fieldNamePrefix,
     index,
+    autofill,
 }: LinkYourRatesProps): React.ReactElement | null => {
     const { values, setFieldValue } = useFormikContext()
 
@@ -62,6 +65,7 @@ export const LinkYourRates = ({
                         ).map((item: { rateId: string; rateName: string }) =>
                             item.rateId ? item.rateId : ''
                         )}
+                        autofill={autofill}
                         onChange={(selectedOptions) =>
                             setFieldValue(
                                 `${fieldNamePrefix}.linkedRates`,

--- a/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
@@ -5,7 +5,7 @@ import { Fieldset, FormGroup, Label } from '@trussworks/react-uswds'
 import styles from '../StateSubmission/StateSubmissionForm.module.scss'
 import { FieldRadio } from '../../components'
 import { getIn, useFormikContext } from 'formik'
-import { LinkRateOptionType, LinkRateSelect } from './LinkRateSelect'
+import { LinkRateSelect } from './LinkRateSelect'
 import { FormikRateForm } from '../StateSubmission/RateDetails/V2/RateDetailsV2'
 import { convertGQLRateToRateForm } from '../StateSubmission/RateDetails/V2/rateDetailsHelpers'
 import { useS3 } from '../../contexts/S3Context'
@@ -21,7 +21,7 @@ export const LinkYourRates = ({
     index,
     autofill,
 }: LinkYourRatesProps): React.ReactElement | null => {
-    const { values, setFieldValue } = useFormikContext()
+    const { values } = useFormikContext()
     const { getKey } = useS3()
 
     return (
@@ -74,28 +74,8 @@ export const LinkYourRates = ({
                         key={`rateOptions-${index}`}
                         inputId={`${fieldNamePrefix}.linkedRates`}
                         name={`${fieldNamePrefix}.linkedRates`}
-                        initialValues={getIn(
-                            values,
-                            `${fieldNamePrefix}.linkedRates`
-                        ).map((item: { rateId: string; rateName: string }) =>
-                            item.rateId ? item.rateId : ''
-                        )}
+                        initialValue={getIn(values, `${fieldNamePrefix}.id`)}
                         autofill={autofill}
-                        onChange={(selectedOptions) =>
-                            setFieldValue(
-                                `${fieldNamePrefix}.linkedRates`,
-                                selectedOptions.map(
-                                    (item: LinkRateOptionType) => {
-                                        return {
-                                            rateId: item.value,
-                                            rateName:
-                                                item.label.props.children[0]
-                                                    .props.children,
-                                        }
-                                    }
-                                )
-                            )
-                        }
                     />
                 </>
             )}

--- a/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
@@ -7,6 +7,8 @@ import { FieldRadio } from '../../components'
 import { getIn, useFormikContext } from 'formik'
 import { LinkRateOptionType, LinkRateSelect } from './LinkRateSelect'
 import { FormikRateForm } from '../StateSubmission/RateDetails/V2/RateDetailsV2'
+import { convertGQLRateToRateForm } from '../StateSubmission/RateDetails/V2/rateDetailsHelpers'
+import { useS3 } from '../../contexts/S3Context'
 
 export type LinkYourRatesProps = {
     fieldNamePrefix: string
@@ -20,6 +22,7 @@ export const LinkYourRates = ({
     autofill,
 }: LinkYourRatesProps): React.ReactElement | null => {
     const { values, setFieldValue } = useFormikContext()
+    const { getKey } = useS3()
 
     return (
         <FormGroup data-testid="link-your-rates">
@@ -36,6 +39,12 @@ export const LinkYourRates = ({
                     name={`${fieldNamePrefix}.ratePreviouslySubmitted`}
                     label="No, this rate certification was not included with any other submissions"
                     value={'NO'}
+                    onChange={() => {
+                        // when someone picks an option, reset the form
+                        const emptyRateForm = convertGQLRateToRateForm(getKey)
+                        emptyRateForm.ratePreviouslySubmitted = 'NO'
+                        autofill(emptyRateForm)
+                    }}
                     aria-required
                 />
                 <FieldRadio
@@ -43,6 +52,12 @@ export const LinkYourRates = ({
                     name={`${fieldNamePrefix}.ratePreviouslySubmitted`}
                     label="Yes, this rate certification is part of another submission"
                     value={'YES'}
+                    onChange={() => {
+                        // when someone picks an option, reset the form
+                        const emptyRateForm = convertGQLRateToRateForm(getKey)
+                        emptyRateForm.ratePreviouslySubmitted = 'YES'
+                        autofill(emptyRateForm)
+                    }}
                     aria-required
                 />
             </Fieldset>

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.test.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.test.ts
@@ -1,0 +1,67 @@
+import { RateDetailsFormSchema } from "./RateDetailsSchema"
+
+describe('RateDetailsSchema', () => {
+    
+    it('Skips validating previously submitted rates', async () => {
+        
+        const badRateRev = {
+            rateForms: [
+                {
+                    id: 'fooba',
+                    rateType: 'NEW',
+                    rateDocuments: [],
+                    supportingDocuments: [],
+                    ratePreviouslySubmitted: 'YES',
+                }
+            ]
+        }
+
+        const res = await RateDetailsFormSchema({'link-rates': true}).validate(badRateRev, {abortEarly: false})
+        expect(res.rateForms?.[0].ratePreviouslySubmitted).toBe('YES')
+    })
+
+    it('checks child rates', async () => {
+        
+        const badRateRev = {
+            rateForms: [
+                {
+                    id: 'fooba',
+                    rateType: 'NEW',
+                    rateDocuments: [],
+                    supportingDocuments: [],
+                    ratePreviouslySubmitted: 'NO',
+                }
+            ]
+        }
+
+        try {
+            await RateDetailsFormSchema({'link-rates': true}).validate(badRateRev, {abortEarly: false})
+        } catch (err) {
+            return
+        }
+
+        expect('Validator should have errored in this case').toBeUndefined()
+    })
+
+    it('checks unspecified rates', async () => {
+        
+        const badRateRev = {
+            rateForms: [
+                {
+                    id: 'fooba',
+                    rateType: 'NEW',
+                    rateDocuments: [],
+                    supportingDocuments: [],
+                }
+            ]
+        }
+
+        try {
+            await RateDetailsFormSchema({'link-rates': true}).validate(badRateRev, {abortEarly: false})
+        } catch (err) {
+            return
+        }
+
+        expect('Validator should have errored in this case').toBeUndefined()
+    })
+})

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
@@ -9,136 +9,138 @@ import {
 
 Yup.addMethod(Yup.date, 'validateDateFormat', validateDateFormat)
 
-// TODO - make the schema ignore linked rates for validation - needs a creative use of yup.when  - maybe Yup.addMethod whenChildRate or something like that
 const SingleRateCertSchema = (_activeFeatureFlags: FeatureFlagSettings) =>
-    Yup.object().shape({
-        ratePreviouslySubmitted: _activeFeatureFlags['rate-edit-unlock'] || _activeFeatureFlags['link-rates']? Yup.string().defined(
-            "You must select yes or no "
-        ) : Yup.string(),
-        rateDocuments: validateFileItemsListSingleUpload({ required: true }),
-        supportingDocuments: validateFileItemsList({ required: false }),
-        hasSharedRateCert:  _activeFeatureFlags['rate-edit-unlock'] || _activeFeatureFlags['link-rates']?  Yup.string(): Yup.string().defined('You must select yes or no'),
-        packagesWithSharedRateCerts: _activeFeatureFlags['rate-edit-unlock'] || _activeFeatureFlags['link-rates']? Yup.array().optional():  Yup.array()
-        .when('hasSharedRateCert', {
-            is: 'YES',
-            then: Yup.array().min(
-                1,
-                'You must select at least one submission'
-            ),
-        })
-        .required(),
-        rateProgramIDs: Yup.array(
-        ).min(1, 'You must select a program'),
-        rateType: Yup.string().defined(
-            'You must choose a rate certification type'
-        ),
-        rateCapitationType: Yup.string().defined(
-            "You must select whether you're certifying rates or rate ranges"
-        ),
-        rateDateStart: Yup.date().when('rateType', (contractType) => {
-            if (contractType) {
-                return (
-                    Yup.date()
-                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                        // @ts-ignore-next-line
-                        .validateDateFormat('YYYY-MM-DD', true)
-                        .defined('You must enter a start date')
-                        .typeError(
-                            'The start date must be in MM/DD/YYYY format'
-                        )
-                )
-            }
-        }),
-        rateDateEnd: Yup.date().when('rateType', (rateType) => {
-            if (rateType) {
-                return (
-                    Yup.date()
-                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                        // @ts-ignore-next-line
-                        .validateDateFormat('YYYY-MM-DD', true)
-                        .defined('You must enter an end date')
-                        .typeError('The end date must be in MM/DD/YYYY format')
-                        .when(
-                            // RateDateEnd must be at minimum the day after Start
-                            'rateDateStart',
-                            (rateDateStart: Date, schema: Yup.DateSchema) => {
-                                const startDate = dayjs(rateDateStart)
-                                if (startDate.isValid()) {
-                                    return schema.min(
-                                        startDate.add(1, 'day'),
-                                        'The end date must come after the start date'
-                                    )
-                                }
-                            }
-                        )
-                )
-            }
-        }),
-        rateDateCertified: Yup.date().when('rateType', (rateType) => {
-            if (rateType) {
-                return (
-                    Yup.date()
-                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                        // @ts-ignore-next-line
-                        .validateDateFormat('YYYY-MM-DD', true)
-                        .defined(
-                            'You must enter the date the document was certified'
-                        )
-                        .typeError(
-                            'The certified date must be in MM/DD/YYYY format'
-                        )
-                )
-            }
-        }),
-        effectiveDateStart: Yup.date().when('rateType', {
-            is: 'AMENDMENT',
-            then: Yup.date()
-                .nullable()
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore-next-line
-                .validateDateFormat('YYYY-MM-DD', true)
-                .defined('You must enter a start date')
-                .typeError('The start date must be in MM/DD/YYYY format'),
-        }),
-        effectiveDateEnd: Yup.date().when('rateType', {
-            is: 'AMENDMENT',
-            then: Yup.date()
-                .nullable()
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore-next-line
-                .validateDateFormat('YYYY-MM-DD', true)
-                .defined('You must enter an end date')
-                .typeError('The end date must be in MM/DD/YYYY format')
-                .min(
-                    Yup.ref('effectiveDateStart'),
-                    'The end date must come after the start date'
+    Yup.object().when('.ratePreviouslySubmitted', {
+        // this first when is skipping all validations for a previously submitted rate.
+        is: 'YES',
+        otherwise: Yup.object().shape({
+            ratePreviouslySubmitted: _activeFeatureFlags['rate-edit-unlock'] || _activeFeatureFlags['link-rates']? Yup.string().defined(
+                "You must select yes or no "
+            ) : Yup.string(),
+            rateDocuments: validateFileItemsListSingleUpload({ required: true }),
+            supportingDocuments: validateFileItemsList({ required: false }),
+            hasSharedRateCert:  _activeFeatureFlags['rate-edit-unlock'] || _activeFeatureFlags['link-rates']?  Yup.string(): Yup.string().defined('You must select yes or no'),
+            packagesWithSharedRateCerts: _activeFeatureFlags['rate-edit-unlock'] || _activeFeatureFlags['link-rates']? Yup.array().optional():  Yup.array()
+            .when('hasSharedRateCert', {
+                is: 'YES',
+                then: Yup.array().min(
+                    1,
+                    'You must select at least one submission'
                 ),
-        }),
-        actuaryContacts: Yup.array().of(
-            Yup.object().shape({
-                name: Yup.string().required('You must provide a name'),
-                titleRole: Yup.string().required(
-                    'You must provide a title/role'
-                ),
-                email: Yup.string()
-                    .email('You must enter a valid email address')
-                    .required('You must provide an email address'),
-                actuarialFirm: Yup.string()
-                    .required('You must select an actuarial firm')
-                    .nullable(),
-                actuarialFirmOther: Yup.string()
-                    .when('actuarialFirm', {
-                        is: 'OTHER',
-                        then: Yup.string()
-                            .required('You must enter a description')
-                            .nullable(),
-                    })
-                    .nullable(),
             })
-        ),
-        actuaryCommunicationPreference: Yup.string().optional(),
+            .required(),
+            rateProgramIDs: Yup.array(
+            ).min(1, 'You must select a program'),
+            rateType: Yup.string().defined(
+                'You must choose a rate certification type'
+            ),
+            rateCapitationType: Yup.string().defined(
+                "You must select whether you're certifying rates or rate ranges"
+            ),
+            rateDateStart: Yup.date().when('rateType', (contractType) => {
+                if (contractType) {
+                    return (
+                        Yup.date()
+                            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                            // @ts-ignore-next-line
+                            .validateDateFormat('YYYY-MM-DD', true)
+                            .defined('You must enter a start date')
+                            .typeError(
+                                'The start date must be in MM/DD/YYYY format'
+                            )
+                    )
+                }
+            }),
+            rateDateEnd: Yup.date().when('rateType', (rateType) => {
+                if (rateType) {
+                    return (
+                        Yup.date()
+                            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                            // @ts-ignore-next-line
+                            .validateDateFormat('YYYY-MM-DD', true)
+                            .defined('You must enter an end date')
+                            .typeError('The end date must be in MM/DD/YYYY format')
+                            .when(
+                                // RateDateEnd must be at minimum the day after Start
+                                'rateDateStart',
+                                (rateDateStart: Date, schema: Yup.DateSchema) => {
+                                    const startDate = dayjs(rateDateStart)
+                                    if (startDate.isValid()) {
+                                        return schema.min(
+                                            startDate.add(1, 'day'),
+                                            'The end date must come after the start date'
+                                        )
+                                    }
+                                }
+                            )
+                    )
+                }
+            }),
+            rateDateCertified: Yup.date().when('rateType', (rateType) => {
+                if (rateType) {
+                    return (
+                        Yup.date()
+                            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                            // @ts-ignore-next-line
+                            .validateDateFormat('YYYY-MM-DD', true)
+                            .defined(
+                                'You must enter the date the document was certified'
+                            )
+                            .typeError(
+                                'The certified date must be in MM/DD/YYYY format'
+                            )
+                    )
+                }
+            }),
+            effectiveDateStart: Yup.date().when('rateType', {
+                is: 'AMENDMENT',
+                then: Yup.date()
+                    .nullable()
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-ignore-next-line
+                    .validateDateFormat('YYYY-MM-DD', true)
+                    .defined('You must enter a start date')
+                    .typeError('The start date must be in MM/DD/YYYY format'),
+            }),
+            effectiveDateEnd: Yup.date().when('rateType', {
+                is: 'AMENDMENT',
+                then: Yup.date()
+                    .nullable()
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-ignore-next-line
+                    .validateDateFormat('YYYY-MM-DD', true)
+                    .defined('You must enter an end date')
+                    .typeError('The end date must be in MM/DD/YYYY format')
+                    .min(
+                        Yup.ref('effectiveDateStart'),
+                        'The end date must come after the start date'
+                    ),
+            }),
+            actuaryContacts: Yup.array().of(
+                Yup.object().shape({
+                    name: Yup.string().required('You must provide a name'),
+                    titleRole: Yup.string().required(
+                        'You must provide a title/role'
+                    ),
+                    email: Yup.string()
+                        .email('You must enter a valid email address')
+                        .required('You must provide an email address'),
+                    actuarialFirm: Yup.string()
+                        .required('You must select an actuarial firm')
+                        .nullable(),
+                    actuarialFirmOther: Yup.string()
+                        .when('actuarialFirm', {
+                            is: 'OTHER',
+                            then: Yup.string()
+                                .required('You must enter a description')
+                                .nullable(),
+                        })
+                        .nullable(),
+                })
+            ),
+            actuaryCommunicationPreference: Yup.string().optional(),
+        })
     })
-
 
 const RateDetailsFormSchema = (activeFeatureFlags?: FeatureFlagSettings) => {
     return activeFeatureFlags?.['rate-edit-unlock'] ||  activeFeatureFlags?.['link-rates'] ?

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
@@ -9,6 +9,7 @@ import {
 
 Yup.addMethod(Yup.date, 'validateDateFormat', validateDateFormat)
 
+// TODO - make the schema ignore linked rates for validation - needs a creative use of yup.when  - maybe Yup.addMethod whenChildRate or something like that
 const SingleRateCertSchema = (_activeFeatureFlags: FeatureFlagSettings) =>
     Yup.object().shape({
         rateDocuments: validateFileItemsListSingleUpload({ required: true }),

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/LinkedRateSummary.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/LinkedRateSummary.tsx
@@ -1,0 +1,70 @@
+import { formatCalendarDate } from '../../../../common-code/dateHelpers'
+import {
+    DataDetail,
+    DataDetailMissingField,
+    DoubleColumnGrid,
+    SectionCard,
+    UploadedDocumentsTable,
+} from '../../../../components'
+import { FormikRateForm } from './RateDetailsV2'
+import { useStatePrograms } from '../../../../hooks'
+import { formatDocumentsForGQL } from '../../../../formHelpers/formatters'
+
+export const LinkedRateSummary = ({
+    rateForm,
+}: {
+    rateForm: FormikRateForm
+}): React.ReactElement | null => {
+    const statePrograms = useStatePrograms()
+
+    return (
+        <SectionCard id={`linked-rate-${rateForm.id}`} key={rateForm.id}>
+            <h3 aria-label={`Rate ID: ${rateForm.rateCertificationName}`}>
+                {rateForm.rateCertificationName}
+            </h3>
+            <dl>
+                <DoubleColumnGrid>
+                    <DataDetail
+                        id="submissionDate"
+                        label="Submission date"
+                        children={formatCalendarDate(
+                            rateForm.rateDateCertified
+                        )}
+                    />
+
+                    <DataDetail
+                        id="ratePrograms"
+                        label="Programs this rate certification covers"
+                        children={statePrograms
+                            .filter((p) =>
+                                rateForm.rateProgramIDs.includes(p.id)
+                            )
+                            .map((p) => p.name)}
+                    />
+                    <DataDetail
+                        id="ratingPeriod"
+                        label="Rating period"
+                        children={
+                            rateForm.rateDateStart && rateForm.rateDateEnd ? (
+                                `${formatCalendarDate(
+                                    rateForm?.rateDateStart
+                                )} to ${formatCalendarDate(
+                                    rateForm?.rateDateEnd
+                                )}`
+                            ) : (
+                                <DataDetailMissingField />
+                            )
+                        }
+                    />
+                </DoubleColumnGrid>
+            </dl>
+            <UploadedDocumentsTable
+                documents={formatDocumentsForGQL(rateForm.rateDocuments)}
+                multipleDocumentsAllowed={false}
+                caption="Rate certification"
+                documentCategory="Rate certification"
+                isSubmitted={true}
+            />
+        </SectionCard>
+    )
+}

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -47,7 +47,6 @@ import {
     convertGQLRateToRateForm,
     convertRateFormToGQLRateFormData,
     generateUpdatedRates,
-    isLinkedRateForm,
 } from './rateDetailsHelpers'
 import { LinkYourRates } from '../../../LinkYourRates/LinkYourRates'
 import { LinkedRateSummary } from './LinkedRateSummary'
@@ -457,15 +456,18 @@ const RateDetailsV2 = ({
                                                                     />
                                                                 )}
 
-                                                                {isLinkedRateForm(
-                                                                    rateForm
-                                                                ) ? (
-                                                                    <LinkedRateSummary
-                                                                        rateForm={
-                                                                            rateForm
-                                                                        }
-                                                                    />
-                                                                ) : (
+                                                                {rateForm.ratePreviouslySubmitted ===
+                                                                    'YES' &&
+                                                                    rateForm.id && (
+                                                                        <LinkedRateSummary
+                                                                            rateForm={
+                                                                                rateForm
+                                                                            }
+                                                                        />
+                                                                    )}
+
+                                                                {rateForm.ratePreviouslySubmitted ===
+                                                                    'NO' && (
                                                                     <SingleRateFormFields
                                                                         rateForm={
                                                                             rateForm

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -47,6 +47,7 @@ import {
     convertGQLRateToRateForm,
     convertRateFormToGQLRateFormData,
     generateUpdatedRates,
+    isLinkedRateForm,
 } from './rateDetailsHelpers'
 import { LinkYourRates } from '../../../LinkYourRates/LinkYourRates'
 import { LinkedRateSummary } from './LinkedRateSummary'
@@ -442,19 +443,18 @@ const RateDetailsV2 = ({
                                                                         }
                                                                         autofill={(
                                                                             rateForm: FormikRateForm
-                                                                        ) =>
-                                                                            replace(
+                                                                        ) => {
+                                                                            return replace(
                                                                                 index,
                                                                                 rateForm
                                                                             )
-                                                                        }
+                                                                        }}
                                                                     />
                                                                 )}
 
-                                                                {rateForm.status ===
-                                                                    'SUBMITTED' ||
-                                                                rateForm.status ===
-                                                                    'RESUBMITTED' ? (
+                                                                {isLinkedRateForm(
+                                                                    rateForm
+                                                                ) ? (
                                                                     <LinkedRateSummary
                                                                         rateForm={
                                                                             rateForm

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -49,10 +49,12 @@ import {
     generateUpdatedRates,
 } from './rateDetailsHelpers'
 import { LinkYourRates } from '../../../LinkYourRates/LinkYourRates'
+import { LinkedRateSummary } from './LinkedRateSummary'
 
 export type FormikRateForm = {
     id?: string // no id if its a new rate
     status?: HealthPlanPackageStatus // need to track status to know if this is a direct child or linked rate
+    rateCertificationName?: string // need to know rate name if this rate is a linked rate
     rateType: RateRevision['formData']['rateType']
     rateCapitationType: RateRevision['formData']['rateCapitationType']
     rateDateStart: RateRevision['formData']['rateDateStart']
@@ -410,10 +412,11 @@ const RateDetailsV2 = ({
                                         {({
                                             remove,
                                             push,
+                                            replace,
                                         }: FieldArrayRenderProps) => (
                                             <>
                                                 {rateForms.map(
-                                                    (rate, index = 0) => (
+                                                    (rateForm, index = 0) => (
                                                         <SectionCard
                                                             key={index}
                                                         >
@@ -437,26 +440,45 @@ const RateDetailsV2 = ({
                                                                         index={
                                                                             index
                                                                         }
+                                                                        autofill={(
+                                                                            rateForm: FormikRateForm
+                                                                        ) =>
+                                                                            replace(
+                                                                                index,
+                                                                                rateForm
+                                                                            )
+                                                                        }
                                                                     />
                                                                 )}
 
-                                                                <SingleRateFormFields
-                                                                    rateForm={
-                                                                        rate
-                                                                    }
-                                                                    index={
-                                                                        index
-                                                                    }
-                                                                    shouldValidate={
-                                                                        shouldValidate
-                                                                    }
-                                                                    previousDocuments={
-                                                                        previousDocuments
-                                                                    }
-                                                                    fieldNamePrefix={fieldNamePrefix(
-                                                                        index
-                                                                    )}
-                                                                />
+                                                                {rateForm.status ===
+                                                                    'SUBMITTED' ||
+                                                                rateForm.status ===
+                                                                    'RESUBMITTED' ? (
+                                                                    <LinkedRateSummary
+                                                                        rateForm={
+                                                                            rateForm
+                                                                        }
+                                                                    />
+                                                                ) : (
+                                                                    <SingleRateFormFields
+                                                                        rateForm={
+                                                                            rateForm
+                                                                        }
+                                                                        index={
+                                                                            index
+                                                                        }
+                                                                        fieldNamePrefix={fieldNamePrefix(
+                                                                            index
+                                                                        )}
+                                                                        shouldValidate={
+                                                                            shouldValidate
+                                                                        }
+                                                                        previousDocuments={
+                                                                            previousDocuments
+                                                                        }
+                                                                    />
+                                                                )}
                                                                 {index >= 1 &&
                                                                     !displayAsStandaloneRate && (
                                                                         <Button

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -69,13 +69,7 @@ export type FormikRateForm = {
     addtlActuaryContacts: RateRevision['formData']['addtlActuaryContacts']
     actuaryCommunicationPreference: RateRevision['formData']['actuaryCommunicationPreference']
     packagesWithSharedRateCerts: RateRevision['formData']['packagesWithSharedRateCerts']
-    linkedRates: linkedRatesDisplay[]
     ratePreviouslySubmitted?: 'YES' | 'NO'
-}
-
-export type linkedRatesDisplay = {
-    rateId?: string
-    rateName?: string
 }
 
 // We have a list of rates to enable multi-rate behavior

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/SingleRateFormFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/SingleRateFormFields.tsx
@@ -26,7 +26,6 @@ import { useS3 } from '../../../../contexts/S3Context'
 import { FormikErrors, getIn, useFormikContext } from 'formik'
 import { ActuaryContactFields } from '../../Contacts'
 import { FormikRateForm, RateDetailFormConfig } from './RateDetailsV2'
-
 const isRateTypeEmpty = (rateForm: FormikRateForm): boolean =>
     rateForm.rateType === undefined
 const isRateTypeAmendment = (rateForm: FormikRateForm): boolean =>
@@ -47,6 +46,7 @@ type SingleRateFormFieldsProps = {
     index: number // defaults to 0
     fieldNamePrefix: string // formik field name prefix - used for looking up values and errors in Formik FieldArray
     previousDocuments: string[] // this only passed in to ensure S3 deleteFile doesn't remove valid files for previous revision
+    autofill?: (rateForm: FormikRateForm) => void // used for multi-rates, when called will FieldArray replace the existing form fields with new data
 }
 
 const RateDatesErrorMessage = ({
@@ -80,10 +80,10 @@ export const SingleRateFormFields = ({
     shouldValidate,
     index = 0,
     previousDocuments,
+    fieldNamePrefix,
 }: SingleRateFormFieldsProps): React.ReactElement => {
     // page level setup
     const { handleDeleteFile, handleUploadFile, handleScanFile } = useS3()
-    const fieldNamePrefix = `rateForms.${index}`
     const { errors, setFieldValue } = useFormikContext<RateDetailFormConfig>()
 
     const showFieldErrors = (
@@ -91,9 +91,6 @@ export const SingleRateFormFields = ({
     ): string | undefined => {
         if (!shouldValidate) return undefined
         return getIn(errors, `${fieldNamePrefix}.${fieldName}`)
-    }
-    if (rateForm.status === 'SUBMITTED' || rateForm.status === 'RESUBMITTED') {
-        return <div>This is a Linked Rate. UI forthcoming</div>
     }
 
     return (

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.test.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.test.ts
@@ -8,8 +8,8 @@ describe('generateUpdatedRates', () => {
         {
             testValue:  [{
                 ...emptyRateForm(),
-                status: 'DRAFT'
-
+                status: 'DRAFT',
+                ratePreviouslySubmitted: 'NO',
             }] as FormikRateForm[],
             testName: 'create brand new rate',
             expectedResult: {type:'CREATE', formData: emptyRateForm(), rateID: undefined}},
@@ -17,23 +17,29 @@ describe('generateUpdatedRates', () => {
             testValue:  [{
                 ...emptyRateForm(),
                 id: 'new-child-rate-being-edited',
-                status: 'DRAFT'}]  as FormikRateForm[],
-                testName: 'edit unsubmitted child rate',
-                expectedResult: {type:'UPDATE', formData: emptyRateForm(), rateID: 'new-child-rate-being-edited',} ,
+                status: 'DRAFT',
+                ratePreviouslySubmitted: 'NO',
+            }]  as FormikRateForm[],
+            testName: 'edit unsubmitted child rate',
+            expectedResult: {type:'UPDATE', formData: emptyRateForm(), rateID: 'new-child-rate-being-edited',} ,
         } ,
         {
             testValue:  [{
                 ...emptyRateForm(),
                 id: 'existing-child-rate',
-                status: 'UNLOCKED'}]  as FormikRateForm[],
-                testName: 'edit unlocked child rate',
+                status: 'UNLOCKED',
+                ratePreviouslySubmitted: 'NO',
+            }]  as FormikRateForm[],
+            testName: 'edit unlocked child rate',
             expectedResult: {type:'UPDATE', formData: emptyRateForm(), rateID: 'existing-child-rate' } ,
         },
         {
             testValue: [{
                 ...emptyRateForm(),
                 id: 'existing-linked-rate1',
-                status: 'SUBMITTED'}]  as FormikRateForm[],
+                status: 'SUBMITTED',
+                ratePreviouslySubmitted: 'YES',
+            }]  as FormikRateForm[],
             testName: 'link submitted rate',
             expectedResult: {type:'LINK', rateID:'existing-linked-rate1', formData: undefined } ,
         },
@@ -41,8 +47,10 @@ describe('generateUpdatedRates', () => {
             testValue: [{
                 ...emptyRateForm(),
                 id: 'existing-linked-rate2',
-                status: 'RESUBMITTED'}]  as FormikRateForm[],
-                testName: 'link resubmitted rate',
+                status: 'RESUBMITTED',
+                ratePreviouslySubmitted: 'YES',
+            }]  as FormikRateForm[],
+            testName: 'link resubmitted rate',
             expectedResult: {type:'LINK', rateID: 'existing-linked-rate2', formData: undefined} ,
         },
     ]

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
@@ -41,6 +41,7 @@ const convertRateFormToGQLRateFormData = (
     rateForm: FormikRateForm
 ): RateFormData => {
     return {
+        // intentionally do not map backend calculated fields on submit such status and rateCertificationName
         rateType: rateForm.rateType,
         rateCapitationType: rateForm.rateCapitationType,
         rateDocuments: formatDocumentsForGQL(rateForm.rateDocuments),
@@ -72,8 +73,9 @@ const convertGQLRateToRateForm = (getKey: S3ClientT['getKey'], rate?: Rate): For
     return {
         id: rate?.id,
         status: rate?.status,
-        rateType: rateForm?.rateType ?? undefined, // keep null collaescing types for radio buttons to ensure error messages work properly
-        rateCapitationType: rateForm?.rateCapitationType ?? undefined, // keep null collaescing types for radio buttons to ensure error messages work properly
+        rateCertificationName: rateForm?.rateCertificationName ?? undefined,
+        rateType: rateForm?.rateType,
+        rateCapitationType: rateForm?.rateCapitationType,
         rateDateStart: formatForForm(rateForm?.rateDateStart),
         rateDateEnd: formatForForm(rateForm?.rateDateEnd),
         rateDateCertified: formatForForm(rateForm?.rateDateCertified),

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
@@ -20,12 +20,13 @@ const generateUpdatedRates = (
 ): UpdateContractRateInput[] => {
     const updatedRates: UpdateContractRateInput[] = newRateForms.map((form) => {
         const { id, ...rateFormData } = form
+        const isLinkedRate = form.ratePreviouslySubmitted === 'YES'
         return {
-            formData: form.ratePreviouslySubmitted
+            formData: isLinkedRate
                 ? undefined
                 : convertRateFormToGQLRateFormData(rateFormData),
             rateID: id,
-            type: form.ratePreviouslySubmitted ? 'LINK' : !id ? 'CREATE' : 'UPDATE',
+            type: isLinkedRate ? 'LINK' : !id ? 'CREATE' : 'UPDATE',
         }
     })
 

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
@@ -110,7 +110,7 @@ const convertGQLRateToRateForm = (getKey: S3ClientT['getKey'], rate?: Rate): For
     }
 }
 
-const isLinkedRateForm = (rateForm: FormikRateForm): boolean => rateForm.status === "SUBMITTED" || rateForm.status === "RESUBMITTED"
+const isLinkedRateForm = (rateForm: FormikRateForm): boolean => isStatusSubmitted(rateForm.status)
 
 export {
     convertGQLRateToRateForm,

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
@@ -100,7 +100,6 @@ const convertGQLRateToRateForm = (getKey: S3ClientT['getKey'], rate?: Rate): For
             rateForm?.actuaryCommunicationPreference?? undefined,
         packagesWithSharedRateCerts:
             rateForm?.packagesWithSharedRateCerts ?? [],
-        linkedRates: [],
         ratePreviouslySubmitted: handleAsLinkedRate? 'YES' : rateForm ? 'NO' : undefined
     }
 }

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContactsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContactsSummarySectionV2.tsx
@@ -12,7 +12,7 @@ import {
     DataDetailContactField,
 } from '../../../../../components/DataDetail'
 import { SectionCard } from '../../../../../components/SectionCard'
-import { Contract } from '../../../../../gen/gqlClient'
+import { Contract, RateRevision } from '../../../../../gen/gqlClient'
 
 export type ContactsSummarySectionProps = {
     contract: Contract
@@ -43,9 +43,14 @@ export const ContactsSummarySection = ({
     const contractFormData =
         contract.draftRevision?.formData ||
         contract.packageSubmissions[0].contractRevision.formData
-    const rateRev = contract.draftRates
-        ? contract.draftRates[0].draftRevision
-        : contract.packageSubmissions[0].rateRevisions[0]
+
+    let rateRev: RateRevision | undefined = undefined
+    if (contractFormData.submissionType === 'CONTRACT_AND_RATES') {
+        rateRev =
+            (contract.draftRates
+                ? contract.draftRates[0].draftRevision
+                : contract.packageSubmissions[0].rateRevisions[0]) || undefined
+    }
     return (
         <SectionCard id="stateContacts" className={styles.summarySection}>
             <SectionHeader

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
@@ -116,8 +116,13 @@ export const RateDetailsSummarySectionV2 = ({
     const getRateFormData = (rate: Rate | RateRevision): RateFormData => {
         const isRateRev = 'formData' in rate
         if (!isRateRev) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            return rate.draftRevision!.formData
+            // TODO: make this support an unlocked child rate.
+            if (rate.status === 'DRAFT') {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                return rate.draftRevision!.formData
+            } else {
+                return rate.revisions[0].formData
+            }
         } else {
             return rate.formData
         }


### PR DESCRIPTION
## Summary

**Still to do for demo**:  
- [ ] Get `LinkRateSummary` to totally match Figma design specs
- [ ] Test "Continue"  when adding a combination of child rates and linked rates
- [ ] Test "Continue" when removing linked rates and / or child rates and then continuing 

**Not needed for demo but blockers for turning on Linked Rates for Production :**
- [ ] adjust single rate schema to ensure we never validate on linked rates (after all, this could prevent submission without the user knowing why is our submitted rates lack fields that are now required in the form validation
- [ ] add caching to indexRates call
- [ ] tests in place for linked rates both jest and cypress
_^ we need Jira tickets for this work or add to AC of remaining tickets_ 

**Notes on significant code changes:**
- adjusted `indexRates` to only return state user's state when a state user hits this API
- adjusted `LinkRateSelect`  to be a single select (not multi select)
- as soon as linked rate selected, override content in that  `rateForm` use the linked rate info instead. FieldArray `replace` will allow autofill of that linked rate. as soon as linked rate is cleared, clear the autofilled form data and go back to an empty `rateForm` 
- added `LinkRateSummary` to display instead of the form when there's a linked rate

#### Related issues
https://jiraent.cms.gov/browse/MCR-3900

#### Screenshots

#### Test cases covered
None yet.

## QA guidance
- I recommend testing this with a combination of adding and removing multiple rates, including  also adding both child rates and linked rates and removing each and hitting "Continue".