### PR TITLE
Change where we wait in 'promote' GHA

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -43,11 +43,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: lock this branch to prevent concurrent builds
-        run: ./.github/github-lock.sh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: set app version
         id: app-version
         shell: bash
@@ -73,6 +68,11 @@ jobs:
           coverageLocations: |
             ${{github.workspace}}/services/app-api/coverage/lcov.info:lcov
             ${{github.workspace}}/services/app-web/coverage/lcov.info:lcov
+
+      - name: lock this branch to prevent concurrent builds
+        run: ./.github/github-lock.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-prisma-client-lambda-layer:
     name: build - postgres prisma layer


### PR DESCRIPTION
## Summary

I was waiting to do some dev testing on a newly merged PR and noticed that we run the 'lock this branch' script before doing any sort of unit tests in `promote`. When the previous merge finishes `promote`, the next one in the queue starts promoting, which includes running unit tests, which takes about 11 minutes between environment setup and tests. I don't see any reason not to run those tests before waiting, which will let a new `promote` taken off the queue just go straight into the `promote` rather than having to then run unit tests.