### PR TITLE
Correct Previous Submission Link

### DIFF
--- a/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
@@ -115,7 +115,7 @@ export const ChangeHistoryV2 = ({
                         </div>
                         {isSubsequentSubmission && r.revisionVersion && (
                             <Link
-                                href={`/contracts/${contract.id}/revisions/${r.revisionVersion}`}
+                                href={`/submissions/${contract.id}/revisions/${r.revisionVersion}`}
                                 data-testid={`revision-link-${r.revisionVersion}`}
                             >
                                 View past contract version


### PR DESCRIPTION
## Summary

We had put "contracts" in the url for previous submissions instead of "submissions" leading to 404s.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4067
