### PR TITLE
MCR-4088: actuary comm preference not functioning correctly for linked rates and UI changes.

### DIFF
--- a/services/app-api/src/domain-models/contractAndRates/convertContractWithRatesToHPP.ts
+++ b/services/app-api/src/domain-models/contractAndRates/convertContractWithRatesToHPP.ts
@@ -1,5 +1,4 @@
 import type {
-    ActuaryCommunicationType,
     HealthPlanFormDataType,
     RateInfoType,
     SubmissionDocument,
@@ -88,9 +87,6 @@ function convertContractWithRatesToFormData(
     stateCode: string,
     stateNumber: number
 ): HealthPlanFormDataType | Error {
-    // additional certifying actuaries are on every rate post refactor but on the package pre-refactor
-    let pkgActuaryCommsPref: ActuaryCommunicationType | undefined = undefined
-
     const rateInfos: RateInfoType[] = contractRev.rateRevisions.map(
         (rateRev) => {
             const {
@@ -110,11 +106,6 @@ function convertContractWithRatesToFormData(
                 amendmentEffectiveDateStart,
                 actuaryCommunicationPreference,
             } = rateRev.formData
-
-            // The first time we find a rate that has an actuary comms pref, we use that to set the package's prefs
-            if (actuaryCommunicationPreference && !pkgActuaryCommsPref) {
-                pkgActuaryCommsPref = actuaryCommunicationPreference
-            }
 
             const rateAmendmentInfo = (amendmentEffectiveDateStart ||
                 amendmentEffectiveDateEnd) && {
@@ -158,7 +149,6 @@ function convertContractWithRatesToFormData(
         riskBasedContract: contractRev.formData.riskBasedContract,
         submissionDescription: contractRev.formData.submissionDescription,
         stateContacts: contractRev.formData.stateContacts,
-        addtlActuaryCommunicationPreference: pkgActuaryCommsPref,
         documents: contractRev.formData.supportingDocuments.map((doc) => ({
             ...doc,
         })) as SubmissionDocument[],
@@ -213,10 +203,10 @@ function convertContractWithRatesToFormData(
             },
         },
         /**
-         * This field is unused and will need cleaned up, additional actuaries have been moved to the rate level.
-         * Leaving this as am empty array to get linked rates feature work in without having to fix all the broken tests
-         * by removing this field.
+         * addtlActuaryCommunicationPreference and addtlActuaryContacts are unused. Leaving cleanup for a standalone PR
+         * as there will be many broken tests.
          */
+        addtlActuaryCommunicationPreference: undefined,
         addtlActuaryContacts: [],
         statutoryRegulatoryAttestation:
             contractRev.formData.statutoryRegulatoryAttestation,

--- a/services/app-api/src/resolvers/healthPlanPackage/contractAndRates/resolverHelpers.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/contractAndRates/resolverHelpers.ts
@@ -133,7 +133,6 @@ const convertHealthPlanPackageRatesToDomain = async (
             rateCertificationName: hppRateFormData.rateCertificationName,
             certifyingActuaryContacts: hppRateFormData.actuaryContacts,
             addtlActuaryContacts: hppRateFormData.addtlActuaryContacts,
-            //  toProtobuffer already does this, so we can directly set the value from the rate data.
             actuaryCommunicationPreference:
                 hppRateFormData.actuaryCommunicationPreference,
             packagesWithSharedRateCerts,

--- a/services/app-web/src/common-code/healthPlanFormDataMocks/healthPlanFormData.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataMocks/healthPlanFormData.ts
@@ -247,7 +247,6 @@ function unlockedWithContacts(): UnlockedHealthPlanFormDataType {
             },
         ],
         addtlActuaryContacts: [],
-        addtlActuaryCommunicationPreference: 'OACT_TO_ACTUARY',
         statutoryRegulatoryAttestation: false,
         statutoryRegulatoryAttestationDescription: 'No compliance',
     }
@@ -355,7 +354,6 @@ function unlockedWithDocuments(): UnlockedHealthPlanFormDataType {
             },
         ],
         addtlActuaryContacts: [],
-        addtlActuaryCommunicationPreference: 'OACT_TO_ACTUARY',
         statutoryRegulatoryAttestation: false,
         statutoryRegulatoryAttestationDescription: 'No compliance',
     }
@@ -457,7 +455,6 @@ function unlockedWithFullRates(): UnlockedHealthPlanFormDataType {
             },
         ],
         addtlActuaryContacts: [],
-        addtlActuaryCommunicationPreference: 'OACT_TO_ACTUARY',
         statutoryRegulatoryAttestation: false,
         statutoryRegulatoryAttestationDescription: 'No compliance',
     }
@@ -586,7 +583,6 @@ function unlockedWithFullContracts(): UnlockedHealthPlanFormDataType {
             },
         ],
         addtlActuaryContacts: [],
-        addtlActuaryCommunicationPreference: 'OACT_TO_ACTUARY',
         statutoryRegulatoryAttestation: false,
         statutoryRegulatoryAttestationDescription: 'No compliance',
     }
@@ -719,7 +715,6 @@ function unlockedWithALittleBitOfEverything(): UnlockedHealthPlanFormDataType {
             },
         ],
         addtlActuaryContacts: [],
-        addtlActuaryCommunicationPreference: 'OACT_TO_ACTUARY',
         statutoryRegulatoryAttestation: false,
         statutoryRegulatoryAttestationDescription: 'No compliance',
     }

--- a/services/app-web/src/common-code/proto/healthPlanFormDataProto/toDomain.ts
+++ b/services/app-web/src/common-code/proto/healthPlanFormDataProto/toDomain.ts
@@ -479,8 +479,6 @@ const toDomain = (
         stateContacts,
         contractInfo,
         rateInfos,
-        addtlActuaryContacts,
-        addtlActuaryCommunicationPreference,
     } = formDataMessage
 
     const cleanedStateContacts = replaceNullsWithUndefineds(stateContacts)
@@ -544,12 +542,13 @@ const toDomain = (
             contractInfo?.contractAmendmentInfo
         ),
         rateInfos: parseRateInfos(rateInfos),
-        addtlActuaryCommunicationPreference: enumToDomain(
-            mcreviewproto.ActuaryCommunicationType,
-            addtlActuaryCommunicationPreference
-        ),
         stateContacts: cleanedStateContacts,
-        addtlActuaryContacts: parseActuaryContacts(addtlActuaryContacts),
+        /**
+         * addtlActuaryCommunicationPreference and addtlActuaryContacts are unused. Leaving cleanup for a standalone PR
+         * as there will be many broken tests
+         */
+        addtlActuaryCommunicationPreference: undefined,
+        addtlActuaryContacts: [],
         documents: parseProtoDocuments(formDataMessage.documents),
         statutoryRegulatoryAttestation:
             contractInfo?.statutoryRegulatoryAttestation ?? undefined,

--- a/services/app-web/src/common-code/proto/healthPlanFormDataProto/toProtoBuffer.ts
+++ b/services/app-web/src/common-code/proto/healthPlanFormDataProto/toProtoBuffer.ts
@@ -272,7 +272,7 @@ const toProtoBuffer = (
                               }
                           ),
                           actuaryCommunicationPreference: domainEnumToProto(
-                              domainData.addtlActuaryCommunicationPreference,
+                              rateInfo.actuaryCommunicationPreference,
                               mcreviewproto.ActuaryCommunicationType
                           ),
                           packagesWithSharedRateCerts:
@@ -281,15 +281,11 @@ const toProtoBuffer = (
                   })
                 : undefined,
         /**
-         * This field is unused and will need cleaned up, additional actuaries have been moved to the rate level.
-         * Leaving this as am empty array to get linked rates feature work in without having to fix all the broken tests
-         * by removing this field.
+         * addtlActuaryCommunicationPreference and addtlActuaryContacts are unused. Leaving cleanup for a standalone PR
+         * as there will be many broken tests
          */
         addtlActuaryContacts: [],
