### PR TITLE
Fix another problemTealium load

### DIFF
--- a/services/app-web/src/hooks/useTealium.ts
+++ b/services/app-web/src/hooks/useTealium.ts
@@ -40,9 +40,9 @@ const useTealium = (): {
     // this effect should only fire on initial app load
     useEffect(() => {
         // Do not add tealium for local dev or review apps
-        if (process.env.REACT_APP_AUTH_MODE !== 'IDM') {
-            return
-        }
+        // if (process.env.REACT_APP_AUTH_MODE !== 'IDM') {
+        //     return
+        // }
 
         const tealiumEnv = getTealiumEnv(
             process.env.REACT_APP_STAGE_NAME || 'main'
@@ -101,9 +101,9 @@ const useTealium = (): {
     useEffect(() => {
 
         // Do not add tealium for local dev or review apps
-        if (process.env.REACT_APP_AUTH_MODE !== 'IDM') {
-            return
-        }
+        // if (process.env.REACT_APP_AUTH_MODE !== 'IDM') {
+        //     return
+        // }
 
         const waitForUtag = async () => {
            return new Promise(resolve => setTimeout(resolve, 1000));

--- a/services/app-web/src/hooks/useTealium.ts
+++ b/services/app-web/src/hooks/useTealium.ts
@@ -55,10 +55,9 @@ const useTealium = (): {
     // Add Tealium setup
     // this effect should only fire on initial app load
     useEffect(() => {
-        // Do not add tealium for local dev or review apps
-            // if (process.env.REACT_APP_AUTH_MODE !== 'IDM') {
-            //     return
-            // }
+        if (process.env.REACT_APP_STAGE_NAME === 'local') {
+            return
+        }
 
         const tealiumEnv = getTealiumEnv(
             process.env.REACT_APP_STAGE_NAME || 'main'
@@ -115,11 +114,9 @@ const useTealium = (): {
     // Add page view
     // this effect should fire on each page view or if something changes about logged in user
     useEffect(() => {
-
-        // Do not add tealium for local dev or review apps
-        // if (process.env.REACT_APP_AUTH_MODE !== 'IDM') {
-        //     return
-        // }
+        if (process.env.REACT_APP_STAGE_NAME === 'local') {
+            return
+        }
 
         const waitForUtag = async () => {
            return new Promise(resolve => setTimeout(resolve, 1000));
@@ -148,18 +145,10 @@ const useTealium = (): {
         tealium_event: TealiumEvent
         content_type?: string
     }) => {
-        // Do not add events on local dev
         if (process.env.REACT_APP_STAGE_NAME === 'local') {
-            // console.info(`mock tealium event: ${JSON.stringify(linkData)}`)
             return
         }
 
-        // Guardrail - protect against trying to call utag before its loaded.
-        if (!window.utag) {
-            console.error(
-                'PROGRAMMING ERROR: tried to use tealium utag before it was loaded'
-            )
-        }
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         const utag = window.utag || { link: () => {}, view: () => {} }
 

--- a/services/app-web/src/hooks/useTealium.ts
+++ b/services/app-web/src/hooks/useTealium.ts
@@ -36,13 +36,29 @@ const useTealium = (): {
         user: loggedInUser,
     })
 
+     const callUTagView = () => {
+         // eslint-disable-next-line @typescript-eslint/no-empty-function
+        const utag = window.utag || { link: () => {}, view: () => {} }
+        const tagData: TealiumViewDataObject = {
+            content_language: 'en',
+            content_type: `${CONTENT_TYPE_BY_ROUTE[currentRoute]}`,
+            page_name: tealiumPageName,
+            page_path: pathname,
+            site_domain: 'cms.gov',
+            site_environment: `${process.env.REACT_APP_STAGE_NAME}`,
+            site_section: `${currentRoute}`,
+            logged_in: `${Boolean(loggedInUser) ?? false}`,
+        }
+        utag.view(tagData)
+     }
+
     // Add Tealium setup
     // this effect should only fire on initial app load
     useEffect(() => {
         // Do not add tealium for local dev or review apps
-        // if (process.env.REACT_APP_AUTH_MODE !== 'IDM') {
-        //     return
-        // }
+            // if (process.env.REACT_APP_AUTH_MODE !== 'IDM') {
+            //     return
+            // }
 
         const tealiumEnv = getTealiumEnv(
             process.env.REACT_APP_STAGE_NAME || 'main'
@@ -116,22 +132,12 @@ const useTealium = (): {
                 recordJSException('Analytics did not load in time')
                 return
             } else {
-                // eslint-disable-next-line @typescript-eslint/no-empty-function
-                const utag = window.utag || { link: () => {}, view: () => {} }
-                const tagData: TealiumViewDataObject = {
-                    content_language: 'en',
-                    content_type: `${CONTENT_TYPE_BY_ROUTE[currentRoute]}`,
-                    page_name: tealiumPageName,
-                    page_path: pathname,
-                    site_domain: 'cms.gov',
-                    site_environment: `${process.env.REACT_APP_STAGE_NAME}`,
-                    site_section: `${currentRoute}`,
-                    logged_in: `${Boolean(loggedInUser) ?? false}`,
-                }
-                utag.view(tagData)
+                callUTagView()
              }
             }
             ).catch(() => { return })
+        } else {
+            callUTagView()
         }
 
     }, [currentRoute, loggedInUser, pathname, tealiumPageName])


### PR DESCRIPTION
## Summary
My last fixed addressed what it should have (initial page loads work). However, it caused regression with subsequent page load functionality. Did more messing with the function calls to get both working again. 

The burden of making changes and waiting to production to verify is obnoxious. I couldn't think of a good enough reason why review apps can't also send analytics (sure it pollutes the dev analytics data... but we aren't checking that). By allowing review apps to send analytics it makes it easier for someone in code review to actually check it works and speed feedback loop.

#### Related issues
This is based on further follow up from the BlastAnalytics team in the CMS slack 

#### Test cases covered
- n/a

## QA guidance
- Add a breakpoint at the `utag.view` function call inside new `callUTagView` function in dev tools on the review app
- This breakpoint should be hit every time we change pages on the application. 

