### PR TITLE
Fix unlock removed child rate crasher

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/unlockContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/unlockContract.ts
@@ -123,8 +123,18 @@ async function unlockContract(
                     },
                 })
 
+                // only unlock children that were submitted in the latest submission
+                const submissionPackageEntries =
+                    currentRev.relatedSubmisions[0].submissionPackages
+
                 for (const childRate of childRates) {
-                    childRateIDs.push(childRate.id)
+                    if (
+                        submissionPackageEntries.some(
+                            (p) => p.rateRevision.rateID === childRate.id
+                        )
+                    ) {
+                        childRateIDs.push(childRate.id)
+                    }
                 }
             } else {
                 // without linked rates, we push all the valid rate revisions attached to the contract revision


### PR DESCRIPTION
## Summary

If you removed a child rate, on unlock it would error saying you can't unlock an already unlocked rate

#### Related issues

https://jiraent.cms.gov/browse/MCR-4093

#### Test cases covered

made a new API test that reproduced the problem

## QA guidance

try the steps in the bug