### PR TITLE
[MCR-4038] dropdown menu does not open until the user clicks into field

### DIFF
--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
@@ -144,7 +144,6 @@ export const LinkRateSelect = ({
 
     return (
         <Select
-            defaultMenuIsOpen
             value={defaultValue}
             className={styles.rateMultiSelect}
             options={

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.test.tsx
@@ -604,7 +604,7 @@ describe('RateDetailsv2', () => {
             })
         })
 
-        it('displays dropdown menu if yes is selected', async () => {
+        it('displays dropdown menu if yes is selected and dropdown is clicked', async () => {
             const { user } = renderWithProviders(
                 <Routes>
                     <Route
@@ -687,7 +687,10 @@ describe('RateDetailsv2', () => {
                 expect(screen.getByRole('combobox')).toBeInTheDocument()
             })
 
-            // Assert the options menu is open
+            // Assert the options menu is open when clicked
+            const dropdown = screen.getByRole('combobox')
+            expect(dropdown).toBeInTheDocument()
+            await user.click(dropdown)
             const dropdownMenu = screen.getByRole('listbox')
             expect(dropdownMenu).toBeInTheDocument()
 
@@ -811,7 +814,10 @@ describe('RateDetailsv2', () => {
                 expect(screen.getByRole('combobox')).toBeInTheDocument()
             })
 
-            // Assert the options menu is open
+            // Assert the options menu is open when clicked
+            const dropdown = screen.getByRole('combobox')
+            expect(dropdown).toBeInTheDocument()
+            await user.click(dropdown)
             const dropdownMenu = screen.getByRole('listbox')
             expect(dropdownMenu).toBeInTheDocument()
 
@@ -897,6 +903,9 @@ describe('RateDetailsv2', () => {
             await user.click(yesRadioButton)
 
             // Assert that the selected value is removed from the list of options
+            const dropdown = screen.getByRole('combobox')
+            expect(dropdown).toBeInTheDocument()
+            await user.click(dropdown)
             const option = screen
                 .getByRole('listbox')
                 .querySelector('#react-select-2-option-0')
@@ -982,6 +991,9 @@ describe('RateDetailsv2', () => {
             await user.click(yesRadioButton)
 
             // Checking that the selected value is removed from the list of options
+            const dropdown = screen.getByRole('combobox')
+            expect(dropdown).toBeInTheDocument()
+            await user.click(dropdown)
             const option = screen
                 .getByRole('listbox')
                 .querySelector('#react-select-2-option-0')


### PR DESCRIPTION
## Summary
This PR is to address the dropdown menu which opens by default when the yes radio button is selected on the rate details page. With these changes the dropdown should no longer open unless clicked by the user.

#### Test cases covered

Tests remained the same minus minor updates to address the changed behavior

## QA guidance

- Start a new submission with rates or navigate to the rate details page via the summary page on an already existing submission.
- Once on the rate details page click the `Yes, this rate certification is part of another submission` radio button
- The dropdown should render but remain closed and only expands when clicked.
