### PR TITLE
[MCR-3886] Display the shared rate UI on historic submissions

### DIFF
--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.test.tsx
@@ -754,6 +754,103 @@ describe('RateDetailsSummarySection', () => {
         ).toBeNull()
     })
 
+    it('renders all necessary information for documents with shared rate certifications', async () => {
+        const draftContract = mockContractPackageDraft()
+        if (
+            draftContract.draftRevision &&
+            draftContract.draftRates &&
+            draftContract.draftRates[0].draftRevision
+        ) {
+            draftContract.draftRates[0].draftRevision.formData.packagesWithSharedRateCerts =
+                [
+                    {
+                        packageId: '333b4225-5b49-4e82-aa71-be0d33d7418d',
+                        packageName: 'MCR-MN-0001-SNBC',
+                    },
+                    {
+                        packageId: '21467dba-6ae8-11ed-a1eb-0242ac120002',
+                        packageName: 'MCR-MN-0002-PMAP',
+                    },
+                ]
+        }
+
+        renderWithProviders(
+            <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
+                contract={draftContract}
+                editNavigateTo="rate-details"
+                submissionName="MN-PMAP-0001"
+                statePrograms={statePrograms}
+            />,
+            {
+                apolloProvider,
+            }
+        )
+        await waitFor(() => {
+            const rateDocsTable = screen.getByRole('table', {
+                name: /Rate certification/,
+            })
+            // has shared tag
+            expect(within(rateDocsTable).getByTestId('tag').textContent).toBe(
+                'SHARED'
+            )
+            // table has 'linked submissions' column
+            expect(
+                within(rateDocsTable).getByText('Linked submissions')
+            ).toBeInTheDocument()
+            // table includes the correct submissions
+            expect(
+                within(rateDocsTable).getByText('MCR-MN-0001-SNBC')
+            ).toBeInTheDocument()
+            expect(
+                within(rateDocsTable).getByText('MCR-MN-0002-PMAP')
+            ).toBeInTheDocument()
+            // the document names link to the correct submissions
+            expect(
+                within(rateDocsTable).getByRole('link', {
+                    name: 'MCR-MN-0001-SNBC',
+                })
+            ).toHaveAttribute(
+                'href',
+                '/submissions/333b4225-5b49-4e82-aa71-be0d33d7418d'
+            )
+            expect(
+                within(rateDocsTable).getByRole('link', {
+                    name: 'MCR-MN-0002-PMAP',
+                })
+            ).toHaveAttribute(
+                'href',
+                '/submissions/21467dba-6ae8-11ed-a1eb-0242ac120002'
+            )
+        })
+    })
+
+    it('does not render shared rate cert info if none are present', async () => {
+        renderWithProviders(
+            <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
+                contract={draftContract}
+                editNavigateTo="rate-details"
+                submissionName="MN-PMAP-0001"
+                statePrograms={statePrograms}
+            />,
+            {
+                apolloProvider,
+            }
+        )
+        await waitFor(() => {
+            const rateDocsTable = screen.getByRole('table', {
+                name: /Rate certification/,
+            })
+            expect(
+                within(rateDocsTable).queryByTestId('tag')
+            ).not.toBeInTheDocument()
+            expect(
+                within(rateDocsTable).queryByText('Linked submissions')
+            ).not.toBeInTheDocument()
+        })
+    })
+
     it('renders inline error when bulk URL is unavailable', async () => {
         const s3Provider = {
             ...testS3Client(),


### PR DESCRIPTION
## Summary

This PR displays the shared rates UI on the uploads table of the ReviewSubmit page for historic submissions

- "historic" submissions are determined if the `packagesWithSharedRateCerts` field is populated (going forward this field this will not be used)
- While it was included as AC for this ticket, removing the "is this rate cert uploaded to any other submissions" field was already removed when the linked rates flag is on

#### Related issues
https://jiraent.cms.gov/browse/MCR-3886

#### Screenshots
**V1 version**
<img width="665" alt="Screenshot 2024-03-15 at 11 52 42 AM" src="https://github.com/Enterprise-CMCS/managed-care-review/assets/67110378/27169fcd-9cf9-4a08-b998-31a163ccf785">


**V2 version**
<img width="580" alt="Screenshot 2024-03-15 at 11 53 05 AM" src="https://github.com/Enterprise-CMCS/managed-care-review/assets/67110378/7b423941-1516-4d8b-a75b-31080879bad5">
#### Test cases covered

- shared rate UI is present when rate is shared
- shared rate UI is not present when the rate isn't shared

## QA guidance

- Create a submission with the linked rates flag off so that you can populate the "is this uploaded to other submissions" field on the Rate Details page
- Once on the ReviewSubmit page turn the linked rates flag on and ensure that the UploadsTable UI under the Rate Details section displays the shared rate UI
