### PR TITLE
Clear yes/no selection for ratePreviouslySubmitted field

### DIFF
--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
@@ -69,6 +69,20 @@ const convertGQLRateToRateForm = (getKey: S3ClientT['getKey'], rate?: Rate, pare
     const handleAsLinkedRate = rate && rate.parentContractID !== parentContractID // TODO: Make this a more sophisticated check for child-rates
     const rateRev = handleAsLinkedRate ? rate?.revisions[0] : rate?.draftRevision
     const rateForm = rateRev?.formData
+
+    // isFilledIn and fillableFields are used for determining if the rateForm 
+    // should be saved in the case of the yes/no question for was this rate included in another submission
+    // fillableFields includes only fields that aren't auto populated on initial yes/no selection, like id and rateName
+    let isFilledIn = false
+    const fillableFields = ['rateCapitationType', 'rateDocuments', 'supportingDocuments', 'rateDateStart',
+        'rateDateEnd', 'rateDateCertified', 'amendmentEffectiveDateStart', 'amendmentEffectiveDateEnd',
+        'rateProgramIDs', 'addtlActuaryContacts',
+        'actuaryCommunicationPreference']
+    rateForm && Object.entries(rateForm).forEach(([field, value]) => {
+        if (fillableFields.includes(field) && Array.isArray(value) && value.length > 0 || fillableFields.includes(field) && value && !Array.isArray(value)) {
+            isFilledIn = true
+        }
+    })
     return {
         id: rate?.id,
         status: rate?.status,
@@ -101,7 +115,7 @@ const convertGQLRateToRateForm = (getKey: S3ClientT['getKey'], rate?: Rate, pare
             rateForm?.actuaryCommunicationPreference ?? undefined,
         packagesWithSharedRateCerts:
             rateForm?.packagesWithSharedRateCerts ?? [],
-        ratePreviouslySubmitted: handleAsLinkedRate? 'YES' : rateForm ? 'NO' : undefined,
+        ratePreviouslySubmitted: handleAsLinkedRate? 'YES' : isFilledIn ? 'NO' : undefined,
         initiallySubmittedAt: rate?.initiallySubmittedAt,
         linkRateSelect: handleAsLinkedRate && rate?.id ? 'true' : undefined
     }

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
@@ -79,7 +79,10 @@ const convertGQLRateToRateForm = (getKey: S3ClientT['getKey'], rate?: Rate, pare
         'rateProgramIDs', 'certifyingActuaryContacts', 'addtlActuaryContacts',
         'actuaryCommunicationPreference']
     rateForm && Object.entries(rateForm).forEach(([field, value]) => {
-        if (fillableFields.includes(field) && Array.isArray(value) && value.length > 0 || fillableFields.includes(field) && value && !Array.isArray(value)) {
+        if (
+            (fillableFields.includes(field) && Array.isArray(value) && value.length > 0) ||
+            (fillableFields.includes(field) && value && !Array.isArray(value))
+        ) {
             isFilledIn = true
         }
     })

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
@@ -76,7 +76,7 @@ const convertGQLRateToRateForm = (getKey: S3ClientT['getKey'], rate?: Rate, pare
     let isFilledIn = false
     const fillableFields = ['rateCapitationType', 'rateDocuments', 'supportingDocuments', 'rateDateStart',
         'rateDateEnd', 'rateDateCertified', 'amendmentEffectiveDateStart', 'amendmentEffectiveDateEnd',
-        'rateProgramIDs', 'addtlActuaryContacts',
+        'rateProgramIDs', 'certifyingActuaryContacts', 'addtlActuaryContacts',
         'actuaryCommunicationPreference']
     rateForm && Object.entries(rateForm).forEach(([field, value]) => {
         if (fillableFields.includes(field) && Array.isArray(value) && value.length > 0 || fillableFields.includes(field) && value && !Array.isArray(value)) {


### PR DESCRIPTION
## Summary

This PR is a small enhancement that makes the No selection behavior the same as the yes flow when a user selects an option for the yes/no Was this rate included in another submission' without filling in any additional info. The selection gets cleared for either selection

The implementation is in rateDetailsHelpers. I found that specific fields had to be omitted for checking if they were filled out or not because a few of the fields are auto populated on No selection. I initially was trying to add checks inside of RateDetails as a part of the save as draft handler flow. If there are other ideas  please let me know

#### Related issues

https://jiraent.cms.gov/browse/MCR-4108

## QA guidance

- As state user on RateDetails page select No to the 'Was this rate included in another submission'
- Without filling out any fields, click 'Save as draft'
- Returning to the page the previously selected No, is no longer selected
