### PR TITLE
MCR-4105 fix: validations and inline errors for linked rates

### DIFF
--- a/services/app-web/jest.config.ts
+++ b/services/app-web/jest.config.ts
@@ -1,3 +1,4 @@
 module.exports = {
     setupFiles: ['jest-launchdarkly-mock'],
+    clearMocks: true
 }

--- a/services/app-web/src/components/Form/ErrorSummary/ErrorSummary.tsx
+++ b/services/app-web/src/components/Form/ErrorSummary/ErrorSummary.tsx
@@ -14,7 +14,7 @@ const ErrorSummaryMessage = ({
     let fieldSelector: string
     let href: string
 
-    // Treat keys that begin with # as ids
+    // Treat keys that begin with # as ids - this is used with react-select Select-  a combobox component
     if (errorKey.startsWith('#')) {
         fieldSelector = `[id="${errorKey}"]`
         href = errorKey

--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
@@ -155,7 +155,7 @@ export const LinkRateSelect = ({
             }
             isSearchable
             maxMenuHeight={400}
-            aria-label="linked rates (required)"
+            aria-label="linked rate (required)"
             ariaLiveMessages={{
                 onFocus,
             }}

--- a/services/app-web/src/pages/LinkYourRates/LinkYourRates.stories.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkYourRates.stories.tsx
@@ -16,6 +16,7 @@ export const LinkRates = (): React.ReactElement => {
                 <LinkYourRates
                     fieldNamePrefix="rateForms.1"
                     index={1}
+                    shouldValidate={false}
                     autofill={() => {
                         console.info('autofill rate')
                     }}

--- a/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
@@ -73,7 +73,7 @@ export const LinkYourRates = ({
                     <LinkRateSelect
                         key={`rateOptions-${index}`}
                         inputId={`${fieldNamePrefix}.linkedRates`}
-                        name={`${fieldNamePrefix}.linkedRates`}
+                        name={`${fieldNamePrefix}.linkRatesSelect`}
                         initialValue={getIn(values, `${fieldNamePrefix}.id`)}
                         autofill={autofill}
                     />

--- a/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
@@ -64,7 +64,7 @@ export const LinkYourRates = ({
             {getIn(values, `${fieldNamePrefix}.ratePreviouslySubmitted`) ===
                 'YES' && (
                 <>
-                    <Label htmlFor={`${fieldNamePrefix}.linkedRates`}>
+                    <Label htmlFor={`${fieldNamePrefix}.linkedRatesYesNo`}>
                         Which rate certification was it?
                     </Label>
                     <span className={styles.requiredOptionalText}>
@@ -72,8 +72,8 @@ export const LinkYourRates = ({
                     </span>
                     <LinkRateSelect
                         key={`rateOptions-${index}`}
-                        inputId={`${fieldNamePrefix}.linkedRates`}
-                        name={`${fieldNamePrefix}.linkRatesSelect`}
+                        inputId={`${fieldNamePrefix}.linkedRatesYesNo`}
+                        name={`${fieldNamePrefix}.linkedRatesYesNo`}
                         initialValue={getIn(values, `${fieldNamePrefix}.id`)}
                         autofill={autofill}
                     />

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
@@ -10,166 +10,177 @@ import {
 Yup.addMethod(Yup.date, 'validateDateFormat', validateDateFormat)
 
 const SingleRateCertSchema = (_activeFeatureFlags: FeatureFlagSettings) =>
-    Yup.object().when('.ratePreviouslySubmitted', {
-        // this first when is skipping all validations for a previously submitted rate.
-        is: 'YES',
-        then: Yup.object().shape({
-            linkedRatesYesNo: Yup.string().defined('You must select a rate certification'),
-        }),
-        otherwise: Yup.object().shape({
-            ratePreviouslySubmitted: _activeFeatureFlags['rate-edit-unlock'] || _activeFeatureFlags['link-rates']? Yup.string().defined(
-                "You must select yes or no "
-            ) : Yup.string(),
-            rateDocuments: validateFileItemsListSingleUpload({ required: true }),
-            supportingDocuments: validateFileItemsList({ required: false }),
-            hasSharedRateCert:  _activeFeatureFlags['rate-edit-unlock'] || _activeFeatureFlags['link-rates']?  Yup.string(): Yup.string().defined('You must select yes or no'),
-            packagesWithSharedRateCerts: _activeFeatureFlags['rate-edit-unlock'] || _activeFeatureFlags['link-rates']? Yup.array().optional():  Yup.array()
-            .when('hasSharedRateCert', {
-                is: 'YES',
-                then: Yup.array().min(
-                    1,
-                    'You must select at least one submission'
-                ),
-            })
-            .required(),
-            rateProgramIDs: Yup.array(
-            ).min(1, 'You must select a program'),
-            rateType: Yup.string().defined(
-                'You must choose a rate certification type'
-            ),
-            rateCapitationType: Yup.string().defined(
-                "You must select whether you're certifying rates or rate ranges"
-            ),
-            rateDateStart: Yup.date().when('rateType', (contractType) => {
-                if (contractType) {
-                    return (
-                        Yup.date()
-                            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                            // @ts-ignore-next-line
-                            .validateDateFormat('YYYY-MM-DD', true)
-                            .defined('You must enter a start date')
-                            .typeError(
-                                'The start date must be in MM/DD/YYYY format'
-                            )
-                    )
-                }
+    Yup.object()
+        .when('.ratePreviouslySubmitted', {
+            // make the user select something for rate preivously submitted yes no question
+            is: undefined,
+            then: Yup.object().shape({
+                ratePreviouslySubmitted: _activeFeatureFlags['link-rates']? Yup.string().defined(
+                    "You must select yes or no "
+                ) : Yup.string(),
             }),
-            rateDateEnd: Yup.date().when('rateType', (rateType) => {
-                if (rateType) {
-                    return (
-                        Yup.date()
-                            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                            // @ts-ignore-next-line
-                            .validateDateFormat('YYYY-MM-DD', true)
-                            .defined('You must enter an end date')
-                            .typeError('The end date must be in MM/DD/YYYY format')
-                            .when(
-                                // RateDateEnd must be at minimum the day after Start
-                                'rateDateStart',
-                                (rateDateStart: Date, schema: Yup.DateSchema) => {
-                                    const startDate = dayjs(rateDateStart)
-                                    if (startDate.isValid()) {
-                                        return schema.min(
-                                            startDate.add(1, 'day'),
-                                            'The end date must come after the start date'
-                                        )
-                                    }
-                                }
-                            )
-                    )
-                }
-            }),
-            rateDateCertified: Yup.date().when('rateType', (rateType) => {
-                if (rateType) {
-                    return (
-                        Yup.date()
-                            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                            // @ts-ignore-next-line
-                            .validateDateFormat('YYYY-MM-DD', true)
-                            .defined(
-                                'You must enter the date the document was certified'
-                            )
-                            .typeError(
-                                'The certified date must be in MM/DD/YYYY format'
-                            )
-                    )
-                }
-            }),
-            effectiveDateStart: Yup.date().when('rateType', {
-                is: 'AMENDMENT',
-                then: Yup.date()
-                    .nullable()
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-ignore-next-line
-                    .validateDateFormat('YYYY-MM-DD', true)
-                    .defined('You must enter a start date')
-                    .typeError('The start date must be in MM/DD/YYYY format'),
-            }),
-            effectiveDateEnd: Yup.date().when('rateType', {
-                is: 'AMENDMENT',
-                then: Yup.date()
-                    .nullable()
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-ignore-next-line
-                    .validateDateFormat('YYYY-MM-DD', true)
-                    .defined('You must enter an end date')
-                    .typeError('The end date must be in MM/DD/YYYY format')
-                    .min(
-                        Yup.ref('effectiveDateStart'),
-                        'The end date must come after the start date'
-                    ),
-            }),
-            actuaryContacts: Yup.array().of(
-                Yup.object().shape({
-                    name: Yup.string().required('You must provide a name'),
-                    titleRole: Yup.string().required(
-                        'You must provide a title/role'
-                    ),
-                    email: Yup.string()
-                        .email('You must enter a valid email address')
-                        .required('You must provide an email address'),
-                    actuarialFirm: Yup.string()
-                        .required('You must select an actuarial firm')
-                        .nullable(),
-                    actuarialFirmOther: Yup.string()
-                        .when('actuarialFirm', {
-                            is: 'OTHER',
-                            then: Yup.string()
-                                .required('You must enter a description')
-                                .nullable(),
-                        })
-                        .nullable(),
                 })
-            ),
-            addtlActuaryContacts: Yup.array().of(
-                Yup.object().shape({
-                    name: Yup.string().required('You must provide a name'),
-                    titleRole: Yup.string().required(
-                        'You must provide a title/role'
-                    ),
-                    email: Yup.string()
-                        .email('You must enter a valid email address')
-                        .required('You must provide an email address'),
-                    actuarialFirm: Yup.string()
-                        .required('You must select an actuarial firm')
-                        .nullable(),
-                    actuarialFirmOther: Yup.string()
-                        .when('actuarialFirm', {
-                            is: 'OTHER',
-                            then: Yup.string()
-                                .required('You must enter a description')
-                                .nullable(),
-                        })
-                        .nullable(),
-                })
-            ),
-            actuaryCommunicationPreference: Yup.string().required(
-                'You must select a communication preference'
-            )
+        .when('.ratePreviouslySubmitted', {
+            // make the user select a linked rate, skip all other validations for a previously submitted rate
+            is: 'YES',
+            then: Yup.object().shape({
+                linkedRateDropdown: Yup.string().defined('You must select a rate certification'),
+            }),
         })
+        .when('.ratePreviouslySubmitted', {
+            // continue with normal rate form validations when its a new rate
+            is: 'NO',
+            then:Yup.object().shape({
+                rateDocuments: validateFileItemsListSingleUpload({ required: true }),
+                supportingDocuments: validateFileItemsList({ required: false }),
+                hasSharedRateCert:  _activeFeatureFlags['rate-edit-unlock'] || _activeFeatureFlags['link-rates']?  Yup.string(): Yup.string().defined('You must select yes or no'),
+                packagesWithSharedRateCerts: _activeFeatureFlags['rate-edit-unlock'] || _activeFeatureFlags['link-rates']? Yup.array().optional():  Yup.array()
+                .when('hasSharedRateCert', {
+                    is: 'YES',
+                    then: Yup.array().min(
+                        1,
+                        'You must select at least one submission'
+                    ),
+                })
+                .required(),
+                rateProgramIDs: Yup.array(
+                ).min(1, 'You must select a program'),
+                rateType: Yup.string().defined(
+                    'You must choose a rate certification type'
+                ),
+                rateCapitationType: Yup.string().defined(
+                    "You must select whether you're certifying rates or rate ranges"
+                ),
+                rateDateStart: Yup.date().when('rateType', (contractType) => {
+                    if (contractType) {
+                        return (
+                            Yup.date()
+                                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                                // @ts-ignore-next-line
+                                .validateDateFormat('YYYY-MM-DD', true)
+                                .defined('You must enter a start date')
+                                .typeError(
+                                    'The start date must be in MM/DD/YYYY format'
+                                )
+                        )
+                    }
+                }),
+                rateDateEnd: Yup.date().when('rateType', (rateType) => {
+                    if (rateType) {
+                        return (
+                            Yup.date()
+                                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                                // @ts-ignore-next-line
+                                .validateDateFormat('YYYY-MM-DD', true)
+                                .defined('You must enter an end date')
+                                .typeError('The end date must be in MM/DD/YYYY format')
+                                .when(
+                                    // RateDateEnd must be at minimum the day after Start
+                                    'rateDateStart',
+                                    (rateDateStart: Date, schema: Yup.DateSchema) => {
+                                        const startDate = dayjs(rateDateStart)
+                                        if (startDate.isValid()) {
+                                            return schema.min(
+                                                startDate.add(1, 'day'),
+                                                'The end date must come after the start date'
+                                            )
+                                        }
+                                    }
+                                )
+                        )
+                    }
+                }),
+                rateDateCertified: Yup.date().when('rateType', (rateType) => {
+                    if (rateType) {
+                        return (
+                            Yup.date()
+                                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                                // @ts-ignore-next-line
+                                .validateDateFormat('YYYY-MM-DD', true)
+                                .defined(
+                                    'You must enter the date the document was certified'
+                                )
+                                .typeError(
+                                    'The certified date must be in MM/DD/YYYY format'
+                                )
+                        )
+                    }
+                }),
+                effectiveDateStart: Yup.date().when('rateType', {
+                    is: 'AMENDMENT',
+                    then: Yup.date()
+                        .nullable()
+                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                        // @ts-ignore-next-line
+                        .validateDateFormat('YYYY-MM-DD', true)
+                        .defined('You must enter a start date')
+                        .typeError('The start date must be in MM/DD/YYYY format'),
+                }),
+                effectiveDateEnd: Yup.date().when('rateType', {
+                    is: 'AMENDMENT',
+                    then: Yup.date()
+                        .nullable()
+                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                        // @ts-ignore-next-line
+                        .validateDateFormat('YYYY-MM-DD', true)
+                        .defined('You must enter an end date')
+                        .typeError('The end date must be in MM/DD/YYYY format')
+                        .min(
+                            Yup.ref('effectiveDateStart'),
+                            'The end date must come after the start date'
+                        ),
+                }),
+                actuaryContacts: Yup.array().of(
+                    Yup.object().shape({
+                        name: Yup.string().required('You must provide a name'),
+                        titleRole: Yup.string().required(
+                            'You must provide a title/role'
+                        ),
+                        email: Yup.string()
+                            .email('You must enter a valid email address')
+                            .required('You must provide an email address'),
+                        actuarialFirm: Yup.string()
+                            .required('You must select an actuarial firm')
+                            .nullable(),
+                        actuarialFirmOther: Yup.string()
+                            .when('actuarialFirm', {
+                                is: 'OTHER',
+                                then: Yup.string()
+                                    .required('You must enter a description')
+                                    .nullable(),
+                            })
+                            .nullable(),
+                    })
+                ),
+                addtlActuaryContacts: Yup.array().of(
+                    Yup.object().shape({
+                        name: Yup.string().required('You must provide a name'),
+                        titleRole: Yup.string().required(
+                            'You must provide a title/role'
+                        ),
+                        email: Yup.string()
+                            .email('You must enter a valid email address')
+                            .required('You must provide an email address'),
+                        actuarialFirm: Yup.string()
+                            .required('You must select an actuarial firm')
+                            .nullable(),
+                        actuarialFirmOther: Yup.string()
+                            .when('actuarialFirm', {
+                                is: 'OTHER',
+                                then: Yup.string()
+                                    .required('You must enter a description')
+                                    .nullable(),
+                            })
+                            .nullable(),
+                    })
+                ),
+                actuaryCommunicationPreference: Yup.string().required(
+                    'You must select a communication preference'
+                )
+            })
     })
 const RateDetailsFormSchema = (activeFeatureFlags?: FeatureFlagSettings) => {
-    return activeFeatureFlags?.['rate-edit-unlock'] ||  activeFeatureFlags?.['link-rates'] ?
+    return activeFeatureFlags?.['link-rates'] ?
     Yup.object().shape({
         rateForms: Yup.array().of(
             SingleRateCertSchema(activeFeatureFlags || {})

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
@@ -14,7 +14,7 @@ const SingleRateCertSchema = (_activeFeatureFlags: FeatureFlagSettings) =>
         // this first when is skipping all validations for a previously submitted rate.
         is: 'YES',
         then: Yup.object().shape({
-            linkRateSelect: Yup.string().defined('You must select a rate certification'),
+            linkedRatesYesNo: Yup.string().defined('You must select a rate certification'),
         }),
         otherwise: Yup.object().shape({
             ratePreviouslySubmitted: _activeFeatureFlags['rate-edit-unlock'] || _activeFeatureFlags['link-rates']? Yup.string().defined(

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -312,17 +312,11 @@ const RateDetailsV2 = ({
         if (rateErrors && Array.isArray(rateErrors)) {
             rateErrors.forEach((rateError, index) => {
                 if (!rateError) return
-                if (
-                    Object.keys(rateError).includes('ratePreviouslySubmitted')
-                ) {
-                    return (errorObject['ratePreviouslySubmitted'] =
-                        'You must select yes or no')
-                }
                 Object.entries(rateError).forEach(([field, value]) => {
                     if (typeof value === 'string') {
-                        //rateProgramIDs error message needs a # proceeding the key name because this is the only way to be able to link to the Select component element see comments in ErrorSummaryMessage component.
+                        // select dropdown component error messages needs a # proceeding the key name because this is the only way to be able to link to react-select based components. See comments in ErrorSummaryMessage component.
                         const errorKey =
-                            field === 'rateProgramIDs'
+                            field === 'rateProgramIDs' || field === 'linkedRateDropdown'
                                 ? `#rateForms.${index}.${field}`
                                 : `rateForms.${index}.${field}`
                         errorObject[errorKey] = value
@@ -481,6 +475,7 @@ const RateDetailsV2 = ({
                                                                                 rateForm
                                                                             )
                                                                         }}
+                                                                        shouldValidate={shouldValidate}
                                                                     />
                                                                 )}
                                                                 {rateForm.ratePreviouslySubmitted ===


### PR DESCRIPTION
## Summary
Link rates error summary links not working and missing inline error

Also added:
- unifying styles around errors (we need that red border to the right of all error form fields)
- change aria label to say linked rate (singular) since you can only link one
- fixed how validations work for NO button click (we were still validating for the linked rate field if the user had started to select something there earlier but abandoned it) 

#### Related issues
https://jiraent.cms.gov/browse/MCR-4105

#### Screenshots

#### Test cases covered
error summary displays as expected 
- when rate previously submitted question is not answered
- when rate previously submitted question is answered with YES
- when rate previously submitted question is answered with NO

## QA guidance
Recheck all validation behavior for the multiple rate experience 

IF NOTHING IS SELECTED
we display errors about the previously submitted yes/no question being empty

IF YES IS SELECTED
we display errors about the missing the rate certification if rate dropdown is still empty

IF NOT IS SELECTED
we display errors for the rate form, we do not display any errors from rate dropdown

🐛 Also check bugs that were fixed here

- all links in the errors summary `<a />` links work and when you click jump you to form fields
- click yes, hit continue, hit no. Only the validations for form should appear. 