### PR TITLE
Display submit date on Submission Summary page

### DIFF
--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -107,7 +107,9 @@ export const SingleRateSummarySection = ({
         !isSubmitted && loggedInUser?.role === 'STATE_USER'
     const isCMSUser = loggedInUser?.role === 'CMS_USER'
     const isSubmittedOrCMSUser =
-        rate.status === 'SUBMITTED' || loggedInUser?.role === 'CMS_USER'
+        rate.status === 'SUBMITTED' ||
+        rate.status === 'RESUBMITTED' ||
+        loggedInUser?.role === 'CMS_USER'
 
     // feature flags
     const ldClient = useLDClient()

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContractDetailsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContractDetailsSummarySectionV2.tsx
@@ -90,7 +90,9 @@ export const ContractDetailsSummarySectionV2 = ({
     const ldClient = useLDClient()
     const { loggedInUser } = useAuth()
     const isSubmittedOrCMSUser =
-        contract.status === 'SUBMITTED' || loggedInUser?.role === 'CMS_USER'
+        contract.status === 'SUBMITTED' ||
+        contract.status === 'RESUBMITTED' ||
+        loggedInUser?.role === 'CMS_USER'
     const isEditing = !isSubmittedOrCMSUser && editNavigateTo !== undefined
     const contractOrRev = contractRev ? contractRev : contract
 

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
@@ -82,7 +82,9 @@ export const RateDetailsSummarySectionV2 = ({
 }: RateDetailsSummarySectionV2Props): React.ReactElement => {
     const { loggedInUser } = useAuth()
     const isSubmittedOrCMSUser =
-        contract.status === 'SUBMITTED' || loggedInUser?.role === 'CMS_USER'
+        contract.status === 'SUBMITTED' ||
+        contract.status === 'RESUBMITTED' ||
+        loggedInUser?.role === 'CMS_USER'
     const isEditing = !isSubmittedOrCMSUser && editNavigateTo !== undefined
     const isPreviousSubmission = usePreviousSubmission()
     const contractOrRev = contractRev ? contractRev : contract

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.tsx
@@ -52,8 +52,8 @@ export const SubmissionTypeSummarySectionV2 = ({
     const programNames = statePrograms
         .filter((p) => contractFormData?.programIDs.includes(p.id))
         .map((p) => p.name)
-    const isSubmitted = contract.status === 'SUBMITTED'
-
+    const isSubmitted =
+        contract.status === 'SUBMITTED' || contract.status === 'RESUBMITTED'
     return (
         <SectionCard
             id="submissionTypeSection"

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.tsx
@@ -54,6 +54,7 @@ export const SubmissionTypeSummarySectionV2 = ({
         .map((p) => p.name)
     const isSubmitted =
         contract.status === 'SUBMITTED' || contract.status === 'RESUBMITTED'
+    const isUnlocked = contract.status === 'UNLOCKED'
     return (
         <SectionCard
             id="submissionTypeSection"
@@ -68,7 +69,7 @@ export const SubmissionTypeSummarySectionV2 = ({
                 {headerChildComponent && headerChildComponent}
             </SectionHeader>
             <dl>
-                {isSubmitted && (
+                {(isSubmitted || isUnlocked) && (
                     <DoubleColumnGrid>
                         <DataDetail
                             id="submitted"


### PR DESCRIPTION
## Summary

This PR is a follow on fix for [this ticket](https://jiraent.cms.gov/browse/MCR-4069). It ensures that the submission type summary display is the same for

#### Related issues

https://jiraent.cms.gov/browse/MCR-4069

#### Screenshots

<img width="926" alt="Screenshot 2024-04-30 at 5 45 41 PM" src="https://github.com/Enterprise-CMCS/managed-care-review/assets/67110378/73db5f69-0a21-40a8-916f-5b3fb4b77b1d">


## QA guidance

- Log in as a CMS user and find a contract that has been submitted, unlocked and then resubmitted
- The Submitted date field should be displayed