### PR TITLE
MCR-4101: Navigating using Back button on rate details page takes user to dashboard.

### DIFF
--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -676,12 +676,16 @@ const RateDetailsV2 = ({
                                                 {
                                                     type: 'CANCEL',
                                                     redirectPath:
-                                                        'DASHBOARD_SUBMISSIONS',
+                                                        displayAsStandaloneRate
+                                                            ? 'DASHBOARD_SUBMISSIONS'
+                                                            : 'SUBMISSIONS_CONTRACT_DETAILS',
                                                 }
                                             )
                                         } else {
                                             navigate(
-                                                RoutesRecord.DASHBOARD_SUBMISSIONS
+                                                displayAsStandaloneRate
+                                                    ? RoutesRecord.DASHBOARD_SUBMISSIONS
+                                                    : '../contract-details'
                                             )
                                         }
                                     }}


### PR DESCRIPTION
## Summary
[MCR-4101](https://jiraent.cms.gov/browse/MCR-4101)

- Fix RateDetailsV2 routing on the back button
   - Fix was to switch routes based on `displayAsStandaloneRate`.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
