### PR TITLE
Fix for MCR-4108

### DIFF
--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.test.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.test.ts
@@ -1,5 +1,6 @@
 import { FormikRateForm } from "./RateDetailsV2"
-import { convertGQLRateToRateForm, generateUpdatedRates } from "./rateDetailsHelpers"
+import { convertGQLRateToRateForm, generateUpdatedRates, isRatePartiallyFilled, convertRateFormToGQLRateFormData } from "./rateDetailsHelpers"
+import {RateFormData} from '../../../../gen/gqlClient';
 
 describe('generateUpdatedRates', () => {
     const emptyRateForm = () => convertGQLRateToRateForm(jest.fn())
@@ -67,5 +68,99 @@ describe('generateUpdatedRates', () => {
         })
         }
     )
+})
 
+describe('isRatePartiallyFilled', () => {
+    const testCases = [
+        {
+            testValue: {
+                rateDocuments: [],
+                supportingDocuments: [],
+                rateProgramIDs: [],
+                certifyingActuaryContacts: [],
+                addtlActuaryContacts: []
+            },
+            testName: 'empty rate',
+            expectedResult: false,
+        },
+        {
+            testValue: {
+                rateDocuments: [],
+                supportingDocuments: [],
+                rateProgramIDs: [],
+                certifyingActuaryContacts: [
+                    {
+                        name: '',
+                        titleRole: '',
+                        email: '',
+                        actuarialFirm: undefined,
+                        actuarialFirmOther: '',
+                    }
+                ],
+                addtlActuaryContacts: []
+            } ,
+            testName: 'there is a certifying actuary with empty values',
+            expectedResult: false,
+        },
+        {
+            testValue: {
+                rateDocuments: [],
+                supportingDocuments: [],
+                rateProgramIDs: [],
+                certifyingActuaryContacts: [
+                    {
+                        name: 'Bob'
+                    }
+                ],
+                addtlActuaryContacts: []
+            },
+            testName: 'there is a certifying actuary',
+            expectedResult: true,
+        },
+        {
+            testValue: {
+                rateDocuments: [],
+                supportingDocuments: [],
+                rateProgramIDs: [],
+                certifyingActuaryContacts: [],
+                addtlActuaryContacts: [
+                    {
+                        actuarialFirm: 'OTHER'
+                    }
+                ]
+            },
+            testName: 'there is an additional actuary',
+            expectedResult: true,
+        },
+        {
+            testValue: {
+                rateDocuments: [],
+                supportingDocuments: [],
+                rateProgramIDs: [],
+                certifyingActuaryContacts: [],
+                addtlActuaryContacts: [],
+                rateType: 'NEW'
+            },
+            testName: 'rate type is filled in',
+            expectedResult: true,
+        },
+        {
+            testValue: {
+                rateDocuments: [],
+                supportingDocuments: [],
+                rateProgramIDs: ['test-program'],
+                certifyingActuaryContacts: [],
+                addtlActuaryContacts: [],
+            },
+            testName: 'rate programs is filled in',
+            expectedResult: true,
+        },
+    ]
+
+    test.each(testCases)(
+        'Returns correct boolean: $testName',
+        ({ testValue, expectedResult }) => {
+            expect(isRatePartiallyFilled(testValue as unknown as RateFormData)).toEqual(expectedResult)
+        }
+    )
 })

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
@@ -87,9 +87,9 @@ const convertGQLRateToRateForm = (getKey: S3ClientT['getKey'], rate?: Rate, pare
     const rateRev = handleAsLinkedRate ? rate?.revisions[0] : rate?.draftRevision
     const rateForm = rateRev?.formData
 
-    // isFilledIn and fillableFields are used for determining if the rateForm
-    // should be saved in the case of the yes/no question for was this rate included in another submission
-    // fillableFields includes only fields that aren't auto populated on initial yes/no selection, like id and rateName
+    // isFilledIn is used for determining if the rateForm should be saved in the case of the yes/no question for was
+    // this rate included in another submission fillable Fields includes only fields that aren't auto populated on
+    // initial yes/no selection, like id and rateName
     const isFilledIn = rateForm && isRatePartiallyFilled(rateForm)
 
     return {

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
@@ -133,5 +133,6 @@ const convertGQLRateToRateForm = (getKey: S3ClientT['getKey'], rate?: Rate, pare
 export {
     convertGQLRateToRateForm,
     convertRateFormToGQLRateFormData,
-    generateUpdatedRates
+    generateUpdatedRates,
+    isRatePartiallyFilled
 }


### PR DESCRIPTION
## Summary
[MCR-4108](https://jiraent.cms.gov/browse/MCR-4108)

The work in MCR-4108 was broken when I added `certifyingActuaryContacts` in the check for filled-in fields in this [PR](https://github.com/Enterprise-CMCS/managed-care-review/pull/2430). 

Adding `certifyingActuaryContacts` broke because the frontend automatically adds a certifying actuary with empty strings into the array. You can find that code in `formatActuaryContactsForForm`. This is done so that Yup has something to validate against and UI errors can be generated (see `generateErrorSummaryErrors`).

The fix was to loop through every actuary contact and check for at least one with some fields filled in. I pulled out that logic and refactored it to keep the types in each property of `RateFormData`. Also, I only checked for filled-in rate data of the top-level fields in the UI and skipped things like `Rate date start` because you cannot see those unless another field was filled in.

#### Related issues

#### Screenshots

#### Test cases covered

`rateDetailsHelpers.test.ts`
- `isRatePartiallyFilled`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
- As state user on RateDetails page select No to the 'Was this rate included in another submission'
- Without filling out any fields, click 'Save as draft'
- Returning to the page the previously selected No, is no longer selected
