### PR TITLE
fix contract history index

### DIFF
--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContractDetailsSummarySectionV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContractDetailsSummarySectionV2.test.tsx
@@ -333,7 +333,7 @@ describe('ContractDetailsSummarySection', () => {
                         id: '123',
                         createdAt: new Date(),
                         updatedAt: new Date(),
-                        contractName: 'MCR-0005-alvhalfhdsalf',
+                        contractName: 'MCR-0005-alvhalfhdsalfdd',
                         formData: mockContractFormData({
                             supportingDocuments: [],
                         }),

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummaryV2.test.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummaryV2.test.tsx
@@ -47,7 +47,7 @@ describe('SubmissionRevisionSummary', () => {
         expect(
             await screen.findByRole('heading', { name: 'Contract details' })
         ).toBeInTheDocument()
-        const submissionVersion = `12/31/23 7:00pm ET version`
+        const submissionVersion = `02/16/24 10:22pm ET version`
         expect(await screen.findByText(submissionVersion)).toBeInTheDocument()
         expect(
             await screen.findByTestId('previous-submission-banner')
@@ -95,11 +95,163 @@ describe('SubmissionRevisionSummary', () => {
                 within(rows[1]).getByText(
                     dayjs(
                         mockContractPackageSubmittedWithRevisions()
-                            .packageSubmissions[0]?.contractRevision?.submitInfo
+                            .packageSubmissions[1]?.contractRevision?.submitInfo
                             ?.updatedAt
                     ).format('M/D/YY')
                 )
             ).toBeInTheDocument()
         })
     })
+
+    it('renders the right indexed version 2', async () => {
+        renderWithProviders(
+            <Routes>
+                <Route
+                    path={RoutesRecord.SUBMISSIONS_REVISION}
+                    element={<SubmissionRevisionSummaryV2 />}
+                />
+            </Routes>,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchContractMockSuccess({
+                            contract: mockContractPackageSubmittedWithRevisions({
+                                id: '15'
+                            })
+                        })
+                    ],
+                },
+                routerProvider: {
+                    route: '/submissions/15/revisions/2',
+                },
+                featureFlags: {
+                    'link-rates': true,
+                },
+            } 
+        )
+        expect(
+            await screen.findByRole('heading', { name: 'Contract details' })
+        ).toBeInTheDocument()
+        
+        expect(await screen.findByLabelText('Submission description')).toHaveTextContent('Submission 2')
+        expect(await screen.findByText('rate2 doc')).toBeInTheDocument()
+
+    })
+
+    it('renders the right indexed version 1', async () => {
+        renderWithProviders(
+            <Routes>
+                <Route
+                    path={RoutesRecord.SUBMISSIONS_REVISION}
+                    element={<SubmissionRevisionSummaryV2 />}
+                />
+            </Routes>,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchContractMockSuccess({
+                            contract: mockContractPackageSubmittedWithRevisions({
+                                id: '15'
+                            })
+                        })
+                    ],
+                },
+                routerProvider: {
+                    route: '/submissions/15/revisions/1',
+                },
+                featureFlags: {
+                    'link-rates': true,
+                },
+            } 
+        )
+        expect(
+            await screen.findByRole('heading', { name: 'Contract details' })
+        ).toBeInTheDocument()
+        
+        expect(await screen.findByLabelText('Submission description')).toHaveTextContent('Submission 1')
+    })
+
+    it('renders the error indexed version 3', async () => {
+        renderWithProviders(
+            <Routes>
+                <Route
+                    path={RoutesRecord.SUBMISSIONS_REVISION}
+                    element={<SubmissionRevisionSummaryV2 />}
+                />
+            </Routes>,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchContractMockSuccess({
+                            contract: mockContractPackageSubmittedWithRevisions({
+                                id: '15'
+                            })
+                        })
+                    ],
+                },
+                routerProvider: {
+                    route: '/submissions/15/revisions/3',
+                },
+                featureFlags: {
+                    'link-rates': true,
+                },
+            } 
+        )
+        expect(await screen.findByRole('heading')).toHaveTextContent('404 / Page not found')
+        
+    })
+
+    // it('extracts the correct dates from the submission and displays them in tables', async () => {
+    //     renderWithProviders(
+    //         <Routes>
+    //             <Route
+    //                 path={RoutesRecord.SUBMISSIONS_REVISION}
+    //                 element={<SubmissionRevisionSummary />}
+    //             />
+    //         </Routes>,
+    //         {
+    //             apolloProvider: {
+    //                 mocks: [
+    //                     fetchCurrentUserMock({
+    //                         user: mockValidCMSUser(),
+    //                         statusCode: 200,
+    //                     }),
+    //                     fetchStateHealthPlanPackageMockSuccess({
+    //                         stateSubmission:
+    //                             mockSubmittedHealthPlanPackageWithRevisions(),
+    //                         id: '15',
+    //                     }),
+    //                 ],
+    //             },
+    //             routerProvider: {
+    //                 route: '/submissions/15/revisions/2',
+    //             },
+    //         }
+    //     )
+    //     await waitFor(() => {
+    //         const rows = screen.getAllByRole('row')
+    //         expect(rows).toHaveLength(2)
+    //         expect(within(rows[0]).getByText('Date added')).toBeInTheDocument()
+    //         expect(
+    //             within(rows[1]).getByText(
+    //                 dayjs(
+    //                     mockSubmittedHealthPlanPackageWithRevisions()
+    //                         .revisions[2]?.node?.submitInfo?.updatedAt
+    //                 ).format('M/D/YY')
+    //             )
+    //         ).toBeInTheDocument()
+    //     })
+    // })
 })

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummaryV2.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummaryV2.tsx
@@ -7,7 +7,6 @@ import { ContactsSummarySection } from '../StateSubmission/ReviewSubmit/V2/Revie
 import { RateDetailsSummarySectionV2 } from '../StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2'
 import { SubmissionTypeSummarySectionV2 } from '../StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2'
 import { usePage } from '../../contexts/PageContext'
