### PR TITLE
MCR-3753: hide header and footer from graphql explorer page

### DIFF
--- a/services/app-web/src/components/Footer/Footer.tsx
+++ b/services/app-web/src/components/Footer/Footer.tsx
@@ -6,6 +6,7 @@ import styles from './Footer.module.scss'
 import { Logo } from '../Logo'
 import { GridContainer, Grid } from '@trussworks/react-uswds'
 import { useStringConstants } from '../../hooks/useStringConstants'
+import { useCurrentRoute } from '../../hooks/useCurrentRoute'
 
 /**
  * CMS Footer
@@ -13,7 +14,9 @@ import { useStringConstants } from '../../hooks/useStringConstants'
 export const Footer = (): React.ReactElement => {
     const stringConstants = useStringConstants()
     const MAIL_TO_SUPPORT = stringConstants.MAIL_TO_SUPPORT
-    return (
+    const { currentRoute: route } = useCurrentRoute()
+
+    return route !== 'GRAPHQL_EXPLORER' ? (
         <footer>
             <div className={styles.logosRow}>
                 <GridContainer>
@@ -55,5 +58,7 @@ export const Footer = (): React.ReactElement => {
                 </GridContainer>
             </div>
         </footer>
+    ) : (
+        <></>
     )
 }

--- a/services/app-web/src/components/Header/Header.tsx
+++ b/services/app-web/src/components/Header/Header.tsx
@@ -45,7 +45,7 @@ export const Header = ({
         })
     }
 
-    return (
+    return route !== 'GRAPHQL_EXPLORER' ? (
         <header>
             <div className={styles.banner}>
                 <GridContainer>
@@ -75,5 +75,7 @@ export const Header = ({
                 loggedInUser={loggedInUser}
             />
         </header>
+    ) : (
+        <></>
     )
 }

--- a/services/app-web/src/pages/GraphQLExplorer/GraphQLExplorer.module.scss
+++ b/services/app-web/src/pages/GraphQLExplorer/GraphQLExplorer.module.scss
@@ -10,11 +10,6 @@
     align-items: stretch;
 }
 
-header,
-footer {
-    display: none;
-}
-
 .explorer {
     width: 100%;
 }

--- a/services/app-web/src/pages/GraphQLExplorer/GraphQLExplorer.module.scss
+++ b/services/app-web/src/pages/GraphQLExplorer/GraphQLExplorer.module.scss
@@ -10,6 +10,11 @@
     align-items: stretch;
 }
 
+header,
+footer {
+    display: none;
+}
+
 .explorer {
     width: 100%;
 }


### PR DESCRIPTION
## Summary
Hides the header and footer from the graphql explorer page to make it easier to use

#### Related issues
https://jiraent.cms.gov/browse/MCR-3753

#### Screenshots

<img width="1512" alt="Screenshot 2024-06-04 at 11 11 08 AM" src="https://github.com/Enterprise-CMCS/managed-care-review/assets/67110378/95bdf84d-6a42-4e68-abf8-2a3b51e5bfe4">
