### PR TITLE
rate name fix

### DIFF
--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
@@ -35,27 +35,32 @@ export const LinkRateSelect = ({
         return {
             value: revision.id,
             label: (
-                <div style={{ lineHeight: '50%' }}>
+                <>
                     <h4>{revision.formData.rateCertificationName}</h4>
-                    <p>
-                        Programs:{' '}
-                        {programNames(
-                            statePrograms,
-                            revision.formData.rateProgramIDs
-                        ).join(', ')}
-                    </p>
-                    <p>
-                        Rating period:{' '}
-                        {formatCalendarDate(revision.formData.rateDateStart)} -{' '}
-                        {formatCalendarDate(revision.formData.rateDateEnd)}
-                    </p>
-                    <p>
-                        Certification date:{' '}
-                        {formatCalendarDate(
-                            revision.formData.rateDateCertified
-                        )}
-                    </p>
-                </div>
+                    <div style={{ lineHeight: '50%' }}>
+                        <p>
+                            Programs:{' '}
+                            {programNames(
+                                statePrograms,
+                                revision.formData.rateProgramIDs
+                            ).join(', ')}
+                        </p>
+                        <p>
+                            Rating period:{' '}
+                            {formatCalendarDate(
+                                revision.formData.rateDateStart
+                            )}{' '}
+                            -{' '}
+                            {formatCalendarDate(revision.formData.rateDateEnd)}
+                        </p>
+                        <p>
+                            Certification date:{' '}
+                            {formatCalendarDate(
+                                revision.formData.rateDateCertified
+                            )}
+                        </p>
+                    </div>
+                </>
             ),
         }
     })

--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
@@ -39,22 +39,21 @@ export const LinkRateSelect = ({
                     <h4>{revision.formData.rateCertificationName}</h4>
                     <div style={{ lineHeight: '50%' }}>
                         <p>
-                            Programs:{' '}
+                            Programs:&nbsp;
                             {programNames(
                                 statePrograms,
                                 revision.formData.rateProgramIDs
                             ).join(', ')}
                         </p>
                         <p>
-                            Rating period:{' '}
+                            Rating period:&nbsp;
                             {formatCalendarDate(
                                 revision.formData.rateDateStart
-                            )}{' '}
-                            -{' '}
-                            {formatCalendarDate(revision.formData.rateDateEnd)}
+                            )}
+                            -{formatCalendarDate(revision.formData.rateDateEnd)}
                         </p>
                         <p>
-                            Certification date:{' '}
+                            Certification date:&nbsp;
                             {formatCalendarDate(
                                 revision.formData.rateDateCertified
                             )}


### PR DESCRIPTION
## Summary
Quick fix for the rate name being displayed in the dropdown

#### Screenshots
Before:
![image](https://github.com/Enterprise-CMCS/managed-care-review/assets/111928238/076101e5-90a9-4788-b7fc-b22da838e5c7)

After:
![image](https://github.com/Enterprise-CMCS/managed-care-review/assets/111928238/55291f40-15d5-455a-8560-7a52486d227b)

