### PR TITLE
Have rate revisions return the most recent set of contracts

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/prismaSubmittedRateHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaSubmittedRateHelpers.ts
@@ -48,7 +48,30 @@ const includeFullRate = {
                     validAfter: 'asc',
                 },
             },
-            relatedSubmissions: true,
+            relatedSubmissions: {
+                orderBy: {
+                    updatedAt: 'asc',
+                },
+                include: {
+                    submittedContracts: {
+                        include: includeContractFormData,
+                    },
+                    submittedRates: {
+                        include: includeRateFormData,
+                    },
+                    updatedBy: true,
+                    submissionPackages: {
+                        include: {
+                            contractRevision: {
+                                include: includeContractFormData,
+                            },
+                        },
+                        orderBy: {
+                            ratePosition: 'asc',
+                        },
+                    },
+                },
+            },
         },
     },
 } satisfies Prisma.RateTableInclude

--- a/services/app-api/src/resolvers/rate/submitRate.test.ts
+++ b/services/app-api/src/resolvers/rate/submitRate.test.ts
@@ -2,6 +2,7 @@ import { testLDService } from '../../testHelpers/launchDarklyHelpers'
 import {
     constructTestPostgresServer,
     createAndUpdateTestHealthPlanPackage,
+    unlockTestHealthPlanPackage,
 } from '../../testHelpers/gqlHelpers'
 import { latestFormData } from '../../testHelpers/healthPlanPackageHelpers'
 import { testStateUser, testCMSUser } from '../../testHelpers/userHelpers'
@@ -10,7 +11,17 @@ import FETCH_RATE from '../../../../app-graphql/src/queries/fetchRate.graphql'
 import UNLOCK_RATE from '../../../../app-graphql/src/mutations/unlockRate.graphql'
 import { submitTestRate, updateTestRate } from '../../testHelpers'
 import SUBMIT_HEALTH_PLAN_PACKAGE from '../../../../app-graphql/src/mutations/submitHealthPlanPackage.graphql'
-import { createSubmitAndUnlockTestRate } from '../../testHelpers/gqlRateHelpers'
+import {
+    addLinkedRateToTestContract,
+    addNewRateToTestContract,
+    createSubmitAndUnlockTestRate,
+    fetchTestRateById,
+} from '../../testHelpers/gqlRateHelpers'
+import {
+    createAndUpdateTestContractWithoutRates,
+    fetchTestContract,
+    submitTestContract,
+} from '../../testHelpers/gqlContractHelpers'
 
 describe('submitRate', () => {
     const ldService = testLDService({
@@ -180,6 +191,113 @@ describe('submitRate', () => {
         // expect formData to be the same
         expect(submittedRateFormData).toEqual(draftFormData)
     })
+
+    it('returns the latest linked contracts', async () => {
+        const ldService = testLDService({
+            'link-rates': true,
+        })
+
+        const stateServer = await constructTestPostgresServer({
+            ldService,
+        })
+        const cmsServer = await constructTestPostgresServer({
+            ldService,
+            context: {
+                user: testCMSUser(),
+            },
+        })
+
+        // 1. Submit A0 with Rate1 and Rate2
+        const draftA0 =
+            await createAndUpdateTestContractWithoutRates(stateServer)
+        const AID = draftA0.id
+        await addNewRateToTestContract(stateServer, draftA0, {
+            rateDateStart: '2001-01-01',
+        })
+
+        const contractA0 = await submitTestContract(stateServer, AID)
+        const subA0 = contractA0.packageSubmissions[0]
+        const rate10 = subA0.rateRevisions[0]
+        const OneID = rate10.rateID
+
+        console.info('ONEID', OneID)
+
+        // 2. Submit B0 with Rate2
+        const draftB0 =
+            await createAndUpdateTestContractWithoutRates(stateServer)
+        await addNewRateToTestContract(stateServer, draftB0, {
+            rateDateStart: '2003-01-01',
+        })
+
+        const contractB0 = await submitTestContract(stateServer, draftB0.id)
+        const subB0 = contractB0.packageSubmissions[0]
+        const rate30 = subB0.rateRevisions[0]
+        const TwoID = rate30.rateID
+        console.info('THREEID', TwoID)
+
+        expect(subB0.rateRevisions[0].rateID).toBe(TwoID)
+
+        // 3. Submit C0 with Rate10 and Rate20
+        const draftC0 =
+            await createAndUpdateTestContractWithoutRates(stateServer)
+        const draftC020 = await addLinkedRateToTestContract(
+            stateServer,
+            draftC0,
+            OneID
+        )
+        await addLinkedRateToTestContract(stateServer, draftC020, TwoID)
+
+        const contractC0 = await submitTestContract(stateServer, draftC0.id)
+
+        // 4. make sure both rates return contract C in their list of revisions
+        const rateOne = await fetchTestRateById(stateServer, OneID)
+
+        expect(rateOne.revisions).toHaveLength(1)
+        expect(rateOne.revisions[0].contractRevisions).toHaveLength(2)
+
+        const rateTwo = await fetchTestRateById(stateServer, TwoID)
+
+        expect(rateTwo.revisions).toHaveLength(1)
+        expect(rateTwo.revisions[0].contractRevisions).toHaveLength(2)
+
+        // 5. unlock and resubmit A
+        await unlockTestHealthPlanPackage(
+            cmsServer,
+            contractA0.id,
+            'does this mess history'
+        )
+
+        const unlockedRateOne = await fetchTestRateById(stateServer, OneID)
+
+        expect(unlockedRateOne.revisions).toHaveLength(1)
+        expect(unlockedRateOne.revisions[0].contractRevisions).toHaveLength(2)
+
+        await submitTestContract(
+            stateServer,
+            contractA0.id,
+            'but what about this'
+        )
+
+        // everything should have the latest
+        const resubmittedRateOne = await fetchTestRateById(stateServer, OneID)
+
+        expect(resubmittedRateOne.revisions).toHaveLength(2)
+        expect(resubmittedRateOne.revisions[0].contractRevisions).toHaveLength(
+            2
+        )
+
+        const postResubmitRateTwo = await fetchTestRateById(stateServer, TwoID)
+
+        expect(postResubmitRateTwo.revisions).toHaveLength(1)
+        expect(postResubmitRateTwo.revisions[0].contractRevisions).toHaveLength(
+            2
+        )
+
+        const postSubmitC = await fetchTestContract(stateServer, contractC0.id)
+
+        expect(postSubmitC.packageSubmissions).toHaveLength(2)
+    }, 10000)
+
     // TODO: this test needs to be updated to remove references to healthplanpackage
     it('can unlock and submit rate independent of contract status', async () => {
         const stateUser = testStateUser()


### PR DESCRIPTION
## Summary

We were seeing contracts disappear on linked rates when contracts+rates were resubmitted. This forces rate revs to always have the latest set of contracts associated with them. 

#### Related issues
https://jiraent.cms.gov/browse/MCR-4091
https://jiraent.cms.gov/browse/MCR-4095
I thought there was a third one

#### Screenshots

#### Test cases covered
