### PR TITLE
Prevent rates from being read as a linked rate just because its unlocked

### DIFF
--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
@@ -65,7 +65,7 @@ const convertRateFormToGQLRateFormData = (
 // if rate is not passed in, return an empty RateForm // we need to pass in the  s3 handler because 3 urls generated client-side
 // useLatestSubmission means to pull the latest submitted info rather than the draft info
 const convertGQLRateToRateForm = (getKey: S3ClientT['getKey'], rate?: Rate): FormikRateForm => {
-    const handleAsLinkedRate = rate?.status && rate.status !== 'DRAFT' // TODO: Make this a more sophisticated check for child-rates
+    const handleAsLinkedRate = rate?.status && rate.status !== 'DRAFT' && rate.status !== 'UNLOCKED' // TODO: Make this a more sophisticated check for child-rates
     const rateRev = handleAsLinkedRate ? rate?.revisions[0] : rate?.draftRevision
     const rateForm = rateRev?.formData
     return {


### PR DESCRIPTION
## Summary

#### Related issues

https://jiraent.cms.gov/browse/MCR-4000

#### Screenshots
<img width="741" alt="Screenshot 2024-04-09 at 12 16 07 PM" src="https://github.com/Enterprise-CMCS/managed-care-review/assets/67110378/8dec8939-f365-4971-ba2f-f987ec27ca9c">

## QA guidance

- Turn Linked rates feature flag off
- Make a contract with rates submission
- Sign in as a CMS user and unlock the submission
- Go to the submission as a state user and navigate to the Rate Details page. It should now display as No for the linked rates question and the other fields should be editable 
