### PR TITLE
Add unlock action to change history for drafts

### DIFF
--- a/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.test.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.test.tsx
@@ -1,0 +1,63 @@
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '../../testHelpers/jestHelpers'
+import { ChangeHistoryV2 as ChangeHistory } from './ChangeHistoryV2'
+import {
+    mockContractPackageSubmitted,
+    fetchCurrentUserMock,
+    mockValidStateUser,
+    mockValidCMSUser,
+    mockContractPackageUnlocked,
+} from '../../testHelpers/apolloMocks'
+
+describe('SubmissionTypeSummarySection', () => {
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+    const submittedContract = mockContractPackageSubmitted()
+
+    it('can render history for initial submission', () => {
+        renderWithProviders(<ChangeHistory contract={submittedContract} />, {
+            apolloProvider: {
+                mocks: [
+                    fetchCurrentUserMock({
+                        user: mockValidCMSUser(),
+                        statusCode: 200,
+                    }),
+                ],
+            },
+        })
+
+        expect(
+            screen.getByRole('heading', {
+                level: 2,
+                name: 'Change history',
+            })
+        ).toBeInTheDocument()
+
+        expect(screen.getByText(`contract submit`)).toBeInTheDocument()
+    })
+
+    it('can render change history for unlocked submission', () => {
+        renderWithProviders(
+            <ChangeHistory contract={mockContractPackageUnlocked()} />,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidStateUser(),
+                            statusCode: 200,
+                        }),
+                    ],
+                },
+            }
+        )
+        expect(
+            screen.getByRole('heading', {
+                level: 2,
+                name: 'Change history',
+            })
+        ).toBeInTheDocument()
+
+        expect(screen.getByText(`unlocked for a test`)).toBeInTheDocument()
+    })
+})

