### PR TITLE
fix: Shared rates across submissions behavior for unlocked packages with linked rates flag on

### DIFF
--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
@@ -515,7 +515,49 @@ describe('UploadedDocumentsTable', () => {
         expect(await screen.findByTestId('tag')).toHaveTextContent('SHARED')
     })
 
-    it('still renders SHARED tag to state user when linked rates flag on', async () => {
+    it('still renders SHARED tag to state user on submission summary when linked rates flag on', async () => {
+        const packagesWithSharedRateCerts = [
+            {
+                packageId: '333b4225-5b49-4e82-aa71-be0d33d7418d',
+                packageName: 'MCR-MN-0001-SNBC',
+            },
+            {
+                packageId: '21467dba-6ae8-11ed-a1eb-0242ac120002',
+                packageName: 'MCR-MN-0002-PMAP',
+            },
+        ]
+        const testDocuments = [
+            {
+                s3URL: 's3://foo/bar/test-1',
+                name: 'supporting docs test 1',
+                sha256: 'fakesha',
+                dateAdded: new Date('01/01/00'),
+            },
+        ]
+        renderWithProviders(
+            <UploadedDocumentsTable
+                documents={testDocuments}
+                caption="Rate"
+                documentCategory="Rate certification"
+                packagesWithSharedRateCerts={packagesWithSharedRateCerts}
+                previousSubmissionDate={new Date('01/01/01')}
+                hideDynamicFeedback={false}
+            />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ user: mockValidStateUser(), statusCode: 200 })],
+                },
+                featureFlags: {
+                    'link-rates': true,
+                },
+            }
+        )
+
+        expect(await screen.findByTestId('tag')).toHaveTextContent('SHARED')
+        expect(await screen.findByText('Linked submissions')).toBeInTheDocument()
+    })
+
+    it('does not render SHARED tag to state user on review submit when linked rates flag on', async () => {
         const packagesWithSharedRateCerts = [
             {
                 packageId: '333b4225-5b49-4e82-aa71-be0d33d7418d',
@@ -553,7 +595,8 @@ describe('UploadedDocumentsTable', () => {
             }
         )
 
-        expect(await screen.findByTestId('tag')).toBeInTheDocument()
+        expect(await screen.findByTestId('tag')).not.toBeInTheDocument()
+        expect(await screen.queryByText('Linked submissions')).not.toBeInTheDocument()
     })
 
     it('does not validations when hideDynamicFeedback is set to true',async() =>{

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ReviewSubmitV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ReviewSubmitV2.test.tsx
@@ -291,4 +291,37 @@ describe('ReviewSubmit', () => {
         )
         expect(ratingPeriod).toHaveTextContent('02/02/2020 to 02/02/2021')
     })
+
+    it('hides the legacy shared rates across submissions UI for state users when unlocked', async () => {
+        renderWithProviders(
+            <Routes>
+                <Route
+                    path={RoutesRecord.SUBMISSIONS_REVIEW_SUBMIT}
+                    element={<ReviewSubmitV2 />}
+                />
+            </Routes>,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            statusCode: 200,
+                            user: mockValidStateUser(),
+                        }),
+                        fetchContractMockSuccess({
+                            contract: mockContractPackageUnlocked(),
+                        }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/submissions/test-abc-123/edit/review-and-submit',
+                },
+                featureFlags: {
+                    'link-rates': true,
+                },
+            }
+        )
+
+        expect(await screen.queryByText('Linked submissions')).not.toBeInTheDocument()
+        expect(await screen.queryByText('SHARED')).not.toBeInTheDocument()
+    })
 })

--- a/services/app-web/src/pages/SubmissionSummary/V2/SubmissionSummaryV2.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/V2/SubmissionSummaryV2.test.tsx
@@ -204,6 +204,45 @@ describe('SubmissionSummary', () => {
         expect(ratingPeriod).toHaveTextContent('01/01/2020 to 01/01/2021')
     })
 
+    it('displays the legacy shared rates across submissions UI for CMS users when unlocked', async () => {
+        renderWithProviders(
+            <Routes>
+                <Route element={<SubmissionSideNav />}>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_SUMMARY}
+                        element={<SubmissionSummaryV2 />}
+                    />
+                </Route>
+            </Routes>,
+            {
+                apolloProvider: {
+                     mocks: [
+                        fetchCurrentUserMock({
+                            statusCode: 200,
+                            user: mockValidCMSUser(),
+                        }),
+                        fetchContractMockSuccess({
+                            contract: mockContractPackageUnlocked(),
+                        }),
+                        fetchStateHealthPlanPackageWithQuestionsMockSuccess({
+                            id: 'test-abc-123',
+                        }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/submissions/test-abc-123',
+                },
+                featureFlags: {
+                    'link-rates': true,
+                },
+            }
+        )
+
+        expect(await screen.findByText('SHARED')).toBeInTheDocument()
+        expect(await screen.findByText('Linked submissions')).toBeInTheDocument()
+    })
+
+
     it('renders add mccrs-id link for CMS user', async () => {
         renderWithProviders(
             <Routes>

--- a/services/app-web/src/testHelpers/apolloMocks/contractPackageDataMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/contractPackageDataMock.ts
@@ -566,7 +566,7 @@ function mockContractPackageUnlocked(
                             },
                         ],
                         actuaryCommunicationPreference: 'OACT_TO_ACTUARY',
-                        packagesWithSharedRateCerts: [],
+                        packagesWithSharedRateCerts: [''],
                     }
                 }
 
@@ -744,7 +744,10 @@ function mockContractPackageUnlocked(
                             },
                         ],
                         actuaryCommunicationPreference: 'OACT_TO_ACTUARY',
-                        packagesWithSharedRateCerts: []
+                        packagesWithSharedRateCerts: [ {
+                            packageName: 'testABC1',
+                            packageId: 'test-abc-1',
+                        },]
                     }
                 },
             ],


### PR DESCRIPTION
## Summary
Got further clarification on expected behavior of our legacy UI once Linked Rates is turned on. State users viewing unlocked packages that previously used the "rates across submissions" feature should NOT see in the data on `ReviewSubmit`. However, viewing `SubmissionSummary`, the UI should be still be visibile. 

Adjusted the documents tables and tests to reflect this. 

#### Related issues

slight adjustment to work on #2387 

#### Screenshots

#### Test cases covered
- still renders SHARED tag to state user on submission summary when linked rates flag on
- does not render SHARED tag to state user on review submit when linked rates flag on
- hides the legacy shared rates across submissions UI for state users when unlocked
- 
<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
