### PR TITLE
MCR-4036 & MCR-4037: link rates dropdown and linked rate submitted date

### DIFF
--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
@@ -41,46 +41,46 @@ export const LinkRateSelect = ({
 
     const rates = data?.indexRates.edges.map((e) => e.node) || []
 
-    const rateNames: LinkRateOptionType[] = rates
-        .map((rate) => {
-            const revision = rate.revisions[0]
-            return {
-                value: rate.id,
-                label: (
-                    <>
-                        <strong>
-                            {revision.formData.rateCertificationName}
-                        </strong>
-                        <div style={{ lineHeight: '50%', fontSize: '14px' }}>
-                            <p>
-                                Programs:&nbsp;
-                                {programNames(
-                                    statePrograms,
-                                    revision.formData.rateProgramIDs
-                                ).join(', ')}
-                            </p>
-                            <p>
-                                Rating period:&nbsp;
-                                {formatCalendarDate(
-                                    revision.formData.rateDateStart
-                                )}
-                                -
-                                {formatCalendarDate(
-                                    revision.formData.rateDateEnd
-                                )}
-                            </p>
-                            <p>
-                                Certification date:&nbsp;
-                                {formatCalendarDate(
-                                    revision.formData.rateDateCertified
-                                )}
-                            </p>
-                        </div>
-                    </>
-                ),
-            }
-        })
-        .reverse()
+    // Sort rates by latest submission in desc order
+    rates.sort(
+        (a, b) =>
+            new Date(b.revisions[0].submitInfo?.updatedAt).getTime() -
+            new Date(a.revisions[0].submitInfo?.updatedAt).getTime()
+    )
+
+    const rateNames: LinkRateOptionType[] = rates.map((rate) => {
+        const revision = rate.revisions[0]
+        return {
+            value: rate.id,
+            label: (
+                <>
+                    <strong>{revision.formData.rateCertificationName}</strong>
+                    <div style={{ lineHeight: '50%', fontSize: '14px' }}>
+                        <p>
+                            Programs:&nbsp;
+                            {programNames(
+                                statePrograms,
+                                revision.formData.rateProgramIDs
+                            ).join(', ')}
+                        </p>
+                        <p>
+                            Rating period:&nbsp;
+                            {formatCalendarDate(
+                                revision.formData.rateDateStart
+                            )}
+                            -{formatCalendarDate(revision.formData.rateDateEnd)}
+                        </p>
+                        <p>
+                            Certification date:&nbsp;
+                            {formatCalendarDate(
+                                revision.formData.rateDateCertified
+                            )}
+                        </p>
+                    </div>
+                </>
+            ),
+        }
+    })
 
     const onFocus: AriaOnFocus<LinkRateOptionType> = ({
         focused,
@@ -143,39 +143,37 @@ export const LinkRateSelect = ({
     const selectedRates = values.rateForms.map((rate) => rate.id && rate.id)
 
     return (
-        <>
-            <Select
-                defaultMenuIsOpen
-                value={defaultValue}
-                className={styles.rateMultiSelect}
-                options={
-                    error || loading
-                        ? undefined
-                        : rateNames.filter(
-                              (rate) => !selectedRates.includes(rate.value)
-                          )
-                }
-                isSearchable
-                maxMenuHeight={400}
-                aria-label="linked rates (required)"
-                ariaLiveMessages={{
-                    onFocus,
-                }}
-                isClearable
-                noOptionsMessage={() => noOptionsMessage()}
-                classNamePrefix="select"
-                id={`${name}-linkRateSelect`}
-                inputId=""
-                placeholder={
-                    loading ? 'Loading rate certifications...' : 'Select...'
-                }
-                loadingMessage={() => 'Loading rate certifications...'}
-                name={name}
-                filterOption={filterOptions}
-                {...selectProps}
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                onChange={onInputChange as any} // TODO see why the types definitions are messed up for react-select "single" (not multi) onChange - may need to upgrade dep if this bug was fixed
-            />
-        </>
+        <Select
+            defaultMenuIsOpen
+            value={defaultValue}
+            className={styles.rateMultiSelect}
+            options={
+                error || loading
+                    ? undefined
+                    : rateNames.filter(
+                          (rate) => !selectedRates.includes(rate.value)
+                      )
+            }
+            isSearchable
+            maxMenuHeight={400}
+            aria-label="linked rates (required)"
+            ariaLiveMessages={{
+                onFocus,
+            }}
+            isClearable
+            noOptionsMessage={() => noOptionsMessage()}
+            classNamePrefix="select"
+            id={`${name}-linkRateSelect`}
+            inputId=""
+            placeholder={
+                loading ? 'Loading rate certifications...' : 'Select...'
+            }
+            loadingMessage={() => 'Loading rate certifications...'}
+            name={name}
+            filterOption={filterOptions}
+            {...selectProps}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            onChange={onInputChange as any} // TODO see why the types definitions are messed up for react-select "single" (not multi) onChange - may need to upgrade dep if this bug was fixed
+        />
     )
 }

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/LinkedRateSummary.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/LinkedRateSummary.tsx
@@ -28,7 +28,7 @@ export const LinkedRateSummary = ({
                         id="submissionDate"
                         label="Submission date"
                         children={formatCalendarDate(
-                            rateForm.rateDateCertified
+                            rateForm.initiallySubmittedAt
                         )}
                     />
 

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -71,6 +71,7 @@ export type FormikRateForm = {
     actuaryCommunicationPreference: RateRevision['formData']['actuaryCommunicationPreference']
     packagesWithSharedRateCerts: RateRevision['formData']['packagesWithSharedRateCerts']
     ratePreviouslySubmitted?: 'YES' | 'NO'
+    initiallySubmittedAt?: Date
 }
 
 // We have a list of rates to enable multi-rate behavior

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
@@ -100,7 +100,8 @@ const convertGQLRateToRateForm = (getKey: S3ClientT['getKey'], rate?: Rate, pare
             rateForm?.actuaryCommunicationPreference?? undefined,
         packagesWithSharedRateCerts:
             rateForm?.packagesWithSharedRateCerts ?? [],
-        ratePreviouslySubmitted: handleAsLinkedRate? 'YES' : rateForm ? 'NO' : undefined
+        ratePreviouslySubmitted: handleAsLinkedRate? 'YES' : rateForm ? 'NO' : undefined,
+        initiallySubmittedAt: rate?.initiallySubmittedAt
     }
 }
 

--- a/services/app-web/src/testHelpers/apolloMocks/rateDataMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/rateDataMock.ts
@@ -244,4 +244,4 @@ const rateDataMock = (
     }
 }
 
-export { rateDataMock, rateRevisionDataMock,draftRateDataMock,   }
+export { rateDataMock, rateRevisionDataMock, draftRateDataMock }


### PR DESCRIPTION
## Summary

Fix for two bugs

[MCR-4036](https://jiraent.cms.gov/browse/MCR-4036): Rate submitted date is incorrect
[MCR-4037](https://jiraent.cms.gov/browse/MCR-4037): Link rates dropdown sort order is incorrect

#### Related issues

#### Screenshots

#### Test cases covered

`RateDetailsV2.test.ts`
- `lists dropdown options in desc order by latest submission date`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