--- a/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.test.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.test.tsx
@@ -13,9 +13,9 @@ describe('SubmissionTypeSummarySection', () => {
     afterEach(() => {
         jest.clearAllMocks()
     })
-    const submittedContract = mockContractPackageSubmitted()
 
     it('can render history for initial submission', () => {
+        const submittedContract = mockContractPackageSubmitted()
         renderWithProviders(<ChangeHistory contract={submittedContract} />, {
             apolloProvider: {
                 mocks: [

--- a/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
@@ -20,11 +20,13 @@ export const ChangeHistoryV2 = ({
     const flattenedRevisions = (): flatRevisions[] => {
         const result: flatRevisions[] = []
 
-        const contractSubmissions = contract.packageSubmissions.filter(
-            (submission) => {
-                return submission.cause === 'CONTRACT_SUBMISSION'
-            }
-        )
+        const contractSubmissions = contract.packageSubmissions
+        // console.log(contract, 'submissions')
+        // const contractSubmissions = contract.packageSubmissions.filter(
+        //     (submission) => {
+        //         return submission.cause === 'CONTRACT_SUBMISSION'
+        //     }
+        // )
 
         //Reverse revisions to order from earliest to latest revision. This is to correctly set version for each
         // contract & recontract.
@@ -36,6 +38,18 @@ export const ChangeHistoryV2 = ({
                 newUnlock.updatedBy = r.contractRevision.unlockInfo.updatedBy
                 newUnlock.updatedReason =
                     r.contractRevision.unlockInfo.updatedReason
+                newUnlock.kind = 'unlock'
+                //Use unshift to push the latest revision unlock info to the beginning of the array
+                result.unshift(newUnlock)
+            }
+            if (contract.draftRevision?.unlockInfo) {
+                const newUnlock: flatRevisions = {} as flatRevisions
+                newUnlock.updatedAt =
+                    contract.draftRevision?.unlockInfo.updatedAt
+                newUnlock.updatedBy =
+                    contract.draftRevision?.unlockInfo.updatedBy
+                newUnlock.updatedReason =
+                    contract.draftRevision?.unlockInfo.updatedReason
                 newUnlock.kind = 'unlock'
                 //Use unshift to push the latest revision unlock info to the beginning of the array
                 result.unshift(newUnlock)

--- a/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistoryV2.tsx
@@ -31,7 +31,7 @@ export const ChangeHistoryV2 = ({
         const reversedRevisions = [
             ...contractSubmissions,
             contract.draftRevision,
-        ].reverse()
+        ]
         reversedRevisions.forEach((r, index) => {
             if (r?.__typename === 'ContractPackageSubmission') {
                 if (r.contractRevision.unlockInfo) {
@@ -48,7 +48,7 @@ export const ChangeHistoryV2 = ({
                 if (r.submitInfo) {
                     const newSubmit: flatRevisions = {} as flatRevisions
                     const revisionVersion =
-                        index !== contract.packageSubmissions.length - 1 // if we aren't at the last item in list, assign a version
+                        index !== contractSubmissions.length - 1 // if we aren't at the last item in list, assign a version
                             ? String(index + 1) //Offset version, we want to start at 1
                             : undefined
 

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummaryV2.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummaryV2.tsx
@@ -50,13 +50,7 @@ export const SubmissionRevisionSummaryV2 = (): React.ReactElement => {
     })
     const contract = fetchContractData?.fetchContract.contract
     //We offset version by +1 of index, remove offset to find revision in revisions
-    const revisionIndex =
-        (contract &&
-            [...contract.packageSubmissions].filter((submission) => {
-                return submission.cause === 'CONTRACT_SUBMISSION'
-            }).length - 1) ||
-        0
-
+    const revisionIndex = Number(revisionVersion) - 1
     const name =
         contract &&
         contract?.packageSubmissions.length > Number(revisionVersion)

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummaryV2.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummaryV2.tsx
@@ -86,7 +86,11 @@ export const SubmissionRevisionSummaryV2 = (): React.ReactElement => {
 
     // Reversing revisions to get correct submission order
     // we offset the index by one so that our indices start at 1
-    const packageSubmission = [...contract.packageSubmissions].reverse()[revisionIndex]
+    const packageSubmission = [...contract.packageSubmissions]
+        .filter((submission) => {
+            return submission.cause === 'CONTRACT_SUBMISSION'
+        })
+        .reverse()[revisionIndex]
     const revision = packageSubmission.contractRevision
     const rateRevisions = packageSubmission.rateRevisions
     const contractData = revision.formData

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummaryV2.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummaryV2.tsx
@@ -50,10 +50,16 @@ export const SubmissionRevisionSummaryV2 = (): React.ReactElement => {
     })
     const contract = fetchContractData?.fetchContract.contract
     //We offset version by +1 of index, remove offset to find revision in revisions
-    const revisionIndex = Number(revisionVersion) - 1
+    const revisionIndex =
+        (contract &&
+            [...contract.packageSubmissions].filter((submission) => {
+                return submission.cause === 'CONTRACT_SUBMISSION'
+            }).length - 1) ||
+        0
 
     const name =
         contract &&
+        revisionIndex &&
         contract?.packageSubmissions.length < Number(revisionVersion)
             ? contract.packageSubmissions.reverse()[revisionIndex]
                   .contractRevision.contractName

--- a/services/app-web/src/testHelpers/apolloMocks/contractPackageDataMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/contractPackageDataMock.ts
@@ -460,8 +460,9 @@ function mockContractPackageSubmitted(
         stateNumber: 5,
         packageSubmissions: [{
             cause: 'CONTRACT_SUBMISSION',
+            __typename: 'ContractPackageSubmission',
             submitInfo: {
-                updatedAt: new Date(),
+                updatedAt: new Date('12/18/2023'),
                 updatedBy: 'example@state.com',
                 updatedReason: 'contract submit'
             },


### PR DESCRIPTION
## Summary

This PR fixes an issue with unlock events not appearing in the change history when the submission is a draft (state hadn't resubmitted yet)

#### Related issues
https://jiraent.cms.gov/browse/MCR-4103

#### Screenshots

<img width="982" alt="Screenshot 2024-05-03 at 11 53 08 AM" src="https://github.com/Enterprise-CMCS/managed-care-review/assets/67110378/d2c1d9d2-eb5a-4de3-b6af-7d150a714621">



#### Test cases covered

- submit and unlock events are displayed in the change history

## QA guidance

- Log in as a CMS user and unlock a submission
- Ensure that the unlock event gets logged in the change submission (without needing to the state user to first resubmit)
