### PR TITLE
MCR-4196: updating rates with packages with shared rates causes system error

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/prismaContractRateAdaptors.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaContractRateAdaptors.ts
@@ -65,6 +65,7 @@ function prismaRateCreateFormDataFromDomain(
         },
         actuaryCommunicationPreference:
             rateFormData.actuaryCommunicationPreference,
+        //TODO: Remove this once HPP resolvers are not used anymore
         contractsWithSharedRateRevision: {
             connect: rateFormData.packagesWithSharedRateCerts
                 ? rateFormData.packagesWithSharedRateCerts.map((p) => ({
@@ -121,6 +122,7 @@ function prismaUpdateRateFormDataFromDomain(
         },
         actuaryCommunicationPreference:
             rateFormData.actuaryCommunicationPreference,
+        //TODO: Remove this once HPP resolvers are not used anymore
         contractsWithSharedRateRevision: {
             set: rateFormData.packagesWithSharedRateCerts
                 ? rateFormData.packagesWithSharedRateCerts.map((p) => ({

--- a/services/app-api/src/resolvers/contract/updateDraftContractRates.test.ts
+++ b/services/app-api/src/resolvers/contract/updateDraftContractRates.test.ts
@@ -159,7 +159,6 @@ describe('updateDraftContractRates', () => {
             ],
             addtlActuaryContacts: [],
             actuaryCommunicationPreference: 'OACT_TO_ACTUARY',
-            packagesWithSharedRateCerts: [],
         }
 
         const stateServer = await constructTestPostgresServer()
@@ -298,7 +297,6 @@ describe('updateDraftContractRates', () => {
                                 ],
                                 actuaryCommunicationPreference:
                                     'OACT_TO_ACTUARY',
-                                packagesWithSharedRateCerts: [],
                             },
                         },
                     ],
@@ -380,7 +378,6 @@ describe('updateDraftContractRates', () => {
                                 ],
                                 actuaryCommunicationPreference:
                                     'OACT_TO_ACTUARY',
-                                packagesWithSharedRateCerts: [],
                             },
                         },
                     ],
@@ -464,7 +461,6 @@ describe('updateDraftContractRates', () => {
                                 ],
                                 actuaryCommunicationPreference:
                                     'OACT_TO_ACTUARY',
-                                packagesWithSharedRateCerts: [],
                             },
                         },
                     ],
@@ -542,7 +538,6 @@ describe('updateDraftContractRates', () => {
                                 ],
                                 actuaryCommunicationPreference:
                                     'OACT_TO_ACTUARY',
-                                packagesWithSharedRateCerts: [],
                             },
                         },
                     ],
@@ -573,7 +568,6 @@ describe('updateDraftContractRates', () => {
                 deprecatedRateProgramIDs: [],
                 certifyingActuaryContacts: [],
                 addtlActuaryContacts: [],
-                packagesWithSharedRateCerts: [],
             }
         )
 
@@ -602,7 +596,6 @@ describe('updateDraftContractRates', () => {
                 deprecatedRateProgramIDs: [],
                 certifyingActuaryContacts: [],
                 addtlActuaryContacts: [],
-                packagesWithSharedRateCerts: [],
             }
         )
 
@@ -752,7 +745,6 @@ describe('updateDraftContractRates', () => {
                                 ],
                                 actuaryCommunicationPreference:
                                     'OACT_TO_ACTUARY',
-                                packagesWithSharedRateCerts: [],
                             },
                         },
                     ],
@@ -899,7 +891,6 @@ describe('updateDraftContractRates', () => {
                                 ],
                                 actuaryCommunicationPreference:
                                     'OACT_TO_ACTUARY',
-                                packagesWithSharedRateCerts: [],
                             },
                         },
                     ],

--- a/services/app-api/src/resolvers/rate/submitRate.test.ts
+++ b/services/app-api/src/resolvers/rate/submitRate.test.ts
@@ -16,6 +16,7 @@ import {
     addNewRateToTestContract,
     createSubmitAndUnlockTestRate,
     fetchTestRateById,
+    formatRateDataForSending,
 } from '../../testHelpers/gqlRateHelpers'
 import {
     createAndUpdateTestContractWithoutRates,
@@ -367,7 +368,9 @@ describe('submitRate', () => {
                 input: {
                     rateID: rateID,
                     submittedReason: 'submit rate',
-                    formData: unlockedRate.draftRevision.formData,
+                    formData: formatRateDataForSending(
+                        unlockedRate.draftRevision.formData
+                    ),
                 },
             },
         })

