### PR TITLE
MCR-40116 & MCR-4115: Fix linked rate select styling and accessbility

### DIFF
--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
@@ -1,5 +1,10 @@
 import React from 'react'
-import Select, { ActionMeta, AriaOnFocus, Props } from 'react-select'
+import Select, {
+    ActionMeta,
+    AriaOnFocus,
+    Props,
+    FormatOptionLabelMeta,
+} from 'react-select'
 import styles from '../../components/Select/RateSelect/RateSelect.module.scss'
 import { StateUser, useIndexRatesQuery } from '../../gen/gqlClient'
 import { useAuth } from '../../contexts/AuthContext'
@@ -15,9 +20,14 @@ import { useFormikContext } from 'formik'
 
 export interface LinkRateOptionType {
     readonly value: string
-    readonly label: React.ReactElement
+    readonly label: string
     readonly isFixed?: boolean
     readonly isDisabled?: boolean
+    readonly rateCertificationName: string
+    readonly rateProgramIDs: string
+    readonly rateDateStart: string
+    readonly rateDateEnd: string
+    readonly rateDateCertified: string
 }
 
 export type LinkRateSelectPropType = {
@@ -52,32 +62,20 @@ export const LinkRateSelect = ({
         const revision = rate.revisions[0]
         return {
             value: rate.id,
-            label: (
-                <>
-                    <strong>{revision.formData.rateCertificationName}</strong>
-                    <div style={{ lineHeight: '50%', fontSize: '14px' }}>
-                        <p>
-                            Programs:&nbsp;
-                            {programNames(
-                                statePrograms,
-                                revision.formData.rateProgramIDs
-                            ).join(', ')}
-                        </p>
-                        <p>
-                            Rating period:&nbsp;
-                            {formatCalendarDate(
-                                revision.formData.rateDateStart
-                            )}
-                            -{formatCalendarDate(revision.formData.rateDateEnd)}
-                        </p>
-                        <p>
-                            Certification date:&nbsp;
-                            {formatCalendarDate(
-                                revision.formData.rateDateCertified
-                            )}
-                        </p>
-                    </div>
-                </>
+            label:
+                revision.formData.rateCertificationName ??
+                'Unknown rate certification',
+            rateCertificationName:
+                revision.formData.rateCertificationName ??
+                'Unknown rate certification',
+            rateProgramIDs: programNames(
+                statePrograms,
+                revision.formData.rateProgramIDs
+            ).join(', '),
+            rateDateStart: formatCalendarDate(revision.formData.rateDateStart),
+            rateDateEnd: formatCalendarDate(revision.formData.rateDateEnd),
+            rateDateCertified: formatCalendarDate(
+                revision.formData.rateDateCertified
             ),
         }
     })
@@ -134,10 +132,32 @@ export const LinkRateSelect = ({
 
     //Need this to make the label searchable since the rate name is buried in a react element
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const filterOptions = ({ label }: any, input: string) =>
-        label.props.children[0].props.children
+    const filterOptions = (value: any, input: string) =>
+        value.data.rateCertificationName
             ?.toLowerCase()
             .includes(input.toLowerCase())
+
+    const formatOptionLabel = (
+        data: LinkRateOptionType,
+        optionMeta: FormatOptionLabelMeta<LinkRateOptionType>
+    ) => {
+        if (optionMeta.context === 'menu') {
+            return (
+                <>
+                    <strong>{data.rateCertificationName}</strong>
+                    <div style={{ lineHeight: '50%' }}>
+                        <p>Programs: {data.rateProgramIDs}</p>
+                        <p>
+                            Rating period: {data.rateDateStart}-
+                            {data.rateDateEnd}
+                        </p>
+                        <p>Certification date: {data.rateDateCertified}</p>
+                    </div>
+                </>
+            )
+        }
+        return <div>{data.rateCertificationName}</div>
+    }
 
     //We track rates that have already been selected to remove them from the dropdown
     const selectedRates = values.rateForms.map((rate) => rate.id && rate.id)
@@ -153,6 +173,7 @@ export const LinkRateSelect = ({
                           (rate) => !selectedRates.includes(rate.value)
                       )
             }
+            formatOptionLabel={formatOptionLabel}
             isSearchable
             maxMenuHeight={400}
             aria-label="linked rate (required)"

--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect.tsx
@@ -4,6 +4,8 @@ import Select, {
     AriaOnFocus,
     Props,
     FormatOptionLabelMeta,
+    SingleValue,
+    createFilter,
 } from 'react-select'
 import styles from '../../components/Select/RateSelect/RateSelect.module.scss'
 import { StateUser, useIndexRatesQuery } from '../../gen/gqlClient'
@@ -41,7 +43,7 @@ export const LinkRateSelect = ({
     initialValue,
     autofill,
     ...selectProps
-}: LinkRateSelectPropType & Props<LinkRateOptionType, true>) => {
+}: LinkRateSelectPropType & Props<LinkRateOptionType, false>) => {
     const { values }: { values: RateDetailFormConfig } = useFormikContext()
     const { data, loading, error } = useIndexRatesQuery()
     const { getKey } = useS3()
@@ -106,10 +108,10 @@ export const LinkRateSelect = ({
     }
 
     const onInputChange = (
-        newValue: LinkRateOptionType,
+        newValue: SingleValue<LinkRateOptionType>,
         { action }: ActionMeta<LinkRateOptionType>
     ) => {
-        if (action === 'select-option') {
+        if (action === 'select-option' && newValue) {
             const linkedRateID = newValue.value
             const linkedRate = rates.find((rate) => rate.id === linkedRateID)
             const linkedRateForm: FormikRateForm = convertGQLRateToRateForm(
@@ -129,13 +131,6 @@ export const LinkRateSelect = ({
             autofill(emptyRateForm)
         }
     }
-
-    //Need this to make the label searchable since the rate name is buried in a react element
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const filterOptions = (value: any, input: string) =>
-        value.data.rateCertificationName
-            ?.toLowerCase()
-            .includes(input.toLowerCase())
 
     const formatOptionLabel = (
         data: LinkRateOptionType,
@@ -189,11 +184,14 @@ export const LinkRateSelect = ({
             }
             loadingMessage={() => 'Loading rate certifications...'}
             name={name}
-            filterOption={filterOptions}
+            filterOption={createFilter({
+                ignoreCase: true,
+                trim: true,
+                matchFrom: 'any' as const,
+            })}
             {...selectProps}
             inputId={name}
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            onChange={onInputChange as any} // TODO see why the types definitions are messed up for react-select "single" (not multi) onChange - may need to upgrade dep if this bug was fixed
+            onChange={onInputChange}
         />
     )
 }

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -549,12 +549,9 @@ const RateDetailsV2 = ({
                                                             Additional rate
                                                             certification
                                                         </h3>
-                                                        <Button
+                                                        <button
                                                             type="button"
-                                                            outline
-                                                            className={
-                                                                styles.addRateBtn
-                                                            }
+                                                            className={`usa-button usa-button--outline ${styles.addRateBtn}`}
                                                             onClick={() => {
                                                                 const newRate =
                                                                     convertGQLRateToRateForm(
@@ -572,7 +569,7 @@ const RateDetailsV2 = ({
                                                         >
                                                             Add another rate
                                                             certification
-                                                        </Button>
+                                                        </button>
                                                     </SectionCard>
                                                 )}
                                             </>

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/SingleRateFormFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/SingleRateFormFields.tsx
@@ -536,10 +536,9 @@ export const SingleRateFormFields = ({
                                         </div>
                                     )
                                 )}
-                            <Button
+                            <button
                                 type="button"
-                                outline
-                                className={styles.addRateBtn}
+                                className={`usa-button usa-button--outline ${styles.addRateBtn}`}
                                 onClick={() => {
                                     push(emptyActuaryContact)
                                     setFocusNewActuaryContact(true)
@@ -547,7 +546,7 @@ export const SingleRateFormFields = ({
                                 ref={newActuaryContactButtonRef}
                             >
                                 Add a certifying actuary
-                            </Button>
+                            </button>
                         </FormGroup>
                     )}
                 </FieldArray>


### PR DESCRIPTION
## Summary
[MCR-4116](https://jiraent.cms.gov/browse/MCR-4116)
[MCR-4115](https://jiraent.cms.gov/browse/MCR-4115)

- Fix `Add another rate certification` and `Add a certifying actuary` focus.
   - Console errors from putting a `ref` in uswds `Button` component.
   - <img src="https://github.com/Enterprise-CMCS/managed-care-review/assets/98117700/0664bf04-d1f9-497f-a599-9033a804fc88" />
   - The fix was to revert back to regular `button` element.

- Fix menu list options sub-categories font size.
- Fix selected option display styling
   - When a rate is selected, the select box should only display the rate name cutting off overflowing portions.
   - When a rate is displayed in the select dropdown menu, then show the rate name and sub-categories.
   - [Figma](https://www.figma.com/file/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?type=design&node-id=9961%3A47335&mode=design&t=JCzr9HscGrtHJkCT-1)
- This code also had a side effect of fixing accessibility issues with the combo box. See [MCR-4115](https://jiraent.cms.gov/browse/MCR-4115). 

#### Related issues

#### Screenshots
<img src="https://github.com/Enterprise-CMCS/managed-care-review/assets/98117700/5743f9a2-841e-4546-9f06-142c09462901" width="450" />

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
- Selecting a rate from the linked rate dropdown list announces the rate name.
- With JAWS a user can remove a linked rate.

<!---These are developer instructions on how to test or validate the work -->
