### PR TITLE
display id and submitted at date in past revision summary

### DIFF
--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.test.tsx
@@ -191,6 +191,7 @@ describe('SubmissionTypeSummarySection', () => {
                 statePrograms={statePrograms}
                 editNavigateTo="submission-type"
                 submissionName="MN-MSHO-0003"
+                initiallySubmittedAt={new Date('2023-01-02')}
                 isStateUser={true}
             />
         )
@@ -218,6 +219,7 @@ describe('SubmissionTypeSummarySection', () => {
                 statePrograms={statePrograms}
                 editNavigateTo="submission-type"
                 submissionName="MN-MSHO-0003"
+                initiallySubmittedAt={new Date('2023-01-02')}
                 isStateUser={true}
             />
         )
@@ -242,6 +244,7 @@ describe('SubmissionTypeSummarySection', () => {
                 statePrograms={statePrograms}
                 editNavigateTo="submission-type"
                 submissionName="MN-MSHO-0003"
+                initiallySubmittedAt={new Date('2023-01-02')}
                 isStateUser={false}
             />
         )

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.tsx
@@ -70,21 +70,22 @@ export const SubmissionTypeSummarySectionV2 = ({
                 {headerChildComponent && headerChildComponent}
             </SectionHeader>
             <dl>
-                {(isSubmitted || (!isStateUser && isUnlocked)) && (
-                    <DoubleColumnGrid>
-                        <DataDetail
-                            id="submitted"
-                            label="Submitted"
-                            children={
-                                <span>
-                                    {dayjs(initiallySubmittedAt).format(
-                                        'MM/DD/YY'
-                                    )}
-                                </span>
-                            }
-                        />
-                    </DoubleColumnGrid>
-                )}
+                {initiallySubmittedAt &&
+                    (isSubmitted || (!isStateUser && isUnlocked)) && (
+                        <DoubleColumnGrid>
+                            <DataDetail
+                                id="submitted"
+                                label="Submitted"
+                                children={
+                                    <span>
+                                        {dayjs(initiallySubmittedAt).format(
+                                            'MM/DD/YY'
+                                        )}
+                                    </span>
+                                }
+                            />
+                        </DoubleColumnGrid>
+                    )}
                 <DoubleColumnGrid>
                     {(programNames?.length > 0 || !isSubmitted) && (
                         <DataDetail

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummaryV2.test.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummaryV2.test.tsx
@@ -139,6 +139,8 @@ describe('SubmissionRevisionSummary', () => {
         
         expect(await screen.findByLabelText('Submission description')).toHaveTextContent('Submission 2')
         expect(await screen.findByText('rate2 doc')).toBeInTheDocument()
+        expect(await screen.findByRole('heading', { name: 'MCR-MN-0005-SNBC'})).toBeInTheDocument()
+        expect(await screen.findByLabelText('Submitted')).toHaveTextContent('01/01/24')
 
     })
 

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummaryV2.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummaryV2.tsx
@@ -54,7 +54,7 @@ export const SubmissionRevisionSummaryV2 = (): React.ReactElement => {
 
     const name =
         contract &&
-        contract?.packageSubmissions.length < Number(revisionVersion)
+        contract?.packageSubmissions.length > Number(revisionVersion)
             ? contract.packageSubmissions.reverse()[revisionIndex]
                   .contractRevision.contractName
             : ''
@@ -86,7 +86,9 @@ export const SubmissionRevisionSummaryV2 = (): React.ReactElement => {
 
     // Reversing revisions to get correct submission order
     // we offset the index by one so that our indices start at 1
-    const packageSubmission = [...contract.packageSubmissions].reverse()[revisionIndex]
+    const packageSubmission = [...contract.packageSubmissions].reverse()[
+        revisionIndex
+    ]
     const revision = packageSubmission.contractRevision
     const rateRevisions = packageSubmission.rateRevisions
     const contractData = revision.formData
@@ -109,6 +111,7 @@ export const SubmissionRevisionSummaryV2 = (): React.ReactElement => {
                     statePrograms={statePrograms}
                     isStateUser={isStateUser}
                     submissionName={name}
+                    initiallySubmittedAt={contract.initiallySubmittedAt}
                     headerChildComponent={
                         submitInfo && (
                             <p


### PR DESCRIPTION
## Summary

A couple things were missing from the submission revision summary page, this adds them back.

#### Related issues

https://jiraent.cms.gov/browse/MCR-4100

For a submission that is older than today, please confirm that the Submitted date on a previous revision shows correctly