### PR TITLE
MCR-3905 CMS links from rate summary to parent submission to unlock a rate

### DIFF
--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
@@ -371,7 +371,9 @@ describe('SingleRateSummarySection', () => {
             })
             await waitFor(() => {
                 const parentContractSubmissionID =
-                    rateData.revisions[0].contractRevisions[0].contract.id
+                    rateData.revisions[0].contractRevisions[
+                        rateData.revisions[0].contractRevisions.length - 1
+                    ].contract.id
                 expect(testLocation.pathname).toBe(
                     `/submissions/${parentContractSubmissionID}`
                 )

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
@@ -436,6 +436,12 @@ describe('SingleRateSummarySection', () => {
                     featureFlags: { 'rate-edit-unlock': true },
                 }
             )
+            // ensure page fully loaded
+            await screen.findByRole('link', {
+                name: 'Download all rate documents',
+            })
+
+            // no unlock rate button present
             expect(
                 await screen.queryByRole('button', {
                     name: 'Unlock rate',

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
@@ -322,7 +322,7 @@ describe('SingleRateSummarySection', () => {
             ).toBeInTheDocument()
         })
 
-        it('renders unlock button that redirects to contract submission page when standalone rate edit and unlock is disabled', async () => {
+        it('renders unlock button that redirects to contract submission page when linked rates on but standalone rate edit and unlock is still disabled', async () => {
             let testLocation: Location // set up location to track URL changes
 
             const rateData = rateDataMock()
@@ -355,7 +355,10 @@ describe('SingleRateSummarySection', () => {
                     routerProvider: {
                         route: `/rates/${rateData.id}`,
                     },
-                    featureFlags: { 'rate-edit-unlock': false },
+                    featureFlags: {
+                        'rate-edit-unlock': false,
+                        'link-rates': true,
+                    },
                     location: (location) => (testLocation = location),
                 }
             )

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
@@ -370,10 +370,10 @@ describe('SingleRateSummarySection', () => {
                 name: 'Unlock rate',
             })
             await waitFor(() => {
-                const firstRelatedContractSubmissionID =
+                const parentContractSubmissionID =
                     rateData.revisions[0].contractRevisions[0].contract.id
                 expect(testLocation.pathname).toBe(
-                    `/submissions/${firstRelatedContractSubmissionID}`
+                    `/submissions/${parentContractSubmissionID}`
                 )
             })
         })

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -24,7 +24,7 @@ import { useS3 } from '../../../contexts/S3Context'
 import useDeepCompareEffect from 'use-deep-compare-effect'
 import { recordJSException } from '../../../otelHelpers'
 import { Link } from '@trussworks/react-uswds'
-import { NavLink } from 'react-router-dom'
+import { NavLink, useNavigate } from 'react-router-dom'
 import { packageName } from '../../../common-code/healthPlanFormDataType'
 import { UploadedDocumentsTableProps } from '../UploadedDocumentsTable/UploadedDocumentsTable'
 import { useAuth } from '../../../contexts/AuthContext'
@@ -129,6 +129,7 @@ export const SingleRateSummarySection = ({
     statePrograms: Program[]
 }): React.ReactElement | null => {
     const { loggedInUser } = useAuth()
+    const navigate = useNavigate()
     const rateRevision = rate.revisions[0]
     const formData: RateFormData = rateRevision?.formData
     const documentDateLookupTable = makeRateDocumentDateTable(rate.revisions)
@@ -238,14 +239,27 @@ export const SingleRateSummarySection = ({
                         'Unknown rate name'
                     }
                 >
-                    {showRateUnlock && isCMSUser ? (
+                    {isCMSUser && showRateUnlock && (
                         <UnlockRateButton
                             disabled={isUnlocked || unlockLoading}
                             onClick={handleUnlockRate}
                         >
                             Unlock rate
                         </UnlockRateButton>
-                    ) : null}
+                    )}
+                    {/* This second option is an interim state for  for unlock rate button and once rate unlock edit is shipped we don't need this anymore */}
+                    {isCMSUser && !showRateUnlock && (
+                        <UnlockRateButton
+                            disabled={isUnlocked || unlockLoading}
+                            onClick={() => {
+                                navigate(
+                                    `/submissions/${rate.revisions[0].contractRevisions[0].contract.id}`
+                                )
+                            }}
+                        >
+                            Unlock rate
+                        </UnlockRateButton>
+                    )}
                 </SectionHeader>
                 {documentError && (
                     <DocumentWarningBanner className={styles.banner} />

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -231,7 +231,9 @@ export const SingleRateSummarySection = ({
         }
     }
     const parentContractSubmissionID =
-        rate.revisions[0].contractRevisions[0].contract.id
+        rate.revisions[0].contractRevisions[
+            rate.revisions[0].contractRevisions.length - 1
+        ].contract.id
     return (
         <React.Fragment key={rate.id}>
             <SectionCard

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -230,7 +230,8 @@ export const SingleRateSummarySection = ({
             )
         }
     }
-
+    const parentContractSubmissionID =
+        rate.revisions[0].contractRevisions[0].contract.id
     return (
         <React.Fragment key={rate.id}>
             <SectionCard
@@ -257,7 +258,7 @@ export const SingleRateSummarySection = ({
                             disabled={isUnlocked || unlockLoading}
                             onClick={() => {
                                 navigate(
-                                    `/submissions/${rate.revisions[0].contractRevisions[0].contract.id}`
+                                    `/submissions/${parentContractSubmissionID}`
                                 )
                             }}
                         >

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -145,6 +145,10 @@ export const SingleRateSummarySection = ({
         featureFlags.RATE_EDIT_UNLOCK.flag,
         featureFlags.RATE_EDIT_UNLOCK.defaultValue
     )
+    const showLinkedRates: boolean = ldClient?.variation(
+        featureFlags.LINK_RATES.flag,
+        featureFlags.LINK_RATES.defaultValue
+    )
 
     // TODO BULK DOWNLOAD
     // needs to be wrap in a standalone hook
@@ -247,8 +251,8 @@ export const SingleRateSummarySection = ({
                             Unlock rate
                         </UnlockRateButton>
                     )}
-                    {/* This second option is an interim state for  for unlock rate button and once rate unlock edit is shipped we don't need this anymore */}
-                    {isCMSUser && !showRateUnlock && (
+                    {/* This second option is an interim state for unlock rate button (when linked rates is turned on but unlock and edit rate is not available yet). Remove when rate unlock is permanently on. */}
+                    {isCMSUser && showLinkedRates && !showRateUnlock && (
                         <UnlockRateButton
                             disabled={isUnlocked || unlockLoading}
                             onClick={() => {

--- a/services/app-web/src/pages/RateSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.tsx
@@ -103,7 +103,7 @@ export const RateSummary = (): React.ReactElement => {
                 </div>
                 <SingleRateSummarySection
                     rate={rate}
-                    isSubmitted // can assume isSubmitted because we are building for CMS users
+                    isSubmitted // can assume isSubmitted because we redirect for unlocked
                     statePrograms={rate.state.programs}
                 />
             </GridContainer>


### PR DESCRIPTION
## Summary
This is interim UI for when Linked Rates is turned on but unlock and edit for standalone rates is still turned off. 

For that case, we render an unlock rate button but redirect to the first related contract submission so the rate can be unlocked with the contract submission unlock. 

#### Related issues
https://jiraent.cms.gov/browse/MCR-3905

#### Screenshots

#### Test cases covered
-  `renders unlock button that redirects to contract submission page when standalone rate edit and unlock is disabled`

## QA guidance
- get a submission in the dashboard
- log in as CMS user with linked rates feature flag ON but unlock edit rates flag OFF
- CMS user can click "Unlock rate" and they are redirected to the submission summary of the contract that made the rate
