### PR TITLE
fix ReviewSubmitV2: Hide shared rates across submission when linked rates flag is on 

### DIFF
--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.test.tsx
@@ -754,30 +754,25 @@ describe('RateDetailsSummarySection', () => {
         ).toBeNull()
     })
 
-    it('renders all necessary information for documents with shared rate certifications', async () => {
-        const draftContract = mockContractPackageDraft()
-        if (
-            draftContract.draftRevision &&
-            draftContract.draftRates &&
-            draftContract.draftRates[0].draftRevision
-        ) {
-            draftContract.draftRates[0].draftRevision.formData.packagesWithSharedRateCerts =
-                [
-                    {
-                        packageId: '333b4225-5b49-4e82-aa71-be0d33d7418d',
-                        packageName: 'MCR-MN-0001-SNBC',
-                    },
-                    {
-                        packageId: '21467dba-6ae8-11ed-a1eb-0242ac120002',
-                        packageName: 'MCR-MN-0002-PMAP',
-                    },
-                ]
-        }
+    it('renders shared rate certifications when submission is locked', async () => {
+        const submittedContract = mockContractPackageSubmitted()
+
+        submittedContract.packageSubmissions[0].rateRevisions[0].formData.packagesWithSharedRateCerts =
+            [
+                {
+                    packageId: '333b4225-5b49-4e82-aa71-be0d33d7418d',
+                    packageName: 'MCR-MN-0001-SNBC',
+                },
+                {
+                    packageId: '21467dba-6ae8-11ed-a1eb-0242ac120002',
+                    packageName: 'MCR-MN-0002-PMAP',
+                },
+            ]
 
         renderWithProviders(
             <RateDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
-                contract={draftContract}
+                contract={submittedContract}
                 editNavigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
@@ -826,6 +821,51 @@ describe('RateDetailsSummarySection', () => {
     })
 
     it('does not render shared rate cert info if none are present', async () => {
+        renderWithProviders(
+            <RateDetailsSummarySection
+                documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}
+                contract={draftContract}
+                editNavigateTo="rate-details"
+                submissionName="MN-PMAP-0001"
+                statePrograms={statePrograms}
+            />,
+            {
+                apolloProvider,
+            }
+        )
+        await waitFor(() => {
+            const rateDocsTable = screen.getByRole('table', {
+                name: /Rate certification/,
+            })
+            expect(
+                within(rateDocsTable).queryByTestId('tag')
+            ).not.toBeInTheDocument()
+            expect(
+                within(rateDocsTable).queryByText('Linked submissions')
+            ).not.toBeInTheDocument()
+        })
+    })
+
+    it('does not render shared rate cert info if submission is being unlocked and being edited', async () => {
+        const draftContract = mockContractPackageDraft()
+        if (
+            draftContract.draftRevision &&
+            draftContract.draftRates &&
+            draftContract.draftRates[0].draftRevision
+        ) {
+            draftContract.draftRates[0].draftRevision.formData.packagesWithSharedRateCerts =
+                [
+                    {
+                        packageId: '333b4225-5b49-4e82-aa71-be0d33d7418d',
+                        packageName: 'MCR-MN-0001-SNBC',
+                    },
+                    {
+                        packageId: '21467dba-6ae8-11ed-a1eb-0242ac120002',
+                        packageName: 'MCR-MN-0002-PMAP',
+                    },
+                ]
+        }
+
         renderWithProviders(
             <RateDetailsSummarySection
                 documentDateLookupTable={{ previousSubmissionDate: '01/01/01' }}

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
@@ -88,6 +88,8 @@ export const RateDetailsSummarySectionV2 = ({
         null
     )
 
+    // For V2 we only call this function and show deprecated shared rates across packages when the submission for historical data
+    // if submission is being edited, don't show this UI
     const refreshPackagesWithSharedRateCert = (
         rateFormData: RateFormData
     ): SharedRateCertDisplay[] | undefined => {
@@ -333,9 +335,13 @@ export const RateDetailsSummarySectionV2 = ({
                                     documentDateLookupTable={
                                         documentDateLookupTable
                                     }
-                                    packagesWithSharedRateCerts={refreshPackagesWithSharedRateCert(
-                                        rateFormData
-                                    )}
+                                    packagesWithSharedRateCerts={
+                                        isEditing
+                                            ? undefined
+                                            : refreshPackagesWithSharedRateCert(
+                                                  rateFormData
+                                              )
+                                    }
                                     multipleDocumentsAllowed={false}
                                     caption="Rate certification"
                                     documentCategory="Rate certification"
@@ -349,9 +355,13 @@ export const RateDetailsSummarySectionV2 = ({
                                     documentDateLookupTable={
                                         documentDateLookupTable
                                     }
-                                    packagesWithSharedRateCerts={refreshPackagesWithSharedRateCert(
-                                        rateFormData
-                                    )}
+                                    packagesWithSharedRateCerts={
+                                        isEditing
+                                            ? undefined
+                                            : refreshPackagesWithSharedRateCert(
+                                                  rateFormData
+                                              )
+                                    }
                                     caption="Rate supporting documents"
                                     isSupportingDocuments
                                     documentCategory="Rate-supporting"


### PR DESCRIPTION
## Summary
We want to show the legacy UI (rates across submissions) only for the submission summary experience. This is for historical data reasons.

For unlocked contracts currently being edited - e.g. Review and Submit - let's hide the old SHARED tag and related submissions field in the documents table.

#### Related issues
product/design review on 
https://jiraent.cms.gov/browse/MCR-3886

#### Test cases covered
- renders shared rate certifications when submission is locked
- does not render shared rate cert info if submission is being unlocked and being edited

## QA guidance
- Look at legacy submission that has the old "rates across submissions" feature - such as[ MCR-MN-016](https://d25pfhkipqgt0p.cloudfront.net/submissions/4a1e13c9-1678-4a01-8d9c-fda00c694d68)
- See shared tag should be visible and linked submissions column is present
- Turn ON linked rates field
-  See shared tag should NOT be visible and linked submissions column will NOT be present on ReviewSubmitb2

