### PR TITLE
Add rate number for admin users

### DIFF
--- a/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsDashboard.tsx
+++ b/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsDashboard.tsx
@@ -12,7 +12,7 @@ import { RateTypeRecord } from '../../../constants/healthPlanPackages'
 
 const RateReviewsDashboard = (): React.ReactElement => {
     const { loggedInUser } = useAuth()
-
+const isAdminUser = loggedInUser?.role === 'ADMIN_USER'
     const { data, loading, error } = useIndexRatesQuery({
         fetchPolicy: 'network-only',
     })
@@ -75,6 +75,7 @@ const RateReviewsDashboard = (): React.ReactElement => {
             reviewRows.push({
                 id: rate.id,
                 name: displayRateFormData.rateCertificationName || missingField,
+                rateNumber: rate.stateNumber,
                 programs: programs.filter(
                     (program) =>
                         displayRateFormData?.rateProgramIDs &&
@@ -105,7 +106,7 @@ const RateReviewsDashboard = (): React.ReactElement => {
     } else {
         return (
             <section className={styles.panel}>
-                <RateReviewsTable tableData={reviewRows} />
+                <RateReviewsTable tableData={reviewRows} isAdminUser={isAdminUser} />
             </section>
         )
     }

--- a/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsTable.test.tsx
+++ b/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsTable.test.tsx
@@ -1,8 +1,9 @@
-import { renderWithProviders } from '../../../testHelpers'
+import {renderWithProviders } from '../../../testHelpers'
 import { RateInDashboardType } from './RateReviewsTable'
 import {
     fetchCurrentUserMock,
     mockMNState,
+    mockValidAdminUser,
     mockValidCMSUser,
 } from '../../../testHelpers/apolloMocks'
 import { RateReviewsTable } from './RateReviewsTable'
@@ -20,6 +21,7 @@ describe('RateReviewsTable', () => {
         {
             id: 'rate-1-id',
             name: 'rate-1-certification-name',
+            rateNumber: 1,
             programs: [statePrograms[0]],
             submittedAt: '2023-10-16',
             rateDateStart: new Date('2023-10-16'),
@@ -33,6 +35,7 @@ describe('RateReviewsTable', () => {
         {
             id: 'rate-2-id',
             name: 'rate-2-certification-name',
+            rateNumber: 1,
             programs: [statePrograms[0]],
             submittedAt: '2023-11-18',
             rateDateStart: new Date('2023-11-18'),
@@ -47,6 +50,7 @@ describe('RateReviewsTable', () => {
             id: 'rate-3-id',
             name: 'rate-3-certification-name',
             programs: [statePrograms[0]],
+            rateNumber: 2,
             submittedAt: '2023-12-01',
             rateDateStart: new Date('2023-12-01'),
             rateDateEnd: new Date('2024-12-01'),
@@ -293,5 +297,48 @@ describe('RateReviewsTable', () => {
         expect(
             screen.getByText('Displaying 3 of 3 rate reviews')
         ).toBeInTheDocument()
+    })
+    it('renders rate number for Admin users', async () => {
+        renderWithProviders(
+            <RateReviewsTable
+                tableData={tableData()}
+                caption={'Test table caption'}
+                isAdminUser={true}
+            />,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            statusCode: 200,
+                            user: mockValidAdminUser(),
+                        }),
+                    ],
+                },
+            }
+        )
+
+        await screen.findByText('Rate period start date')
+        await screen.findByText('Rate #')
+    })
+    it('does not render rate number by default', async () => {
+        renderWithProviders(
+            <RateReviewsTable
+                tableData={tableData()}
+                caption={'Test table caption'}
+            />,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            statusCode: 200,
+                            user: mockValidCMSUser(),
+                        }),
+                    ],
+                },
+            }
+        )
+
+    await screen.findByText('Rate period start date')
+       expect(screen.queryByText('Rate #')).toBeNull()
     })
 })

--- a/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsTable.tsx
+++ b/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsTable.tsx
@@ -54,6 +54,7 @@ declare module '@tanstack/table-core' {
 export type RateInDashboardType = {
     id: string
     name: string
+    rateNumber: number,
     submittedAt: string
     updatedAt: Date
     status: HealthPlanPackageStatus
@@ -68,6 +69,7 @@ export type RateInDashboardType = {
 export type RateTableProps = {
     tableData: RateInDashboardType[]
     caption?: string
+    isAdminUser?: boolean
 }
 
 function rateURL(rate: RateInDashboardType): string {
@@ -190,6 +192,7 @@ type TableVariantConfig = {
 export const RateReviewsTable = ({
     caption,
     tableData,
+    isAdminUser = false,
 }: RateTableProps): React.ReactElement => {
     const lastClickedElement = useRef<string | null>(null)
     const filterDateRangeRef = useRef<FilterDateRangeRef>(null)
@@ -265,6 +268,11 @@ export const RateReviewsTable = ({
                 },
                 filterFn: `arrIncludesSome`,
             }),
+            columnHelper.accessor('rateNumber', {
+                id: 'rateNumber',
+                header: 'Rate #',
+                cell: (info) => <span>{info.getValue()}</span>,
+            }),
             columnHelper.accessor('programs', {
                 header: 'Programs',
                 cell: (info) =>
@@ -333,6 +341,11 @@ export const RateReviewsTable = ({
         data: tableData.sort((a, b) =>
             a['updatedAt'] > b['updatedAt'] ? -1 : 1
         ),
+        initialState: {
+            columnVisibility: {
+              rateNumber: isAdminUser,
+            },
+        },
         columns: tableColumns,
         filterFns: {
             dateRangeFilter: dateRangeFilter,
@@ -346,6 +359,7 @@ export const RateReviewsTable = ({
         getFilteredRowModel: getFilteredRowModel(),
         getSortedRowModel: getSortedRowModel(),
         getFacetedMinMaxValues: getFacetedMinMaxValues(),
+
     })
 
     const filteredRows = reactTable.getRowModel().rows


### PR DESCRIPTION
## Summary
Display human readable rate id on rate review dashboard - Product asked we add this just to see what these values look like in production. 

#### Related issues
https://jiraent.cms.gov/browse/MCR-4161

### Screenshots
![Screenshot 2024-05-20 at 4 59 49 PM](https://github.com/Enterprise-CMCS/managed-care-review/assets/10750442/bba91e00-68ac-487b-95e3-25e4fd4d2621)

### Test cases covered
- renders rate number for Admin users
- does not render rate number by default

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
