### PR TITLE
unlockResubmit cypress for linked rates and other bugfix 

### DIFF
--- a/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
@@ -25,7 +25,7 @@ export const ChangeHistoryV2 = ({
                 return submission.cause === 'CONTRACT_SUBMISSION'
             }
         )
-        console.log(contractSubmissions)
+
         //Reverse revisions to order from earliest to latest revision. This is to correctly set version for each
         // contract & recontract.
         const reversedRevisions = [...contractSubmissions].reverse()

--- a/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
@@ -101,18 +101,16 @@ export const ChangeHistoryV2 = ({
                         <div>
                             <span className={styles.tag}>
                                 {isSubsequentSubmission
-                                    ? 'Submitted by:'
-                                    : 'Unlocked by:'}
-                                    &nbsp;
+                                    ? 'Submitted by: '
+                                    : 'Unlocked by: '}
                             </span>
                             <span>{r.updatedBy}&nbsp;</span>
                         </div>
                         <div>
                             <span className={styles.tag}>
                                 {isSubsequentSubmission
-                                    ? 'Changes made:'
-                                    : 'Reason for unlock:'}
-                                     &nbsp;
+                                    ? 'Changes made: '
+                                    : 'Reason for unlock: '}
                             </span>
                             <span>{r.updatedReason}</span>
                         </div>

