### PR TITLE
[MCR-4090] fixing rate details step indicator bug

### DIFF
--- a/services/app-web/src/components/DynamicStepIndicator/DynamicStepIndicator.test.tsx
+++ b/services/app-web/src/components/DynamicStepIndicator/DynamicStepIndicator.test.tsx
@@ -2,6 +2,8 @@ import { screen, render } from '@testing-library/react'
 import { DynamicStepIndicator } from './DynamicStepIndicator'
 
 import { STATE_SUBMISSION_FORM_ROUTES } from '../../constants/routes'
+import { activeFormPages } from '../../pages/StateSubmission/StateSubmissionForm'
+import { mockContractFormData } from '../../testHelpers/apolloMocks/contractPackageDataMock'
 
 describe('DynamicStepIndicator', () => {
     it('renders without errors', () => {
@@ -34,5 +36,31 @@ describe('DynamicStepIndicator', () => {
         )
 
         expect(screen.getByTestId('container')).toBeEmptyDOMElement()
+    })
+
+    it('renders the rate details step for contract and rates submissions', () => {
+        const contract = mockContractFormData()
+        render(
+            <DynamicStepIndicator
+                formPages={activeFormPages(contract)}
+                currentFormPage={STATE_SUBMISSION_FORM_ROUTES[5]}
+            />
+        )
+
+        expect(screen.getByText('Rate details')).toBeInTheDocument()
+    })
+
+    it('does not render the rate details step for contract only submissions', () => {
+        const contract = mockContractFormData({
+            submissionType: 'CONTRACT_ONLY',
+        })
+        render(
+            <DynamicStepIndicator
+                formPages={activeFormPages(contract)}
+                currentFormPage={STATE_SUBMISSION_FORM_ROUTES[5]}
+            />
+        )
+
+        expect(screen.queryByText('Rate details')).not.toBeInTheDocument()
     })
 })

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ReviewSubmitV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ReviewSubmitV2.tsx
@@ -10,10 +10,7 @@ import { PageActionsContainer } from '../../../PageActions'
 import styles from '../../../ReviewSubmit/ReviewSubmit.module.scss'
 import { ActionButton } from '../../../../../components/ActionButton'
 import { useRouteParams, useStatePrograms } from '../../../../../hooks'
-import {
-    RoutesRecord,
-    STATE_SUBMISSION_FORM_ROUTES,
-} from '../../../../../constants'
+import { RoutesRecord } from '../../../../../constants'
 import { UnlockSubmitModalV2 } from '../../../../../components/Modal/V2/UnlockSubmitModalV2'
 import { getVisibleLatestContractFormData } from '../../../../../gqlHelpers/contractsAndRates'
 import { useAuth } from '../../../../../contexts/AuthContext'
@@ -29,6 +26,7 @@ import { Loading } from '../../../../../components'
 import { PageBannerAlerts } from '../../../PageBannerAlerts'
 import { packageName } from '../../../../../common-code/healthPlanFormDataType'
 import { usePage } from '../../../../../contexts/PageContext'
+import { activeFormPages } from '../../../StateSubmissionForm'
 
 export const ReviewSubmitV2 = (): React.ReactElement => {
     const navigate = useNavigate()
@@ -101,7 +99,7 @@ export const ReviewSubmitV2 = (): React.ReactElement => {
         <>
             <div className={styles.stepIndicator}>
                 <DynamicStepIndicator
-                    formPages={STATE_SUBMISSION_FORM_ROUTES}
+                    formPages={activeFormPages(contractFormData)}
                     currentFormPage="SUBMISSIONS_REVIEW_SUBMIT"
                 />
                 <PageBannerAlerts

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
@@ -18,6 +18,7 @@ import { Documents } from './Documents'
 import { ReviewSubmit } from './ReviewSubmit'
 import { SubmissionType } from './SubmissionType'
 import { UnlockedHealthPlanFormDataType } from '../../common-code/healthPlanFormDataType'
+import { ContractFormData } from '../../gen/gqlClient'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { featureFlags } from '../../common-code/featureFlags'
 import { RateDetailsV2 } from './RateDetails/V2/RateDetailsV2'
@@ -89,7 +90,7 @@ export const StateSubmissionForm = (): React.ReactElement => {
 // Utilities
 
 export const activeFormPages = (
-    draft: UnlockedHealthPlanFormDataType
+    draft: UnlockedHealthPlanFormDataType | ContractFormData
 ): RouteTWithUnknown[] => {
     // If submission type is contract only, rate details is left out of the step indicator
     return STATE_SUBMISSION_FORM_ROUTES.filter(


### PR DESCRIPTION
## Summary
This fixes the step indicator to only display the `Rate details` segment for contract and rate submissions and vice versa on the review submit page

#### Related issues
[MCR-4090](https://jiraent.cms.gov/browse/MCR-4090)

## QA guidance

- Access an unlocked contract only submission and verify the rate details step indicator segment does not exist 
- Access an unlocked contract and rates submission and verify the rate details step indicator segment does exist 