-import { GenericErrorPage } from '../Errors/GenericErrorPage'
 import { dayjs } from '../../common-code/dateHelpers'
 import styles from './SubmissionRevisionSummary.module.scss'
 import { PreviousSubmissionBanner } from '../../components'
@@ -16,6 +15,7 @@ import {
     ErrorOrLoadingPage,
     handleAndReturnErrorState,
 } from '../StateSubmission/ErrorOrLoadingPage'
+import { Error404 } from '../Errors/Error404Page'
 
 type RouteParams = {
     id: string
@@ -50,11 +50,11 @@ export const SubmissionRevisionSummaryV2 = (): React.ReactElement => {
     })
     const contract = fetchContractData?.fetchContract.contract
     //We offset version by +1 of index, remove offset to find revision in revisions
-    const revisionIndex = Number(revisionVersion)
+    const revisionIndex = Number(revisionVersion) - 1
 
     const name =
         contract &&
-        contract?.packageSubmissions.length === Number(revisionVersion)
+        contract?.packageSubmissions.length < Number(revisionVersion)
             ? contract.packageSubmissions.reverse()[revisionIndex]
                   .contractRevision.contractName
             : ''
@@ -79,17 +79,16 @@ export const SubmissionRevisionSummaryV2 = (): React.ReactElement => {
 
     if (
         !contract ||
-        contract.packageSubmissions.length === Number(revisionVersion)
+        contract.packageSubmissions.length <= Number(revisionVersion)
     ) {
-        return <GenericErrorPage />
+        return <Error404 />
     }
 
-    //Reversing revisions to get correct submission order
-    const revision = [...contract.packageSubmissions].reverse()[revisionIndex]
-        .contractRevision
-    const rateRevisions = [...contract.packageSubmissions].reverse()[
-        revisionIndex
-    ].rateRevisions
+    // Reversing revisions to get correct submission order
+    // we offset the index by one so that our indices start at 1
+    const packageSubmission = [...contract.packageSubmissions].reverse()[revisionIndex]
+    const revision = packageSubmission.contractRevision
+    const rateRevisions = packageSubmission.rateRevisions
     const contractData = revision.formData
     const statePrograms = contract.state.programs
     const submitInfo = revision.submitInfo || undefined

--- a/services/app-web/src/testHelpers/apolloMocks/contractPackageDataMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/contractPackageDataMock.ts
@@ -1,5 +1,163 @@
 import { mockMNState } from '../../common-code/healthPlanFormDataMocks/healthPlanFormData'
-import { Contract, ContractFormData } from '../../gen/gqlClient'
+import { Contract, ContractFormData, ContractRevision, RateRevision } from '../../gen/gqlClient'
+
+
+function mockContractRevision(name?: string, partial?: Partial<ContractRevision>): ContractRevision {
+    name = name || '1'
+    return {
+        __typename: 'ContractRevision',
+        contractName: 'MCR-MN-0005-SNBC',
+        createdAt: new Date('01/01/2024'),
+        updatedAt: new Date('12/31/2024'),
+        id: `123${name}`,
+        submitInfo: {
+            updatedAt: new Date(`2024-02-17T03:2${name}:00`),
+            updatedBy: 'example@state.com',
+            updatedReason: 'contract submit'
+        },
+        unlockInfo: {
+            updatedAt: new Date(),
+            updatedBy: 'example@state.com',
+            updatedReason: 'contract unlock'
+        },
+        formData: {
+            __typename: 'ContractFormData',
+            programIDs: ['abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce'],
+            populationCovered: 'MEDICAID',
+            submissionType: 'CONTRACT_AND_RATES',
+            riskBasedContract: true,
+            submissionDescription: `Submission ${name}`,
+            supportingDocuments: [
+                {
+                    s3URL: `s3://bucketname/key/contractsupporting${name}1`,
+                    sha256: 'fakesha',
+                    name: `contractSupporting${name}1`,
+                    dateAdded: new Date('01/15/2024')
+                },
+                {
+                    s3URL: `s3://bucketname/key/contractsupporting${name}2`,
+                    sha256: 'fakesha',
+                    name: `contractSupporting${name}2`,
+                    dateAdded: new Date('01/13/2024')
+                },
+            ],
+            stateContacts: [],
+            contractType: 'AMENDMENT',
+            contractExecutionStatus: 'EXECUTED',
+            contractDocuments: [
+                {
+                    s3URL: `s3://bucketname/key/contract${name}`,
+                    sha256: 'fakesha',
+                    name: `contract${name}`,
+                    dateAdded: new Date('2024-02-17')
+                },
+            ],
+            contractDateStart: new Date(),
+            contractDateEnd: new Date(),
+            managedCareEntities: ['MCO'],
+            federalAuthorities: ['STATE_PLAN'],
+            inLieuServicesAndSettings: true,
+            modifiedBenefitsProvided: true,
+            modifiedGeoAreaServed: false,
+            modifiedMedicaidBeneficiaries: true,
+            modifiedRiskSharingStrategy: true,
+            modifiedIncentiveArrangements: false,
+            modifiedWitholdAgreements: false,
+            modifiedStateDirectedPayments: true,
+            modifiedPassThroughPayments: true,
+            modifiedPaymentsForMentalDiseaseInstitutions: false,
+            modifiedMedicalLossRatioStandards: true,
+            modifiedOtherFinancialPaymentIncentive: false,
+            modifiedEnrollmentProcess: true,
+            modifiedGrevienceAndAppeal: false,
+            modifiedNetworkAdequacyStandards: true,
+            modifiedLengthOfContract: false,
+            modifiedNonRiskPaymentArrangements: true,
+            statutoryRegulatoryAttestation: true,
+            statutoryRegulatoryAttestationDescription: "everything meets regulatory attestation"
+        },
+        ...partial
+    }
+}
+
+function mockRateRevision(name?: string, partial?: Partial<RateRevision>): RateRevision {
+    name = name || '1'
+    return {
+        __typename: 'RateRevision',
+        id: `1234${name}`,
+        rateID: '123',
+        createdAt: new Date('01/01/2023'),
+        updatedAt: new Date('01/01/2023'),
+        submitInfo: {
+            updatedAt: new Date(),
+            updatedBy: 'example@state.com',
+            updatedReason: 'contract submit'
+        },
+        unlockInfo: {
+            updatedAt: new Date(),
+            updatedBy: 'example@state.com',
+            updatedReason: 'contract unlock'
+        },
+        contractRevisions: [],
+        formData: {
+            __typename: 'RateFormData',
+            rateType: 'AMENDMENT',
+            rateCapitationType: 'RATE_CELL',
+            rateCertificationName: 'fooname',
+            rateDocuments: [
+                {
+                    s3URL: 's3://bucketname/key/rate',
+                    sha256: 'fakesha',
+                    name: `rate${name} doc`,
+                    dateAdded: new Date('01/01/2023')
+                },
+            ],
+            supportingDocuments: [
+                {
+                    s3URL: 's3://bucketname/key/rateSupporting1',
+                    sha256: 'fakesha',
+                    name: `rate supporting ${name}1`,
+                    dateAdded: new Date('01/15/2023')
+                },
+                {
+                    s3URL: 's3://bucketname/key/rateSupporting1',
+                    sha256: 'fakesha',
+                    name: `rate supporting ${name}2`,
+                    dateAdded: new Date('01/15/2023')
+                },
+            ],
+            rateDateStart: new Date(),
+            rateDateEnd: new Date(),
+            rateDateCertified: new Date(),
+            amendmentEffectiveDateStart: new Date(),
+            amendmentEffectiveDateEnd: new Date(),
+            rateProgramIDs: ['abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce'],
+            certifyingActuaryContacts: [
+                {
+                    id: null,
+                    actuarialFirmOther: null,
+                    actuarialFirm: 'DELOITTE',
+                    name: `Actuary Contact ${name}`,
+                    titleRole: `Test Actuary Contact ${name}`,
+                    email: 'actuarycontact1@test.com',
+                },
+            ],
+            addtlActuaryContacts: [
+                {
+                    id: null,
+                    actuarialFirmOther: null,
+                    actuarialFirm: 'DELOITTE',
+                    name: `Additional Actuary Contact ${name}`,
+                    titleRole: 'Test Actuary Contact 1',
+                    email: 'actuarycontact1@test.com',
+                },
+            ],
+            actuaryCommunicationPreference: 'OACT_TO_ACTUARY',
+            packagesWithSharedRateCerts: []
+        }
+    }
+}
+
 
 // Assemble versions of Contract data (with or without rates) for jest testing. Intended for use with related GQL Moc file.
 function mockContractPackageDraft(
@@ -23,7 +181,7 @@ function mockContractPackageDraft(
             id: '123',
             createdAt: new Date(),
             updatedAt: new Date(),
-            contractName: 'MCR-0005-alvhalfhdsalf',
+            contractName: 'MCR-0005-alvhalfhdsalfee',
             formData: mockContractFormData(partial?.draftRevision?.formData)
         },
 
@@ -77,6 +235,8 @@ function mockContractPackageDraft(
                         rateProgramIDs: ['abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce'],
                         certifyingActuaryContacts: [
                             {
+                                id: null,
+                                actuarialFirmOther: null,
                                 actuarialFirm: 'DELOITTE',
                                 name: 'Actuary Contact 1',
                                 titleRole: 'Test Actuary Contact 1',
@@ -85,6 +245,8 @@ function mockContractPackageDraft(
                         ],
                         addtlActuaryContacts: [
                             {
+                                id: null,
+                                actuarialFirmOther: null,
                                 actuarialFirm: 'DELOITTE',
                                 name: 'Actuary Contact 1',
                                 titleRole: 'Test Actuary Contact 1',
@@ -123,7 +285,7 @@ function mockContractWithLinkedRateDraft(
             id: '123',
             createdAt: new Date(),
             updatedAt: new Date(),
-            contractName: 'MCR-0005-alvhalfhdsalf',
+            contractName: 'MCR-0005-alvhalfhdsalfss',
             formData: {
                 programIDs: ['abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce'],
                 populationCovered: 'MEDICAID',
@@ -439,503 +601,71 @@ function mockContractPackageSubmittedWithRevisions(
     partial?: Partial<Contract>
 ): Contract {
     return {
+        __typename: 'Contract',
         status: 'SUBMITTED',
         createdAt: new Date(),
         updatedAt: new Date(),
+        initiallySubmittedAt: '2024-01-01',
+        mccrsID: null,
         id: 'test-abc-123',
         stateCode: 'MN',
-        __typename: 'Contract',
         state: mockMNState(),
         stateNumber: 5,
+        draftRevision: null,
+        draftRates: null,
         packageSubmissions: [
-        {
-            cause: 'CONTRACT_SUBMISSION',
-            submitInfo: {
-                updatedAt: new Date('01/01/2024'),
-                updatedBy: 'example@state.com',
-                updatedReason: 'contract submit'
-            },
-            submittedRevisions: [
-                {
-                    contractName: 'MCR-MN-0005-SNBC',
-                    createdAt: new Date('01/01/2024'),
-                    updatedAt: new Date('12/31/2024'),
-                    id: '123',
-                    submitInfo: {
-                        updatedAt: new Date(),
-                        updatedBy: 'example@state.com',
-                        updatedReason: 'contract submit'
-                    },
-                    unlockInfo: {
-                        updatedAt: new Date(),
-                        updatedBy: 'example@state.com',
-                        updatedReason: 'contract unlock'
-                    },
-                    formData: {
-                        programIDs: ['abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce'],
-                        populationCovered: 'MEDICAID',
-                        submissionType: 'CONTRACT_AND_RATES',
-                        riskBasedContract: true,
-                        submissionDescription: 'A real submission',
-                        supportingDocuments: [
-                            {
-                                s3URL: 's3://bucketname/key/contractsupporting1',
-                                sha256: 'fakesha',
-                                name: 'contractSupporting1',
-                                dateAdded: new Date('01/15/2024')
-                            },
-                            {
-                                s3URL: 's3://bucketname/key/contractSupporting2',
-                                sha256: 'fakesha',
-                                name: 'contractSupporting2',
-                                dateAdded: new Date('01/13/2024')
-                            },
-                        ],
-                        stateContacts: [],
-                        contractType: 'AMENDMENT',
-                        contractExecutionStatus: 'EXECUTED',
-                        contractDocuments: [
-                            {
-                                s3URL: 's3://bucketname/key/contract',
-                                sha256: 'fakesha',
-                                name: 'contract',
-                                dateAdded: new Date('01/01/2024')
-                            },
-                        ],
-                        contractDateStart: new Date(),
-                        contractDateEnd: new Date(),
-                        managedCareEntities: ['MCO'],
-                        federalAuthorities: ['STATE_PLAN'],
-                        inLieuServicesAndSettings: true,
-                        modifiedBenefitsProvided: true,
-                        modifiedGeoAreaServed: false,
-                        modifiedMedicaidBeneficiaries: true,
-                        modifiedRiskSharingStrategy: true,
-                        modifiedIncentiveArrangements: false,
-                        modifiedWitholdAgreements: false,
-                        modifiedStateDirectedPayments: true,
-                        modifiedPassThroughPayments: true,
-                        modifiedPaymentsForMentalDiseaseInstitutions: false,
-                        modifiedMedicalLossRatioStandards: true,
-                        modifiedOtherFinancialPaymentIncentive: false,
-                        modifiedEnrollmentProcess: true,
-                        modifiedGrevienceAndAppeal: false,
-                        modifiedNetworkAdequacyStandards: true,
-                        modifiedLengthOfContract: false,
-                        modifiedNonRiskPaymentArrangements: true,
-                        statutoryRegulatoryAttestation: true,
-                        statutoryRegulatoryAttestationDescription: "everything meets regulatory attestation"
-                    }
-                }    
-            ],
-            contractRevision: {
-                contractName: 'MCR-MN-0005-SNBC',
-                createdAt: new Date('01/01/2024'),
-                updatedAt: new Date('12/31/2024'),
-                __typename: 'ContractRevision',
-                id: '123',
+            {
+                __typename: 'ContractPackageSubmission',
+                cause: 'CONTRACT_SUBMISSION',
                 submitInfo: {
-                    updatedAt: new Date('01/01/2024'),
+                    __typename: 'UpdateInformation',
+                    updatedAt: '2024-03-03',
                     updatedBy: 'example@state.com',
-                    updatedReason: 'contract submit'
+                    updatedReason: 'submit 3'
                 },
-                unlockInfo: undefined,
-                formData: {
-                    programIDs: ['abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce'],
-                    populationCovered: 'MEDICAID',
-                    submissionType: 'CONTRACT_AND_RATES',
-                    riskBasedContract: true,
-                    submissionDescription: 'A initial submission',
-                    supportingDocuments: [
-                        {
-                            s3URL: 's3://bucketname/key/contractsupporting1',
-                            sha256: 'fakesha',
-                            name: 'contractSupporting1',
-                            dateAdded: new Date('01/15/2024')
-                        },
-                        {
-                            s3URL: 's3://bucketname/key/contractSupporting2',
-                            sha256: 'fakesha',
-                            name: 'contractSupporting2',
-                            dateAdded: new Date('01/13/2024')
-                        },
-                    ],
-                    stateContacts: [],
-                    contractType: 'AMENDMENT',
-                    contractExecutionStatus: 'EXECUTED',
-                    contractDocuments: [
-                        {
-                            s3URL: 's3://bucketname/key/contract',
-                            sha256: 'fakesha',
-                            name: 'contract',
-                            dateAdded: new Date('01/01/2024')
-                        },
-                    ],
-                    contractDateStart: new Date(),
-                    contractDateEnd: new Date(),
-                    managedCareEntities: ['MCO'],
-                    federalAuthorities: ['STATE_PLAN'],
-                    inLieuServicesAndSettings: true,
-                    modifiedBenefitsProvided: true,
-                    modifiedGeoAreaServed: false,
-                    modifiedMedicaidBeneficiaries: true,
-                    modifiedRiskSharingStrategy: true,
-                    modifiedIncentiveArrangements: false,
-                    modifiedWitholdAgreements: false,
-                    modifiedStateDirectedPayments: true,
-                    modifiedPassThroughPayments: true,
-                    modifiedPaymentsForMentalDiseaseInstitutions: false,
-                    modifiedMedicalLossRatioStandards: true,
-                    modifiedOtherFinancialPaymentIncentive: false,
-                    modifiedEnrollmentProcess: true,
-                    modifiedGrevienceAndAppeal: false,
-                    modifiedNetworkAdequacyStandards: true,
-                    modifiedLengthOfContract: false,
-                    modifiedNonRiskPaymentArrangements: true,
-                    statutoryRegulatoryAttestation: true,
-                    statutoryRegulatoryAttestationDescription: "everything meets regulatory attestation"
-                }
+                submittedRevisions: [
+                    mockContractRevision('3'),
+                ],
+                contractRevision: mockContractRevision('3'),
+                rateRevisions: [
+                    mockRateRevision('3'),
+                ],
             },
-            rateRevisions: [
-                {
-                    id: '1234',
-                    rateID: '123',
-                    __typename: 'RateRevision',
-                    createdAt: new Date('01/01/2023'),
-                    updatedAt: new Date('01/01/2023'),
-                    contractRevisions: [],
-                    formData: {
-                        rateType: 'AMENDMENT',
-                        rateCapitationType: 'RATE_CELL',
-                        rateDocuments: [
-                            {
-                                s3URL: 's3://bucketname/key/rate',
-                                sha256: 'fakesha',
-                                name: 'rate',
-                                dateAdded: new Date('01/01/2023')
-                            },
-                        ],
-                        supportingDocuments: [
-                            {
-                                s3URL: 's3://bucketname/key/rateSupporting1',
-                                sha256: 'fakesha',
-                                name: 'rate supporting 1',
-                                dateAdded: new Date('01/15/2023')
-                            },
-                            {
-                                s3URL: 's3://bucketname/key/rateSupporting1',
-                                sha256: 'fakesha',
-                                name: 'rate supporting 2',
-                                dateAdded: new Date('01/15/2023')
-                            },
-                        ],
-                        rateDateStart: new Date(),
-                        rateDateEnd: new Date(),
-                        rateDateCertified: new Date(),
-                        amendmentEffectiveDateStart: new Date(),
-                        amendmentEffectiveDateEnd: new Date(),
-                        rateProgramIDs: ['abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce'],
-                        certifyingActuaryContacts: [
-                            {
-                                actuarialFirm: 'DELOITTE',
-                                name: 'Actuary Contact 1',
-                                titleRole: 'Test Actuary Contact 1',
-                                email: 'actuarycontact1@test.com',
-                            },
-                        ],
-                        addtlActuaryContacts: [
-                            {
-                                actuarialFirm: 'DELOITTE',
-                                name: 'Actuary Contact 1',
-                                titleRole: 'Test Actuary Contact 1',
-                                email: 'actuarycontact1@test.com',
-                            },
-                        ],
-                        actuaryCommunicationPreference: 'OACT_TO_ACTUARY',
-                        packagesWithSharedRateCerts: []
-                    }
-                },
-            ],
-        },
-        {
-            cause: 'CONTRACT_SUBMISSION',
-            submitInfo: {
-                updatedAt: new Date(),
-                updatedBy: 'example@state.com',
-                updatedReason: 'contract submit'
-            },
-            submittedRevisions: [],
-            contractRevision: {
-                __typename: 'ContractRevision',
-                contractName: 'MCR-MN-0005-SNBC',
-                createdAt: new Date('01/01/2024'),
-                updatedAt: new Date('12/31/2024'),
-                id: '123',
+            {
+                __typename: 'ContractPackageSubmission',
+                cause: 'CONTRACT_SUBMISSION',
                 submitInfo: {
-                    updatedAt: new Date(),
+                    __typename: 'UpdateInformation',
+                    updatedAt: '2024-02-02',
                     updatedBy: 'example@state.com',
-                    updatedReason: 'contract submit'
+                    updatedReason: 'submit 2'
                 },
-                unlockInfo: {
-                    updatedAt: new Date(),
-                    updatedBy: 'example@state.com',
-                    updatedReason: 'contract unlock'
-                },
-                formData: {
-                    programIDs: ['abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce'],
-                    populationCovered: 'MEDICAID',
-                    submissionType: 'CONTRACT_AND_RATES',
-                    riskBasedContract: true,
-                    submissionDescription: 'A real submission',
-                    supportingDocuments: [
-                        {
-                            s3URL: 's3://bucketname/key/contractsupporting1',
-                            sha256: 'fakesha',
-                            name: 'contractSupporting1',
-                            dateAdded: new Date('01/15/2024')
-                        },
-                        {
-                            s3URL: 's3://bucketname/key/contractSupporting2',
-                            sha256: 'fakesha',
-                            name: 'contractSupporting2',
-                            dateAdded: new Date('01/13/2024')
-                        },
-                    ],
-                    stateContacts: [],
-                    contractType: 'AMENDMENT',
-                    contractExecutionStatus: 'EXECUTED',
-                    contractDocuments: [
-                        {
-                            s3URL: 's3://bucketname/key/contract',
-                            sha256: 'fakesha',
-                            name: 'contract',
-                            dateAdded: new Date('01/01/2024')
-                        },
-                    ],
-                    contractDateStart: new Date(),
-                    contractDateEnd: new Date(),
-                    managedCareEntities: ['MCO'],
-                    federalAuthorities: ['STATE_PLAN'],
-                    inLieuServicesAndSettings: true,
-                    modifiedBenefitsProvided: true,
-                    modifiedGeoAreaServed: false,
-                    modifiedMedicaidBeneficiaries: true,
-                    modifiedRiskSharingStrategy: true,
-                    modifiedIncentiveArrangements: false,
-                    modifiedWitholdAgreements: false,
-                    modifiedStateDirectedPayments: true,
-                    modifiedPassThroughPayments: true,
-                    modifiedPaymentsForMentalDiseaseInstitutions: false,
-                    modifiedMedicalLossRatioStandards: true,
-                    modifiedOtherFinancialPaymentIncentive: false,
-                    modifiedEnrollmentProcess: true,
-                    modifiedGrevienceAndAppeal: false,
-                    modifiedNetworkAdequacyStandards: true,
-                    modifiedLengthOfContract: false,
-                    modifiedNonRiskPaymentArrangements: true,
-                    statutoryRegulatoryAttestation: true,
-                    statutoryRegulatoryAttestationDescription: "everything meets regulatory attestation"
-                }
+                submittedRevisions: [
+                    mockContractRevision('2'),
+                ],
+                contractRevision: mockContractRevision('2'),
+                rateRevisions: [
+                    mockRateRevision('2'),
+                ],
             },
-            rateRevisions: [
-                {
-                    id: '1234',
-                    rateID: '123',
-                    createdAt: new Date('01/01/2023'),
-                    updatedAt: new Date('01/01/2023'),
-                    contractRevisions: [],
-                    __typename: 'RateRevision',
-                    formData: {
-                        rateType: 'AMENDMENT',
-                        rateCapitationType: 'RATE_CELL',
-                        rateDocuments: [
-                            {
-                                s3URL: 's3://bucketname/key/rate',
-                                sha256: 'fakesha',
-                                name: 'rate',
-                                dateAdded: new Date('01/01/2023')
-                            },
-                        ],
-                        supportingDocuments: [
-                            {
-                                s3URL: 's3://bucketname/key/rateSupporting1',
-                                sha256: 'fakesha',
-                                name: 'rate supporting 1',
-                                dateAdded: new Date('01/15/2023')
-                            },
-                            {
-                                s3URL: 's3://bucketname/key/rateSupporting1',
-                                sha256: 'fakesha',
-                                name: 'rate supporting 2',
-                                dateAdded: new Date('01/15/2023')
-                            },
-                        ],
-                        rateDateStart: new Date(),
-                        rateDateEnd: new Date(),
-                        rateDateCertified: new Date(),
-                        amendmentEffectiveDateStart: new Date(),
-                        amendmentEffectiveDateEnd: new Date(),
-                        rateProgramIDs: ['abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce'],
-                        certifyingActuaryContacts: [
-                            {
-                                actuarialFirm: 'DELOITTE',
-                                name: 'Actuary Contact 1',
-                                titleRole: 'Test Actuary Contact 1',
-                                email: 'actuarycontact1@test.com',
-                            },
-                        ],
-                        addtlActuaryContacts: [
-                            {
-                                actuarialFirm: 'DELOITTE',
-                                name: 'Actuary Contact 1',
-                                titleRole: 'Test Actuary Contact 1',
-                                email: 'actuarycontact1@test.com',
-                            },
-                        ],
-                        actuaryCommunicationPreference: 'OACT_TO_ACTUARY',
-                        packagesWithSharedRateCerts: []
-                    }
-                },
-            ],
-        },
-        {
-            cause: 'CONTRACT_SUBMISSION',
-            submitInfo: {
-                updatedAt: new Date(),
-                updatedBy: 'example@state.com',
-                updatedReason: 'contract resubmit'
-            },
-            submittedRevisions: [],
-            contractRevision: {
-                contractName: 'MCR-MN-0005-SNBC',
-                createdAt: new Date('01/01/2024'),
-                updatedAt: new Date('12/31/2024'),
-                __typename: 'ContractRevision',
-                id: '123',
+            {
+                __typename: 'ContractPackageSubmission',
+                cause: 'CONTRACT_SUBMISSION',
                 submitInfo: {
-                    updatedAt: new Date(),
+                    __typename: 'UpdateInformation',
+                    updatedAt: '2024-01-01',
                     updatedBy: 'example@state.com',
-                    updatedReason: 'contract resubmit'
+                    updatedReason: 'submit 1'
                 },
-                unlockInfo: undefined,
-                formData: {
-                    programIDs: ['abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce'],
-                    populationCovered: 'MEDICAID',
-                    submissionType: 'CONTRACT_AND_RATES',
-                    riskBasedContract: true,
-                    submissionDescription: 'A real submission',
-                    supportingDocuments: [
-                        {
-                            s3URL: 's3://bucketname/key/contractsupporting1',
-                            sha256: 'fakesha',
-                            name: 'contractSupporting1',
-                            dateAdded: new Date('01/15/2024')
-                        },
-                        {
-                            s3URL: 's3://bucketname/key/contractSupporting2',
-                            sha256: 'fakesha',
-                            name: 'contractSupporting2',
-                            dateAdded: new Date('01/13/2024')
-                        },
-                    ],
-                    stateContacts: [],
-                    contractType: 'AMENDMENT',
-                    contractExecutionStatus: 'EXECUTED',
-                    contractDocuments: [
-                        {
-                            s3URL: 's3://bucketname/key/contract',
-                            sha256: 'fakesha',
-                            name: 'contract',
-                            dateAdded: new Date('01/01/2024')
-                        },
-                    ],
-                    contractDateStart: new Date(),
-                    contractDateEnd: new Date(),
-                    managedCareEntities: ['MCO'],
-                    federalAuthorities: ['STATE_PLAN'],
-                    inLieuServicesAndSettings: true,
-                    modifiedBenefitsProvided: true,
-                    modifiedGeoAreaServed: false,
-                    modifiedMedicaidBeneficiaries: true,
-                    modifiedRiskSharingStrategy: true,
-                    modifiedIncentiveArrangements: false,
-                    modifiedWitholdAgreements: false,
-                    modifiedStateDirectedPayments: true,
-                    modifiedPassThroughPayments: true,
-                    modifiedPaymentsForMentalDiseaseInstitutions: false,
-                    modifiedMedicalLossRatioStandards: true,
-                    modifiedOtherFinancialPaymentIncentive: false,
-                    modifiedEnrollmentProcess: true,
-                    modifiedGrevienceAndAppeal: false,
-                    modifiedNetworkAdequacyStandards: true,
-                    modifiedLengthOfContract: false,
-                    modifiedNonRiskPaymentArrangements: true,
-                    statutoryRegulatoryAttestation: true,
-                    statutoryRegulatoryAttestationDescription: "everything meets regulatory attestation"
-                }
+                submittedRevisions: [
+                    mockContractRevision('1'),
+                ],
+                contractRevision: mockContractRevision('1'),
+                rateRevisions: [
+                    mockRateRevision('1'),
+                ],
             },
-            rateRevisions: [
-                {
-                    id: '1234',
-                    __typename: 'RateRevision',
-                    rateID: '123',
-                    createdAt: new Date('01/01/2023'),
-                    updatedAt: new Date('01/01/2023'),
-                    contractRevisions: [],
-                    formData: {
-                        rateType: 'AMENDMENT',
-                        rateCapitationType: 'RATE_CELL',
-                        rateDocuments: [
-                            {
-                                s3URL: 's3://bucketname/key/rate',
-                                sha256: 'fakesha',
-                                name: 'rate',
-                                dateAdded: new Date('01/01/2023')
-                            },
-                        ],
-                        supportingDocuments: [
-                            {
-                                s3URL: 's3://bucketname/key/rateSupporting1',
-                                sha256: 'fakesha',
-                                name: 'rate supporting 1',
-                                dateAdded: new Date('01/15/2023')
-                            },
-                            {
-                                s3URL: 's3://bucketname/key/rateSupporting1',
-                                sha256: 'fakesha',
-                                name: 'rate supporting 2',
-                                dateAdded: new Date('01/15/2023')
-                            },
-                        ],
-                        rateDateStart: new Date(),
-                        rateDateEnd: new Date(),
-                        rateDateCertified: new Date(),
-                        amendmentEffectiveDateStart: new Date(),
-                        amendmentEffectiveDateEnd: new Date(),
-                        rateProgramIDs: ['abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce'],
-                        certifyingActuaryContacts: [
-                            {
-                                actuarialFirm: 'DELOITTE',
-                                name: 'Actuary Contact 1',
-                                titleRole: 'Test Actuary Contact 1',
-                                email: 'actuarycontact1@test.com',
-                            },
-                        ],
-                        addtlActuaryContacts: [
-                            {
-                                actuarialFirm: 'DELOITTE',
-                                name: 'Actuary Contact 1',
-                                titleRole: 'Test Actuary Contact 1',
-                                email: 'actuarycontact1@test.com',
-                            },
-                        ],
-                        actuaryCommunicationPreference: 'OACT_TO_ACTUARY',
-                        packagesWithSharedRateCerts: []
-                    }
-                },
-            ],
-        },
-    ],
+        ],
         ...partial,
     }
 }
@@ -1328,5 +1058,12 @@ function mockContractFormData( partial?: Partial<ContractFormData>): ContractFor
     }
 }
 
-export { mockContractPackageDraft, mockContractPackageSubmitted, mockContractWithLinkedRateDraft, mockContractPackageUnlocked, mockContractFormData, mockContractPackageSubmittedWithRevisions}
+export { 
+    mockContractPackageDraft, 
+    mockContractPackageSubmitted, 
+    mockContractWithLinkedRateDraft, 
+    mockContractPackageUnlocked, 
+    mockContractFormData, 
+    mockContractPackageSubmittedWithRevisions,
+}
 


### PR DESCRIPTION
## Summary

off by one error computing index. We want the indices for history revisions to be 1 indexed, not 0 indexed

#### Related issues

https://jiraent.cms.gov/browse/MCR-4100

Should be able to look at past submissions in all their glory now