### PR TITLE
[MCR-3996] link rates chooser default and filter values

### DIFF
--- a/services/app-web/src/components/Select/Select.module.scss
+++ b/services/app-web/src/components/Select/Select.module.scss
@@ -4,6 +4,7 @@
 
 // react-select draws the chips in two parts, so we round the outer and square in the inner corners
 .multiSelect {
+    z-index: 4;
     padding-top: 12px;
     [class*='select__multi-value'] {
         border-radius: 99rem 99rem 99rem 99rem;

--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
@@ -30,39 +30,46 @@ export const LinkRateSelect = ({
     const user = loggedInUser as StateUser
     const statePrograms = user.state.programs
 
-    const rateNames = data?.indexRates.edges.map((edge) => {
-        const revision = edge.node.revisions[0]
-        return {
-            value: revision.id,
-            label: (
-                <>
-                    <strong>{revision.formData.rateCertificationName}</strong>
-                    <div style={{ lineHeight: '50%', fontSize: '14px' }}>
-                        <p>
-                            Programs:&nbsp;
-                            {programNames(
-                                statePrograms,
-                                revision.formData.rateProgramIDs
-                            ).join(', ')}
-                        </p>
-                        <p>
-                            Rating period:&nbsp;
-                            {formatCalendarDate(
-                                revision.formData.rateDateStart
-                            )}
-                            -{formatCalendarDate(revision.formData.rateDateEnd)}
-                        </p>
-                        <p>
-                            Certification date:&nbsp;
-                            {formatCalendarDate(
-                                revision.formData.rateDateCertified
-                            )}
-                        </p>
-                    </div>
-                </>
-            ),
-        }
-    })
+    const rateNames = data?.indexRates.edges
+        .map((edge) => {
+            const revision = edge.node.revisions[0]
+            return {
+                value: revision.id,
+                label: (
+                    <>
+                        <strong>
+                            {revision.formData.rateCertificationName}
+                        </strong>
+                        <div style={{ lineHeight: '50%', fontSize: '14px' }}>
+                            <p>
+                                Programs:&nbsp;
+                                {programNames(
+                                    statePrograms,
+                                    revision.formData.rateProgramIDs
+                                ).join(', ')}
+                            </p>
+                            <p>
+                                Rating period:&nbsp;
+                                {formatCalendarDate(
+                                    revision.formData.rateDateStart
+                                )}
+                                -
+                                {formatCalendarDate(
+                                    revision.formData.rateDateEnd
+                                )}
+                            </p>
+                            <p>
+                                Certification date:&nbsp;
+                                {formatCalendarDate(
+                                    revision.formData.rateDateCertified
+                                )}
+                            </p>
+                        </div>
+                    </>
+                ),
+            }
+        })
+        .reverse()
 
     const onFocus: AriaOnFocus<LinkRateOptionType> = ({
         focused,

--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
@@ -38,7 +38,9 @@ export const LinkRateSelect = ({
                 label: (
                     <>
                         <strong>
-                            {revision.formData.rateCertificationName}
+                            {revision.formData.rateCertificationName
+                                ? revision.formData.rateCertificationName
+                                : 'Unknown rate'}
                         </strong>
                         <div style={{ lineHeight: '50%', fontSize: '14px' }}>
                             <p>

--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
@@ -36,8 +36,8 @@ export const LinkRateSelect = ({
             value: revision.id,
             label: (
                 <>
-                    <h4>{revision.formData.rateCertificationName}</h4>
-                    <div style={{ lineHeight: '50%' }}>
+                    <strong>{revision.formData.rateCertificationName}</strong>
+                    <div style={{ lineHeight: '50%', fontSize: '14px' }}>
                         <p>
                             Programs:&nbsp;
                             {programNames(
@@ -106,15 +106,23 @@ export const LinkRateSelect = ({
         }
     }
 
+    //Need this to make the label searchable since it's buried in a react element
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const filterOptions = ({ label }: any, input: string) =>
+        label.props.children[0].props.children
+            ?.toLowerCase()
+            .includes(input.toLowerCase())
+
     return (
         <>
             <Select
+                defaultMenuIsOpen
                 value={defaultValues}
                 className={styles.multiSelect}
                 options={error || loading ? undefined : rateNames}
                 isSearchable
                 isMulti
-                maxMenuHeight={169}
+                maxMenuHeight={405}
                 aria-label="linked rates (required)"
                 ariaLiveMessages={{
                     onFocus,
@@ -135,6 +143,7 @@ export const LinkRateSelect = ({
                         )
                     )
                 }
+                filterOption={filterOptions}
                 {...selectProps}
             />
         </>

--- a/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
@@ -70,8 +70,11 @@ export const LinkYourRates = ({
                                         return {
                                             rateId: item.value,
                                             rateName:
-                                                item.label.props.children[0]
-                                                    .props.children,
+                                                typeof item.label === 'string'
+                                                    ? item.label
+                                                    : item.label.props
+                                                          .children[0].props
+                                                          .children,
                                         }
                                     }
                                 )

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -238,7 +238,7 @@ const RateDetailsV2 = ({
                             rateID: id ?? 'no-id',
                             formData: convertRateFormToGQLRateFormData(
                                 rateForms[0]
-                            ), // only grab the first rate in the array for standalone rate submissiob
+                            ), // only grab the first rate in the array for standalone rate submission
                         },
                     },
                     fetchPolicy: 'network-only',

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
@@ -101,8 +101,8 @@ const convertGQLRateToRateForm = (getKey: S3ClientT['getKey'], rate?: Rate): For
         packagesWithSharedRateCerts:
             rateForm?.packagesWithSharedRateCerts ?? [],
         linkedRates: handleAsLinkedRate? [{
-            rateId: rate.id,
-            rateName: rateForm?.rateCertificationName ?? 'Unknown Rate'
+            rateId: rate.revisions[0].id,
+            rateName: rate.revisions[0].formData.rateCertificationName ?? 'Unknown Rate'
         }]:[],
         ratePreviouslySubmitted: handleAsLinkedRate? 'YES' : rateForm ? 'NO' : undefined
     }


### PR DESCRIPTION
## Summary
This pr prepopulates the select field with existing linked rates

#### Related issues
[MCR-3996](https://jiraent.cms.gov/browse/MCR-3996)

## QA guidance

1. Navigate to the rate details page for a contract with an existing rate(s)
2. Select Yes
3. field should populate with existing rates if any