--- a/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
@@ -84,15 +84,15 @@ export const ChangeHistoryV2 = ({
                 headingLevel: 'h4',
                 content: isInitialSubmission ? (
                     <div data-testid={`change-history-record`}>
-                        <span className={styles.tag}>Submitted by:</span>
-                        <span> {r.updatedBy}</span>
+                        <span className={styles.tag}>Submitted by:&nbsp;</span>
+                        <span> {r.updatedBy}&nbsp;</span>
                         <br />
                         {r.revisionVersion && hasSubsequentSubmissions && (
                             <Link
-                                href={`/contracts/${contract.id}/revisions/${r.revisionVersion}`}
+                                href={`/submissions/${contract.id}/revisions/${r.revisionVersion}`}
                                 data-testid={`revision-link-${r.revisionVersion}`}
                             >
-                                View past contract version
+                                View past submission version
                             </Link>
                         )}
                     </div>
@@ -102,7 +102,7 @@ export const ChangeHistoryV2 = ({
                             <span className={styles.tag}>
                                 {isSubsequentSubmission
                                     ? 'Submitted by: '
-                                    : 'Unlocked by: '}{' '}
+                                    : 'Unlocked by: '}
                             </span>
                             <span>{r.updatedBy}</span>
                         </div>
@@ -119,7 +119,7 @@ export const ChangeHistoryV2 = ({
                                 href={`/submissions/${contract.id}/revisions/${r.revisionVersion}`}
                                 data-testid={`revision-link-${r.revisionVersion}`}
                             >
-                                View past contract version
+                                View past submission version
                             </Link>
                         )}
                     </div>

--- a/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
@@ -105,7 +105,7 @@ export const ChangeHistoryV2 = ({
                                     : 'Unlocked by:'}
                                     &nbsp;
                             </span>
-                            <span>{r.updatedBy}</span>
+                            <span>{r.updatedBy}&nbsp;</span>
                         </div>
                         <div>
                             <span className={styles.tag}>

--- a/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
@@ -63,7 +63,7 @@ export const ChangeHistoryV2 = ({
 
     const revisedItems: AccordionItemProps[] = revisionHistory.map(
         (r, index) => {
-            const isInitialSubmission = r.updatedReason === 'Initial contract'
+            const isInitialSubmission = r.updatedReason === 'Initial submission'
             const isSubsequentSubmission = r.kind === 'submit'
             // We want to know if this contract has multiple submissions. To have multiple submissions, there must be minimum
             // more than the initial contract revision.

--- a/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
@@ -19,11 +19,13 @@ export const ChangeHistoryV2 = ({
 }: ChangeHistoryProps): React.ReactElement => {
     const flattenedRevisions = (): flatRevisions[] => {
         const result: flatRevisions[] = []
+
         const contractSubmissions = contract.packageSubmissions.filter(
             (submission) => {
                 return submission.cause === 'CONTRACT_SUBMISSION'
             }
         )
+        console.log(contractSubmissions)
         //Reverse revisions to order from earliest to latest revision. This is to correctly set version for each
         // contract & recontract.
         const reversedRevisions = [...contractSubmissions].reverse()
@@ -40,9 +42,8 @@ export const ChangeHistoryV2 = ({
             }
             if (r.submitInfo) {
                 const newSubmit: flatRevisions = {} as flatRevisions
-
                 const revisionVersion =
-                    index !== contract.packageSubmissions.length - 1
+                    index !== contract.packageSubmissions.length - 1 // if we aren't at the last item in list, assign a version
                         ? String(index + 1) //Offset version, we want to start at 1
                         : undefined
 

--- a/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
@@ -84,7 +84,7 @@ export const ChangeHistoryV2 = ({
                 headingLevel: 'h4',
                 content: isInitialSubmission ? (
                     <div data-testid={`change-history-record`}>
-                        <span className={styles.tag}>Submitted by:&nbsp;</span>
+                        <span className={styles.tag}>Submitted by:</span>
                         <span> {r.updatedBy}&nbsp;</span>
                         <br />
                         {r.revisionVersion && hasSubsequentSubmissions && (
@@ -101,16 +101,18 @@ export const ChangeHistoryV2 = ({
                         <div>
                             <span className={styles.tag}>
                                 {isSubsequentSubmission
-                                    ? 'Submitted by: '
-                                    : 'Unlocked by: '}
+                                    ? 'Submitted by:'
+                                    : 'Unlocked by:'}
+                                    &nbsp;
                             </span>
                             <span>{r.updatedBy}</span>
                         </div>
                         <div>
                             <span className={styles.tag}>
                                 {isSubsequentSubmission
-                                    ? 'Changes made: '
-                                    : 'Reason for unlock: '}
+                                    ? 'Changes made:'
+                                    : 'Reason for unlock:'}
+                                     &nbsp;
                             </span>
                             <span>{r.updatedReason}</span>
                         </div>

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -67,10 +67,10 @@ const relatedSubmissions = (
     statePrograms: Program[]
 ): React.ReactElement => {
     return (
-        <>
+        <ul>
             {contractRevisions.map((contractRev) => (
-                <Link
-                    key={contractRev.contract.id}
+                <li key={contractRev.contract.id}>
+                    <Link
                     asCustom={NavLink}
                     to={`/submissions/${contractRev.contract.id}`}
                 >
@@ -80,9 +80,9 @@ const relatedSubmissions = (
                         contractRev.formData.programIDs,
                         statePrograms
                     )}
-                </Link>
+                </Link></li>
             ))}
-        </>
+        </ul>
     )
 }
 

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -67,7 +67,7 @@ const relatedSubmissions = (
     statePrograms: Program[]
 ): React.ReactElement => {
     return (
-        <ul>
+        <ul className={styles.commaList}>
             {contractRevisions.map((contractRev) => (
                 <li key={contractRev.contract.id}>
                     <Link

--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionSummarySection.module.scss
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionSummarySection.module.scss
@@ -30,7 +30,19 @@
         li {
             padding: uswds.units(1) 0;
         }
+        &.commaList {
+            li {
+                padding: 0;
+            }
+            li:after {
+                content: ', ';
+            }
+            li:last-of-type::after{
+                display: none;
+            }
+        }
     }
+
 
     // align state contacts
     dl div[class^='grid-container'] {
@@ -115,3 +127,4 @@
         padding: 0;
     }
 }
+

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -456,7 +456,6 @@ const RateDetailsV2 = ({
                                                                         }}
                                                                     />
                                                                 )}
-                            FIX THIS
                                                                 {rateForm.ratePreviouslySubmitted ===
                                                                     'YES' &&
                                                                     rateForm.id && (

--- a/services/app-web/src/pages/SubmissionSummary/V2/SubmissionSummaryV2.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/V2/SubmissionSummaryV2.test.tsx
@@ -153,7 +153,7 @@ describe('SubmissionSummary', () => {
                 /on: (0?[1-9]|[12][0-9]|3[01])\/[0-9]+\/[0-9]+\s[0-9]+:[0-9]+[a-zA-Z]+ ET/i
             )
             expect(screen.getByTestId('unlockedBanner')).toHaveTextContent(
-                'by: example@state.com'
+                'by: cms@example.com'
             )
             expect(screen.getByTestId('unlockedBanner')).toHaveTextContent(
                 'Reason for unlock: unlocked for a test'
@@ -377,7 +377,7 @@ describe('SubmissionSummary', () => {
                 /on: (0?[1-9]|[12][0-9]|3[01])\/[0-9]+\/[0-9]+\s[0-9]+:[0-9]+[a-zA-Z]+ ET/i
             )
             expect(screen.getByTestId('unlockedBanner')).toHaveTextContent(
-                'by: example@state.com'
+                'by: cms@example.com'
             )
             expect(screen.getByTestId('unlockedBanner')).toHaveTextContent(
                 'Reason for unlock: unlocked for a test'

--- a/services/app-web/src/pages/SubmissionSummary/V2/SubmissionSummaryV2.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/V2/SubmissionSummaryV2.tsx
@@ -122,8 +122,8 @@ export const SubmissionSummaryV2 = (): React.ReactElement => {
     const statePrograms = contract.state.programs
 
     const contractFormData = getVisibleLatestContractFormData(contract, isStateUser)
-    if (!contractFormData) {
-        console.error('no form data inside submission summary')
+    if (!contractFormData || !contract || !statePrograms) {
+        console.error('missing fundamental contract data inside submission summary')
         return <GenericErrorPage />
     }
 
@@ -164,7 +164,7 @@ export const SubmissionSummaryV2 = (): React.ReactElement => {
 
     return (
         <div className={styles.background}>
-            <div style={{ textAlign: 'center' }}>
+           <div style={{ textAlign: 'center' }}>
                 This is the V2 page of the SubmissionSummary
             </div>
             <GridContainer
@@ -214,7 +214,7 @@ export const SubmissionSummaryV2 = (): React.ReactElement => {
                     </Link>
                 )}
 
-                {contract && statePrograms && (
+                {
                     <SubmissionTypeSummarySectionV2
                         subHeaderComponent={
                             isCMSUser ? (
@@ -260,9 +260,9 @@ export const SubmissionSummaryV2 = (): React.ReactElement => {
                         initiallySubmittedAt={contract.initiallySubmittedAt}
                         isStateUser={isStateUser}
                     />
-                )}
+                }
 
-                {contract && (
+                {(
                     <ContractDetailsSummarySectionV2
                         contract={contract}
                         isCMSUser={isCMSUser}
@@ -271,9 +271,7 @@ export const SubmissionSummaryV2 = (): React.ReactElement => {
                     />
                 )}
 
-                {contract &&
-                    statePrograms &&
-                    isContractActionAndRateCertification && (
+                {isContractActionAndRateCertification && (
                         <RateDetailsSummarySectionV2
                             contract={contract}
                             submissionName={name}
@@ -283,16 +281,16 @@ export const SubmissionSummaryV2 = (): React.ReactElement => {
                         />
                     )}
 
-                {contract && <ContactsSummarySection contract={contract} />}
+                {<ContactsSummarySection contract={contract} />}
 
-                {contract && <ChangeHistoryV2 contract={contract} />}
-                {contract && (
+                {<ChangeHistoryV2 contract={contract} />}
+                {
                     <UnlockSubmitModalV2
                         modalRef={modalRef}
                         modalType="UNLOCK_CONTRACT"
                         submissionData={contract}
                     />
-                )}
+                }
             </GridContainer>
         </div>
     )

--- a/services/app-web/src/pages/SubmissionSummary/V2/SubmissionSummaryV2.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/V2/SubmissionSummaryV2.tsx
@@ -147,9 +147,7 @@ export const SubmissionSummaryV2 = (): React.ReactElement => {
     if (submissionStatus === 'UNLOCKED' || submissionStatus === 'RESUBMITTED') {
         updateInfo =
             (submissionStatus === 'UNLOCKED'
-                ? contract.packageSubmissions[0].submittedRevisions.find(
-                      (rev) => rev.unlockInfo
-                  )?.unlockInfo
+                ? contract.draftRevision?.unlockInfo
                 : contract.packageSubmissions[0].contractRevision.submitInfo) ||
             undefined
     }

--- a/services/app-web/src/testHelpers/apolloMocks/contractPackageDataMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/contractPackageDataMock.ts
@@ -452,7 +452,7 @@ function mockContractPackageUnlocked(
             submitInfo: undefined,
             unlockInfo: {
                 updatedAt: new Date(),
-                updatedBy: 'soandso@example.com',
+                updatedBy: 'cms@example.com',
                 updatedReason: 'unlocked for a test',
             },
             id: '123',
@@ -528,7 +528,7 @@ function mockContractPackageUnlocked(
                     updatedAt: new Date(),
                     unlockInfo: {
                         updatedAt: new Date(),
-                        updatedBy: 'soandso@example.com',
+                        updatedBy: 'cms@example.com',
                         updatedReason: 'unlocked for a test',
                     },
                     formData: {

--- a/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -452,7 +452,7 @@ describe('CMS user', () => {
                     expect(recordText[3]).to.contain('Reason for unlock: Unlock submission reason.')
 
                     // Test for initial submission
-                    expect(recordText[4]).to.contain(/Submitted by: aang@example.com/)
+                    expect(recordText[4]).to.contain(/aang@example.com/)
                     expect(recordText[4]).to.contain(/View past submission version/)
                     expect(recordText[4]).to.not.contain(/Changes made:/)
                     expect(recordText[4]).to.not.contain(/Reason for unlock:/)

--- a/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -5,7 +5,7 @@ describe('CMS user', () => {
         cy.stubFeatureFlags()
         cy.interceptGraphQL()
     })
-    it('can unlock and resubmit', () => {
+    it('can unlock and resubmit child rates', () => {
         cy.logInAsStateUser()
 
         // fill out an entire submission
@@ -158,7 +158,8 @@ describe('CMS user', () => {
                     button.trigger('click')
                     button.siblings().hasClass('usa-accordion__content') /// make sure accordion is expanded
                 })
-                //Check for view previous submission link in the initial accordion item to exist
+
+                // Check for view previous submission link in the initial accordion item to exist
                 cy.findByTestId('revision-link-1').should('be.visible')
                 cy.clickSubmissionLink('revision-link-1')
                 //Making sure we are on SubmissionRevisionSummary page and contains version text
@@ -167,7 +168,8 @@ describe('CMS user', () => {
                     .contains(
                         /(0?[1-9]|[12][0-9]|3[01])\/[0-9]+\/[0-9]+\s[0-9]+:[0-9]+[a-zA-Z]+ ET version/i
                     )
-                //Previous submission banner should exist and able to click link to go back to current submission
+
+                // Previous submission banner should exist and able to click link to go back to current submission
                 cy.findByTestId('previous-submission-banner').should('exist')
                 //Navigate back to current submission using link inside banner.
                 cy.clickSubmissionLink('currentSubmissionLink')
@@ -226,7 +228,7 @@ describe('CMS user', () => {
         })
     })
 
-    it.skip('can unlock and resubmit with linked rates', () => {
+    it('can unlock and resubmit child rates with linked rates flag', () => {
         cy.interceptFeatureFlags({"link-rates": true, '438-attestation': true})
         cy.logInAsStateUser()
 
@@ -389,24 +391,26 @@ describe('CMS user', () => {
                     button.trigger('click')
                     button.siblings().hasClass('usa-accordion__content') /// make sure accordion is expanded
                 })
-                //Check for view previous submission link in the initial accordion item to exist
-                cy.findByTestId('revision-link-1').should('be.visible')
-                cy.clickSubmissionLink('revision-link-1')
-                //Making sure we are on SubmissionRevisionSummary page and contains version text
-                cy.findByTestId('revision-version')
-                    .should('exist')
-                    .contains(
-                        /(0?[1-9]|[12][0-9]|3[01])\/[0-9]+\/[0-9]+\s[0-9]+:[0-9]+[a-zA-Z]+ ET version/i
-                    )
-                //Previous submission banner should exist and able to click link to go back to current submission
-                cy.findByTestId('previous-submission-banner').should('exist')
-                //Navigate back to current submission using link inside banner.
-                cy.clickSubmissionLink('currentSubmissionLink')
-                //Make sure banner and revision version text are gone.
-                cy.findByTestId('previous-submission-banner').should(
-                    'not.exist'
-                )
-                cy.findByTestId('revision-version').should('not.exist')
+
+                // TURN THIS BACK ON WHEN PREVIOUS SUBMISSION FIXED
+                // //Check for view previous submission link in the initial accordion item to exist
+                // cy.findByTestId('revision-link-1').should('be.visible')
+                // cy.clickSubmissionLink('revision-link-1')
+                // //Making sure we are on SubmissionRevisionSummary page and contains version text
+                // cy.findByTestId('revision-version')
+                //     .should('exist')
+                //     .contains(
+                //         /(0?[1-9]|[12][0-9]|3[01])\/[0-9]+\/[0-9]+\s[0-9]+:[0-9]+[a-zA-Z]+ ET version/i
+                //     )
+                // //Previous submission banner should exist and able to click link to go back to current submission
+                // cy.findByTestId('previous-submission-banner').should('exist')
+                // //Navigate back to current submission using link inside banner.
+                // cy.clickSubmissionLink('currentSubmissionLink')
+                // //Make sure banner and revision version text are gone.
+                // cy.findByTestId('previous-submission-banner').should(
+                //     'not.exist'
+                // )
+                // cy.findByTestId('revision-version').should('not.exist')
 
                 // Unlock again and resubmit to test change history
                 cy.unlockSubmission('Second Unlock')
@@ -457,4 +461,8 @@ describe('CMS user', () => {
             })
         })
     })
+
+    // TODO AFTER LINKED RATES AND LINKED RATES CHANGE HISTORY SHIPS
+    // it('can unlock and resubmit a linked rate and change history updates')
+    // it('can unlock and resubmit combination of linked and child rates as expected' )
 })

--- a/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -228,7 +228,7 @@ describe('CMS user', () => {
         })
     })
 
-    it('can unlock and resubmit child rates with linked rates flag', () => {
+    it.only('can unlock and resubmit child rates with linked rates flag', () => {
         cy.interceptFeatureFlags({"link-rates": true, '438-attestation': true})
         cy.logInAsStateUser()
 
@@ -452,10 +452,10 @@ describe('CMS user', () => {
                     expect(recordText[3]).to.contain('Reason for unlock: Unlock submission reason.')
 
                     // Test for initial submission
-                    expect(recordText[4]).to.contain('Submitted by: aang@example.com')
-                    expect(recordText[4]).to.contain('View past submission version')
-                    expect(recordText[4]).to.not.contain('Changes made:')
-                    expect(recordText[4]).to.not.contain('Reason for unlock:')
+                    expect(recordText[4]).to.contain(/Submitted by: aang@example.com/)
+                    expect(recordText[4]).to.contain(/View past submission version/)
+                    expect(recordText[4]).to.not.contain(/Changes made:/)
+                    expect(recordText[4]).to.not.contain(/Reason for unlock:/)
                     console.log(recordText)
                 })
             })

--- a/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -228,7 +228,7 @@ describe('CMS user', () => {
         })
     })
 
-    it('can unlock and resubmit child rates with linked rates flag', () => {
+    it.only('can unlock and resubmit child rates with linked rates flag', () => {
         cy.interceptFeatureFlags({"link-rates": true, '438-attestation': true})
         cy.logInAsStateUser()
 
@@ -392,25 +392,24 @@ describe('CMS user', () => {
                     button.siblings().hasClass('usa-accordion__content') /// make sure accordion is expanded
                 })
 
-                // TURN THIS BACK ON WHEN PREVIOUS SUBMISSION FIXED
-                // //Check for view previous submission link in the initial accordion item to exist
-                // cy.findByTestId('revision-link-1').should('be.visible')
-                // cy.clickSubmissionLink('revision-link-1')
-                // //Making sure we are on SubmissionRevisionSummary page and contains version text
-                // cy.findByTestId('revision-version')
-                //     .should('exist')
-                //     .contains(
-                //         /(0?[1-9]|[12][0-9]|3[01])\/[0-9]+\/[0-9]+\s[0-9]+:[0-9]+[a-zA-Z]+ ET version/i
-                //     )
-                // //Previous submission banner should exist and able to click link to go back to current submission
-                // cy.findByTestId('previous-submission-banner').should('exist')
-                // //Navigate back to current submission using link inside banner.
-                // cy.clickSubmissionLink('currentSubmissionLink')
-                // //Make sure banner and revision version text are gone.
-                // cy.findByTestId('previous-submission-banner').should(
-                //     'not.exist'
-                // )
-                // cy.findByTestId('revision-version').should('not.exist')
+                //Check for view previous submission link in the initial accordion item to exist
+                cy.findByTestId('revision-link-1').should('be.visible')
+                cy.clickSubmissionLink('revision-link-1')
+                //Making sure we are on SubmissionRevisionSummary page and contains version text
+                cy.findByTestId('revision-version')
+                    .should('exist')
+                    .contains(
+                        /(0?[1-9]|[12][0-9]|3[01])\/[0-9]+\/[0-9]+\s[0-9]+:[0-9]+[a-zA-Z]+ ET version/i
+                    )
+                //Previous submission banner should exist and able to click link to go back to current submission
+                cy.findByTestId('previous-submission-banner').should('exist')
+                //Navigate back to current submission using link inside banner.
+                cy.clickSubmissionLink('currentSubmissionLink')
+                //Make sure banner and revision version text are gone.
+                cy.findByTestId('previous-submission-banner').should(
+                    'not.exist'
+                )
+                cy.findByTestId('revision-version').should('not.exist')
 
                 // Unlock again and resubmit to test change history
                 cy.unlockSubmission('Second Unlock')
@@ -452,9 +451,10 @@ describe('CMS user', () => {
                     expect(recordText[3]).to.contain('Reason for unlock: Unlock submission reason.')
 
                     // Test for initial submission
-                    expect(recordText[4]).to.contain(/View past submission version/)
-                    expect(recordText[4]).to.not.contain(/Changes made:/)
-                    expect(recordText[4]).to.not.contain(/Reason for unlock:/)
+                    expect(recordText[4]).to.contain('aang@example.com')
+                    expect(recordText[4]).to.contain('View past submission version')
+                    expect(recordText[4]).to.not.contain('Changes made:')
+                    expect(recordText[4]).to.not.contain('Reason for unlock:')
 
                 })
             })

--- a/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -228,7 +228,7 @@ describe('CMS user', () => {
         })
     })
 
-    it('can unlock and resubmit child rates with linked rates flag', () => {
+    it.only('can unlock and resubmit child rates with linked rates flag', () => {
         cy.interceptFeatureFlags({"link-rates": true, '438-attestation': true})
         cy.logInAsStateUser()
 

--- a/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -228,7 +228,7 @@ describe('CMS user', () => {
         })
     })
 
-    it.only('can unlock and resubmit child rates with linked rates flag', () => {
+    it('can unlock and resubmit child rates with linked rates flag', () => {
         cy.interceptFeatureFlags({"link-rates": true, '438-attestation': true})
         cy.logInAsStateUser()
 

--- a/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -452,7 +452,6 @@ describe('CMS user', () => {
                     expect(recordText[3]).to.contain('Reason for unlock: Unlock submission reason.')
 
                     // Test for initial submission
-                    expect(recordText[4]).to.contain(/aang@example.com/)
                     expect(recordText[4]).to.contain(/View past submission version/)
                     expect(recordText[4]).to.not.contain(/Changes made:/)
                     expect(recordText[4]).to.not.contain(/Reason for unlock:/)

--- a/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -222,7 +222,7 @@ describe('CMS user', () => {
                     expect(recordText[4]).to.contain('View past submission version')
                     expect(recordText[4]).to.not.contain('Changes made:')
                     expect(recordText[4]).to.not.contain('Reason for unlock:')
-                    console.log(recordText)
+
                 })
             })
         })
@@ -456,7 +456,7 @@ describe('CMS user', () => {
                     expect(recordText[4]).to.contain(/View past submission version/)
                     expect(recordText[4]).to.not.contain(/Changes made:/)
                     expect(recordText[4]).to.not.contain(/Reason for unlock:/)
-                    console.log(recordText)
+
                 })
             })
         })


### PR DESCRIPTION
## Summary
- Turn on `unlockResubmit` for linked rate flag on.
- Fix unlock banner does not display bug
- Fix contract actions list display (emulate what we do for checkbox fields on summary pages)
- Fix "Initial contract" display (which was happening on migrated submissions on another branch) and it should not show the updated reason in the Change history anyway

#### Related issues
https://jiraent.cms.gov/browse/MCR-4052
https://jiraent.cms.gov/browse/MCR-4073

#### Test cases covered
- unlockResubmit tests pass for Cypress (except for previous submission page cases)
<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
- As CMS user - Check a submitted package with linked rates for the "Contract actions" display". [example submission](https://dvwwmg3ijqha8.cloudfront.net/rates/deb2ccb5-3fdc-4d64-9191-b4ee236ae1d2)
- AS CMS user - Confirm unlock banner appears on unlock submission. [example submission](https://dvwwmg3ijqha8.cloudfront.net/submissions/26d051eb-1a65-4241-8f0c-d6eb5fbe9248)
- As a user viewing change history, initial submissions should only appear with the date and the previous submission link. No change reason should be logged
<!---These are developer instructions on how to test or validate the work -->
