### PR TITLE
Fix form errors and styling on rate details page

### DIFF
--- a/services/app-web/src/pages/StateSubmission/Contacts/ActuaryContactFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/ActuaryContactFields.tsx
@@ -168,10 +168,16 @@ export const ActuaryContactFields = ({
                             Other actuarial firm
                         </label>
                         <PoliteErrorMessage>
-                            {getIn(
-                                errors,
-                                `${fieldNamePrefix}.actuarialFirmOther`
-                            )}
+                            {showFieldErrors(
+                                getIn(
+                                    errors,
+                                    `${fieldNamePrefix}.actuarialFirmOther`
+                                )
+                            ) &&
+                                getIn(
+                                    errors,
+                                    `${fieldNamePrefix}.actuarialFirmOther`
+                                )}
                         </PoliteErrorMessage>
                         <Field
                             name={`${fieldNamePrefix}.actuarialFirmOther`}

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -299,6 +299,27 @@ export const RateDetails = ({
                             }
                         )
                     }
+
+                    // If the field is addtlActuaryContacts, then it should be an array.
+                    if (
+                        field === 'addtlActuaryContacts' &&
+                        Array.isArray(value)
+                    ) {
+                        // Loops through every additional certifying actuary and adds each actuary field with an error to
+                        // the errorObject.
+                        value.forEach((contact, contactIndex) => {
+                            if (!contact) return
+
+                            Object.entries(contact).forEach(
+                                ([field, value]) => {
+                                    const errorKey = `rateInfos.${index}.addtlActuaryContacts.${contactIndex}.${field}`
+                                    if (typeof value === 'string') {
+                                        errorObject[errorKey] = value
+                                    }
+                                }
+                            )
+                        })
+                    }
                 })
             })
         }

--- a/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateCert.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateCert.tsx
@@ -584,11 +584,7 @@ export const SingleRateCert = ({
                         name={`${fieldNamePrefix}.addtlActuaryContacts`}
                     >
                         {({ remove, push }: FieldArrayRenderProps) => (
-                            <div
-                                style={{ marginTop: '40px' }}
-                                className={styles.actuaryContacts}
-                                data-testid="actuary-contacts"
-                            >
+                            <FormGroup data-testid="actuary-contacts">
                                 {rateInfo.addtlActuaryContacts.length > 0 &&
                                     rateInfo.addtlActuaryContacts.map(
                                         (_actuaryContact, index) => (
@@ -621,7 +617,7 @@ export const SingleRateCert = ({
                                                     }}
                                                     data-testid="removeContactBtn"
                                                 >
-                                                    Remove
+                                                    Remove certifying actuary
                                                 </Button>
                                             </div>
                                         )
@@ -637,7 +633,7 @@ export const SingleRateCert = ({
                                 >
                                     Add a certifying actuary
                                 </Button>
-                            </div>
+                            </FormGroup>
                         )}
                     </FieldArray>
                 </FormGroup>

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -358,6 +358,27 @@ const RateDetailsV2 = ({
                             }
                         )
                     }
+
+                    // If the field is addtlActuaryContacts, then it should be an array.
+                    if (
+                        field === 'addtlActuaryContacts' &&
+                        Array.isArray(value)
+                    ) {
+                        // Loops through every additional certifying actuary and adds each actuary field with an error to
+                        // the errorObject.
+                        value.forEach((contact, contactIndex) => {
+                            if (!contact) return
+
+                            Object.entries(contact).forEach(
+                                ([field, value]) => {
+                                    const errorKey = `rateForms.${index}.addtlActuaryContacts.${contactIndex}.${field}`
+                                    if (typeof value === 'string') {
+                                        errorObject[errorKey] = value
+                                    }
+                                }
+                            )
+                        })
+                    }
                 })
             })
         }

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/SingleRateFormFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/SingleRateFormFields.tsx
@@ -535,7 +535,7 @@ export const SingleRateFormFields = ({
                                                 }}
                                                 data-testid="removeContactBtn"
                                             >
-                                                Remove
+                                                Remove certifying actuary
                                             </Button>
                                         </div>
                                     )

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/SingleRateFormFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/SingleRateFormFields.tsx
@@ -502,11 +502,7 @@ export const SingleRateFormFields = ({
                 />
                 <FieldArray name={`${fieldNamePrefix}.addtlActuaryContacts`}>
                     {({ remove, push }: FieldArrayRenderProps) => (
-                        <div
-                            style={{ marginTop: '40px' }}
-                            className={styles.actuaryContacts}
-                            data-testid="actuary-contacts"
-                        >
+                        <FormGroup data-testid="actuary-contacts">
                             {rateForm.addtlActuaryContacts.length > 0 &&
                                 rateForm.addtlActuaryContacts.map(
                                     (_actuaryContact, index) => (
@@ -551,7 +547,7 @@ export const SingleRateFormFields = ({
                             >
                                 Add a certifying actuary
                             </Button>
-                        </div>
+                        </FormGroup>
                     )}
                 </FieldArray>
             </FormGroup>

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.module.scss
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.module.scss
@@ -105,10 +105,10 @@
 
 .stateContact,
 .actuaryContact {
-    margin-bottom: uswds.units(5);
+    margin-bottom: uswds.units(2);
 
     .removeContactBtn {
-        margin-top: 0.5rem;
+        margin-top: uswds.units(3);
         @include uswds.u-text('secondary');
     }
 }
@@ -128,7 +128,7 @@
     }
 
     .removeContactBtn {
-        margin-top: uswds.units(4);
+        margin-top: uswds.units(3);
     }
 }
 


### PR DESCRIPTION
## Summary
Fixed form errors not showing up and some styling.

Form Errors

- [Slack about form errors](https://cmsgov.slack.com/archives/C014CRU197U/p1714488591378709?thread_ts=1714487387.788659&cid=C014CRU197U)
- under actuarial firm if I select "other" the validation error "you must enter a description" appears right away. It should only appear after I hit continue
   <img src="https://github.com/Enterprise-CMCS/managed-care-review/assets/98117700/59b13a7b-6b24-45f7-a9e7-54f470e7b128" width="300" />

- If I am missing a form field in the additional actuaries and try to continue, I get only line item errors. I am NOT seeing the error appear within the error summary banner at the top like I would expect.
   <img src="https://github.com/Enterprise-CMCS/managed-care-review/assets/98117700/60930e8c-2bb9-435d-b187-84c82c077048" width="300" />

- I also find "remove" to be vague given all the competing links. I would suggest "remove certifying actuary" or something like that. (there are a lot of links, something for Kelsey to noodle on I think, but not a blocker)
   <img src="https://github.com/Enterprise-CMCS/managed-care-review/assets/98117700/b696e5c0-3a0e-4f41-9c28-e5b09a0166a1" width="300" />

UI styling
- [Figma](https://www.figma.com/file/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?type=design&node-id=12177-110618&mode=design&t=3luGCRGl2IsVVkyQ-0)
- Fixed spacing on the `Remove certifying actuary` button 

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