--- a/services/app-api/src/resolvers/rate/submitRate.ts
+++ b/services/app-api/src/resolvers/rate/submitRate.ts
@@ -162,12 +162,7 @@ export function submitRate(
                           : [],
                       actuaryCommunicationPreference:
                           formData.actuaryCommunicationPreference ?? undefined,
-                      packagesWithSharedRateCerts:
-                          formData.packagesWithSharedRateCerts.map((pkg) => ({
-                              packageName: pkg.packageName ?? undefined,
-                              packageId: pkg.packageId ?? undefined,
-                              packageStatus: pkg.packageStatus ?? undefined,
-                          })),
+                      packagesWithSharedRateCerts: [],
                       rateCertificationName:
                           formData.rateCertificationName ??
                           generatedRateCertName,

--- a/services/app-api/src/testHelpers/gqlRateHelpers.ts
+++ b/services/app-api/src/testHelpers/gqlRateHelpers.ts
@@ -143,7 +143,6 @@ async function addNewRateToTestContract(
     rateFormDataOverrides?: Partial<RateFormDataInput>
 ): Promise<Contract> {
     const rateUpdateInput = updateRatesInputFromDraftContract(contract)
-
     const addedInput = addNewRateToRateInput(
         rateUpdateInput,
         rateFormDataOverrides
@@ -204,7 +203,6 @@ function addNewRateToRateInput(
             },
         ],
         actuaryCommunicationPreference: 'OACT_TO_ACTUARY',
-        packagesWithSharedRateCerts: [],
 
         ...rateFormDataOverrides,
     }
@@ -263,7 +261,20 @@ function formatRateDataForSending(
     rateFormData: RateFormData
 ): RateFormDataInput {
     return {
-        ...rateFormData,
+        rateType: rateFormData.rateType,
+        rateCapitationType: rateFormData.rateCapitationType,
+        rateDocuments: rateFormData.rateDocuments,
+        supportingDocuments: rateFormData.supportingDocuments,
+        rateDateStart: rateFormData.rateDateStart,
+        rateDateEnd: rateFormData.rateDateEnd,
+        rateDateCertified: rateFormData.rateDateCertified,
+        amendmentEffectiveDateStart: rateFormData.amendmentEffectiveDateStart,
+        amendmentEffectiveDateEnd: rateFormData.amendmentEffectiveDateEnd,
+        deprecatedRateProgramIDs: rateFormData.deprecatedRateProgramIDs,
+        rateProgramIDs: rateFormData.rateProgramIDs,
+        rateCertificationName: rateFormData.rateCertificationName,
+        actuaryCommunicationPreference:
+            rateFormData.actuaryCommunicationPreference,
         certifyingActuaryContacts: rateFormData.certifyingActuaryContacts.map(
             formatGQLRateContractForSending
         ),
@@ -291,6 +302,7 @@ function updateRatesInputFromDraftContract(
         ) {
             // this is an editable child rate
             const revision = rate.draftRevision
+
             if (!revision) {
                 console.error(
                     'programming error no draft revision found for rate',
@@ -416,4 +428,5 @@ export {
     submitTestRate,
     unlockTestRate,
     updateTestRate,
+    formatRateDataForSending,
 }

--- a/services/app-api/src/testHelpers/rateDataMocks.ts
+++ b/services/app-api/src/testHelpers/rateDataMocks.ts
@@ -187,7 +187,6 @@ function mockRateFormDataInput(): RateFormDataInput {
             },
         ],
         actuaryCommunicationPreference: 'OACT_TO_ACTUARY',
-        packagesWithSharedRateCerts: [],
     }
 }
 

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -1115,12 +1115,6 @@ type PackageWithSameRate {
     packageStatus: HealthPlanPackageStatus
 }
 
-input PackageWithSameRateInput {
-    packageName: String!
-    packageId: String!
-    packageStatus: HealthPlanPackageStatus
-}
-
 """
 RateFormData represents the form data that was inputted by the state
 This type is used for the form data field found on a rate revision
@@ -1570,13 +1564,6 @@ input RateFormDataInput {
     directly or go through them
     """
     actuaryCommunicationPreference: ActuaryCommunication
-    """
-    Deprecated - an array of PackageWithSameRate elements
-    which contain the packageName, packageId, and packageStatus
-    These elements represent other packages in the system
-    that are using this rate
-    """
-    packagesWithSharedRateCerts: [PackageWithSameRateInput!]!
 }
 
 input SubmitRateInput {

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
@@ -61,7 +61,6 @@ const convertRateFormToGQLRateFormData = (
         certifyingActuaryContacts: rateForm.actuaryContacts,
         addtlActuaryContacts: rateForm.addtlActuaryContacts,
         actuaryCommunicationPreference: rateForm.actuaryCommunicationPreference ?? undefined,
-        packagesWithSharedRateCerts: [],
     }
 }
 

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/rateDetailsHelpers.ts
@@ -9,7 +9,7 @@ import {
 import {
     ActuaryContact,
     Rate,
-    RateFormData,
+    RateFormData, RateFormDataInput,
     UpdateContractRateInput,
 } from '../../../../gen/gqlClient'
 import { S3ClientT } from '../../../../s3'
@@ -38,7 +38,7 @@ const generateUpdatedRates = (
 // convert from FormikRateForm to GQL RateFormData used in API
 const convertRateFormToGQLRateFormData = (
     rateForm: FormikRateForm
-): RateFormData => {
+): RateFormDataInput => {
     return {
         // intentionally do not map backend calculated fields on submit such status and rateCertificationName
         rateType: rateForm.rateType,
@@ -61,7 +61,7 @@ const convertRateFormToGQLRateFormData = (
         certifyingActuaryContacts: rateForm.actuaryContacts,
         addtlActuaryContacts: rateForm.addtlActuaryContacts,
         actuaryCommunicationPreference: rateForm.actuaryCommunicationPreference ?? undefined,
-        packagesWithSharedRateCerts: rateForm.packagesWithSharedRateCerts,
+        packagesWithSharedRateCerts: [],
     }
 }
 

--- a/services/app-web/src/testHelpers/apolloMocks/contractGQLMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/contractGQLMock.ts
@@ -65,7 +65,6 @@ const updateDraftContractRatesMockSuccess = ({
                 ],
                 addtlActuaryContacts: [],
                 actuaryCommunicationPreference: undefined,
-                packagesWithSharedRateCerts: [],
             },
             rateID: undefined,
             type: "CREATE"


### PR DESCRIPTION
## Summary
[MCR-4196](https://jiraent.cms.gov/browse/MCR-4196)

Fix system error when updating rates with `packagesWithSharedRateCerts` with `linked-rates` flag on.

This bug was caused by the difference in `packagesWithSharedRateCerts` between the GraphQL `RateFormDataInput` and `RateFormData` type.

There were three solutions
1. Map through `packagesWithSharedRateCerts` and return the object that matches the input type
2. Pass in an empty array, because we no longer want to  carry forward this field in new rate revisions
3. Remove `packagesWithSharedRateCerts` from the update rate mutations all together since it is depreciated and we no longer want to carry forward this data.

I choose option 3, removing it from the input of the mutation altogether by removing `packagesWithSharedRateCerts` from `RateFromDataInput` and removed `PackageWithSameRateInput` type. This still kept `packagesWithSharedRateCerts` in `RateFromData` so historical rate revisions will still contain the field. 

With the new Contract and Rate API, removing the `packagesWithSharedRateCerts` input field will clear out this data from new revisions. The HPP API will still be able to set this field, I want to leave that intact and only removed once we remove the HPP API.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

You can test this with the following steps

1. With `link-rates` feature flag off, start a new contract and rate submission.
2. On the rate details page select a rate for the field `Please select the submissions that also contain this rate certification.`. 
4. Continue the submission and submit.
5. Turn the `link-rates` flag on and as a CMS user unlock the submission.
6. Log in as a State user and go to the rate details page of the unlocked submission.
7. Fix any missing data from depreciating old programs and requiring new rate programs to be selected.
8. Continuing the form should no longer cause a system error.

It will be hard to test retaining `packagesWithSharedRateCerts` on historical rate revisions, since we do not have a rate history yet and I don't think we display it anywhere, but you can verify this using the GraphQL explorer tool. 

Please note that the tool no longer works on LOCAL deployment. Here is a bug [ticket](https://jiraent.cms.gov/browse/MCR-4197) for that.

<!---These are developer instructions on how to test or validate the work -->
