### PR TITLE
Fully remove (Draft) handling from legacy shared rates UI

### DIFF
--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
@@ -210,7 +210,6 @@ export const UploadedDocumentsTable = ({
                                 ? packagesWithSharedRateCerts && (
                                       <td>
                                           {linkedPackagesList({
-                                              unlinkDrafts: Boolean(isCMSUser),
                                               packages:
                                                   packagesWithSharedRateCerts,
                                           })}
@@ -232,27 +231,15 @@ type DocumentWithS3Data = {
 } & GenericDocument
 
 type LinkedPackagesListProps = {
-    unlinkDrafts: boolean
     packages: SharedRateCertDisplay[]
 }
 
 const linkedPackagesList = ({
-    unlinkDrafts,
     packages,
 }: LinkedPackagesListProps): React.ReactElement[] => {
     return packages.map((item, index) => {
         const maybeComma = index > 0 ? ', ' : ''
-        const linkedPackageIsDraft =
-            item.packageName && item.packageName.includes('(Draft)')
 
-        if (linkedPackageIsDraft && unlinkDrafts) {
-            return (
-                <span key={item.packageId}>
-                    {maybeComma}
-                    <span>{item.packageName}</span>
-                </span>
-            )
-        } else {
             return (
                 <span key={item.packageId}>
                     {maybeComma}
@@ -264,6 +251,5 @@ const linkedPackagesList = ({
                     </Link>
                 </span>
             )
-        }
-    })
+        })
 }


### PR DESCRIPTION
## Summary
Follow on cleanup to a fix I made in #2378 where I [deleted the `('Draft')` handling](https://github.com/Enterprise-CMCS/managed-care-review/pull/2378/files#diff-97d1efcaeb0cb06ef777a0e379865170389f972294ac2521df366a9f60ebd4ddR108-R112) all together in the legacy rates across submissions UI shown on the summary pages. This was to address a [bug](https://jiraent.cms.gov/browse/MCR-4074).

To my eye, the way we were calculating Draft didn't seem proper anyway. Also, this is a legacy UI (the shared rates across submissions experience for state users) that we will be turning off within a week as we ship LinkedRates. [Product seemed to confirm this](https://cmsgov.slack.com/archives/C014CRU197U/p1714411273689879)  -- so going ahead and just deleting the code paths around handling draft shared rates across submissions all together in the submission summary document table UI.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4074

#### Test cases covered

- no tests needed, removing an unused code path 

## QA guidance
I think this is just straight code review no QA needed
