### PR TITLE
Make state analysts email table easier to check

### DIFF
--- a/services/app-web/src/pages/Settings/EmailSettingsTables/EmailAnalystsTable.tsx
+++ b/services/app-web/src/pages/Settings/EmailSettingsTables/EmailAnalystsTable.tsx
@@ -1,0 +1,153 @@
+import { Column, createColumnHelper, getCoreRowModel, getFacetedUniqueValues, getFilteredRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table"
+import { StateAnalystsConfiguration } from "../../../gen/gqlClient"
+import { useMemo, useRef } from "react"
+import { FilterSelect, FilterSelectedOptionsType } from "../../../components/FilterAccordion"
+import { DoubleColumnGrid } from "../../../components"
+import { formatEmails } from "./EmailSettingsTables"
+import { Table } from "@trussworks/react-uswds"
+
+import styles from '../Settings.module.scss'
+import { pluralize } from "../../../common-code/formatters"
+
+const columnHelper = createColumnHelper< StateAnalystsConfiguration>()
+
+const EmailAnalystsTable = ({
+    analysts,
+}: {
+    analysts: StateAnalystsConfiguration[]
+}) => {
+    const lastClickedElement = useRef<string | null>(null)
+    const tableColumns = useMemo(
+        () => [
+            columnHelper.accessor('stateCode', {
+                id: 'stateCode',
+                header: 'State',
+                cell: (info) => <span>{info.getValue()}</span>,
+                filterFn: `arrIncludesSome`,
+            }),
+            columnHelper.accessor('emails', {
+                id: 'emails',
+                header: 'Emails',
+                cell: (info) => <span>{info.getValue()}</span>,
+                filterFn: `arrIncludesSome`,
+            }),
+        ],
+        []
+    )
+
+    const reactTable = useReactTable({
+        data: analysts.sort((a, b) =>
+            a['stateCode'] > b['stateCode'] ? -1 : 1
+        ),
+        filterFns: {
+            dateRangeFilter: () => true,
+        },
+        getCoreRowModel: getCoreRowModel(),
+        columns: tableColumns,
+        getFacetedUniqueValues: getFacetedUniqueValues(),
+        getFilteredRowModel: getFilteredRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+    })
+
+    const filteredRows = reactTable.getRowModel().rows
+
+    const stateColumn = reactTable.getColumn(
+        'stateCode'
+    ) as Column<StateAnalystsConfiguration>
+    const emailsColumn = reactTable.getColumn(
+        'emails'
+    ) as Column<StateAnalystsConfiguration>
+    const rowCount = `Displaying ${filteredRows.length} of ${analysts.length} ${pluralize(
+          'analyst',
+          analysts.length
+      )}`
+    const updateFilters = (
+        column: Column<StateAnalystsConfiguration>,
+        selectedOptions: FilterSelectedOptionsType,
+        filterName: string
+    ) => {
+        lastClickedElement.current = filterName
+        column.setFilterValue(
+            selectedOptions.map((selection) => selection.value)
+        )
+    }
+
+    return (
+        <>
+            <h2>State Analyst emails</h2>
+            <p>
+                State analysts email settings. Currently a standalone
+                configuration based on the state programs spreadsheet.
+            </p>
+
+            <DoubleColumnGrid>
+                <FilterSelect
+                    name="state"
+                    label="State"
+                    filterOptions={Array.from(
+                        stateColumn.getFacetedUniqueValues().keys()
+                    )
+                        .sort()
+                        .map((state) => ({
+                            value: state,
+                            label: state,
+                        }))}
+                    onChange={(selectedOptions) =>
+                        updateFilters(
+                            stateColumn,
+                            selectedOptions,
+                            'state'
+                        )
+                    }
+                />
+                <FilterSelect
+                    name="emails"
+                    label="Emails"
+                    filterOptions={Array.from(
+                        emailsColumn.getFacetedUniqueValues().keys()
+                    )
+                        .sort()
+                        .map((state) => ({
+                            value: state,
+                            label: state,
+                        }))}
+                    onChange={(selectedOptions) =>
+                        updateFilters(
+                            emailsColumn,
+                            selectedOptions,
+                            'emails'
+                        )
+                    }
+                />
+            </DoubleColumnGrid>
+            <div className={styles.filterCount}>
+                {rowCount}
+            </div>
+            <hr />
+
+            <Table bordered>
+                <caption className="srOnly">Analyst emails</caption>
+                <thead>
+                    <tr>
+                        <th>State</th>
+                        <th>Inbox</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {filteredRows.map((row) => {
+                            return (
+                                <tr key={row.id}>
+                                    <td>{row.getValue('stateCode')}</td>
+                                    <td>
+                                        {formatEmails(row.getValue('emails') || [])}
+                                    </td>
+
+                                </tr>
+                            )
+                        })}
+                </tbody>
+            </Table>
+        </>
+    )
+}
+export {EmailAnalystsTable}

--- a/services/app-web/src/pages/Settings/EmailSettingsTables/EmailSettingsTables.tsx
+++ b/services/app-web/src/pages/Settings/EmailSettingsTables/EmailSettingsTables.tsx
@@ -3,15 +3,15 @@ import React from 'react'
 import { Loading } from '../../../components'
 import {
     EmailConfiguration,
-    StateAnalystsConfiguration,
     useFetchEmailSettingsQuery,
 } from '../../../gen/gqlClient'
 import { SettingsErrorAlert } from '../SettingsErrorAlert'
 import styles from '../Settings.module.scss'
+import { EmailAnalystsTable } from './EmailAnalystsTable'
 
 const formatEmails = (arr?: string[]) => (arr ? arr.join(',') : 'NOT DEFINED')
 
-export const EmailSettingsTable = ({
+const EmailSettingsTable = ({
     type,
 }: {
     type: 'GENERAL' | 'ANALYSTS' | 'SUPPORT'
@@ -26,20 +26,20 @@ export const EmailSettingsTable = ({
             {loading && <Loading />}
 
             {data && config && type === 'GENERAL' && (
-                <EmailsGeneralTable config={config} />
+                <EmailGeneralTable config={config} />
             )}
 
             {data && analysts && type === 'ANALYSTS' && (
-                <EmailsAnalystsTable analysts={analysts} />
+                <EmailAnalystsTable analysts={analysts} />
             )}
             {data && config && type === 'SUPPORT' && (
-                <EmailsSupportTable config={config} />
+                <EmailSupportTable config={config} />
             )}
         </div>
     )
 }
 
-const EmailsGeneralTable = ({ config }: { config: EmailConfiguration }) => {
+const EmailGeneralTable = ({ config }: { config: EmailConfiguration }) => {
     console.info('ALL CONFIG', JSON.stringify(config))
     return (
         <>
@@ -98,45 +98,7 @@ const EmailsGeneralTable = ({ config }: { config: EmailConfiguration }) => {
     )
 }
 
-const EmailsAnalystsTable = ({
-    analysts,
-}: {
-    analysts: StateAnalystsConfiguration[]
-}) => {
-    return (
-        <>
-            <h2>State Analyst emails</h2>
-            <p>
-                State analysts email settings. Currently a standalone
-                configuration based on the state programs spreadsheet.
-            </p>
-            <Table bordered>
-                <caption className="srOnly">Analyst emails</caption>
-                <thead>
-                    <tr>
-                        <th>Inbox</th>
-                        <th>State</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {analysts &&
-                        analysts.map((analyst, index) => {
-                            return (
-                                <tr key={index}>
-                                    <td>
-                                        {formatEmails(analyst.emails || [])}
-                                    </td>
-                                    <td>{analyst.stateCode}</td>
-                                </tr>
-                            )
-                        })}
-                </tbody>
-            </Table>
-        </>
-    )
-}
-
-const EmailsSupportTable = ({ config }: { config: EmailConfiguration }) => {
+const EmailSupportTable = ({ config }: { config: EmailConfiguration }) => {
     return (
         <>
             <h2>Support emails</h2>
@@ -176,3 +138,5 @@ const EmailsSupportTable = ({ config }: { config: EmailConfiguration }) => {
         </>
     )
 }
+
+export {EmailSettingsTable, formatEmails}

--- a/services/app-web/src/pages/Settings/Settings.module.scss
+++ b/services/app-web/src/pages/Settings/Settings.module.scss
@@ -12,6 +12,10 @@
             border-left: 0;
             border-right: 0;
         }
+        td {
+        word-wrap: break-word;
+        overflow-wrap: break-word;
+        }
     }
 
     table {


### PR DESCRIPTION
## Summary
To prepare for 20+ changes to states list and emails, want to make this table easier to filter. Spot checking by eye is getting difficult because the table has too much data in it to grok all at once.

Decided to throw instate and email filters at the top to make it easier to check for specific entries. 

#### Related issues
https://jiraent.cms.gov/browse/MCR-4028

#### Screenshots
![Screenshot 2024-04-19 at 4 41 49 PM](https://github.com/Enterprise-CMCS/managed-care-review/assets/10750442/d1bd239b-895e-440d-8e3d-be072bb32781)


## QA guidance
This is dev only functionality for internal admins - dont think it needs QA.
