### PR TITLE
Create graphql for submitcontract

### DIFF
--- a/services/app-graphql/src/mutations/submitContract.grapqhl
+++ b/services/app-graphql/src/mutations/submitContract.grapqhl
@@ -1,0 +1,282 @@
+mutation submitContract($input: SubmitContractInput!) {
+    submitContract(input: $input) {      
+        contract {
+            ...contractFieldsForSubmitContract
+
+            packageSubmissions {
+                ...packageSubmissionsFragmentForSubmitContract
+            }
+        }
+    }
+}
+
+fragment contractFieldsForSubmitContract on Contract {
+    id
+    status
+    createdAt
+    updatedAt
+    initiallySubmittedAt
+    stateCode
+    state {
+        code
+        name
+        programs {
+            id
+            name
+            fullName
+        }
+    }
+    stateNumber
+}
+
+fragment rateFieldsForSubmitContract on Rate {
+    id
+    createdAt
+    updatedAt
+    stateCode
+    stateNumber
+    state {
+        code
+        name
+        programs {
+            id
+            name
+            fullName
+        }
+    }
+    status
+    initiallySubmittedAt
+}
+
+fragment rateRevisionFragmentForSubmitContract on RateRevision {
+    id
+    createdAt
+    updatedAt
+    unlockInfo {
+        updatedAt
+        updatedBy
+        updatedReason
+    }
+    submitInfo {
+        updatedAt
+        updatedBy
+        updatedReason
+    }
+    formData {
+        rateType
+        rateCapitationType
+        rateDocuments {
+            name
+            s3URL
+            sha256
+        }
+        supportingDocuments {
+            name
+            s3URL
+            sha256
+        }
+        rateDateStart
+        rateDateEnd
+        rateDateCertified
+        amendmentEffectiveDateStart
+        amendmentEffectiveDateEnd
+        rateProgramIDs
+        rateCertificationName
+        certifyingActuaryContacts {
+            id
+            name
+            titleRole
+            email
+            actuarialFirm
+            actuarialFirmOther
+        }
+        addtlActuaryContacts {
+            id
+            name
+            titleRole
+            email
+            actuarialFirm
+            actuarialFirmOther
+        }
+        actuaryCommunicationPreference
+        packagesWithSharedRateCerts {
+            packageName
+            packageId
+            packageStatus
+        }
+    }
+    contractRevisions {
+        id
+        contract {
+            id
+            stateCode
+            stateNumber
+        }
+        createdAt
+        updatedAt
+        submitInfo {
+            updatedAt
+            updatedBy
+            updatedReason
+        }
+        unlockInfo {
+            updatedAt
+            updatedBy
+            updatedReason
+        }
+        formData {
+            programIDs
+            populationCovered
+            submissionType
+            riskBasedContract
+            submissionDescription
+            stateContacts {
+                name
+                titleRole
+                email
+            }
+            supportingDocuments {
+                name
+                s3URL
+                sha256
+            }
+            contractType
+            contractExecutionStatus
+            contractDocuments {
+                name
+                s3URL
+                sha256
+            }
+            contractDateStart
+            contractDateEnd
+            managedCareEntities
+            federalAuthorities
+            inLieuServicesAndSettings
+            modifiedBenefitsProvided
+            modifiedGeoAreaServed
+            modifiedMedicaidBeneficiaries
+            modifiedRiskSharingStrategy
+            modifiedIncentiveArrangements
+            modifiedWitholdAgreements
+            modifiedStateDirectedPayments
+            modifiedPassThroughPayments
+            modifiedPaymentsForMentalDiseaseInstitutions
+            modifiedMedicalLossRatioStandards
+            modifiedOtherFinancialPaymentIncentive
+            modifiedEnrollmentProcess
+            modifiedGrevienceAndAppeal
+            modifiedNetworkAdequacyStandards
+            modifiedLengthOfContract
+            modifiedNonRiskPaymentArrangements
+        }
+    }
+}
+
+fragment contractFormDataFragmentForSubmitContract on ContractFormData {
+    programIDs
+
+    populationCovered
+    submissionType
+
+    riskBasedContract
+    submissionDescription
+
+    stateContacts {
+        name
+        titleRole
+        email
+    }
+
+    supportingDocuments {
+        name
+        s3URL
+        sha256
+    }
+
+    contractType
+    contractExecutionStatus
+    contractDocuments {
+        name
+        s3URL
+        sha256
+    }
+
+    contractDateStart
+    contractDateEnd
+    managedCareEntities
+    federalAuthorities
+    inLieuServicesAndSettings
+    modifiedBenefitsProvided
+    modifiedGeoAreaServed
+    modifiedMedicaidBeneficiaries
+    modifiedRiskSharingStrategy
+    modifiedIncentiveArrangements
+    modifiedWitholdAgreements
+    modifiedStateDirectedPayments
+    modifiedPassThroughPayments
+    modifiedPaymentsForMentalDiseaseInstitutions
+    modifiedMedicaidBeneficiaries
+    modifiedMedicalLossRatioStandards
+    modifiedOtherFinancialPaymentIncentive
+    modifiedEnrollmentProcess
+    modifiedGrevienceAndAppeal
+    modifiedNetworkAdequacyStandards
+    modifiedLengthOfContract
+    modifiedNonRiskPaymentArrangements
+}
+
+fragment contractRevisionFragmentForSubmitContract on ContractRevision {
+    id
+    createdAt
+    updatedAt
+    contractName
+
+    submitInfo {
+        updatedAt
+        updatedBy
+        updatedReason
+    }
+
+    unlockInfo {
+        updatedAt
+        updatedBy
+        updatedReason
+    }
+
+    formData {
+        ...contractFormDataFragmentForSubmitContract
+    }
+}
+
+fragment packageSubmissionsFragmentForSubmitContract on ContractPackageSubmission {
+    cause
+    submitInfo {
+        ...updateInformationFieldsForSubmitContract
+    }
+
+    submittedRevisions {
+        ...submittableRevisionsFieldsForSubmitContract
+    }
+
+    contractRevision {
+        ...contractRevisionFragmentForSubmitContract
+    }
+    rateRevisions {
+        ...rateRevisionFragmentForSubmitContract
+    }
+}
+
+fragment submittableRevisionsFieldsForSubmitContract on SubmittableRevision {
+    ... on ContractRevision {
+        ...contractRevisionFragmentForSubmitContract
+    }
+    ... on RateRevision {
+        ...rateRevisionFragmentForSubmitContract
+    }
+}
+
+fragment updateInformationFieldsForSubmitContract on UpdateInformation {
+    updatedAt
+    updatedBy
+    updatedReason
+}

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -348,6 +348,29 @@ type Mutation {
             - Attempted to unlock a rate in the DRAFT or UNLOCKED state
     """
     submitRate(input: SubmitRateInput!): SubmitRatePayload!
+
+    """
+    submitContract will submit an unlocked contract and return the submitted contract data.
+
+    This can only be called by a StateUser.
+    The contract must be in the DRAFT or UNLOCKED state to be submitted.
+
+    Errors:
+    - ForbiddenError:
+        - A non State user called this
+    - UserInputError
+        - A rate cannot be found with the given `contractID`
+    - INTERNAL_SERVER_ERROR
+        - DB_ERROR
+            - Postgres returns error when attempting to finding contract
+            - Postgres returns error when attempting to update contract
+            - Postgres returns error when attempting to submit contract
+            - Postgres returns error when both contractID or contractRevisionID are blank.
+            - Postgres returns error when current contract revision to submit cannot be found
+        - INVALID_PACKAGE_STATUS
+            - Attempted to unlock a contract in the DRAFT or UNLOCKED state
+    """
+    submitContract(input: SubmitContractInput!): SubmitContractPayload!
 }
 
 input CreateHealthPlanPackageInput {
@@ -878,6 +901,133 @@ type StateContact {
     name: String
     titleRole: String
     email: String
+}
+
+"Contact information for contacting states regarding their submission"
+input StateContactInput {
+    name: String
+    titleRole: String
+    email: String
+}
+
+"""
+ContractFormData represents the form data that was inputted by the state
+This type is used for the form data field found on a contract revision
+"""
+input ContractFormDataInput {
+    """
+    An array of IDs representing state programs that the contract covers
+    """
+    programIDs: [String!]!
+    """
+    The large overarching population of people that the program covers.
+    Options are MEDICAID, CHIP, MEDICAID_AND_CHIP
+    """
+    populationCovered: PopulationCovered
+    """
+    The submission type of this package
+    Options are CONTRACT_ONLY and CONTRACT_AND_RATES
+    """
+    submissionType: SubmissionType!
+    """
+    Whether or not this contract is risk based
+    Risk-based contracts have specific requirements that
+    non-risk based contracts do not have
+    """
+    riskBasedContract: Boolean
+    "State provided summary of the contract being submitted"
+    submissionDescription: String!
+    """
+    Array of state contacts of state representatives who should be
+    contacted about updates to the contract
+    Each state contact contains string fields for: name, title, and email
+    """
+    stateContacts: [StateContactInput!]!
+    """
+    Additional documents the state uploads to support a contract
+    Files can be PDF, DOC, DOCX, XLSX, CSV format
+    """
+    supportingDocuments: [GenericDocumentInput!]!
+    """
+    Type of contract the state is submitting
+    Options are: BASE, AMENDMENT
+    """
+    contractType: ContractType!
+    """
+    Execution status for a contract.
+    Contracts are fully executed or unexecuted by some or all parties
+    Status can be either EXECUTED or UNEXECUTED
+    """
+    contractExecutionStatus: ContractExecutionStatus
+    """
+    State upload of the submitted contract
+    """
+    contractDocuments: [GenericDocumentInput!]!
+    "Start date of the contract"
+    contractDateStart: Date
+    "End date of the contract"
+    contractDateEnd: Date
+    """
+    The type of organization the state is contracting with
+    in order to deliver managed care services
+    Options are MCO, PIHP, PAHP, and PCCM
+    """
+    managedCareEntities: [ManagedCareEntity!]!
+    """
+    The state plan and/or waiver authorities that allow the state
+    to run its managed care programs
+    """
+    federalAuthorities: [FederalAuthority!]!
+    """
+    If contract is in Lieu-of Services and Settings (ILOSs)
+    in accordance with 42 CFR § 438.3(e)(2)
+    """
+    inLieuServicesAndSettings: Boolean
+    "If contract includes modifications to benefits provided by the managed care plans"
+    modifiedBenefitsProvided: Boolean
+    "If contract includes modifications to the geographic areas served by the managed care plans"
+    modifiedGeoAreaServed: Boolean
+    """
+    If contract includes modifications to the Medicaid beneficiaries served by the managed care
+    plans (e.g. eligibility or enrollment criteria)
+    """
+    modifiedMedicaidBeneficiaries: Boolean
+    "If contract includes modifications to the risk sharing strategy"
+    modifiedRiskSharingStrategy: Boolean
+    "If contract includes modifications to incentive arrangements"
+    modifiedIncentiveArrangements: Boolean
+    "If contract includes modifications to the withold agreements"
+    modifiedWitholdAgreements: Boolean
+    "If contract includes modifications to the state directed payments"
+    modifiedStateDirectedPayments: Boolean
+    "If contract includes modifications to the pass-through payments"
+    modifiedPassThroughPayments: Boolean
+    """
+    If contract includes modifications to payments to MCOs and PIHPs for enrollees that
+    are a patient in an institution for mental disease
+    """
+    modifiedPaymentsForMentalDiseaseInstitutions: Boolean
+    "If contract includes modifications to the medical loss ratio standards"
+    modifiedMedicalLossRatioStandards: Boolean
+    """
+    If contract includes modifications to
+    other financial, payment, incentive or related contractual provisions
+    """
+    modifiedOtherFinancialPaymentIncentive: Boolean
+    "If contract includes modifications to the enrollment/disenrollment process"
+    modifiedEnrollmentProcess: Boolean
+    "If contract includes modifications to the grevience and appeal system"
+    modifiedGrevienceAndAppeal: Boolean
+    "If contract includes modifications to the network adequacy standards"
+    modifiedNetworkAdequacyStandards: Boolean
+    "If contract includes modifications to the length of the contract period"
+    modifiedLengthOfContract: Boolean
+    "If contract includes modifications to the non-risk payment arrangements"
+    modifiedNonRiskPaymentArrangements: Boolean,
+    "If contract has statutory regulatory attestation"
+    statutoryRegulatoryAttestation: Boolean,
+    "Description provided for if contract has statutory regulatory attestation"
+    statutoryRegulatoryAttestationDescription: String
 }
 
 """
@@ -1426,6 +1576,10 @@ type SubmitRatePayload {
     rate: Rate!
 }
 
+type SubmitContractPayload {
+    contract: Contract!
+}
+
 input UnlockRateInput {
     rateID: ID!
     "User given reason this rate was unlocked"
@@ -1524,4 +1678,12 @@ input SubmitRateInput {
     submittedReason: String
     "Rate related form data to be updated with submission"
     formData: RateFormDataInput
+}
+
+input SubmitContractInput {
+    contractID: ID!
+    "User given submission description"
+    submittedReason: String
+    "Rate related form data to be updated with submission"
+    formData: ContractFormDataInput
 }


### PR DESCRIPTION
## Summary

Creates the mutation for `submitContract`. 

#### Related issues
https://jiraent.cms.gov/browse/MCR-4015

## QA guidance

- `./dev generate` runs without errors