-        addtlActuaryCommunicationPreference: domainEnumToProto(
-            domainData.addtlActuaryCommunicationPreference,
-            mcreviewproto.ActuaryCommunicationType
-        ),
+        addtlActuaryCommunicationPreference: undefined,
         documents: domainData.documents.map((doc) => ({
             s3Url: doc.s3URL,
             name: doc.name,

--- a/services/app-web/src/components/DataDetail/DataDetailContactField/DataDetailContactField.tsx
+++ b/services/app-web/src/components/DataDetail/DataDetailContactField/DataDetailContactField.tsx
@@ -3,11 +3,18 @@ import {
     ActuaryContact,
     StateContact,
 } from '../../../common-code/healthPlanFormDataType'
-import { getActuaryFirm } from '../../SubmissionSummarySection'
+import { getActuaryFirm } from '../../../gqlHelpers/contractsAndRates'
 import { DataDetailMissingField } from '../DataDetailMissingField'
-import { ActuaryContact as GQLActuaryContact, StateContact as GQLStateContact } from '../../../gen/gqlClient'
+import {
+    ActuaryContact as GQLActuaryContact,
+    StateContact as GQLStateContact,
+} from '../../../gen/gqlClient'
 
-type Contact = ActuaryContact | GQLActuaryContact | StateContact | GQLStateContact
+type Contact =
+    | ActuaryContact
+    | GQLActuaryContact
+    | StateContact
+    | GQLStateContact
 function isCertainActuaryContact(contact: Contact): contact is ActuaryContact {
     return (contact as ActuaryContact).actuarialFirm !== undefined
 }

--- a/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/ContactsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/ContactsSummarySection.test.tsx
@@ -26,12 +26,6 @@ describe('ContactsSummarySection', () => {
             })
         ).toBeInTheDocument()
         expect(
-            screen.getByRole('heading', {
-                level: 2,
-                name: 'Additional actuary contacts',
-            })
-        ).toBeInTheDocument()
-        expect(
             screen.getByRole('link', { name: 'Edit State contacts' })
         ).toHaveAttribute('href', '/contacts')
     })
@@ -50,7 +44,7 @@ describe('ContactsSummarySection', () => {
         expect(screen.queryByText('Edit')).not.toBeInTheDocument()
     })
 
