### PR TITLE
SubmissionSummaryV2 bug

### DIFF
--- a/services/app-web/src/pages/SubmissionSummary/V2/SubmissionSummaryV2.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/V2/SubmissionSummaryV2.test.tsx
@@ -34,9 +34,7 @@ describe('SubmissionSummary', () => {
                             statusCode: 200,
                         }),
                         fetchContractMockSuccess({
-                            contract: {
-                                id: 'test-abc-123',
-                            },
+                            contract: mockContractPackageSubmitted(),
                         }),
                         fetchStateHealthPlanPackageWithQuestionsMockSuccess({
                             id: 'test-abc-123',
@@ -51,7 +49,6 @@ describe('SubmissionSummary', () => {
                 },
             }
         )
-        screen.debug()
         expect(
             await screen.findByRole('heading', { name: 'Contract details' })
         ).toBeInTheDocument()
@@ -461,9 +458,7 @@ describe('SubmissionSummary', () => {
                             id: 'test-abc-123',
                         }),
                         fetchContractMockSuccess({
-                            contract: {
-                                id: 'test-abc-123',
-                            },
+                            contract: mockContractPackageSubmitted(),
                         }),
                     ],
                 },
@@ -475,6 +470,7 @@ describe('SubmissionSummary', () => {
                 },
             }
         )
+        screen.debug()
         expect(
             await screen.findByRole('heading', {
                 name: 'Contract details',

--- a/services/app-web/src/pages/SubmissionSummary/V2/SubmissionSummaryV2.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/V2/SubmissionSummaryV2.tsx
@@ -8,7 +8,6 @@ import {
 import React, { useEffect, useRef, useState } from 'react'
 import { NavLink } from 'react-router-dom'
 import { useAuth } from '../../../contexts/AuthContext'
-import { packageName } from '../../../common-code/healthPlanFormDataType'
 import { ContractDetailsSummarySectionV2 } from '../../StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContractDetailsSummarySectionV2'
 import { ContactsSummarySection } from '../../StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContactsSummarySectionV2'
 import { RateDetailsSummarySectionV2 } from '../../StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2'
@@ -61,13 +60,9 @@ export const SubmissionSummaryV2 = (): React.ReactElement => {
     // Page level state
     const { updateHeading } = usePage()
     const modalRef = useRef<ModalRef>(null)
-    const [pkgName, setPkgName] = useState<string | undefined>(undefined)
     const [documentError, setDocumentError] = useState(false)
     const { loggedInUser } = useAuth()
 
-    useEffect(() => {
-        updateHeading({ customHeading: pkgName })
-    }, [pkgName, updateHeading])
     const { id } = useRouteParams()
 
     const ldClient = useLDClient()
@@ -87,16 +82,29 @@ export const SubmissionSummaryV2 = (): React.ReactElement => {
                 contractID: id ?? 'unknown-contract',
             },
         },
-        fetchPolicy: 'network-only'
+        fetchPolicy: 'network-only',
     })
     const contract = fetchContractData?.fetchContract.contract
+    const name =
+        contract && contract?.packageSubmissions.length > 0
+            ? contract.packageSubmissions[0].contractRevision.contractName
+            : ''
+    useEffect(() => {
+        updateHeading({
+            customHeading: name,
+        })
+    }, [name, updateHeading])
     if (fetchContractLoading) {
         return (
             <GridContainer>
                 <Loading />
             </GridContainer>
         )
-    } else if (fetchContractError || !contract) {
+    } else if (
+        fetchContractError ||
+        !contract ||
+        contract.packageSubmissions.length === 0
+    ) {
         //error handling for a state user that tries to access rates for a different state
         if (
             fetchContractError?.graphQLErrors[0]?.extensions?.code ===
@@ -121,25 +129,13 @@ export const SubmissionSummaryV2 = (): React.ReactElement => {
     const submissionStatus = contract.status
     const statePrograms = contract.state.programs
 
-    const contractFormData = getVisibleLatestContractFormData(contract, isStateUser)
+    const contractFormData = getVisibleLatestContractFormData(
+        contract,
+        isStateUser
+    )
     if (!contractFormData) {
         console.error('no form data inside submission summary')
         return <GenericErrorPage />
-    }
-
-    const programIDs = contractFormData.programIDs
-    const programs = statePrograms.filter((program) =>
-        programIDs.includes(program.id)
-    )
-    // set the page heading
-    const name = packageName(
-        contract.stateCode,
-        contract.stateNumber,
-        contractFormData.programIDs,
-        programs
-    )
-    if (pkgName !== name) {
-        setPkgName(name)
     }
 
     // Get the correct update info depending on the submission status


### PR DESCRIPTION
## Summary

- Pages in val were crashing instead of displaying the error container. The submissions with the failures hadn't had data migrated yet. One issue with page was the assumption that `contract.packageSubmissions[0].` would be populated. This PR updates to check the packageSubmissions length and return the generic error page when there aren't any submissions
- Updates the heading name to use the `contractName` field on the submitted contract revision 

#### Related issues
https://jiraent.cms.gov/browse/MCR-4066

#### Test cases covered

- Previously written test cases that were using a mocked draft submission failed and were updated to use a submitted contract

