### PR TITLE
Remove incomplete warnings on submission summary page

### DIFF
--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -313,7 +313,7 @@ export const ContractDetailsSummarySection = ({
                 }
                 caption="Contract"
                 documentCategory="Contract"
-                isEditing={isEditing}
+                hideDynamicFeedback={!isEditing}
             />
             <UploadedDocumentsTable
                 documents={convertFromSubmissionDocumentsToGenericDocuments(
@@ -330,7 +330,7 @@ export const ContractDetailsSummarySection = ({
                 caption="Contract supporting documents"
                 documentCategory="Contract-supporting"
                 isSupportingDocuments
-                isEditing={isEditing}
+                hideDynamicFeedback={!isEditing}
             />
         </SectionCard>
     )

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -356,7 +356,7 @@ export const RateDetailsSummarySection = ({
                                         rateInfo.rateDocuments,
                                         documentDateLookupTable
                                     )}
-                                    packagesWithSharedRateCerts={refreshPackagesWithSharedRateCert(
+                                    packagesWithSharedRateCerts={isPreviousSubmission? []:refreshPackagesWithSharedRateCert(
                                         rateInfo
                                     )}
                                     previousSubmissionDate={
@@ -369,7 +369,7 @@ export const RateDetailsSummarySection = ({
                                     multipleDocumentsAllowed={false}
                                     caption="Rate certification"
                                     documentCategory="Rate certification"
-                                    isEditing={isEditing}
+                                    hideDynamicFeedback={!isEditing}
                                 />
                             ) : (
                                 <span className="srOnly">'LOADING...'</span>
@@ -380,7 +380,7 @@ export const RateDetailsSummarySection = ({
                                         rateInfo.supportingDocuments,
                                         documentDateLookupTable
                                     )}
-                                    packagesWithSharedRateCerts={refreshPackagesWithSharedRateCert(
+                                    packagesWithSharedRateCerts={isPreviousSubmission? []: refreshPackagesWithSharedRateCert(
                                         rateInfo
                                     )}
                                     previousSubmissionDate={
@@ -393,7 +393,7 @@ export const RateDetailsSummarySection = ({
                                     caption="Rate supporting documents"
                                     isSupportingDocuments
                                     documentCategory="Rate-supporting"
-                                    isEditing={isEditing}
+                                    hideDynamicFeedback={!isEditing}
                                 />
                             ) : (
                                 <span className="srOnly">'LOADING...'</span>

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -391,7 +391,6 @@ export const RateDetailsSummarySection = ({
                                             : null
                                     }
                                     caption="Rate supporting documents"
-                                    isSupportingDocuments
                                     documentCategory="Rate-supporting"
                                     hideDynamicFeedback={!isEditing}
                                 />

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
@@ -100,7 +100,7 @@ describe('SingleRateSummarySection', () => {
         ).toBeInTheDocument()
     })
     // can delete the next test when linked rates flag is permanently on
-    it('renders documents with linked submissions correctly (legacy feature)', async () => {
+    it('renders documents with linked submissions correctly for CMS users (legacy feature)', async () => {
         const rateData = rateDataMock()
         const parentContractRev = rateData.revisions[0].contractRevisions[0]
         const rateDoc = rateData.revisions[0].formData.rateDocuments[0]

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -106,6 +106,8 @@ export const SingleRateSummarySection = ({
     const explainMissingData =
         !isSubmitted && loggedInUser?.role === 'STATE_USER'
     const isCMSUser = loggedInUser?.role === 'CMS_USER'
+    const isSubmittedOrCMSUser =
+    rate.status === 'SUBMITTED' || loggedInUser?.role === 'CMS_USER'
 
     // feature flags
     const ldClient = useLDClient()
@@ -348,12 +350,14 @@ export const SingleRateSummarySection = ({
                     multipleDocumentsAllowed={false}
                     previousSubmissionDate={lastSubmittedDate}
                     caption="Rate certification"
+                    hideDynamicFeedback={!isSubmittedOrCMSUser}
                 />
                 <UploadedDocumentsTable
                     documents={formData.supportingDocuments}
                     packagesWithSharedRateCerts={appendDraftToSharedPackages}
                     previousSubmissionDate={lastSubmittedDate}
                     caption="Rate supporting documents"
+                    hideDynamicFeedback={!isSubmittedOrCMSUser}
                 />
             </SectionCard>
         </React.Fragment>

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/DocumentTag.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/DocumentTag.tsx
@@ -3,7 +3,7 @@ import { InfoTag } from '../../InfoTag/InfoTag'
 import styles from './UploadedDocumentsTable.module.scss'
 
 type DocumentTagProps = {
-    isShared?: boolean // can be delted after LINK_RATES
+    isShared?: boolean // can be deleted after legacy submissions addressed and LINK_RATES permanently on
     isNew?: boolean
 }
 export const DocumentTag = ({

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
@@ -329,6 +329,7 @@ describe('UploadedDocumentsTable', () => {
                 caption="Contract"
                 documentCategory="Contract"
                 multipleDocumentsAllowed={false}
+                hideDynamicFeedback={false}
             />,
             {
                 apolloProvider: {

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
@@ -515,7 +515,7 @@ describe('UploadedDocumentsTable', () => {
         expect(await screen.findByTestId('tag')).toHaveTextContent('SHARED')
     })
 
-    it('no longer renders SHARED tag to state user when linked rates flag on', async () => {
+    it('still renders SHARED tag to state user when linked rates flag on', async () => {
         const packagesWithSharedRateCerts = [
             {
                 packageId: '333b4225-5b49-4e82-aa71-be0d33d7418d',
@@ -553,7 +553,7 @@ describe('UploadedDocumentsTable', () => {
             }
         )
 
-        expect(await screen.findByTestId('tag')).not.toBeInTheDocument()
+        expect(await screen.findByTestId('tag')).toBeInTheDocument()
     })
 
     it('does not validations when hideDynamicFeedback is set to true',async() =>{

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
@@ -9,6 +9,10 @@ import {
 import type { GenericDocument } from '../../../gen/gqlClient'
 
 describe('UploadedDocumentsTable', () => {
+
+    afterEach ( () => {
+        jest.clearAllMocks()
+    })
     it('renders documents without errors', async () => {
         const testDocuments = [
             {
@@ -24,6 +28,7 @@ describe('UploadedDocumentsTable', () => {
                 caption="Contract"
                 documentCategory="Contract"
                 previousSubmissionDate={new Date('01/01/01')}
+                hideDynamicFeedback={true}
             />,
             {
                 apolloProvider: {
@@ -72,6 +77,7 @@ describe('UploadedDocumentsTable', () => {
                 caption="Contract supporting"
                 documentCategory="Contract-supporting"
                 isSupportingDocuments
+                hideDynamicFeedback={true}
             />,
             {
                 apolloProvider: {
@@ -121,6 +127,7 @@ describe('UploadedDocumentsTable', () => {
                 documentCategory="Contract-supporting"
                 isSupportingDocuments
                 previousSubmissionDate={new Date('03/26/2022')}
+                hideDynamicFeedback={true}
             />,
             {
                 apolloProvider: {
@@ -171,6 +178,7 @@ describe('UploadedDocumentsTable', () => {
                 caption="Contract supporting"
                 documentCategory="Contract-supporting"
                 isSupportingDocuments
+                hideDynamicFeedback={true}
             />,
             {
                 apolloProvider: {
@@ -222,6 +230,7 @@ describe('UploadedDocumentsTable', () => {
                 caption="Contract supporting"
                 documentCategory="Contract-supporting"
                 isSupportingDocuments
+                hideDynamicFeedback={true}
             />,
             {
                 apolloProvider: {
@@ -251,7 +260,7 @@ describe('UploadedDocumentsTable', () => {
             })
         })
     })
-    it('shows the NEW tag when a document is submitted after the last submission', async () => {
+    it('renders the NEW tag when a document is submitted after the last submission', async () => {
         const testDocuments: GenericDocument[] = [
             {
                 s3URL: 's3://foo/bar/test-1',
@@ -279,6 +288,7 @@ describe('UploadedDocumentsTable', () => {
                 caption="Contract supporting"
                 documentCategory="Contract-supporting"
                 isSupportingDocuments
+                hideDynamicFeedback={true}
             />,
             {
                 apolloProvider: {
@@ -338,7 +348,7 @@ describe('UploadedDocumentsTable', () => {
         })
     })
 
-    it('does not show the NEW tag if the user is not a CMS user', async () => {
+    it('does not show the NEW tag to state user', async () => {
         const testDocuments = [
             {
                 s3URL: 's3://foo/bar/test-1',
@@ -366,6 +376,7 @@ describe('UploadedDocumentsTable', () => {
                 caption="Contract supporting"
                 documentCategory="Contract-supporting"
                 isSupportingDocuments
+                hideDynamicFeedback={true}
             />,
             {
                 apolloProvider: {
@@ -377,6 +388,251 @@ describe('UploadedDocumentsTable', () => {
             const rows = screen.getAllByRole('row')
             expect(rows).toHaveLength(4)
             expect(screen.queryByTestId('tag')).not.toBeInTheDocument()
+        })
+    })
+
+    it('renders SHARED tag to CMS users when packages across submissions present', async () => {
+        const packagesWithSharedRateCerts = [
+            {
+                packageId: '333b4225-5b49-4e82-aa71-be0d33d7418d',
+                packageName: 'MCR-MN-0001-SNBC',
+            },
+            {
+                packageId: '21467dba-6ae8-11ed-a1eb-0242ac120002',
+                packageName: 'MCR-MN-0002-PMAP',
+            },
+        ]
+        const testDocuments = [
+            {
+                s3URL: 's3://foo/bar/test-1',
+                name: 'supporting docs test 1',
+                sha256: 'fakesha',
+                dateAdded: new Date('01/01/00'),
+            },
+        ]
+        renderWithProviders(
+            <UploadedDocumentsTable
+                documents={testDocuments}
+                caption="Rate"
+                documentCategory="Rate certification"
+                packagesWithSharedRateCerts={packagesWithSharedRateCerts}
+                previousSubmissionDate={new Date('01/01/01')}
+                hideDynamicFeedback={true}
+            />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ user: mockValidCMSUser(), statusCode: 200 })],
+                },
+                featureFlags: {
+                    'link-rates': false,
+                },
+            }
+        )
+
+        expect(await screen.findByTestId('tag')).toHaveTextContent('SHARED')
+    })
+
+    it('renders SHARED tag to state users when packages across submissions present', async () => {
+        const packagesWithSharedRateCerts = [
+            {
+                packageId: '333b4225-5b49-4e82-aa71-be0d33d7418d',
+                packageName: 'MCR-MN-0001-SNBC',
+            },
+            {
+                packageId: '21467dba-6ae8-11ed-a1eb-0242ac120002',
+                packageName: 'MCR-MN-0002-PMAP',
+            },
+        ]
+        const testDocuments = [
+            {
+                s3URL: 's3://foo/bar/test-1',
+                name: 'supporting docs test 1',
+                sha256: 'fakesha',
+                dateAdded: new Date('01/01/00'),
+            },
+        ]
+        renderWithProviders(
+            <UploadedDocumentsTable
+                documents={testDocuments}
+                caption="Rate"
+                documentCategory="Rate certification"
+                packagesWithSharedRateCerts={packagesWithSharedRateCerts}
+                previousSubmissionDate={new Date('01/01/01')}
+                hideDynamicFeedback={true}
+            />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+                featureFlags: {
+                    'link-rates': false,
+                },
+            }
+        )
+
+        expect(await screen.findByTestId('tag')).toHaveTextContent('SHARED')
+    })
+
+    it('still renders SHARED tag to CMS user if linked rates flag on', async () => {
+        const packagesWithSharedRateCerts = [
+            {
+                packageId: '333b4225-5b49-4e82-aa71-be0d33d7418d',
+                packageName: 'MCR-MN-0001-SNBC',
+            },
+            {
+                packageId: '21467dba-6ae8-11ed-a1eb-0242ac120002',
+                packageName: 'MCR-MN-0002-PMAP',
+            },
+        ]
+        const testDocuments = [
+            {
+                s3URL: 's3://foo/bar/test-1',
+                name: 'supporting docs test 1',
+                sha256: 'fakesha',
+                dateAdded: new Date('01/01/00'),
+            },
+        ]
+        renderWithProviders(
+            <UploadedDocumentsTable
+                documents={testDocuments}
+                caption="Rate"
+                documentCategory="Rate certification"
+                packagesWithSharedRateCerts={packagesWithSharedRateCerts}
+                previousSubmissionDate={new Date('01/01/01')}
+                hideDynamicFeedback={true}
+            />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ user: mockValidCMSUser(), statusCode: 200 })],
+                },
+                featureFlags: {
+                    'link-rates': true,
+                },
+            }
+        )
+
+        expect(await screen.findByTestId('tag')).toHaveTextContent('SHARED')
+    })
+
+    it('no longer renders SHARED tag to state user when linked rates flag on', async () => {
+        const packagesWithSharedRateCerts = [
+            {
+                packageId: '333b4225-5b49-4e82-aa71-be0d33d7418d',
+                packageName: 'MCR-MN-0001-SNBC',
+            },
+            {
+                packageId: '21467dba-6ae8-11ed-a1eb-0242ac120002',
+                packageName: 'MCR-MN-0002-PMAP',
+            },
+        ]
+        const testDocuments = [
+            {
+                s3URL: 's3://foo/bar/test-1',
+                name: 'supporting docs test 1',
+                sha256: 'fakesha',
+                dateAdded: new Date('01/01/00'),
+            },
+        ]
+        renderWithProviders(
+            <UploadedDocumentsTable
+                documents={testDocuments}
+                caption="Rate"
+                documentCategory="Rate certification"
+                packagesWithSharedRateCerts={packagesWithSharedRateCerts}
+                previousSubmissionDate={new Date('01/01/01')}
+                hideDynamicFeedback={true}
+            />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ user: mockValidStateUser(), statusCode: 200 })],
+                },
+                featureFlags: {
+                    'link-rates': true,
+                },
+            }
+        )
+
+        expect(await screen.findByTestId('tag')).not.toBeInTheDocument()
+    })
+
+    it('does not validations when hideDynamicFeedback is set to true',async() =>{
+        const testDocuments = [
+            {
+                s3URL: 's3://foo/bar/test-1',
+                name: 'supporting docs test 1',
+                sha256: 'fakesha',
+                dateAdded: new Date('03/25/2022'),
+            },
+            {
+                s3URL: 's3://foo/bar/test-2',
+                name: 'supporting docs test 2',
+                sha256: 'fakesha1',
+                dateAdded: new Date('03/25/2022'),
+            },
+            {
+                s3URL: 's3://foo/bar/test-3',
+                name: 'supporting docs test 3',
+                sha256: 'fakesha2',
+                dateAdded: new Date('03/27/2022'),
+            },
+        ]
+        renderWithProviders(
+            <UploadedDocumentsTable
+                documents={testDocuments}
+                previousSubmissionDate={new Date('03/27/2022')}
+                caption="Contract"
+                documentCategory="Contract-supporting"
+                multipleDocumentsAllowed={false}
+                hideDynamicFeedback={true}
+            />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+        )
+        await waitFor(() => {
+            expect(screen.queryByText(/Only one document is allowed/)).not.toBeInTheDocument()
+        })
+    })
+    it('renders document validations if hideDynamicFeedback is false and too many documents uploaded',async() =>{
+        const testDocuments = [
+            {
+                s3URL: 's3://foo/bar/test-1',
+                name: 'supporting docs test 1',
+                sha256: 'fakesha',
+                dateAdded: new Date('03/25/2022'),
+            },
+            {
+                s3URL: 's3://foo/bar/test-2',
+                name: 'supporting docs test 2',
+                sha256: 'fakesha1',
+                dateAdded: new Date('03/25/2022'),
+            },
+            {
+                s3URL: 's3://foo/bar/test-3',
+                name: 'supporting docs test 3',
+                sha256: 'fakesha2',
+                dateAdded: new Date('03/27/2022'),
+            },
+        ]
+        renderWithProviders(
+            <UploadedDocumentsTable
+                documents={testDocuments}
+                previousSubmissionDate={new Date('03/27/2022')}
+                caption="Contract"
+                documentCategory="Contract-supporting"
+                multipleDocumentsAllowed={false}
+                hideDynamicFeedback={false}
+            />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+        )
+        await waitFor(() => {
+            expect(screen.queryByText(/Only one document is allowed/)).toBeInTheDocument()
         })
     })
 })

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
@@ -152,7 +152,7 @@ export const UploadedDocumentsTable = ({
                     <div className={styles.captionContainer}>
                         {tableCaptionJSX}
                     </div>
-                    {!!isSubmitted && hasMultipleDocs && !isEditing && (
+                    {!isSubmitted && hasMultipleDocs && !isEditing && (
                         <DataDetailMissingField
                             classname={styles.missingInfo}
                             requiredText="Only one document is allowed for a rate

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
@@ -38,6 +38,7 @@ export type UploadedDocumentsTableProps = {
     multipleDocumentsAllowed?: boolean // used to determined if we display validations based on doc list length
     documentCategory?: string // used to determine if we display document category column
     isEditing?: boolean // default false, used to determine if we display validations for state users (or else extra context for CMS reviewers)
+    isSubmitted?: boolean // default false, used to determine if we display validations for CMS users
 }
 
 export const UploadedDocumentsTable = ({
@@ -49,6 +50,7 @@ export const UploadedDocumentsTable = ({
     isSupportingDocuments = false,
     multipleDocumentsAllowed = true,
     isEditing = false,
+    isSubmitted = false,
 }: UploadedDocumentsTableProps): React.ReactElement => {
     const initialDocState = documents.map((doc) => ({
         ...doc,
@@ -94,6 +96,7 @@ export const UploadedDocumentsTable = ({
         ? styles.withMarginTop
         : ''
 
+    const hasMultipleDocs = !multipleDocumentsAllowed && documents.length > 1
     const tableCaptionJSX = (
         <>
             <span>{caption}</span>
@@ -149,16 +152,14 @@ export const UploadedDocumentsTable = ({
                     <div className={styles.captionContainer}>
                         {tableCaptionJSX}
                     </div>
-                    {!multipleDocumentsAllowed &&
-                        documents.length > 1 &&
-                        !isEditing && (
-                            <DataDetailMissingField
-                                classname={styles.missingInfo}
-                                requiredText="Only one document is allowed for a rate
+                    {!!isSubmitted && hasMultipleDocs && !isEditing && (
+                        <DataDetailMissingField
+                            classname={styles.missingInfo}
+                            requiredText="Only one document is allowed for a rate
                         certification. You must remove documents before
                         continuing."
-                            />
-                        )}
+                        />
+                    )}
                 </caption>
                 <thead>
                     <tr>

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
@@ -13,8 +13,6 @@ import { useAuth } from '../../../contexts/AuthContext'
 import { DataDetailMissingField } from '../../DataDetail/DataDetailMissingField'
 import { GenericDocument } from '../../../gen/gqlClient'
 import { DocumentDateLookupTableType } from '../../../documentHelpers/makeDocumentDateLookupTable'
-import { featureFlags } from '../../../common-code/featureFlags'
-import { useLDClient } from 'launchdarkly-react-client-sdk'
 
 // V2 API migration note: intentionally trying to avoid making V2 version of this reuseable sub component since it has such a contained focus (on displaying documents only).
 // Use props to pass needed information and seek to make content as domain agnostic as possible.
@@ -53,19 +51,12 @@ export const UploadedDocumentsTable = ({
     multipleDocumentsAllowed = true,
     hideDynamicFeedback = false,
 }: UploadedDocumentsTableProps): React.ReactElement => {
-    const ldClient = useLDClient()
-
-    const useLinkedRates = ldClient?.variation(
-        featureFlags.LINK_RATES.flag,
-        featureFlags.LINK_RATES.defaultValue
-    ) ?? false
     const initialDocState = documents.map((doc) => ({
         ...doc,
         url: null,
         s3Key: null,
     }))
     const { loggedInUser } = useAuth()
-    const isStateUser = loggedInUser?.__typename === 'StateUser'
     const isCMSUser = loggedInUser?.__typename === 'CMSUser'
     const { getDocumentsWithS3KeyAndUrl } = useDocument()
     const [refreshedDocs, setRefreshedDocs] =

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
@@ -95,7 +95,7 @@ export const UploadedDocumentsTable = ({
 
     // show legacy shared rates across submissions (this is feature replaced by linked rates)
     // to cms users always when data available, to state users only when linked rates flag is off
-    const showLegacySharedRatesAcross =  Boolean((useLinkedRates? !isStateUser: true) && (packagesWithSharedRateCerts && packagesWithSharedRateCerts.length > 0))
+    const showLegacySharedRatesAcross =  Boolean(packagesWithSharedRateCerts && packagesWithSharedRateCerts.length > 0)
 
     const borderTopGradientStyles = `borderTopLinearGradient ${styles.uploadedDocumentsTable}`
     const supportingDocsTopMarginStyles = isSupportingDocuments

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/LinkedRateSummary.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/LinkedRateSummary.tsx
@@ -63,7 +63,7 @@ export const LinkedRateSummary = ({
                 multipleDocumentsAllowed={false}
                 caption="Rate certification"
                 documentCategory="Rate certification"
-                isEditing={false}
+                hideDynamicFeedback={true} // linked rates always displayed without validations
                 previousSubmissionDate={null}
             />
         </SectionCard>

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -363,9 +363,7 @@ const RateDetailsV2 = ({
                     />
                 )}
             </div>
-            <div style={{ textAlign: 'center' }}>
-                This is the V2 version of the Rate Details Page
-            </div>
+
             <Formik
                 initialValues={initialValues}
                 onSubmit={(rateFormValues, { setSubmitting }) => {

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContractDetailsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContractDetailsSummarySectionV2.tsx
@@ -13,6 +13,7 @@ import { DoubleColumnGrid } from '../../../../../components/DoubleColumnGrid'
 import { DownloadButton } from '../../../../../components/DownloadButton'
 import { usePreviousSubmission } from '../../../../../hooks/usePreviousSubmission'
 import styles from '../../../../../components/SubmissionSummarySection/SubmissionSummarySection.module.scss'
+import { useAuth } from '../../../../../contexts/AuthContext'
 
 import {
     sortModifiedProvisions,
@@ -84,8 +85,10 @@ export const ContractDetailsSummarySectionV2 = ({
         string | undefined | Error
     >(undefined)
     const ldClient = useLDClient()
-    const isEditing = !isSubmitted(contract) && editNavigateTo !== undefined
-
+    const { loggedInUser } = useAuth()
+    const isSubmittedOrCMSUser =
+    contract.status === 'SUBMITTED' || loggedInUser?.role === 'CMS_USER'
+    const isEditing = !isSubmittedOrCMSUser && editNavigateTo !== undefined
     const contractFormData = getVisibleLatestContractFormData(
         contract,
         isEditing
@@ -113,7 +116,7 @@ export const ContractDetailsSummarySectionV2 = ({
 
     useDeepCompareEffect(() => {
         // skip getting urls of this if this is a previous contract or draft
-        if (!isSubmitted(contract) || isPreviousSubmission) return
+        if (!isSubmittedOrCMSUser || isPreviousSubmission) return
 
         // get all the keys for the documents we want to zip
         async function fetchZipUrl() {
@@ -170,7 +173,7 @@ export const ContractDetailsSummarySectionV2 = ({
                 header="Contract details"
                 editNavigateTo={editNavigateTo}
             >
-                {isSubmitted(contract) &&
+                {isSubmittedOrCMSUser &&
                     !isPreviousSubmission &&
                     renderDownloadButton(zippedFilesURL)}
             </SectionHeader>

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContractDetailsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContractDetailsSummarySectionV2.tsx
@@ -25,7 +25,6 @@ import {
     isBaseContract,
     isCHIPOnly,
     isContractWithProvisions,
-    isSubmitted,
 } from '../../../../../common-code/ContractType'
 import {
     federalAuthorityKeysForCHIP,

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContractDetailsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContractDetailsSummarySectionV2.tsx
@@ -192,7 +192,7 @@ export const ContractDetailsSummarySectionV2 = ({
                                             StatutoryRegulatoryAttestationQuestion
                                         }
                                         explainMissingData={
-                                            !isSubmitted(contract)
+                                            !isSubmittedOrCMSUser
                                         }
                                         children={
                                             StatutoryRegulatoryAttestation[
@@ -210,7 +210,7 @@ export const ContractDetailsSummarySectionV2 = ({
                                 <DataDetail
                                     id="statutoryRegulatoryAttestationDescription"
                                     label="Non-compliance description"
-                                    explainMissingData={!isSubmitted}
+                                    explainMissingData={!isSubmittedOrCMSUser}
                                     children={
                                         contractFormData?.statutoryRegulatoryAttestationDescription
                                     }
@@ -223,7 +223,7 @@ export const ContractDetailsSummarySectionV2 = ({
                     <DataDetail
                         id="contractExecutionStatus"
                         label="Contract status"
-                        explainMissingData={!isSubmitted(contract)}
+                        explainMissingData={!isSubmittedOrCMSUser}
                         children={
                             contractFormData?.contractExecutionStatus
                                 ? ContractExecutionStatusRecord[
@@ -239,7 +239,7 @@ export const ContractDetailsSummarySectionV2 = ({
                                 ? 'Contract amendment effective dates'
                                 : 'Contract effective dates'
                         }
-                        explainMissingData={!isSubmitted(contract)}
+                        explainMissingData={!isSubmittedOrCMSUser}
                         children={
                             contractFormData?.contractDateStart &&
                             contractFormData?.contractDateEnd
@@ -254,7 +254,7 @@ export const ContractDetailsSummarySectionV2 = ({
                     <DataDetail
                         id="managedCareEntities"
                         label="Managed care entities"
-                        explainMissingData={!isSubmitted(contract)}
+                        explainMissingData={!isSubmittedOrCMSUser}
                         children={
                             contractFormData?.managedCareEntities && (
                                 <DataDetailCheckboxList
@@ -267,7 +267,7 @@ export const ContractDetailsSummarySectionV2 = ({
                     <DataDetail
                         id="federalAuthorities"
                         label="Active federal operating authority"
-                        explainMissingData={!isSubmitted(contract)}
+                        explainMissingData={!isSubmittedOrCMSUser}
                         children={
                             applicableFederalAuthorities && (
                                 <DataDetailCheckboxList
@@ -288,7 +288,7 @@ export const ContractDetailsSummarySectionV2 = ({
                                     : 'This contract action includes new or modified provisions related to the following'
                             }
                             explainMissingData={
-                                provisionsAreInvalid && !isSubmitted(contract)
+                                provisionsAreInvalid && !isSubmittedOrCMSUser
                             }
                         >
                             {provisionsAreInvalid ? null : (
@@ -308,7 +308,7 @@ export const ContractDetailsSummarySectionV2 = ({
                                     : 'This contract action does NOT include new or modified provisions related to the following'
                             }
                             explainMissingData={
-                                provisionsAreInvalid && !isSubmitted(contract)
+                                provisionsAreInvalid && !isSubmittedOrCMSUser
                             }
                         >
                             {provisionsAreInvalid ? null : (
@@ -328,7 +328,7 @@ export const ContractDetailsSummarySectionV2 = ({
                     previousSubmissionDate={lastSubmittedDate}
                     caption="Contract"
                     documentCategory="Contract"
-                    isEditing={isEditing}
+                    hideDynamicFeedback={isSubmittedOrCMSUser}
                 />
             )}
             {contractSupportingDocuments && (
@@ -338,7 +338,7 @@ export const ContractDetailsSummarySectionV2 = ({
                     caption="Contract supporting documents"
                     documentCategory="Contract-supporting"
                     isSupportingDocuments
-                    isEditing={isEditing}
+                    hideDynamicFeedback={isSubmittedOrCMSUser}
                 />
             )}
         </SectionCard>

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
@@ -73,7 +73,6 @@ export const RateDetailsSummarySectionV2 = ({
     submissionName,
     statePrograms,
     onDocumentError,
-    isCMSUser,
 }: RateDetailsSummarySectionV2Props): React.ReactElement => {
     const { loggedInUser } = useAuth()
     const isSubmittedOrCMSUser =

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
@@ -367,7 +367,7 @@ export const RateDetailsSummarySectionV2 = ({
                                     caption="Rate certification"
                                     documentCategory="Rate certification"
                                     previousSubmissionDate={lastSubmittedDate}
-                                    isEditing={isEditing}
+                                    hideDynamicFeedback={isSubmittedOrCMSUser}
                                 />
                             )}
                             {rateFormData.supportingDocuments && (
@@ -384,7 +384,7 @@ export const RateDetailsSummarySectionV2 = ({
                                     caption="Rate supporting documents"
                                     isSupportingDocuments
                                     documentCategory="Rate-supporting"
-                                    isEditing={isEditing}
+                                    hideDynamicFeedback={isSubmittedOrCMSUser}
                                 />
                             )}
                         </SectionCard>

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
@@ -382,7 +382,6 @@ export const RateDetailsSummarySectionV2 = ({
                                               )
                                     }
                                     caption="Rate supporting documents"
-                                    isSupportingDocuments
                                     documentCategory="Rate-supporting"
                                     hideDynamicFeedback={isSubmittedOrCMSUser}
                                 />

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ReviewSubmitV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ReviewSubmitV2.tsx
@@ -108,7 +108,6 @@ export const ReviewSubmitV2 = (): React.ReactElement => {
                 />
             </div>
             <GridContainer className={styles.reviewSectionWrapper}>
-                <div>This is the V2 version of the Review Submit Page</div>
                 <SubmissionTypeSummarySectionV2
                     contract={contract}
                     submissionName={submissionName}

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.test.tsx
@@ -163,6 +163,7 @@ describe('SubmissionTypeSummarySection', () => {
     })
 
     it('renders expected fields for submitted package on submission summary', () => {
+        const stateSubmission = mockContractPackageSubmitted()
         renderWithProviders(
             <SubmissionTypeSummarySection
                 contract={{ ...stateSubmission, status: 'SUBMITTED' }}
@@ -215,5 +216,32 @@ describe('SubmissionTypeSummarySection', () => {
         expect(
             screen.queryByRole('button', { name: 'Test button' })
         ).toBeInTheDocument()
+    })
+
+    it('does not render fields with missing fields for submitted package on submission summary', () => {
+        const stateSubmission = mockContractPackageSubmitted()
+        const submittedPackage = stateSubmission.packageSubmissions[0]
+        submittedPackage.contractRevision.formData = {
+            ...submittedPackage.contractRevision.formData,
+            submissionDescription: '',
+            programIDs: [],
+        }
+        stateSubmission.packageSubmissions[0] = submittedPackage
+
+        renderWithProviders(
+            <SubmissionTypeSummarySection
+                contract={{ ...stateSubmission, status: 'SUBMITTED' }}
+                statePrograms={statePrograms}
+                editNavigateTo="submission-type"
+                submissionName="MN-MSHO-0003"
+                isStateUser={true}
+            />
+        )
+        expect(
+            screen.queryByRole('definition', { name: 'Program(s)' })
+        ).not.toBeInTheDocument()
+        expect(
+            screen.queryByRole('definition', { name: 'Submission description' })
+        ).not.toBeInTheDocument()
     })
 })

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.tsx
@@ -79,7 +79,7 @@ export const SubmissionTypeSummarySectionV2 = ({
                     </DoubleColumnGrid>
                 )}
                 <DoubleColumnGrid>
-                    {programNames && (
+                    {(programNames?.length > 0 || !isSubmitted) && (
                         <DataDetail
                             id="program"
                             label="Program(s)"
@@ -87,7 +87,7 @@ export const SubmissionTypeSummarySectionV2 = ({
                             children={programNames}
                         />
                     )}
-                    {contractFormData && contractFormData.submissionType && (
+                    {(contractFormData.submissionType || !isSubmitted) && (
                         <DataDetail
                             id="submissionType"
                             label="Submission type"
@@ -99,7 +99,7 @@ export const SubmissionTypeSummarySectionV2 = ({
                             }
                         />
                     )}
-                    {contractFormData.contractType && (
+                    {(contractFormData.contractType || !isSubmitted) && (
                         <DataDetail
                             id="contractType"
                             label="Contract action type"
@@ -113,23 +113,25 @@ export const SubmissionTypeSummarySectionV2 = ({
                             }
                         />
                     )}
-                    {contractFormData &&
-                        contractFormData.riskBasedContract !== null && (
-                            <DataDetail
-                                id="riskBasedContract"
-                                label="Is this a risk based contract"
-                                explainMissingData={!isSubmitted}
-                                children={booleanAsYesNoUserValue(
-                                    contractFormData.riskBasedContract
-                                )}
-                            />
-                        )}
-                    {contractFormData && contractFormData.populationCovered && (
+                    {(contractFormData.riskBasedContract !== null ||
+                        (!isSubmitted &&
+                            contractFormData.riskBasedContract !== null)) && (
+                        <DataDetail
+                            id="riskBasedContract"
+                            label="Is this a risk based contract"
+                            explainMissingData={!isSubmitted}
+                            children={booleanAsYesNoUserValue(
+                                contractFormData.riskBasedContract
+                            )}
+                        />
+                    )}
+                    {(contractFormData.populationCovered || !isSubmitted) && (
                         <DataDetail
                             id="populationCoverage"
                             label="Which populations does this contract action cover?"
                             explainMissingData={!isSubmitted}
                             children={
+                                contractFormData.populationCovered &&
                                 PopulationCoveredRecord[
                                     contractFormData.populationCovered
                                 ]
@@ -140,7 +142,8 @@ export const SubmissionTypeSummarySectionV2 = ({
 
                 <Grid row gap className={styles.reviewDataRow}>
                     <Grid col={12}>
-                        {contractFormData && (
+                        {(contractFormData.submissionDescription ||
+                            !isSubmitted) && (
                             <DataDetail
                                 id="submissionDescription"
                                 label="Submission description"

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.tsx
@@ -38,7 +38,10 @@ export const SubmissionTypeSummarySectionV2 = ({
     isStateUser,
 }: SubmissionTypeSummarySectionV2Props): React.ReactElement => {
     const isPreviousSubmission = usePreviousSubmission()
-    const contractFormData = getVisibleLatestContractFormData(contract, isStateUser)
+    const contractFormData = getVisibleLatestContractFormData(
+        contract,
+        isStateUser
+    )
     if (!contractFormData) return <GenericErrorPage />
 
     const programNames = statePrograms
@@ -76,13 +79,15 @@ export const SubmissionTypeSummarySectionV2 = ({
                     </DoubleColumnGrid>
                 )}
                 <DoubleColumnGrid>
-                    <DataDetail
-                        id="program"
-                        label="Program(s)"
-                        explainMissingData={!isSubmitted}
-                        children={programNames}
-                    />
-                    {contractFormData && (
+                    {programNames && (
+                        <DataDetail
+                            id="program"
+                            label="Program(s)"
+                            explainMissingData={!isSubmitted}
+                            children={programNames}
+                        />
+                    )}
+                    {contractFormData && contractFormData.submissionType && (
                         <DataDetail
                             id="submissionType"
                             label="Submission type"
@@ -94,7 +99,7 @@ export const SubmissionTypeSummarySectionV2 = ({
                             }
                         />
                     )}
-                    {
+                    {contractFormData.contractType && (
                         <DataDetail
                             id="contractType"
                             label="Contract action type"
@@ -107,7 +112,7 @@ export const SubmissionTypeSummarySectionV2 = ({
                                     : ''
                             }
                         />
-                    }
+                    )}
                     {contractFormData &&
                         contractFormData.riskBasedContract !== null && (
                             <DataDetail
@@ -119,13 +124,12 @@ export const SubmissionTypeSummarySectionV2 = ({
                                 )}
                             />
                         )}
-                    {contractFormData && (
+                    {contractFormData && contractFormData.populationCovered && (
                         <DataDetail
                             id="populationCoverage"
                             label="Which populations does this contract action cover?"
                             explainMissingData={!isSubmitted}
                             children={
-                                contractFormData.populationCovered &&
                                 PopulationCoveredRecord[
                                     contractFormData.populationCovered
                                 ]

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.tsx
@@ -11,7 +11,6 @@ import {
 import { GenericErrorPage } from '../../../../Errors/GenericErrorPage'
 import { getVisibleLatestContractFormData } from '../../../../../gqlHelpers/contractsAndRates'
 import { Program, Contract } from '../../../../../gen/gqlClient'
-import { usePreviousSubmission } from '../../../../../hooks/usePreviousSubmission'
 import { booleanAsYesNoUserValue } from '../../../../../components/Form/FieldYesNo/FieldYesNo'
 import { SectionCard } from '../../../../../components/SectionCard'
 import styles from '../../../../../components/SubmissionSummarySection/SubmissionSummarySection.module.scss'
@@ -37,7 +36,6 @@ export const SubmissionTypeSummarySectionV2 = ({
     submissionName,
     isStateUser,
 }: SubmissionTypeSummarySectionV2Props): React.ReactElement => {
-    const isPreviousSubmission = usePreviousSubmission()
     const contractFormData = getVisibleLatestContractFormData(
         contract,
         isStateUser
@@ -63,7 +61,7 @@ export const SubmissionTypeSummarySectionV2 = ({
                 {headerChildComponent && headerChildComponent}
             </SectionHeader>
             <dl>
-                {isSubmitted && !isPreviousSubmission && (
+                {isSubmitted && (
                     <DoubleColumnGrid>
                         <DataDetail
                             id="submitted"

--- a/services/app-web/src/pages/SubmissionSummary/V2/SubmissionSummaryV2.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/V2/SubmissionSummaryV2.tsx
@@ -162,9 +162,6 @@ export const SubmissionSummaryV2 = (): React.ReactElement => {
 
     return (
         <div className={styles.background}>
-            <div style={{ textAlign: 'center' }}>
-                This is the V2 page of the SubmissionSummary
-            </div>
             <GridContainer
                 data-testid="submission-summary"
                 className={styles.container}


### PR DESCRIPTION
## Summary

- If there's missing data the field is not included in the UI for the submission summary page
- submission date is now included for all submitted submissions on the submission summary page

#### Related issues
https://jiraent.cms.gov/browse/MCR-4072
[MCR-4069](https://jiraent.cms.gov/browse/MCR-4069)
https://jiraent.cms.gov/browse/MCR-4071

#### Test cases covered

- Missing fields are not displayed on submission summary page
- Warning for multiple files is not included on any pages (_Hana note: think this is the implied scope of MCR-4071 and trying to prepare for linked rates_)
- renders SHARED tag on docs table to CMS users when packages across submissions present 
- renders SHARED tag to state users when packages across submissions present

#### QA Guidance
- It's not possible to get a new submission into a state with missing required information. Check test 