-    it('can render all state and actuary contact fields', () => {
+    it('can render all state contact fields', () => {
         renderWithProviders(
             <ContactsSummarySection
                 submission={draftSubmission}
@@ -64,31 +58,10 @@ describe('ContactsSummarySection', () => {
                 name: 'State contacts',
             })
         ).toBeInTheDocument()
-        expect(screen.queryByText('Contact 1')).toBeInTheDocument()
-        // expect(screen.queryByText('State Contact 1')).toBeInTheDocument()
-        // expect(screen.queryByText('Test State Contact 1')).toBeInTheDocument()
-        expect(
-            screen.getByRole('heading', {
-                level: 2,
-                name: 'Additional actuary contacts',
-            })
-        ).toBeInTheDocument()
-        expect(
-            screen.queryByText('Additional actuary contact')
-        ).toBeInTheDocument()
-        expect(
-            screen.getByRole('link', {
-                name: 'additionalactuarycontact1@test.com',
-            })
-        ).toBeInTheDocument()
-        expect(
-            screen.queryByText('Actuaries’ communication preference')
-        ).toBeInTheDocument()
-        expect(
-            screen.queryByText(
-                'OACT can communicate directly with the state’s actuaries but should copy the state on all written communication and all appointments for verbal discussions.'
-            )
-        ).toBeInTheDocument()
+        expect(screen.getByText(/State Contact 1/)).toBeInTheDocument()
+        expect(screen.getByText(/Test State Contact 1/)).toBeInTheDocument()
+        expect(screen.getByText(/State Contact 2/)).toBeInTheDocument()
+        expect(screen.getByText(/Test State Contact 2/)).toBeInTheDocument()
     })
 
     it('can render only state contacts for contract only submission', () => {

--- a/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/ContactsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/ContactsSummarySection.tsx
@@ -1,12 +1,7 @@
 import { Grid, GridContainer } from '@trussworks/react-uswds'
 import styles from '../SubmissionSummarySection.module.scss'
 import { SectionHeader } from '../../SectionHeader'
-import {
-    ActuaryFirmsRecord,
-    ActuaryCommunicationRecord,
-} from '../../../constants/healthPlanPackages'
 import { HealthPlanFormDataType } from '../../../common-code/healthPlanFormDataType'
-import { ActuaryContact } from '../../../common-code/healthPlanFormDataType'
 import { DataDetail, DataDetailContactField } from '../../DataDetail'
 import { SectionCard } from '../../SectionCard'
 
@@ -15,37 +10,11 @@ export type ContactsSummarySectionProps = {
     editNavigateTo?: string
 }
 
-export const getActuaryFirm = (actuaryContact: ActuaryContact): string => {
-    if (
-        actuaryContact.actuarialFirmOther &&
-        actuaryContact.actuarialFirm === 'OTHER'
-    ) {
-        return actuaryContact.actuarialFirmOther
-    } else if (
-        actuaryContact.actuarialFirm &&
-        ActuaryFirmsRecord[actuaryContact.actuarialFirm]
-    ) {
-        return ActuaryFirmsRecord[actuaryContact.actuarialFirm]
-    } else {
-        return ''
-    }
-}
-
 export const ContactsSummarySection = ({
     submission,
     editNavigateTo,
 }: ContactsSummarySectionProps): React.ReactElement => {
     const isSubmitted = submission.status === 'SUBMITTED'
-
-    // Combine additional actuaries from all rates.
-    const additionalActuaries: ActuaryContact[] = submission.rateInfos.flatMap(
-        (rate) => {
-            if (rate.addtlActuaryContacts?.length) {
-                return rate.addtlActuaryContacts
-            }
-            return []
-        }
-    )
 
     return (
         <SectionCard id="stateContacts" className={styles.summarySection}>
@@ -83,59 +52,6 @@ export const ContactsSummarySection = ({
                     </dl>
                 </Grid>
             </GridContainer>
-
-            {submission.submissionType === 'CONTRACT_AND_RATES' && (
-                <>
-                    {additionalActuaries.length > 0 && (
-                        <dl>
-                            <SectionHeader header="Additional actuary contacts" />
-                            <GridContainer>
-                                <Grid row>
-                                    {additionalActuaries.map(
-                                        (actuaryContact, index) => (
-                                            <Grid
-                                                col={6}
-                                                key={'actuarycontact_' + index}
-                                            >
-                                                <DataDetail
-                                                    id={
-                                                        'actuarycontact_' +
-                                                        index
-                                                    }
-                                                    label="Additional actuary contact"
-                                                    children={
-                                                        <DataDetailContactField
-                                                            contact={
-                                                                actuaryContact
-                                                            }
-                                                        />
-                                                    }
-                                                />
-                                            </Grid>
-                                        )
-                                    )}
-                                </Grid>
-                            </GridContainer>
-                        </dl>
-                    )}
-                    <dl>
-                        <GridContainer>
-                            <DataDetail
-                                id="communicationPreference"
-                                label="Actuaries’ communication preference"
-                                children={
-                                    submission.addtlActuaryCommunicationPreference &&
-                                    ActuaryCommunicationRecord[
-                                        submission
-                                            .addtlActuaryCommunicationPreference
-                                    ]
-                                }
-                                explainMissingData={!isSubmitted}
-                            />
-                        </GridContainer>
-                    </dl>
-                </>
-            )}
         </SectionCard>
     )
 }

--- a/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/index.ts
+++ b/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/index.ts
@@ -1,4 +1,3 @@
 export {
     ContactsSummarySection,
-    getActuaryFirm,
 } from './ContactsSummarySection'

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -25,6 +25,7 @@ import useDeepCompareEffect from 'use-deep-compare-effect'
 import { InlineDocumentWarning } from '../../DocumentWarning'
 import { SectionCard } from '../../SectionCard'
 import { convertFromSubmissionDocumentsToGenericDocuments } from '../UploadedDocumentsTable/UploadedDocumentsTable'
+import { ActuaryCommunicationRecord } from '../../../constants'
 // Used for refreshed packages names keyed by their package id
 // package name includes (Draft) for draft packages.
 type PackageNameType = string
@@ -327,6 +328,12 @@ export const RateDetailsSummarySection = ({
                                             )}`}
                                         />
                                     ) : null}
+                                    <DataDetail
+                                        id="rateCapitationType"
+                                        label="Does the actuary certify capitation rates specific to each rate cell or a rate range?"
+                                        explainMissingData={!isSubmitted}
+                                        children={rateCapitationType(rateInfo)}
+                                    />
                                     {rateInfo.actuaryContacts[0] && (
                                         <DataDetail
                                             id="certifyingActuary"
@@ -342,11 +349,36 @@ export const RateDetailsSummarySection = ({
                                             }
                                         />
                                     )}
+                                    {rateInfo.addtlActuaryContacts?.length
+                                        ? rateInfo.addtlActuaryContacts.map(
+                                              (contact, addtlContactIndex) => (
+                                                  <DataDetail
+                                                      key={`addtlCertifyingActuary-${addtlContactIndex}`}
+                                                      id={`addtlCertifyingActuary-${addtlContactIndex}`}
+                                                      label="Certifying actuary"
+                                                      explainMissingData={
+                                                          !isSubmitted
+                                                      }
+                                                      children={
+                                                          <DataDetailContactField
+                                                              contact={contact}
+                                                          />
+                                                      }
+                                                  />
+                                              )
+                                          )
+                                        : null}
                                     <DataDetail
-                                        id="rateCapitationType"
-                                        label="Does the actuary certify capitation rates specific to each rate cell or a rate range?"
+                                        id="communicationPreference"
+                                        label="Actuaries’ communication preference"
+                                        children={
+                                            rateInfo.actuaryCommunicationPreference &&
+                                            ActuaryCommunicationRecord[
+                                                rateInfo
+                                                    .actuaryCommunicationPreference
+                                            ]
+                                        }
                                         explainMissingData={!isSubmitted}
-                                        children={rateCapitationType(rateInfo)}
                                     />
                                 </DoubleColumnGrid>
                             </dl>

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
@@ -82,8 +82,8 @@ describe('SingleRateSummarySection', () => {
             })
         ).toHaveTextContent('10/16/2023')
         expect(
-            screen.getByRole('definition', { name: 'Certifying actuary' })
-        ).toBeInTheDocument()
+            screen.getAllByRole('definition', { name: 'Certifying actuary' })
+        ).toHaveLength(2)
         expect(
             screen.getByRole('definition', {
                 name: 'Does the actuary certify capitation rates specific to each rate cell or a rate range?',

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -21,14 +21,14 @@ import { DocumentWarningBanner } from '../../Banner'
 import { useS3 } from '../../../contexts/S3Context'
 import useDeepCompareEffect from 'use-deep-compare-effect'
 import { recordJSException } from '../../../otelHelpers'
-import { Link } from '@trussworks/react-uswds'
+import { Grid, Link } from '@trussworks/react-uswds'
 import { NavLink, useNavigate } from 'react-router-dom'
 import { packageName } from '../../../common-code/healthPlanFormDataType'
 import { UploadedDocumentsTableProps } from '../UploadedDocumentsTable/UploadedDocumentsTable'
 import { useAuth } from '../../../contexts/AuthContext'
 import { SectionCard } from '../../SectionCard'
 import { UnlockRateButton } from './UnlockRateButton'
-import { ERROR_MESSAGES } from '../../../constants'
+import { ActuaryCommunicationRecord, ERROR_MESSAGES } from '../../../constants'
 import { handleApolloErrorsAndAddUserFacingMessages } from '../../../gqlHelpers/mutationWrappersForUserFriendlyErrors'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { featureFlags } from '../../../common-code/featureFlags'
@@ -302,18 +302,6 @@ export const SingleRateSummarySection = ({
                             />
                         ) : null}
                         <DataDetail
-                            id="certifyingActuary"
-                            label="Certifying actuary"
-                            explainMissingData={explainMissingData}
-                            children={
-                                <DataDetailContactField
-                                    contact={
-                                        formData.certifyingActuaryContacts[0]
-                                    }
-                                />
-                            }
-                        />
-                        <DataDetail
                             id="rateSubmissionDate"
                             label="Rate submission date"
                             explainMissingData={!isSubmitted}
@@ -328,6 +316,50 @@ export const SingleRateSummarySection = ({
                             children={rateCapitationType(formData)}
                         />
                         <DataDetail
+                            id="certifyingActuary"
+                            label="Certifying actuary"
+                            explainMissingData={explainMissingData}
+                            children={
+                                <DataDetailContactField
+                                    contact={
+                                        formData.certifyingActuaryContacts[0]
+                                    }
+                                />
+                            }
+                        />
+                        {formData.addtlActuaryContacts?.length
+                            ? formData.addtlActuaryContacts.map(
+                                  (contact, addtlContactIndex) => (
+                                      <DataDetail
+                                          key={`addtlCertifyingActuary-${addtlContactIndex}`}
+                                          id={`addtlCertifyingActuary-${addtlContactIndex}`}
+                                          label="Certifying actuary"
+                                          explainMissingData={
+                                              explainMissingData
+                                          }
+                                          children={
+                                              <DataDetailContactField
+                                                  contact={contact}
+                                              />
+                                          }
+                                      />
+                                  )
+                              )
+                            : null}
+                    </DoubleColumnGrid>
+                    <Grid row gap className={styles.singleColumnGrid}>
+                        <DataDetail
+                            id="communicationPreference"
+                            label="Actuaries’ communication preference"
+                            children={
+                                formData.actuaryCommunicationPreference &&
+                                ActuaryCommunicationRecord[
+                                    formData.actuaryCommunicationPreference
+                                ]
+                            }
+                            explainMissingData={explainMissingData}
+                        />
+                        <DataDetail
                             id="submittedWithContract"
                             label={
                                 showLinkedRates
@@ -339,7 +371,7 @@ export const SingleRateSummarySection = ({
                                 statePrograms
                             )}
                         />
-                    </DoubleColumnGrid>
+                    </Grid>
                 </dl>
             </SectionCard>
             <SectionCard className={styles.summarySection}>

--- a/services/app-web/src/components/SubmissionSummarySection/index.ts
+++ b/services/app-web/src/components/SubmissionSummarySection/index.ts
@@ -1,8 +1,5 @@
 export { SubmissionTypeSummarySection } from './SubmissionTypeSummarySection'
 export { ContractDetailsSummarySection } from './ContractDetailsSummarySection'
 export { RateDetailsSummarySection } from './RateDetailsSummarySection'
-export {
-    ContactsSummarySection,
-    getActuaryFirm,
-} from './ContactsSummarySection'
+export { ContactsSummarySection } from './ContactsSummarySection'
 export { UploadedDocumentsTable } from './UploadedDocumentsTable'

--- a/services/app-web/src/gqlHelpers/contractsAndRates.ts
+++ b/services/app-web/src/gqlHelpers/contractsAndRates.ts
@@ -4,6 +4,8 @@ If the data doesn't exist, returns undefined reliably
 */
 
 import { Contract, ContractFormData, ContractPackageSubmission, ContractRevision, Rate, RateRevision } from "../gen/gqlClient"
+import {ActuaryContact} from '../common-code/healthPlanFormDataType';
+import {ActuaryFirmsRecord} from '../constants';
 
 
 function getVisibleLatestRateRevisions(contract: Contract, isEditing: boolean): RateRevision[] | undefined {
@@ -66,4 +68,20 @@ const getDraftRates = (contract: Contract): Rate[] | undefined => {
     return (contract.draftRates && contract.draftRates[0]) ? contract.draftRates : undefined
 }
 
-export {getDraftRates, getLastContractSubmission, getVisibleLatestContractFormData, getVisibleLatestRateRevisions}
+const getActuaryFirm = (actuaryContact: ActuaryContact): string => {
+    if (
+        actuaryContact.actuarialFirmOther &&
+        actuaryContact.actuarialFirm === 'OTHER'
+    ) {
+        return actuaryContact.actuarialFirmOther
+    } else if (
+        actuaryContact.actuarialFirm &&
+        ActuaryFirmsRecord[actuaryContact.actuarialFirm]
+    ) {
+        return ActuaryFirmsRecord[actuaryContact.actuarialFirm]
+    } else {
+        return ''
+    }
+}
+
+export {getDraftRates, getLastContractSubmission, getVisibleLatestContractFormData, getVisibleLatestRateRevisions, getActuaryFirm}

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -280,7 +280,7 @@ describe('RateDetails', () => {
 
             // check for expected errors
             await waitFor(() => {
-                expect(screen.queryAllByTestId('errorMessage')).toHaveLength(8)
+                expect(screen.queryAllByTestId('errorMessage')).toHaveLength(7)
                 expect(
                     screen.queryAllByText('You must select a program')
                 ).toHaveLength(2)
@@ -1750,7 +1750,7 @@ const fillOutIndexRate = async (screen: Screen, index: number) => {
     await userEvent.click(withinTargetRateCert.getByLabelText('Mercer'))
 
     await userEvent.click(
-        screen.getByText(
+        withinTargetRateCert.getByText(
             "OACT can communicate directly with the state's actuaries but should copy the state on all written communication and all appointments for verbal discussions."
         )
     )

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
@@ -160,6 +160,9 @@ const SingleRateCertSchema = (_activeFeatureFlags: FeatureFlagSettings) =>
                         .nullable(),
                 })
             ),
+            actuaryCommunicationPreference: Yup.string().required(
+                'You must select a communication preference'
+            )
         })
     })
 const RateDetailsFormSchema = (activeFeatureFlags?: FeatureFlagSettings) => {
@@ -168,17 +171,11 @@ const RateDetailsFormSchema = (activeFeatureFlags?: FeatureFlagSettings) => {
         rateForms: Yup.array().of(
             SingleRateCertSchema(activeFeatureFlags || {})
         ),
-        actuaryCommunicationPreference: Yup.string().required(
-            'You must select a communication preference'
-        )
     }):
     Yup.object().shape({
         rateInfos: Yup.array().of(
             SingleRateCertSchema(activeFeatureFlags || {})
         ),
-        actuaryCommunicationPreference: Yup.string().required(
-            'You must select a communication preference'
-        )
     })
 }
 

--- a/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateCert.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateCert.tsx
@@ -637,6 +637,53 @@ export const SingleRateCert = ({
                         )}
                     </FieldArray>
                 </FormGroup>
+                <FormGroup
+                    error={Boolean(
+                        showFieldErrors('actuaryCommunicationPreference')
+                    )}
+                >
+                    <Fieldset
+                        className={styles.radioGroup}
+                        legend="Actuaries' communication preference"
+                        role="radiogroup"
+                        aria-required
+                    >
+                        <span
+                            className={styles.requiredOptionalText}
+                            style={{
+                                marginBottom: '10px',
+                            }}
+                        >
+                            Required
+                        </span>
+                        <span className={styles.requiredOptionalText}>
+                            Communication preference between CMS Office of the
+                            Actuary (OACT) and all state’s actuaries (i.e.
+                            certifying actuaries and additional actuary
+                            contacts)
+                        </span>
+                        <PoliteErrorMessage>
+                            {showFieldErrors(
+                                'actuaryCommunicationPreference'
+                            ) &&
+                                getIn(errors, 'actuaryCommunicationPreference')}
+                        </PoliteErrorMessage>
+                        <FieldRadio
+                            id={`${fieldNamePrefix}.actuaryCommunicationPreference.OACTtoActuary`}
+                            name={`${fieldNamePrefix}.actuaryCommunicationPreference`}
+                            label={`OACT can communicate directly with the state's actuaries but should copy the state on all written communication and all appointments for verbal discussions.`}
+                            value={'OACT_TO_ACTUARY'}
+                            aria-required
+                        />
+                        <FieldRadio
+                            id={`${fieldNamePrefix}.actuaryCommunicationPreference.OACTtoState`}
+                            name={`${fieldNamePrefix}.actuaryCommunicationPreference`}
+                            label={`OACT can communicate directly with the state, and the state will relay all written communication to their actuaries and set up time for any potential verbal discussions.`}
+                            value={'OACT_TO_STATE'}
+                            aria-required
+                        />
+                    </Fieldset>
+                </FormGroup>
                 {index >= 1 && multiRatesConfig && (
                     <Button
                         type="button"

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -1,25 +1,12 @@
 import React, { useEffect, useState } from 'react'
-import {
-    Button,
-    Fieldset,
-    FormGroup,
-    Form as UswdsForm,
-} from '@trussworks/react-uswds'
-import {
-    FieldArray,
-    FieldArrayRenderProps,
-    Formik,
-    FormikErrors,
-    getIn,
-} from 'formik'
+import { Button, Fieldset, Form as UswdsForm } from '@trussworks/react-uswds'
+import { FieldArray, FieldArrayRenderProps, Formik, FormikErrors } from 'formik'
 import { generatePath, useNavigate } from 'react-router-dom'
 
 import styles from '../../StateSubmissionForm.module.scss'
 import {
     DynamicStepIndicator,
     ErrorSummary,
-    FieldRadio,
-    PoliteErrorMessage,
     SectionCard,
 } from '../../../../components'
 import { RateDetailsFormSchema } from '../RateDetailsSchema'
@@ -64,7 +51,6 @@ import {
 import { LinkYourRates } from '../../../LinkYourRates/LinkYourRates'
 import { LinkedRateSummary } from './LinkedRateSummary'
 import { usePage } from '../../../../contexts/PageContext'
-import { ActuaryCommunicationType } from '../../../../common-code/healthPlanFormDataType'
 
 export type FormikRateForm = {
     id?: string // no id if its a new rate
@@ -91,7 +77,6 @@ export type FormikRateForm = {
 // We have a list of rates to enable multi-rate behavior
 export type RateDetailFormConfig = {
     rateForms: FormikRateForm[]
-    actuaryCommunicationPreference: ActuaryCommunicationType | undefined
 }
 
 type RateDetailsV2Props = {
@@ -210,10 +195,6 @@ const RateDetailsV2 = ({
 
     const initialValues: RateDetailFormConfig = {
         rateForms: initialRateForm,
-        actuaryCommunicationPreference: initialRateForm[0]
-            .actuaryCommunicationPreference
-            ? initialRateForm[0].actuaryCommunicationPreference
-            : undefined,
     }
 
     // Display any full page interim state resulting from the initial fetch API requests
@@ -320,8 +301,6 @@ const RateDetailsV2 = ({
         errors: FormikErrors<RateDetailFormConfig>
     ) => {
         const rateErrors = errors.rateForms
-        const actuaryCommunicationPreference =
-            errors.actuaryCommunicationPreference
         const errorObject: { [field: string]: string } = {}
         if (rateErrors && Array.isArray(rateErrors)) {
             rateErrors.forEach((rateError, index) => {
@@ -383,15 +362,8 @@ const RateDetailsV2 = ({
             })
         }
 
-        if (actuaryCommunicationPreference) {
-            errorObject['actuaryCommunicationPreference'] =
-                actuaryCommunicationPreference
-        }
-
         return errorObject
     }
-    const showFieldErrors = (error?: string | undefined) =>
-        shouldValidate && Boolean(error)
 
     const fieldNamePrefix = (idx: number) => `rateForms.${idx}`
     return (
@@ -419,29 +391,18 @@ const RateDetailsV2 = ({
 
             <Formik
                 initialValues={initialValues}
-                onSubmit={(rateFormValues, { setSubmitting }) => {
-                    const actuaryCommunicationPreference =
-                        rateFormValues.actuaryCommunicationPreference
-                    rateFormValues.rateForms.forEach((rateForm) => {
-                        rateForm.actuaryCommunicationPreference =
-                            actuaryCommunicationPreference
+                onSubmit={(rateFormValues, { setSubmitting }) =>
+                    handlePageAction(rateFormValues.rateForms, setSubmitting, {
+                        type: 'CONTINUE',
+                        redirectPath: displayAsStandaloneRate
+                            ? 'DASHBOARD_SUBMISSIONS'
+                            : 'SUBMISSIONS_CONTACTS',
                     })
-
-                    return handlePageAction(
-                        rateFormValues.rateForms,
-                        setSubmitting,
-                        {
-                            type: 'CONTINUE',
-                            redirectPath: displayAsStandaloneRate
-                                ? 'DASHBOARD_SUBMISSIONS'
-                                : 'SUBMISSIONS_CONTACTS',
-                        }
-                    )
-                }}
+                }
                 validationSchema={rateDetailsFormSchema}
             >
                 {({
-                    values: { rateForms, actuaryCommunicationPreference },
+                    values: { rateForms },
                     errors,
                     dirty,
                     handleSubmit,
@@ -597,66 +558,6 @@ const RateDetailsV2 = ({
                                             </>
                                         )}
                                     </FieldArray>
-                                    <SectionCard>
-                                        <FormGroup
-                                            error={showFieldErrors(
-                                                errors.actuaryCommunicationPreference
-                                            )}
-                                        >
-                                            <Fieldset
-                                                className={styles.radioGroup}
-                                                legend="Actuaries' communication preference"
-                                                role="radiogroup"
-                                                aria-required
-                                            >
-                                                <span
-                                                    className={
-                                                        styles.requiredOptionalText
-                                                    }
-                                                    style={{
-                                                        marginBottom: '10px',
-                                                    }}
-                                                >
-                                                    Required
-                                                </span>
-                                                <span
-                                                    className={
-                                                        styles.requiredOptionalText
-                                                    }
-                                                >
-                                                    Communication preference
-                                                    between CMS Office of the
-                                                    Actuary (OACT) and all
-                                                    state’s actuaries (i.e.
-                                                    certifying actuaries and
-                                                    additional actuary contacts)
-                                                </span>
-                                                <PoliteErrorMessage>
-                                                    {showFieldErrors(
-                                                        errors.actuaryCommunicationPreference
-                                                    ) &&
-                                                        getIn(
-                                                            errors,
-                                                            'actuaryCommunicationPreference'
-                                                        )}
-                                                </PoliteErrorMessage>
-                                                <FieldRadio
-                                                    id={`OACTtoActuary`}
-                                                    name={`actuaryCommunicationPreference`}
-                                                    label={`OACT can communicate directly with the state's actuaries but should copy the state on all written communication and all appointments for verbal discussions.`}
-                                                    value={'OACT_TO_ACTUARY'}
-                                                    aria-required
-                                                />
-                                                <FieldRadio
-                                                    id={`OACTtoState`}
-                                                    name={`actuaryCommunicationPreference`}
-                                                    label={`OACT can communicate directly with the state, and the state will relay all written communication to their actuaries and set up time for any potential verbal discussions.`}
-                                                    value={'OACT_TO_STATE'}
-                                                    aria-required
-                                                />
-                                            </Fieldset>
-                                        </FormGroup>
-                                    </SectionCard>
                                 </fieldset>
                                 <PageActions
                                     pageVariant={
@@ -666,10 +567,6 @@ const RateDetailsV2 = ({
                                     }
                                     backOnClick={async () => {
                                         if (dirty) {
-                                            rateForms.forEach((rateForm) => {
-                                                rateForm.actuaryCommunicationPreference =
-                                                    actuaryCommunicationPreference
-                                            })
                                             await handlePageAction(
                                                 rateForms,
                                                 setSubmitting,
@@ -689,12 +586,6 @@ const RateDetailsV2 = ({
                                         displayAsStandaloneRate
                                             ? () => undefined
                                             : async () => {
-                                                  rateForms.forEach(
-                                                      (rateForm) => {
-                                                          rateForm.actuaryCommunicationPreference =
-                                                              actuaryCommunicationPreference
-                                                      }
-                                                  )
                                                   await handlePageAction(
                                                       rateForms,
                                                       setSubmitting,

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/SingleRateFormFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/SingleRateFormFields.tsx
@@ -551,6 +551,50 @@ export const SingleRateFormFields = ({
                     )}
                 </FieldArray>
             </FormGroup>
+            <FormGroup
+                error={Boolean(
+                    showFieldErrors('actuaryCommunicationPreference')
+                )}
+            >
+                <Fieldset
+                    className={styles.radioGroup}
+                    legend="Actuaries' communication preference"
+                    role="radiogroup"
+                    aria-required
+                >
+                    <span
+                        className={styles.requiredOptionalText}
+                        style={{
+                            marginBottom: '10px',
+                        }}
+                    >
+                        Required
+                    </span>
+                    <span className={styles.requiredOptionalText}>
+                        Communication preference between CMS Office of the
+                        Actuary (OACT) and all state’s actuaries (i.e.
+                        certifying actuaries and additional actuary contacts)
+                    </span>
+                    <PoliteErrorMessage>
+                        {showFieldErrors('actuaryCommunicationPreference') &&
+                            getIn(errors, 'actuaryCommunicationPreference')}
+                    </PoliteErrorMessage>
+                    <FieldRadio
+                        id={`${fieldNamePrefix}.actuaryCommunicationPreference.OACTtoActuary`}
+                        name={`${fieldNamePrefix}.actuaryCommunicationPreference`}
+                        label={`OACT can communicate directly with the state's actuaries but should copy the state on all written communication and all appointments for verbal discussions.`}
+                        value={'OACT_TO_ACTUARY'}
+                        aria-required
+                    />
+                    <FieldRadio
+                        id={`${fieldNamePrefix}.actuaryCommunicationPreference.OACTtoState`}
+                        name={`${fieldNamePrefix}.actuaryCommunicationPreference`}
+                        label={`OACT can communicate directly with the state, and the state will relay all written communication to their actuaries and set up time for any potential verbal discussions.`}
+                        value={'OACT_TO_STATE'}
+                        aria-required
+                    />
+                </Fieldset>
+            </FormGroup>
         </>
     )
 }

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
@@ -98,7 +98,7 @@ const convertGQLRateToRateForm = (getKey: S3ClientT['getKey'], rate?: Rate, pare
             rateForm?.addtlActuaryContacts
         ),
         actuaryCommunicationPreference:
-            rateForm?.actuaryCommunicationPreference?? undefined,
+            rateForm?.actuaryCommunicationPreference ?? undefined,
         packagesWithSharedRateCerts:
             rateForm?.packagesWithSharedRateCerts ?? [],
         ratePreviouslySubmitted: handleAsLinkedRate? 'YES' : rateForm ? 'NO' : undefined,

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContactsSummarySectionV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContactsSummarySectionV2.test.tsx
@@ -27,12 +27,6 @@ describe('ContactsSummarySection', () => {
             })
         ).toBeInTheDocument()
         expect(
-            screen.getByRole('heading', {
-                level: 2,
-                name: 'Additional actuary contacts',
-            })
-        ).toBeInTheDocument()
-        expect(
             screen.getByRole('link', { name: 'Edit State contacts' })
         ).toHaveAttribute('href', '/contacts')
     })
@@ -51,7 +45,7 @@ describe('ContactsSummarySection', () => {
         expect(screen.queryByText('Edit')).not.toBeInTheDocument()
     })
 
-    it('can render all state and actuary contact fields', () => {
+    it('can render all state contact fields', () => {
         renderWithProviders(
             <ContactsSummarySection
                 contract={draftSubmission}
@@ -66,31 +60,8 @@ describe('ContactsSummarySection', () => {
                 name: 'State contacts',
             })
         ).toBeInTheDocument()
-        expect(screen.queryByText('Contact 1')).toBeInTheDocument()
-        // expect(screen.queryByText('State Contact 1')).toBeInTheDocument()
-        // expect(screen.queryByText('Test State Contact 1')).toBeInTheDocument()
-        expect(
-            screen.getByRole('heading', {
-                level: 2,
-                name: 'Additional actuary contacts',
-            })
-        ).toBeInTheDocument()
-        expect(
-            screen.queryByText('Additional actuary contact')
-        ).toBeInTheDocument()
-        expect(
-            screen.getByRole('link', {
-                name: 'additionalactuarycontact1@test.com',
-            })
-        ).toBeInTheDocument()
-        expect(
-            screen.queryByText('Actuaries’ communication preference')
-        ).toBeInTheDocument()
-        expect(
-            screen.queryByText(
-                'OACT can communicate directly with the state’s actuaries but should copy the state on all written communication and all appointments for verbal discussions.'
-            )
-        ).toBeInTheDocument()
+        expect(screen.getByText(/State Contact 1/)).toBeInTheDocument()
+        expect(screen.getByText(/Test State Contact 1/)).toBeInTheDocument()
     })
 
     it('can render only state contacts for contract only submission', () => {
@@ -135,7 +106,10 @@ describe('ContactsSummarySection', () => {
                 addtlActuaryContacts: [],
             }
             renderWithProviders(
-                <ContactsSummarySection isStateUser contract={draftSubmission} />
+                <ContactsSummarySection
+                    isStateUser
+                    contract={draftSubmission}
+                />
             )
         }
         expect(screen.queryByText(/Additional actuary contacts/)).toBeNull()

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContactsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContactsSummarySectionV2.tsx
@@ -3,47 +3,18 @@ import styles from '../../../../../components/SubmissionSummarySection/Submissio
 
 import { SectionHeader } from '../../../../../components/SectionHeader'
 import {
-    ActuaryFirmsRecord,
-    ActuaryCommunicationRecord,
-} from '../../../../../constants/healthPlanPackages'
-import { ActuaryContact } from '../../../../../common-code/healthPlanFormDataType'
-import {
     DataDetail,
     DataDetailContactField,
 } from '../../../../../components/DataDetail'
 import { SectionCard } from '../../../../../components/SectionCard'
-import {
-    Contract,
-    RateRevision,
-    ContractRevision,
-} from '../../../../../gen/gqlClient'
-import {
-    getDraftRates,
-    getLastContractSubmission,
-    getVisibleLatestContractFormData,
-} from '../../../../../gqlHelpers/contractsAndRates'
+import { Contract, ContractRevision } from '../../../../../gen/gqlClient'
+import { getVisibleLatestContractFormData } from '../../../../../gqlHelpers/contractsAndRates'
 
 export type ContactsSummarySectionProps = {
     contract: Contract
     contractRev?: ContractRevision
     editNavigateTo?: string
     isStateUser: boolean
-}
-
-export const getActuaryFirm = (actuaryContact: ActuaryContact): string => {
-    if (
-        actuaryContact.actuarialFirmOther &&
-        actuaryContact.actuarialFirm === 'OTHER'
-    ) {
-        return actuaryContact.actuarialFirmOther
-    } else if (
-        actuaryContact.actuarialFirm &&
-        ActuaryFirmsRecord[actuaryContact.actuarialFirm]
-    ) {
-        return ActuaryFirmsRecord[actuaryContact.actuarialFirm]
-    } else {
-        return ''
-    }
 }
 
 export const ContactsSummarySection = ({
@@ -59,16 +30,6 @@ export const ContactsSummarySection = ({
         contractOrRev,
         isStateUser
     )
-    let rateRev: RateRevision | undefined = undefined
-
-    if (contractFormData?.submissionType === 'CONTRACT_AND_RATES') {
-        // Find first rate associated with the contract to deal with rates info on contacts page
-        // TODO move the fields using this data to rate details
-        const draftRates = getDraftRates(contract)
-        rateRev =
-            (draftRates && draftRates[0]?.draftRevision) ||
-            getLastContractSubmission(contract)?.rateRevisions[0]
-    }
     return (
         <SectionCard id="stateContacts" className={styles.summarySection}>
             <SectionHeader
@@ -106,64 +67,6 @@ export const ContactsSummarySection = ({
                     </dl>
                 </Grid>
             </GridContainer>
-
-            {contractFormData?.submissionType === 'CONTRACT_AND_RATES' && (
-                <>
-                    {rateRev?.formData?.addtlActuaryContacts !== undefined &&
-                        rateRev.formData.addtlActuaryContacts.length > 0 && (
-                            <dl>
-                                <SectionHeader header="Additional actuary contacts" />
-                                <GridContainer>
-                                    <Grid row>
-                                        {rateRev.formData?.addtlActuaryContacts.map(
-                                            (actuaryContact, index) => (
-                                                <Grid
-                                                    col={6}
-                                                    key={
-                                                        'actuarycontact_' +
-                                                        index
-                                                    }
-                                                >
-                                                    <DataDetail
-                                                        id={
-                                                            'actuarycontact_' +
-                                                            index
-                                                        }
-                                                        label="Additional actuary contact"
-                                                        children={
-                                                            <DataDetailContactField
-                                                                contact={
-                                                                    actuaryContact
-                                                                }
-                                                            />
-                                                        }
-                                                    />
-                                                </Grid>
-                                            )
-                                        )}
-                                    </Grid>
-                                </GridContainer>
-                            </dl>
-                        )}
-                    <dl>
-                        <GridContainer>
-                            <DataDetail
-                                id="communicationPreference"
-                                label="Actuaries’ communication preference"
-                                children={
-                                    rateRev?.formData
-                                        ?.actuaryCommunicationPreference &&
-                                    ActuaryCommunicationRecord[
-                                        rateRev.formData
-                                            .actuaryCommunicationPreference
-                                    ]
-                                }
-                                explainMissingData={!isSubmitted}
-                            />
-                        </GridContainer>
-                    </dl>
-                </>
-            )}
         </SectionCard>
     )
 }

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.test.tsx
@@ -10,6 +10,7 @@ import { renderWithProviders } from '../../../../../testHelpers/jestHelpers'
 import { RateDetailsSummarySectionV2 as RateDetailsSummarySection } from './RateDetailsSummarySectionV2'
 import { Rate } from '../../../../../gen/gqlClient'
 import { testS3Client } from '../../../../../testHelpers/s3Helpers'
+import { ActuaryCommunicationRecord } from '../../../../../constants'
 
 describe('RateDetailsSummarySection', () => {
     const draftContract = mockContractPackageDraft()
@@ -61,7 +62,15 @@ describe('RateDetailsSummarySection', () => {
                                 email: 'jj.actuary@test.com',
                             },
                         ],
-                        addtlActuaryContacts: [],
+                        addtlActuaryContacts: [
+                            {
+                                actuarialFirm: 'DELOITTE',
+                                name: 'Additional actuary',
+                                titleRole: 'Test Actuary Contact 1',
+                                email: 'additionalactuarycontact1@test.com',
+                            },
+                        ],
+                        actuaryCommunicationPreference: 'OACT_TO_ACTUARY',
                         packagesWithSharedRateCerts: [],
                     },
                 },
@@ -111,6 +120,7 @@ describe('RateDetailsSummarySection', () => {
                             },
                         ],
                         addtlActuaryContacts: [],
+                        actuaryCommunicationPreference: 'OACT_TO_STATE',
                         packagesWithSharedRateCerts: [],
                     },
                 },
@@ -676,7 +686,7 @@ describe('RateDetailsSummarySection', () => {
         })
     })
 
-    it('renders multiple rate certifications with certifying actuary', async () => {
+    it('renders multiple rate certifications with certifying actuaries and actuary communication preference', async () => {
         const draftContract = mockContractPackageDraft()
         draftContract.draftRates = makeMockRateInfos()
         renderWithProviders(
@@ -694,7 +704,7 @@ describe('RateDetailsSummarySection', () => {
             const certifyingActuary = screen.getAllByRole('definition', {
                 name: 'Certifying actuary',
             })
-            expect(certifyingActuary).toHaveLength(2)
+            expect(certifyingActuary).toHaveLength(3)
             expect(
                 within(certifyingActuary[0]).queryByRole('link', {
                     name: 'jj.actuary@test.com',
@@ -702,9 +712,24 @@ describe('RateDetailsSummarySection', () => {
             ).toBeInTheDocument()
             expect(
                 within(certifyingActuary[1]).queryByRole('link', {
+                    name: 'additionalactuarycontact1@test.com',
+                })
+            ).toBeInTheDocument()
+            expect(
+                within(certifyingActuary[2]).queryByRole('link', {
                     name: 'tt.actuary@test.com',
                 })
             ).toBeInTheDocument()
+            const actuaryCommPreference = screen.getAllByRole('definition', {
+                name: 'Actuaries’ communication preference',
+            })
+            expect(actuaryCommPreference).toHaveLength(2)
+            expect(actuaryCommPreference[0]).toHaveTextContent(
+                ActuaryCommunicationRecord['OACT_TO_ACTUARY']
+            )
+            expect(actuaryCommPreference[1]).toHaveTextContent(
+                ActuaryCommunicationRecord['OACT_TO_STATE']
+            )
         })
     })
 

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
@@ -31,6 +31,7 @@ import {
     getVisibleLatestContractFormData,
 } from '../../../../../gqlHelpers/contractsAndRates'
 import { useAuth } from '../../../../../contexts/AuthContext'
+import { ActuaryCommunicationRecord } from '../../../../../constants'
 
 export type RateDetailsSummarySectionV2Props = {
     contract: Contract
@@ -248,7 +249,7 @@ export const RateDetailsSummarySectionV2 = ({
                     renderDownloadButton(zippedFilesURL)}
             </SectionHeader>
             {rates && rates.length > 0 ? (
-                rates.map((rate) => {
+                rates.map((rate, rateIndex) => {
                     const rateFormData = getRateFormData(rate)
                     if (!rateFormData) {
                         return <GenericErrorPage />
@@ -336,6 +337,14 @@ export const RateDetailsSummarySectionV2 = ({
                                             )}`}
                                         />
                                     ) : null}
+                                    <DataDetail
+                                        id="rateCapitationType"
+                                        label="Does the actuary certify capitation rates specific to each rate cell or a rate range?"
+                                        explainMissingData={
+                                            !isSubmittedOrCMSUser
+                                        }
+                                        children={rateCapitationType(rate)}
+                                    />
                                     {rateFormData
                                         .certifyingActuaryContacts[0] && (
                                         <DataDetail
@@ -354,13 +363,36 @@ export const RateDetailsSummarySectionV2 = ({
                                             }
                                         />
                                     )}
+                                    {rateFormData.addtlActuaryContacts.map(
+                                        (contact, addtlContactIndex) => (
+                                            <DataDetail
+                                                key={`addtlCertifyingActuary-${addtlContactIndex}`}
+                                                id={`addtlCertifyingActuary-${addtlContactIndex}`}
+                                                label="Certifying actuary"
+                                                explainMissingData={
+                                                    !isSubmittedOrCMSUser
+                                                }
+                                                children={
+                                                    <DataDetailContactField
+                                                        contact={contact}
+                                                    />
+                                                }
+                                            />
+                                        )
+                                    )}
                                     <DataDetail
-                                        id="rateCapitationType"
-                                        label="Does the actuary certify capitation rates specific to each rate cell or a rate range?"
+                                        id="communicationPreference"
+                                        label="Actuaries’ communication preference"
+                                        children={
+                                            rateFormData.actuaryCommunicationPreference &&
+                                            ActuaryCommunicationRecord[
+                                                rateFormData
+                                                    .actuaryCommunicationPreference
+                                            ]
+                                        }
                                         explainMissingData={
                                             !isSubmittedOrCMSUser
                                         }
-                                        children={rateCapitationType(rate)}
                                     />
                                 </DoubleColumnGrid>
                             </dl>

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -1068,12 +1068,6 @@ describe('SubmissionSummary', () => {
             expect(
                 screen.getByRole('heading', { name: 'State contacts' })
             ).toBeInTheDocument()
-            expect(screen.getByText('Contact 1')).toBeInTheDocument()
-            expect(
-                screen.getByRole('heading', {
-                    name: 'Additional actuary contacts',
-                })
-            ).toBeInTheDocument()
             expect(screen.getByText('Contact 2')).toBeInTheDocument()
             const soAndSo = screen.getAllByRole('link', {
                 name: 'soandso@example.com',
@@ -1093,10 +1087,7 @@ describe('SubmissionSummary', () => {
                 screen.getAllByRole('link', { name: 'lodar@example.com' })
             ).toHaveLength(2)
 
-            expect(screen.getByText('Certifying actuary')).toBeInTheDocument()
-            expect(
-                screen.getByText('Additional actuary contact')
-            ).toBeInTheDocument()
+            expect(screen.getAllByText('Certifying actuary')).toHaveLength(2)
             expect(
                 screen.getByText(
                     'OACT can communicate directly with the state’s actuaries but should copy the state on all written communication and all appointments for verbal discussions.'
@@ -1436,12 +1427,6 @@ describe('SubmissionSummary', () => {
             expect(
                 screen.getByRole('heading', { name: 'State contacts' })
             ).toBeInTheDocument()
-            expect(screen.getByText('Contact 1')).toBeInTheDocument()
-            expect(
-                screen.getByRole('heading', {
-                    name: 'Additional actuary contacts',
-                })
-            ).toBeInTheDocument()
             expect(screen.getByText('Contact 2')).toBeInTheDocument()
             const soAndSo = screen.getAllByRole('link', {
                 name: 'soandso@example.com',
@@ -1461,10 +1446,7 @@ describe('SubmissionSummary', () => {
                 screen.getAllByRole('link', { name: 'lodar@example.com' })
             ).toHaveLength(2)
 
-            expect(screen.getByText('Certifying actuary')).toBeInTheDocument()
-            expect(
-                screen.getByText('Additional actuary contact')
-            ).toBeInTheDocument()
+            expect(screen.getAllByText('Certifying actuary')).toHaveLength(2)
             expect(
                 screen.getByText(
                     'OACT can communicate directly with the state’s actuaries but should copy the state on all written communication and all appointments for verbal discussions.'
@@ -1804,12 +1786,6 @@ describe('SubmissionSummary', () => {
             expect(
                 screen.getByRole('heading', { name: 'State contacts' })
             ).toBeInTheDocument()
-            expect(screen.getByText('Contact 1')).toBeInTheDocument()
-            expect(
-                screen.getByRole('heading', {
-                    name: 'Additional actuary contacts',
-                })
-            ).toBeInTheDocument()
             expect(screen.getByText('Contact 2')).toBeInTheDocument()
             const soAndSo = screen.getAllByRole('link', {
                 name: 'soandso@example.com',
@@ -1829,10 +1805,7 @@ describe('SubmissionSummary', () => {
                 screen.getAllByRole('link', { name: 'lodar@example.com' })
             ).toHaveLength(2)
 
-            expect(screen.getByText('Certifying actuary')).toBeInTheDocument()
-            expect(
-                screen.getAllByText('Additional actuary contact')
-            ).toHaveLength(1)
+            expect(screen.getAllByText('Certifying actuary')).toHaveLength(2)
             expect(
                 screen.getByText(
                     'OACT can communicate directly with the state’s actuaries but should copy the state on all written communication and all appointments for verbal discussions.'
@@ -2171,12 +2144,6 @@ describe('SubmissionSummary', () => {
             expect(
                 screen.getByRole('heading', { name: 'State contacts' })
             ).toBeInTheDocument()
-            expect(screen.getByText('Contact 1')).toBeInTheDocument()
-            expect(
-                screen.getByRole('heading', {
-                    name: 'Additional actuary contacts',
-                })
-            ).toBeInTheDocument()
             expect(screen.getByText('Contact 2')).toBeInTheDocument()
             const soAndSo = screen.getAllByRole('link', {
                 name: 'soandso@example.com',
@@ -2196,10 +2163,7 @@ describe('SubmissionSummary', () => {
                 screen.getAllByRole('link', { name: 'lodar@example.com' })
             ).toHaveLength(2)
 
-            expect(screen.getByText('Certifying actuary')).toBeInTheDocument()
-            expect(
-                screen.getAllByText('Additional actuary contact')
-            ).toHaveLength(1)
+            expect(screen.getAllByText('Certifying actuary')).toHaveLength(2)
             expect(
                 screen.getByText(
                     'OACT can communicate directly with the state’s actuaries but should copy the state on all written communication and all appointments for verbal discussions.'

--- a/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -22,14 +22,6 @@ describe('CMS user', () => {
         cy.findAllByTestId('rate-certification-form').each((form) =>
             cy.wrap(form).within(() => cy.fillOutNewRateCertification())
         )
-        cy.findByRole('radiogroup', {
-            name: /Actuaries' communication preference/
-        })
-            .should('exist')
-            .within(() => { 
-                cy.findByText("OACT can communicate directly with the state's actuaries but should copy the state on all written communication and all appointments for verbal discussions.")
-                .click()
-            })
         cy.navigateFormByButtonClick('CONTINUE')
 
         cy.findByRole('heading', {
@@ -256,14 +248,6 @@ describe('CMS user', () => {
                 cy.fillOutNewRateCertification();
         })
         )
-        cy.findByRole('radiogroup', {
-            name: /Actuaries' communication preference/
-        })
-            .should('exist')
-            .within(() => { 
-                cy.findByText("OACT can communicate directly with the state's actuaries but should copy the state on all written communication and all appointments for verbal discussions.")
-                .click()
-            })
         cy.navigateContractRatesFormByButtonClick('CONTINUE')
 
         // fill out the rest of the form

--- a/services/cypress/integration/cmsWorkflow/viewSubmission.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/viewSubmission.spec.ts
@@ -16,14 +16,6 @@ describe('CMS user can view submission', () => {
         }).should('exist')
         cy.fillOutNewRateCertification()
         cy.fillOutAdditionalActuaryContact()
-        cy.findByRole('radiogroup', {
-            name: /Actuaries' communication preference/
-        })
-            .should('exist')
-            .within(() => { 
-                cy.findByText("OACT can communicate directly with the state's actuaries but should copy the state on all written communication and all appointments for verbal discussions.")
-                .click()
-            })
         cy.navigateFormByButtonClick('CONTINUE')
 
         cy.findByRole('heading', {

--- a/services/cypress/integration/stateWorkflow/stateSubmissionForm/rateDetails.spec.ts
+++ b/services/cypress/integration/stateWorkflow/stateSubmissionForm/rateDetails.spec.ts
@@ -44,15 +44,6 @@ describe('rate details', () => {
                 `/submissions/${draftSubmissionId}/edit/rate-details`
             )
 
-            cy.findByRole('radiogroup', {
-                name: /Actuaries' communication preference/
-            })
-                .should('exist')
-                .within(() => { 
-                    cy.findByText("OACT can communicate directly with the state's actuaries but should copy the state on all written communication and all appointments for verbal discussions.")
-                    .click()
-                })
-
             cy.fillOutAmendmentToPriorRateCertification()
             /* Choose another submission that the rate cert was uploaded to, then check that your selection
             is still there when you come back */
@@ -107,15 +98,6 @@ describe('rate details', () => {
         }).click()
 
         cy.findAllByTestId('rate-certification-form').should('have.length', 3)
-
-        cy.findByRole('radiogroup', {
-            name: /Actuaries' communication preference/
-        })
-            .should('exist')
-            .within(() => { 
-                cy.findByText("OACT can communicate directly with the state's actuaries but should copy the state on all written communication and all appointments for verbal discussions.")
-                .click()
-            })
 
         //Fill out every rate certification form
         cy.findAllByTestId('rate-certification-form').each(

--- a/services/cypress/support/stateSubmissionFormCommands.ts
+++ b/services/cypress/support/stateSubmissionFormCommands.ts
@@ -369,6 +369,16 @@ Cypress.Commands.add('fillOutNewRateCertification', () => {
         cy.findAllByLabelText('Email').eq(0).type('actuarycontact@example.com')
         cy.findAllByLabelText('Mercer').eq(0).safeClick()
 
+        //Actuary communication preference
+        cy.findByRole('radiogroup', {
+            name: /Actuaries' communication preference/
+        })
+            .should('exist')
+            .within(() => {
+                cy.findByText("OACT can communicate directly with the state's actuaries but should copy the state on all written communication and all appointments for verbal discussions.")
+                    .click()
+            })
+
         // Upload a rate certification and rate supporting document
         cy.findAllByTestId('file-input-input').each(fileInput =>
             cy.wrap(fileInput).attachFile('documents/trussel-guide.pdf')
@@ -445,6 +455,16 @@ Cypress.Commands.add('fillOutAmendmentToPriorRateCertification', (id = 0) => {
     cy.findAllByLabelText('Title/Role').eq(0).type('Actuary Contact Title')
     cy.findAllByLabelText('Email').eq(0).type('actuarycontact@example.com')
     cy.findAllByLabelText('Mercer').eq(0).safeClick()
+
+    //Actuary communication preference
+    cy.findByRole('radiogroup', {
+        name: /Actuaries' communication preference/
+    })
+        .should('exist')
+        .within(() => {
+            cy.findByText("OACT can communicate directly with the state's actuaries but should copy the state on all written communication and all appointments for verbal discussions.")
+                .click()
+        })
 
     // Upload a rate certification and rate supporting document
     cy.findAllByTestId('file-input-input').each(fileInput =>


### PR DESCRIPTION
## Summary
[MCR-4088](https://jiraent.cms.gov/browse/MCR-4088)
[Figma](https://www.figma.com/file/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?type=design&node-id=12168-102675&mode=design&t=fdPmi5rqLTxBsv5H-0)

- Fixed the issue of Actuary communication preference not  being displayed with data by updating UI
- Moved Actuary communication preference radio to each rate certification section on the Rate details page.
   - This change is applied to both V1 and V2
   - V1 saves Actuary communication preference to each respective rate instead of top level package
- Moved Additional actuaries and Actuary communication preferences to each respective rate certification section on the review and submit and summary pages.
- Added Additional actuaries and Actuary communication preferences to the rate summary page.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
