### PR TITLE
MCR-4195: CMS user shouldn't see missing field error for populations covered

### DIFF
--- a/services/app-web/src/common-code/ContractTypeProvisions.ts
+++ b/services/app-web/src/common-code/ContractTypeProvisions.ts
@@ -129,7 +129,7 @@ const sortModifiedProvisions = (
 }
 
 /*
-    Returns boolean for weher a submission variant is missing required provisions 
+    Returns boolean for whether a submission variant is missing required provisions
     This is used to determine if we display the missing data warning on review and submit  
 */
 const isMissingProvisions = (contract: Contract): boolean => {

--- a/services/app-web/src/components/DataDetail/DataDetail.tsx
+++ b/services/app-web/src/components/DataDetail/DataDetail.tsx
@@ -36,7 +36,7 @@ export const DataDetail = ({
         !children || children === '' || (handleArray && children.length === 0)
     if (!explainMissingData && noData) return null // displays nothing - this is generally used for submission summary page
     return (
-        <div className={styles.dataDetail}>
+        <div className={styles.dataDetail} data-testid={id}>
             <dt id={id}>{label}</dt>
             <dd role="definition" aria-labelledby={id}>
                 {explainMissingData && noData ? (

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
@@ -223,8 +223,7 @@ export const HealthPlanPackageTable = ({
 
     const [tableCaption, setTableCaption] = useState<React.ReactNode | null>()
 
-    const isCMSOrAdminUser =
-        user.__typename === 'CMSUser' || user.__typename === 'AdminUser'
+    const isCMSOrAdminUser = user.__typename !== 'StateUser'
     const tableColumns = React.useMemo(
         () => [
             columnHelper.accessor((row) => row, {

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
@@ -77,9 +77,9 @@ const isSubmitted = (status: HealthPlanPackageStatus) =>
 function submissionURL(
     id: PackageInDashboardType['id'],
     status: PackageInDashboardType['status'],
-    isCMSOrAdminUser: boolean
+    isNotStateUser: boolean
 ): string {
-    if (isCMSOrAdminUser) {
+    if (isNotStateUser) {
         return `/submissions/${id}`
     } else if (status === 'DRAFT') {
         return `/submissions/${id}/edit/type`
@@ -223,7 +223,7 @@ export const HealthPlanPackageTable = ({
 
     const [tableCaption, setTableCaption] = useState<React.ReactNode | null>()
 
-    const isCMSOrAdminUser = user.__typename !== 'StateUser'
+    const isNotStateUser = user.__typename !== 'StateUser'
     const tableColumns = React.useMemo(
         () => [
             columnHelper.accessor((row) => row, {
@@ -237,7 +237,7 @@ export const HealthPlanPackageTable = ({
                         to={submissionURL(
                             info.getValue().id,
                             info.getValue().status,
-                            isCMSOrAdminUser
+                            isNotStateUser
                         )}
                         className={`${styles.ID}`}
                     >
@@ -312,7 +312,7 @@ export const HealthPlanPackageTable = ({
                 },
             }),
         ],
-        [isCMSOrAdminUser, tableConfig.rowIDName]
+        [isNotStateUser, tableConfig.rowIDName]
     )
 
     const reactTable = useReactTable({
@@ -327,8 +327,8 @@ export const HealthPlanPackageTable = ({
         state: {
             columnFilters,
             columnVisibility: {
-                stateName: isCMSOrAdminUser,
-                submissionType: isCMSOrAdminUser,
+                stateName: isNotStateUser,
+                submissionType: isNotStateUser,
             },
         },
         onColumnFiltersChange: setColumnFilters,

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
@@ -318,18 +318,13 @@ describe('SingleRateSummarySection', () => {
     })
 
     it('should display missing field text to state users', async () => {
-        const rateData = rateDataMock(
-            {
-                rateType: undefined,
-                rateDateCertified: undefined,
-                rateProgramIDs: [],
-            } as unknown as Partial<RateRevision>,
-            { status: 'UNLOCKED' }
-        )
+        const rateData = rateDataMock({}, { status: 'UNLOCKED' })
         rateData.revisions[0].formData.deprecatedRateProgramIDs = [
             rateData.state.programs[0].id,
         ]
         rateData.revisions[0].formData.rateProgramIDs = []
+        rateData.revisions[0].formData.rateType = undefined
+        rateData.revisions[0].formData.rateDateCertified = undefined
         renderWithProviders(
             <SingleRateSummarySection
                 rate={rateData}

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
@@ -456,8 +456,8 @@ describe('SingleRateSummarySection', () => {
         const emptyRateFormData = draftRates[0].draftRevision
             ?.formData as RateFormData
 
-        it('should not display missing field text to CMS users', async () => {
-            const rateData = rateDataMock(
+        const mockEmptyRateData = () =>
+            rateDataMock(
                 {
                     formData: {
                         ...emptyRateFormData,
@@ -466,6 +466,9 @@ describe('SingleRateSummarySection', () => {
                 },
                 { status: 'UNLOCKED' }
             )
+
+        it('should not display missing field text to CMS users', async () => {
+            const rateData = mockEmptyRateData()
             renderWithProviders(
                 <SingleRateSummarySection
                     rate={rateData}
@@ -499,15 +502,7 @@ describe('SingleRateSummarySection', () => {
         })
 
         it('should display missing field text to state users', async () => {
-            const rateData = rateDataMock(
-                {
-                    formData: {
-                        ...emptyRateFormData,
-                        rateType: 'AMENDMENT',
-                    },
-                },
-                { status: 'UNLOCKED' }
-            )
+            const rateData = mockEmptyRateData()
             renderWithProviders(
                 <SingleRateSummarySection
                     rate={rateData}
@@ -590,16 +585,7 @@ describe('SingleRateSummarySection', () => {
         })
 
         it('should display missing field text to helpdesk users', async () => {
-            const emptyRateFormData = draftRates[0].draftRevision
-                ?.formData as RateFormData
-            const rateData = rateDataMock(
-                {
-                    formData: {
-                        ...emptyRateFormData,
-                    },
-                },
-                { status: 'UNLOCKED' }
-            )
+            const rateData = mockEmptyRateData()
             renderWithProviders(
                 <SingleRateSummarySection
                     rate={rateData}
@@ -633,14 +619,8 @@ describe('SingleRateSummarySection', () => {
         })
 
         it('should not display missing field text on submitted rates', async () => {
-            const rateData = rateDataMock(
-                {
-                    formData: {
-                        ...emptyRateFormData,
-                    },
-                },
-                { status: 'SUBMITTED' }
-            )
+            const rateData = mockEmptyRateData()
+            rateData.status = 'SUBMITTED'
             renderWithProviders(
                 <SingleRateSummarySection
                     rate={rateData}

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
@@ -282,228 +282,6 @@ describe('SingleRateSummarySection', () => {
         )
     })
 
-    it('should not display missing field text to CMS users', async () => {
-        const rateData = rateDataMock({
-            rateType: undefined,
-            rateDateCertified: undefined,
-        } as unknown as Partial<RateRevision>)
-        renderWithProviders(
-            <SingleRateSummarySection
-                rate={rateData}
-                isSubmitted={false}
-                statePrograms={rateData.state.programs}
-            />,
-            {
-                apolloProvider: {
-                    mocks: [
-                        fetchCurrentUserMock({
-                            statusCode: 200,
-                            user: mockValidCMSUser(),
-                        }),
-                    ],
-                },
-                featureFlags: { 'rate-edit-unlock': true },
-            }
-        )
-
-        // Wait for all the documents to be in the table
-        await screen.findByText(
-            rateData.revisions[0].formData.rateDocuments[0].name
-        )
-        await screen.findByRole('link', {
-            name: 'Download all rate documents',
-        })
-
-        expect(
-            screen.queryByText(/You must provide this information/)
-        ).toBeNull()
-    })
-
-    it('should display missing field text to state users', async () => {
-        const draftRates = mockEmptyDraftContractAndRate().draftRates
-        if (!draftRates) {
-            throw new Error('Unexpected error: draft rates is undefined')
-        }
-        const emptyRateFormData = draftRates[0].draftRevision
-            ?.formData as RateFormData
-        const rateData = rateDataMock(
-            {
-                formData: {
-                    ...emptyRateFormData,
-                    rateType: 'AMENDMENT',
-                },
-            },
-            { status: 'UNLOCKED' }
-        )
-        renderWithProviders(
-            <SingleRateSummarySection
-                rate={rateData}
-                isSubmitted={false}
-                statePrograms={rateData.state.programs}
-            />,
-            {
-                apolloProvider: {
-                    mocks: [
-                        fetchCurrentUserMock({
-                            statusCode: 200,
-                            user: mockValidStateUser(),
-                        }),
-                    ],
-                },
-                featureFlags: { 'rate-edit-unlock': true },
-            }
-        )
-
-        // Wait for all the documents to be in the table
-        await screen.findByText(
-            rateData.revisions[0].formData.rateDocuments[0].name
-        )
-        await screen.findByRole('link', {
-            name: 'Download all rate documents',
-        })
-
-        const text = /You must provide this information/
-
-        expect(await screen.findAllByText(text)).toHaveLength(8)
-
-        // expect Amendment rate
-        expect(
-            within(await screen.findByTestId('rateType')).getByText(
-                /Amendment to prior rate certification/
-            )
-        ).toBeInTheDocument()
-
-        // expected errors
-        expect(
-            within(
-                await screen.findByTestId('effectiveRatingPeriod')
-            ).getByText(text)
-        ).toBeInTheDocument()
-        expect(
-            within(await screen.findByTestId('ratePrograms')).getByText(text)
-        ).toBeInTheDocument()
-        expect(
-            within(await screen.findByTestId('ratingPeriod')).getByText(text)
-        ).toBeInTheDocument()
-        expect(
-            within(await screen.findByTestId('dateCertified')).getByText(text)
-        ).toBeInTheDocument()
-        expect(
-            within(await screen.findByTestId('rateCapitationType')).getByText(
-                text
-            )
-        ).toBeInTheDocument()
-        expect(
-            within(await screen.findByTestId('certifyingActuary')).getByText(
-                text
-            )
-        ).toBeInTheDocument()
-        expect(
-            within(
-                await screen.findByTestId('addtlCertifyingActuary-0')
-            ).getByText(text)
-        ).toBeInTheDocument()
-        expect(
-            within(
-                await screen.findByTestId('communicationPreference')
-            ).getByText(text)
-        ).toBeInTheDocument()
-    })
-
-    it('should display missing field text to helpdesk users', async () => {
-        const draftRates = mockEmptyDraftContractAndRate().draftRates
-        if (!draftRates) {
-            throw new Error('Unexpected error: draft rates is undefined')
-        }
-        const emptyRateFormData = draftRates[0].draftRevision
-            ?.formData as RateFormData
-        const rateData = rateDataMock(
-            {
-                formData: {
-                    ...emptyRateFormData,
-                },
-            },
-            { status: 'UNLOCKED' }
-        )
-        renderWithProviders(
-            <SingleRateSummarySection
-                rate={rateData}
-                isSubmitted={false}
-                statePrograms={rateData.state.programs}
-            />,
-            {
-                apolloProvider: {
-                    mocks: [
-                        fetchCurrentUserMock({
-                            statusCode: 200,
-                            user: mockValidHelpDeskUser(),
-                        }),
-                    ],
-                },
-                featureFlags: { 'rate-edit-unlock': true },
-            }
-        )
-
-        // Wait for all the documents to be in the table
-        await screen.findByText(
-            rateData.revisions[0].formData.rateDocuments[0].name
-        )
-        await screen.findByRole('link', {
-            name: 'Download all rate documents',
-        })
-
-        expect(
-            await screen.findAllByText(/You must provide this information/)
-        ).toHaveLength(8)
-    })
-
-    it('should not display missing field text on submitted rates', async () => {
-        const draftRates = mockEmptyDraftContractAndRate().draftRates
-        if (!draftRates) {
-            throw new Error('Unexpected error: draft rates is undefined')
-        }
-        const emptyRateFormData = draftRates[0].draftRevision
-            ?.formData as RateFormData
-        const rateData = rateDataMock(
-            {
-                formData: {
-                    ...emptyRateFormData,
-                },
-            },
-            { status: 'SUBMITTED' }
-        )
-        renderWithProviders(
-            <SingleRateSummarySection
-                rate={rateData}
-                isSubmitted={true}
-                statePrograms={rateData.state.programs}
-            />,
-            {
-                apolloProvider: {
-                    mocks: [
-                        fetchCurrentUserMock({
-                            statusCode: 200,
-                            user: mockValidHelpDeskUser(),
-                        }),
-                    ],
-                },
-                featureFlags: { 'rate-edit-unlock': true },
-            }
-        )
-
-        // Wait for all the documents to be in the table
-        await screen.findByText(
-            rateData.revisions[0].formData.rateDocuments[0].name
-        )
-        await screen.findByRole('link', {
-            name: 'Download all rate documents',
-        })
-
-        expect(
-            screen.queryAllByText(/You must provide this information/)
-        ).toHaveLength(0)
-    })
-
     describe('Unlock rate', () => {
         it('renders the unlock button to CMS users when rate edit and unlock is enabled', async () => {
             const rateData = rateDataMock(
@@ -665,6 +443,234 @@ describe('SingleRateSummarySection', () => {
                     name: 'Unlock rate',
                 })
             ).toBeNull()
+        })
+    })
+
+    describe('Missing data error notifications', () => {
+        const draftRates = mockEmptyDraftContractAndRate().draftRates
+
+        if (!draftRates) {
+            throw new Error('Unexpected error: draft rates is undefined')
+        }
+
+        const emptyRateFormData = draftRates[0].draftRevision
+            ?.formData as RateFormData
+
+        it('should not display missing field text to CMS users', async () => {
+            const rateData = rateDataMock(
+                {
+                    formData: {
+                        ...emptyRateFormData,
+                        rateType: 'AMENDMENT',
+                    },
+                },
+                { status: 'UNLOCKED' }
+            )
+            renderWithProviders(
+                <SingleRateSummarySection
+                    rate={rateData}
+                    isSubmitted={false}
+                    statePrograms={rateData.state.programs}
+                />,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                statusCode: 200,
+                                user: mockValidCMSUser(),
+                            }),
+                        ],
+                    },
+                    featureFlags: { 'rate-edit-unlock': true },
+                }
+            )
+
+            // Wait for all the documents to be in the table
+            await screen.findByText(
+                rateData.revisions[0].formData.rateDocuments[0].name
+            )
+            await screen.findByRole('link', {
+                name: 'Download all rate documents',
+            })
+
+            expect(
+                screen.queryByText(/You must provide this information/)
+            ).toBeNull()
+        })
+
+        it('should display missing field text to state users', async () => {
+            const rateData = rateDataMock(
+                {
+                    formData: {
+                        ...emptyRateFormData,
+                        rateType: 'AMENDMENT',
+                    },
+                },
+                { status: 'UNLOCKED' }
+            )
+            renderWithProviders(
+                <SingleRateSummarySection
+                    rate={rateData}
+                    isSubmitted={false}
+                    statePrograms={rateData.state.programs}
+                />,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                statusCode: 200,
+                                user: mockValidStateUser(),
+                            }),
+                        ],
+                    },
+                    featureFlags: { 'rate-edit-unlock': true },
+                }
+            )
+
+            // Wait for all the documents to be in the table
+            await screen.findByText(
+                rateData.revisions[0].formData.rateDocuments[0].name
+            )
+            await screen.findByRole('link', {
+                name: 'Download all rate documents',
+            })
+
+            const text = /You must provide this information/
+
+            expect(await screen.findAllByText(text)).toHaveLength(8)
+
+            // expect Amendment rate
+            expect(
+                within(await screen.findByTestId('rateType')).getByText(
+                    /Amendment to prior rate certification/
+                )
+            ).toBeInTheDocument()
+
+            // expected errors
+            expect(
+                within(
+                    await screen.findByTestId('effectiveRatingPeriod')
+                ).getByText(text)
+            ).toBeInTheDocument()
+            expect(
+                within(await screen.findByTestId('ratePrograms')).getByText(
+                    text
+                )
+            ).toBeInTheDocument()
+            expect(
+                within(await screen.findByTestId('ratingPeriod')).getByText(
+                    text
+                )
+            ).toBeInTheDocument()
+            expect(
+                within(await screen.findByTestId('dateCertified')).getByText(
+                    text
+                )
+            ).toBeInTheDocument()
+            expect(
+                within(
+                    await screen.findByTestId('rateCapitationType')
+                ).getByText(text)
+            ).toBeInTheDocument()
+            expect(
+                within(
+                    await screen.findByTestId('certifyingActuary')
+                ).getByText(text)
+            ).toBeInTheDocument()
+            expect(
+                within(
+                    await screen.findByTestId('addtlCertifyingActuary-0')
+                ).getByText(text)
+            ).toBeInTheDocument()
+            expect(
+                within(
+                    await screen.findByTestId('communicationPreference')
+                ).getByText(text)
+            ).toBeInTheDocument()
+        })
+
+        it('should display missing field text to helpdesk users', async () => {
+            const emptyRateFormData = draftRates[0].draftRevision
+                ?.formData as RateFormData
+            const rateData = rateDataMock(
+                {
+                    formData: {
+                        ...emptyRateFormData,
+                    },
+                },
+                { status: 'UNLOCKED' }
+            )
+            renderWithProviders(
+                <SingleRateSummarySection
+                    rate={rateData}
+                    isSubmitted={false}
+                    statePrograms={rateData.state.programs}
+                />,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                statusCode: 200,
+                                user: mockValidHelpDeskUser(),
+                            }),
+                        ],
+                    },
+                    featureFlags: { 'rate-edit-unlock': true },
+                }
+            )
+
+            // Wait for all the documents to be in the table
+            await screen.findByText(
+                rateData.revisions[0].formData.rateDocuments[0].name
+            )
+            await screen.findByRole('link', {
+                name: 'Download all rate documents',
+            })
+
+            expect(
+                await screen.findAllByText(/You must provide this information/)
+            ).toHaveLength(8)
+        })
+
+        it('should not display missing field text on submitted rates', async () => {
+            const rateData = rateDataMock(
+                {
+                    formData: {
+                        ...emptyRateFormData,
+                    },
+                },
+                { status: 'SUBMITTED' }
+            )
+            renderWithProviders(
+                <SingleRateSummarySection
+                    rate={rateData}
+                    isSubmitted={true}
+                    statePrograms={rateData.state.programs}
+                />,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                statusCode: 200,
+                                user: mockValidHelpDeskUser(),
+                            }),
+                        ],
+                    },
+                    featureFlags: { 'rate-edit-unlock': true },
+                }
+            )
+
+            // Wait for all the documents to be in the table
+            await screen.findByText(
+                rateData.revisions[0].formData.rateDocuments[0].name
+            )
+            await screen.findByRole('link', {
+                name: 'Download all rate documents',
+            })
+
+            expect(
+                screen.queryAllByText(/You must provide this information/)
+            ).toHaveLength(0)
         })
     })
 })

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
@@ -5,13 +5,15 @@ import {
 import { SingleRateSummarySection } from './SingleRateSummarySection'
 import {
     fetchCurrentUserMock,
+    mockEmptyDraftContractAndRate,
     mockValidCMSUser,
+    mockValidHelpDeskUser,
     mockValidStateUser,
     rateDataMock,
 } from '../../../testHelpers/apolloMocks'
 import { screen, waitFor, within } from '@testing-library/react'
 import { packageName } from '../../../common-code/healthPlanFormDataType'
-import { RateRevision } from '../../../gen/gqlClient'
+import { RateFormData, RateRevision } from '../../../gen/gqlClient'
 import { type Location, Route, Routes } from 'react-router-dom'
 import { RoutesRecord } from '../../../constants'
 
@@ -318,13 +320,21 @@ describe('SingleRateSummarySection', () => {
     })
 
     it('should display missing field text to state users', async () => {
-        const rateData = rateDataMock({}, { status: 'UNLOCKED' })
-        rateData.revisions[0].formData.deprecatedRateProgramIDs = [
-            rateData.state.programs[0].id,
-        ]
-        rateData.revisions[0].formData.rateProgramIDs = []
-        rateData.revisions[0].formData.rateType = undefined
-        rateData.revisions[0].formData.rateDateCertified = undefined
+        const draftRates = mockEmptyDraftContractAndRate().draftRates
+        if (!draftRates) {
+            throw new Error('Unexpected error: draft rates is undefined')
+        }
+        const emptyRateFormData = draftRates[0].draftRevision
+            ?.formData as RateFormData
+        const rateData = rateDataMock(
+            {
+                formData: {
+                    ...emptyRateFormData,
+                    rateType: 'AMENDMENT',
+                },
+            },
+            { status: 'UNLOCKED' }
+        )
         renderWithProviders(
             <SingleRateSummarySection
                 rate={rateData}
@@ -352,9 +362,146 @@ describe('SingleRateSummarySection', () => {
             name: 'Download all rate documents',
         })
 
+        const text = /You must provide this information/
+
+        expect(await screen.findAllByText(text)).toHaveLength(8)
+
+        // expect Amendment rate
+        expect(
+            within(await screen.findByTestId('rateType')).getByText(
+                /Amendment to prior rate certification/
+            )
+        ).toBeInTheDocument()
+
+        // expected errors
+        expect(
+            within(
+                await screen.findByTestId('effectiveRatingPeriod')
+            ).getByText(text)
+        ).toBeInTheDocument()
+        expect(
+            within(await screen.findByTestId('ratePrograms')).getByText(text)
+        ).toBeInTheDocument()
+        expect(
+            within(await screen.findByTestId('ratingPeriod')).getByText(text)
+        ).toBeInTheDocument()
+        expect(
+            within(await screen.findByTestId('dateCertified')).getByText(text)
+        ).toBeInTheDocument()
+        expect(
+            within(await screen.findByTestId('rateCapitationType')).getByText(
+                text
+            )
+        ).toBeInTheDocument()
+        expect(
+            within(await screen.findByTestId('certifyingActuary')).getByText(
+                text
+            )
+        ).toBeInTheDocument()
+        expect(
+            within(
+                await screen.findByTestId('addtlCertifyingActuary-0')
+            ).getByText(text)
+        ).toBeInTheDocument()
+        expect(
+            within(
+                await screen.findByTestId('communicationPreference')
+            ).getByText(text)
+        ).toBeInTheDocument()
+    })
+
+    it('should display missing field text to helpdesk users', async () => {
+        const draftRates = mockEmptyDraftContractAndRate().draftRates
+        if (!draftRates) {
+            throw new Error('Unexpected error: draft rates is undefined')
+        }
+        const emptyRateFormData = draftRates[0].draftRevision
+            ?.formData as RateFormData
+        const rateData = rateDataMock(
+            {
+                formData: {
+                    ...emptyRateFormData,
+                },
+            },
+            { status: 'UNLOCKED' }
+        )
+        renderWithProviders(
+            <SingleRateSummarySection
+                rate={rateData}
+                isSubmitted={false}
+                statePrograms={rateData.state.programs}
+            />,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            statusCode: 200,
+                            user: mockValidHelpDeskUser(),
+                        }),
+                    ],
+                },
+                featureFlags: { 'rate-edit-unlock': true },
+            }
+        )
+
+        // Wait for all the documents to be in the table
+        await screen.findByText(
+            rateData.revisions[0].formData.rateDocuments[0].name
+        )
+        await screen.findByRole('link', {
+            name: 'Download all rate documents',
+        })
+
         expect(
             await screen.findAllByText(/You must provide this information/)
-        ).toHaveLength(3)
+        ).toHaveLength(8)
+    })
+
+    it('should not display missing field text on submitted rates', async () => {
+        const draftRates = mockEmptyDraftContractAndRate().draftRates
+        if (!draftRates) {
+            throw new Error('Unexpected error: draft rates is undefined')
+        }
+        const emptyRateFormData = draftRates[0].draftRevision
+            ?.formData as RateFormData
+        const rateData = rateDataMock(
+            {
+                formData: {
+                    ...emptyRateFormData,
+                },
+            },
+            { status: 'SUBMITTED' }
+        )
+        renderWithProviders(
+            <SingleRateSummarySection
+                rate={rateData}
+                isSubmitted={true}
+                statePrograms={rateData.state.programs}
+            />,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            statusCode: 200,
+                            user: mockValidHelpDeskUser(),
+                        }),
+                    ],
+                },
+                featureFlags: { 'rate-edit-unlock': true },
+            }
+        )
+
+        // Wait for all the documents to be in the table
+        await screen.findByText(
+            rateData.revisions[0].formData.rateDocuments[0].name
+        )
+        await screen.findByRole('link', {
+            name: 'Download all rate documents',
+        })
+
+        expect(
+            screen.queryAllByText(/You must provide this information/)
+        ).toHaveLength(0)
     })
 
     describe('Unlock rate', () => {

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -116,7 +116,9 @@ export const SingleRateSummarySection = ({
     const isRateAmendment = formData.rateType === 'AMENDMENT'
     const isUnlocked = rate.status === 'UNLOCKED'
     const explainMissingData =
-        !isSubmitted && loggedInUser?.role === 'STATE_USER'
+        !isSubmitted &&
+        (loggedInUser?.role === 'STATE_USER' ||
+            loggedInUser?.role === 'HELPDESK_USER')
     const isCMSUser = loggedInUser?.role === 'CMS_USER'
     const isSubmittedOrCMSUser =
         rate.status === 'SUBMITTED' ||
@@ -267,18 +269,16 @@ export const SingleRateSummarySection = ({
                                     )}
                                 />
                             )}
-                        {ratePrograms && (
-                            <DataDetail
-                                id="ratePrograms"
-                                label="Rates this rate certification covers"
-                                explainMissingData={explainMissingData}
-                                children={ratePrograms(
-                                    formData,
-                                    statePrograms,
-                                    false
-                                )}
-                            />
-                        )}
+                        <DataDetail
+                            id="ratePrograms"
+                            label="Rates this rate certification covers"
+                            explainMissingData={explainMissingData}
+                            children={ratePrograms(
+                                formData,
+                                statePrograms,
+                                false
+                            )}
+                        />
                         <DataDetail
                             id="rateType"
                             label="Rate certification type"

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -1,13 +1,10 @@
 import React, { useState } from 'react'
 import styles from '../SubmissionSummarySection.module.scss'
 import { DoubleColumnGrid } from '../../DoubleColumnGrid'
-import {
-    DataDetail,
-    DataDetailContactField,
-    DataDetailMissingField,
-} from '../../DataDetail'
+import { DataDetail, DataDetailContactField } from '../../DataDetail'
 import { formatCalendarDate } from '../../../common-code/dateHelpers'
 import {
+    ActuaryContact,
     Program,
     Rate,
     RateFormData,
@@ -153,6 +150,23 @@ export const SingleRateSummarySection = ({
                     : pkg.packageName,
         }))
 
+    const formatDatePeriod = (
+        startDate: Date | undefined,
+        endDate: Date | undefined
+    ): string | undefined => {
+        if (!startDate || !endDate) {
+            return undefined
+        }
+        return `${formatCalendarDate(startDate)} to ${formatCalendarDate(endDate)}`
+    }
+
+    const validateActuary = (actuary: ActuaryContact): boolean => {
+        if (!actuary?.name || !actuary?.email) {
+            return false
+        }
+        return true
+    }
+
     useDeepCompareEffect(() => {
         // get all the keys for the documents we want to zip
         async function fetchZipUrl() {
@@ -261,7 +275,7 @@ export const SingleRateSummarySection = ({
                                 <DataDetail
                                     id="historicRatePrograms"
                                     label="Programs this rate certification covers"
-                                    explainMissingData={!isSubmittedOrCMSUser}
+                                    explainMissingData={explainMissingData}
                                     children={ratePrograms(
                                         formData,
                                         statePrograms,
@@ -293,18 +307,10 @@ export const SingleRateSummarySection = ({
                                     : 'Rating period'
                             }
                             explainMissingData={explainMissingData}
-                            children={
-                                formData.rateDateStart &&
-                                formData.rateDateEnd ? (
-                                    `${formatCalendarDate(
-                                        formData.rateDateStart
-                                    )} to ${formatCalendarDate(
-                                        formData.rateDateEnd
-                                    )}`
-                                ) : (
-                                    <DataDetailMissingField />
-                                )
-                            }
+                            children={formatDatePeriod(
+                                formData.rateDateStart,
+                                formData.rateDateEnd
+                            )}
                         />
                         <DataDetail
                             id="dateCertified"
@@ -323,17 +329,16 @@ export const SingleRateSummarySection = ({
                                 id="effectiveRatingPeriod"
                                 label="Rate amendment effective dates"
                                 explainMissingData={explainMissingData}
-                                children={`${formatCalendarDate(
-                                    formData.amendmentEffectiveDateStart
-                                )} to ${formatCalendarDate(
+                                children={formatDatePeriod(
+                                    formData.amendmentEffectiveDateStart,
                                     formData.amendmentEffectiveDateEnd
-                                )}`}
+                                )}
                             />
                         ) : null}
                         <DataDetail
                             id="rateSubmissionDate"
                             label="Rate submission date"
-                            explainMissingData={!isSubmitted}
+                            explainMissingData={explainMissingData}
                             children={formatCalendarDate(
                                 rate.initiallySubmittedAt
                             )}
@@ -349,11 +354,16 @@ export const SingleRateSummarySection = ({
                             label="Certifying actuary"
                             explainMissingData={explainMissingData}
                             children={
-                                <DataDetailContactField
-                                    contact={
-                                        formData.certifyingActuaryContacts[0]
-                                    }
-                                />
+                                validateActuary(
+                                    formData.certifyingActuaryContacts[0]
+                                ) && (
+                                    <DataDetailContactField
+                                        contact={
+                                            formData
+                                                .certifyingActuaryContacts[0]
+                                        }
+                                    />
+                                )
                             }
                         />
                         {formData.addtlActuaryContacts?.length
@@ -367,9 +377,11 @@ export const SingleRateSummarySection = ({
                                               explainMissingData
                                           }
                                           children={
-                                              <DataDetailContactField
-                                                  contact={contact}
-                                              />
+                                              validateActuary(contact) && (
+                                                  <DataDetailContactField
+                                                      contact={contact}
+                                                  />
+                                              )
                                           }
                                       />
                                   )

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContactsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContactsSummarySectionV2.tsx
@@ -15,6 +15,7 @@ export type ContactsSummarySectionProps = {
     contractRev?: ContractRevision
     editNavigateTo?: string
     isStateUser: boolean
+    explainMissingData?: boolean
 }
 
 export const ContactsSummarySection = ({
@@ -22,8 +23,8 @@ export const ContactsSummarySection = ({
     contractRev,
     editNavigateTo,
     isStateUser,
+    explainMissingData,
 }: ContactsSummarySectionProps): React.ReactElement => {
-    const isSubmitted = contract.status === 'SUBMITTED'
     const contractOrRev = contractRev ? contractRev : contract
 
     const contractFormData = getVisibleLatestContractFormData(
@@ -60,7 +61,7 @@ export const ContactsSummarySection = ({
                             <DataDetail
                                 id="statecontact"
                                 label="Contact"
-                                explainMissingData={!isSubmitted}
+                                explainMissingData={explainMissingData}
                                 children={undefined}
                             />
                         )}

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContractDetailsSummarySectionV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContractDetailsSummarySectionV2.test.tsx
@@ -210,6 +210,7 @@ describe('ContractDetailsSummarySection', () => {
                     contract={contract}
                     isStateUser
                     submissionName="MN-PMAP-0001"
+                    explainMissingData
                 />,
                 {
                     apolloProvider: defaultApolloMocks,
@@ -753,6 +754,7 @@ describe('ContractDetailsSummarySection', () => {
                         submissionName="MN-PMAP-0001"
                         editNavigateTo="contract-details"
                         isStateUser
+                        explainMissingData
                     />,
                     {
                         apolloProvider: defaultApolloMocks,
@@ -797,6 +799,7 @@ describe('ContractDetailsSummarySection', () => {
                         isStateUser
                         submissionName="MN-PMAP-0001"
                         editNavigateTo="contract-details"
+                        explainMissingData
                     />,
                     {
                         apolloProvider: defaultApolloMocks,

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContractDetailsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContractDetailsSummarySectionV2.tsx
@@ -56,6 +56,7 @@ export type ContractDetailsSummarySectionV2Props = {
     isStateUser: boolean
     submissionName: string
     onDocumentError?: (error: true) => void
+    explainMissingData?: boolean
 }
 
 function renderDownloadButton(zippedFilesURL: string | undefined | Error) {
@@ -75,10 +76,10 @@ function renderDownloadButton(zippedFilesURL: string | undefined | Error) {
 export const ContractDetailsSummarySectionV2 = ({
     contract,
     contractRev,
-    isStateUser,
     editNavigateTo, // this is the edit link for the section. When this prop exists, summary section is loaded in edit mode
     submissionName,
     onDocumentError,
+    explainMissingData,
 }: ContractDetailsSummarySectionV2Props): React.ReactElement => {
     // Checks if submission is a previous submission
     const isPreviousSubmission = usePreviousSubmission()
@@ -198,9 +199,7 @@ export const ContractDetailsSummarySectionV2 = ({
                                         label={
                                             StatutoryRegulatoryAttestationQuestion
                                         }
-                                        explainMissingData={
-                                            !isSubmittedOrCMSUser
-                                        }
+                                        explainMissingData={explainMissingData}
                                         children={
                                             StatutoryRegulatoryAttestation[
                                                 attestationYesNo
@@ -217,7 +216,7 @@ export const ContractDetailsSummarySectionV2 = ({
                                 <DataDetail
                                     id="statutoryRegulatoryAttestationDescription"
                                     label="Non-compliance description"
-                                    explainMissingData={!isSubmittedOrCMSUser}
+                                    explainMissingData={explainMissingData}
                                     children={
                                         contractFormData?.statutoryRegulatoryAttestationDescription
                                     }
@@ -230,7 +229,7 @@ export const ContractDetailsSummarySectionV2 = ({
                     <DataDetail
                         id="contractExecutionStatus"
                         label="Contract status"
-                        explainMissingData={!isSubmittedOrCMSUser}
+                        explainMissingData={explainMissingData}
                         children={
                             contractFormData?.contractExecutionStatus
                                 ? ContractExecutionStatusRecord[
@@ -246,7 +245,7 @@ export const ContractDetailsSummarySectionV2 = ({
                                 ? 'Contract amendment effective dates'
                                 : 'Contract effective dates'
                         }
-                        explainMissingData={!isSubmittedOrCMSUser}
+                        explainMissingData={explainMissingData}
                         children={
                             contractFormData?.contractDateStart &&
                             contractFormData?.contractDateEnd
@@ -261,12 +260,13 @@ export const ContractDetailsSummarySectionV2 = ({
                     <DataDetail
                         id="managedCareEntities"
                         label="Managed care entities"
-                        explainMissingData={!isSubmittedOrCMSUser}
                         children={
                             contractFormData?.managedCareEntities && (
                                 <DataDetailCheckboxList
                                     list={contractFormData?.managedCareEntities}
                                     dict={ManagedCareEntityRecord}
+                                    // if showing error for missing data, then we do NOT display empty list
+                                    displayEmptyList={!explainMissingData}
                                 />
                             )
                         }
@@ -274,12 +274,13 @@ export const ContractDetailsSummarySectionV2 = ({
                     <DataDetail
                         id="federalAuthorities"
                         label="Active federal operating authority"
-                        explainMissingData={!isSubmittedOrCMSUser}
                         children={
                             applicableFederalAuthorities && (
                                 <DataDetailCheckboxList
                                     list={applicableFederalAuthorities}
                                     dict={FederalAuthorityRecord}
+                                    // if error for missing data, then we do NOT display empty list
+                                    displayEmptyList={!explainMissingData}
                                 />
                             )
                         }
@@ -295,7 +296,7 @@ export const ContractDetailsSummarySectionV2 = ({
                                     : 'This contract action includes new or modified provisions related to the following'
                             }
                             explainMissingData={
-                                provisionsAreInvalid && !isSubmittedOrCMSUser
+                                provisionsAreInvalid && explainMissingData
                             }
                         >
                             {provisionsAreInvalid ? null : (
@@ -315,7 +316,7 @@ export const ContractDetailsSummarySectionV2 = ({
                                     : 'This contract action does NOT include new or modified provisions related to the following'
                             }
                             explainMissingData={
-                                provisionsAreInvalid && !isSubmittedOrCMSUser
+                                provisionsAreInvalid && explainMissingData
                             }
                         >
                             {provisionsAreInvalid ? null : (

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.test.tsx
@@ -930,6 +930,7 @@ describe('RateDetailsSummarySection', () => {
                 editNavigateTo="rate-details"
                 submissionName="MN-PMAP-0001"
                 statePrograms={statePrograms}
+                explainMissingData
             />,
             {
                 apolloProvider,

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
@@ -24,6 +24,7 @@ import {
     RateRevision,
     RateFormData,
     HealthPlanPackageStatus,
+    ActuaryContact,
 } from '../../../../../gen/gqlClient'
 import {
     getLastContractSubmission,
@@ -41,6 +42,7 @@ export type RateDetailsSummarySectionV2Props = {
     submissionName: string
     statePrograms: Program[]
     onDocumentError?: (error: true) => void
+    explainMissingData?: boolean
 }
 
 type SharedRateCertDisplay = {
@@ -78,6 +80,7 @@ export const RateDetailsSummarySectionV2 = ({
     submissionName,
     statePrograms,
     onDocumentError,
+    explainMissingData,
 }: RateDetailsSummarySectionV2Props): React.ReactElement => {
     const { loggedInUser } = useAuth()
     const isSubmitted =
@@ -166,6 +169,16 @@ export const RateDetailsSummarySectionV2 = ({
         }
     }
 
+    const formatDatePeriod = (
+        startDate: Date | undefined,
+        endDate: Date | undefined
+    ): string | undefined => {
+        if (!startDate || !endDate) {
+            return undefined
+        }
+        return `${formatCalendarDate(startDate)} to ${formatCalendarDate(endDate)}`
+    }
+
     const getRateFormData = (rate: Rate | RateRevision): RateFormData => {
         const isRateRev = 'formData' in rate
         if (!isRateRev) {
@@ -179,6 +192,13 @@ export const RateDetailsSummarySectionV2 = ({
         } else {
             return rate.formData
         }
+    }
+
+    const validateActuary = (actuary: ActuaryContact): boolean => {
+        if (!actuary?.name || !actuary?.email) {
+            return false
+        }
+        return true
     }
 
     useDeepCompareEffect(() => {
@@ -243,208 +263,203 @@ export const RateDetailsSummarySectionV2 = ({
                     !isPreviousSubmission &&
                     renderDownloadButton(zippedFilesURL)}
             </SectionHeader>
-            {rates && rates.length > 0 ? (
-                rates.map((rate, rateIndex) => {
-                    const rateFormData = getRateFormData(rate)
-                    if (!rateFormData) {
-                        return <GenericErrorPage />
-                    }
-                    return (
-                        <SectionCard
-                            id={`rate-details-${rate.id}`}
-                            key={rate.id}
-                        >
-                            <h3
-                                aria-label={`Rate ID: ${rateFormData.rateCertificationName}`}
-                                className={styles.rateName}
-                            >
-                                {rateFormData.rateCertificationName}
-                            </h3>
-                            <dl>
-                                <DoubleColumnGrid>
-                                    {rateFormData.deprecatedRateProgramIDs
-                                        .length > 0 &&
-                                        isSubmitted && (
-                                            <DataDetail
-                                                id="historicRatePrograms"
-                                                label="Programs this rate certification covers"
-                                                explainMissingData={
-                                                    !isSubmittedOrCMSUser
-                                                }
-                                                children={ratePrograms(
-                                                    rate,
-                                                    true
-                                                )}
-                                            />
-                                        )}
-                                    {ratePrograms && (
-                                        <DataDetail
-                                            id="ratePrograms"
-                                            label="Rates this rate certification covers"
-                                            explainMissingData={
-                                                !isSubmittedOrCMSUser
-                                            }
-                                            children={ratePrograms(rate, false)}
-                                        />
-                                    )}
-                                    <DataDetail
-                                        id="rateType"
-                                        label="Rate certification type"
-                                        explainMissingData={
-                                            !isSubmittedOrCMSUser
-                                        }
-                                        children={rateCertificationType(rate)}
-                                    />
-                                    <DataDetail
-                                        id="ratingPeriod"
-                                        label={
-                                            rateFormData.rateType ===
-                                            'AMENDMENT'
-                                                ? 'Rating period of original rate certification'
-                                                : 'Rating period'
-                                        }
-                                        explainMissingData={
-                                            !isSubmittedOrCMSUser
-                                        }
-                                        children={
-                                            rateFormData.rateDateStart &&
-                                            rateFormData.rateDateEnd ? (
-                                                `${formatCalendarDate(
-                                                    rateFormData.rateDateStart
-                                                )} to ${formatCalendarDate(
-                                                    rateFormData.rateDateEnd
-                                                )}`
-                                            ) : (
-                                                <DataDetailMissingField />
-                                            )
-                                        }
-                                    />
-                                    <DataDetail
-                                        id="dateCertified"
-                                        label={
-                                            rateFormData.amendmentEffectiveDateStart
-                                                ? 'Date certified for rate amendment'
-                                                : 'Date certified'
-                                        }
-                                        explainMissingData={
-                                            !isSubmittedOrCMSUser
-                                        }
-                                        children={formatCalendarDate(
-                                            rateFormData.rateDateCertified
-                                        )}
-                                    />
-                                    {rateFormData.amendmentEffectiveDateStart ? (
-                                        <DataDetail
-                                            id="effectiveRatingPeriod"
-                                            label="Rate amendment effective dates"
-                                            explainMissingData={
-                                                !isSubmittedOrCMSUser
-                                            }
-                                            children={`${formatCalendarDate(
-                                                rateFormData.amendmentEffectiveDateStart
-                                            )} to ${formatCalendarDate(
-                                                rateFormData.amendmentEffectiveDateEnd
-                                            )}`}
-                                        />
-                                    ) : null}
-                                    <DataDetail
-                                        id="rateCapitationType"
-                                        label="Does the actuary certify capitation rates specific to each rate cell or a rate range?"
-                                        explainMissingData={
-                                            !isSubmittedOrCMSUser
-                                        }
-                                        children={rateCapitationType(rate)}
-                                    />
-                                    {rateFormData
-                                        .certifyingActuaryContacts[0] && (
-                                        <DataDetail
-                                            id="certifyingActuary"
-                                            label="Certifying actuary"
-                                            explainMissingData={
-                                                !isSubmittedOrCMSUser
-                                            }
-                                            children={
-                                                <DataDetailContactField
-                                                    contact={
-                                                        rateFormData
-                                                            .certifyingActuaryContacts[0]
-                                                    }
-                                                />
-                                            }
-                                        />
-                                    )}
-                                    {rateFormData.addtlActuaryContacts.map(
-                                        (contact, addtlContactIndex) => (
-                                            <DataDetail
-                                                key={`addtlCertifyingActuary-${addtlContactIndex}`}
-                                                id={`addtlCertifyingActuary-${addtlContactIndex}`}
-                                                label="Certifying actuary"
-                                                explainMissingData={
-                                                    !isSubmittedOrCMSUser
-                                                }
-                                                children={
-                                                    <DataDetailContactField
-                                                        contact={contact}
-                                                    />
-                                                }
-                                            />
-                                        )
-                                    )}
-                                    <DataDetail
-                                        id="communicationPreference"
-                                        label="Actuaries’ communication preference"
-                                        children={
-                                            rateFormData.actuaryCommunicationPreference &&
-                                            ActuaryCommunicationRecord[
-                                                rateFormData
-                                                    .actuaryCommunicationPreference
-                                            ]
-                                        }
-                                        explainMissingData={
-                                            !isSubmittedOrCMSUser
-                                        }
-                                    />
-                                </DoubleColumnGrid>
-                            </dl>
-                            {rateFormData.rateDocuments && (
-                                <UploadedDocumentsTable
-                                    documents={rateFormData.rateDocuments}
-                                    packagesWithSharedRateCerts={
-                                        isEditing
-                                            ? undefined
-                                            : refreshPackagesWithSharedRateCert(
+            {rates && rates.length > 0
+                ? rates.map((rate, rateIndex) => {
+                      const rateFormData = getRateFormData(rate)
+                      if (!rateFormData) {
+                          return <GenericErrorPage />
+                      }
+                      return (
+                          <SectionCard
+                              id={`rate-details-${rate.id}`}
+                              key={rate.id}
+                          >
+                              <h3
+                                  aria-label={`Rate ID: ${rateFormData.rateCertificationName}`}
+                                  className={styles.rateName}
+                              >
+                                  {rateFormData.rateCertificationName}
+                              </h3>
+                              <dl>
+                                  <DoubleColumnGrid>
+                                      {rateFormData.deprecatedRateProgramIDs
+                                          .length > 0 &&
+                                          isSubmitted && (
+                                              <DataDetail
+                                                  id="historicRatePrograms"
+                                                  label="Programs this rate certification covers"
+                                                  explainMissingData={
+                                                      explainMissingData
+                                                  }
+                                                  children={ratePrograms(
+                                                      rate,
+                                                      true
+                                                  )}
+                                              />
+                                          )}
+                                      <DataDetail
+                                          id="ratePrograms"
+                                          label="Rates this rate certification covers"
+                                          explainMissingData={
+                                              explainMissingData
+                                          }
+                                          children={ratePrograms(rate, false)}
+                                      />
+                                      <DataDetail
+                                          id="rateType"
+                                          label="Rate certification type"
+                                          explainMissingData={
+                                              explainMissingData
+                                          }
+                                          children={rateCertificationType(rate)}
+                                      />
+                                      <DataDetail
+                                          id="ratingPeriod"
+                                          label={
+                                              rateFormData.rateType ===
+                                              'AMENDMENT'
+                                                  ? 'Rating period of original rate certification'
+                                                  : 'Rating period'
+                                          }
+                                          explainMissingData={
+                                              explainMissingData
+                                          }
+                                          children={formatDatePeriod(
+                                              rateFormData.rateDateStart,
+                                              rateFormData.rateDateEnd
+                                          )}
+                                      />
+                                      <DataDetail
+                                          id="dateCertified"
+                                          label={
+                                              rateFormData.amendmentEffectiveDateStart
+                                                  ? 'Date certified for rate amendment'
+                                                  : 'Date certified'
+                                          }
+                                          explainMissingData={
+                                              explainMissingData
+                                          }
+                                          children={formatCalendarDate(
+                                              rateFormData.rateDateCertified
+                                          )}
+                                      />
+                                      {rateFormData.rateType === 'AMENDMENT' ? (
+                                          <DataDetail
+                                              id="effectiveRatingPeriod"
+                                              label="Rate amendment effective dates"
+                                              explainMissingData={
+                                                  explainMissingData
+                                              }
+                                              children={formatDatePeriod(
+                                                  rateFormData.amendmentEffectiveDateStart,
+                                                  rateFormData.amendmentEffectiveDateEnd
+                                              )}
+                                          />
+                                      ) : null}
+                                      <DataDetail
+                                          id="rateCapitationType"
+                                          label="Does the actuary certify capitation rates specific to each rate cell or a rate range?"
+                                          explainMissingData={
+                                              explainMissingData
+                                          }
+                                          children={rateCapitationType(rate)}
+                                      />
+                                      <DataDetail
+                                          id="certifyingActuary"
+                                          label="Certifying actuary"
+                                          explainMissingData={
+                                              explainMissingData
+                                          }
+                                          children={
+                                              validateActuary(
                                                   rateFormData
+                                                      .certifyingActuaryContacts[0]
+                                              ) && (
+                                                  <DataDetailContactField
+                                                      contact={
+                                                          rateFormData
+                                                              .certifyingActuaryContacts[0]
+                                                      }
+                                                  />
                                               )
-                                    }
-                                    multipleDocumentsAllowed={false}
-                                    caption="Rate certification"
-                                    documentCategory="Rate certification"
-                                    previousSubmissionDate={lastSubmittedDate}
-                                    hideDynamicFeedback={isSubmittedOrCMSUser}
-                                />
-                            )}
-                            {rateFormData.supportingDocuments && (
-                                <UploadedDocumentsTable
-                                    documents={rateFormData.supportingDocuments}
-                                    previousSubmissionDate={lastSubmittedDate}
-                                    packagesWithSharedRateCerts={
-                                        isEditing
-                                            ? undefined
-                                            : refreshPackagesWithSharedRateCert(
+                                          }
+                                      />
+                                      {rateFormData.addtlActuaryContacts.map(
+                                          (contact, addtlContactIndex) => (
+                                              <DataDetail
+                                                  key={`addtlCertifyingActuary-${addtlContactIndex}`}
+                                                  id={`addtlCertifyingActuary-${addtlContactIndex}`}
+                                                  label="Certifying actuary"
+                                                  explainMissingData={
+                                                      explainMissingData
+                                                  }
+                                                  children={
+                                                      validateActuary(
+                                                          contact
+                                                      ) && (
+                                                          <DataDetailContactField
+                                                              contact={contact}
+                                                          />
+                                                      )
+                                                  }
+                                              />
+                                          )
+                                      )}
+                                      <DataDetail
+                                          id="communicationPreference"
+                                          label="Actuaries’ communication preference"
+                                          children={
+                                              rateFormData.actuaryCommunicationPreference &&
+                                              ActuaryCommunicationRecord[
                                                   rateFormData
-                                              )
-                                    }
-                                    caption="Rate supporting documents"
-                                    documentCategory="Rate-supporting"
-                                    hideDynamicFeedback={isSubmittedOrCMSUser}
-                                />
-                            )}
-                        </SectionCard>
-                    )
-                })
-            ) : (
-                <DataDetailMissingField />
-            )}
+                                                      .actuaryCommunicationPreference
+                                              ]
+                                          }
+                                          explainMissingData={
+                                              explainMissingData
+                                          }
+                                      />
+                                  </DoubleColumnGrid>
+                              </dl>
+                              {rateFormData.rateDocuments && (
+                                  <UploadedDocumentsTable
+                                      documents={rateFormData.rateDocuments}
+                                      packagesWithSharedRateCerts={
+                                          isEditing
+                                              ? undefined
+                                              : refreshPackagesWithSharedRateCert(
+                                                    rateFormData
+                                                )
+                                      }
+                                      multipleDocumentsAllowed={false}
+                                      caption="Rate certification"
+                                      documentCategory="Rate certification"
+                                      previousSubmissionDate={lastSubmittedDate}
+                                      hideDynamicFeedback={isSubmittedOrCMSUser}
+                                  />
+                              )}
+                              {rateFormData.supportingDocuments && (
+                                  <UploadedDocumentsTable
+                                      documents={
+                                          rateFormData.supportingDocuments
+                                      }
+                                      previousSubmissionDate={lastSubmittedDate}
+                                      packagesWithSharedRateCerts={
+                                          isEditing
+                                              ? undefined
+                                              : refreshPackagesWithSharedRateCert(
+                                                    rateFormData
+                                                )
+                                      }
+                                      caption="Rate supporting documents"
+                                      documentCategory="Rate-supporting"
+                                      hideDynamicFeedback={isSubmittedOrCMSUser}
+                                  />
+                              )}
+                          </SectionCard>
+                      )
+                  })
+                : explainMissingData && <DataDetailMissingField />}
         </SectionCard>
     )
 }

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ReviewSubmitV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ReviewSubmitV2.test.tsx
@@ -5,10 +5,17 @@ import {
     fetchCurrentUserMock,
     fetchContractMockSuccess,
     mockValidStateUser,
+    mockEmptyDraftContractAndRate,
+    mockContractPackageDraft,
 } from '../../../../../testHelpers/apolloMocks'
 import { Route, Routes } from 'react-router-dom'
 import { RoutesRecord } from '../../../../../constants'
-import { mockContractPackageUnlocked } from '../../../../../testHelpers/apolloMocks/contractPackageDataMock'
+import {
+    mockContractFormData,
+    mockContractPackageUnlocked,
+} from '../../../../../testHelpers/apolloMocks/contractPackageDataMock'
+import { Contract } from '../../../../../gen/gqlClient'
+import { mockMNState } from '../../../../../common-code/healthPlanFormDataMocks/healthPlanFormData'
 
 describe('ReviewSubmit', () => {
     it('renders without errors', async () => {
@@ -321,7 +328,316 @@ describe('ReviewSubmit', () => {
             }
         )
 
-        expect(await screen.queryByText('Linked submissions')).not.toBeInTheDocument()
+        expect(
+            await screen.queryByText('Linked submissions')
+        ).not.toBeInTheDocument()
         expect(await screen.queryByText('SHARED')).not.toBeInTheDocument()
+    })
+
+    describe('Missing data error notifications', () => {
+        it('renders missing data error notifications for state user', async () => {
+            renderWithProviders(
+                <Routes>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_REVIEW_SUBMIT}
+                        element={<ReviewSubmitV2 />}
+                    />
+                </Routes>,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({ statusCode: 200 }),
+                            fetchContractMockSuccess({
+                                contract: mockEmptyDraftContractAndRate(),
+                            }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: '/submissions/test-abc-123/edit/review-and-submit',
+                    },
+                    featureFlags: {
+                        'link-rates': true,
+                        '438-attestation': true,
+                    },
+                }
+            )
+            // Expect 20 notifications, if this fails change length to what is found in test to isolate which field failed.
+            await waitFor(() => {
+                expect(
+                    screen.getAllByText(/You must provide this information/)
+                ).toHaveLength(20)
+            })
+            const text = /You must provide this information/
+
+            //Submission type summary section
+            expect(
+                within(await screen.findByTestId('submissionType')).getByText(
+                    text
+                )
+            ).toBeInTheDocument()
+            expect(
+                within(await screen.findByTestId('program')).getByText(text)
+            ).toBeInTheDocument()
+            expect(
+                within(await screen.findByTestId('contractType')).getByText(
+                    text
+                )
+            ).toBeInTheDocument()
+            expect(
+                within(
+                    await screen.findByTestId('riskBasedContract')
+                ).getByText(text)
+            ).toBeInTheDocument()
+            expect(
+                within(
+                    await screen.findByTestId('populationCoverage')
+                ).getByText(text)
+            ).toBeInTheDocument()
+            expect(
+                within(
+                    await screen.findByTestId('submissionDescription')
+                ).getByText(text)
+            ).toBeInTheDocument()
+
+            //Contract details summary section
+            expect(
+                within(
+                    await screen.findByTestId(
+                        'statutoryRegulatoryAttestationDescription'
+                    )
+                ).getByText(text)
+            ).toBeInTheDocument()
+            expect(
+                within(
+                    await screen.findByTestId('contractExecutionStatus')
+                ).getByText(text)
+            ).toBeInTheDocument()
+            expect(
+                within(
+                    await screen.findByTestId('contractEffectiveDates')
+                ).getByText(text)
+            ).toBeInTheDocument()
+            expect(
+                within(
+                    await screen.findByTestId('managedCareEntities')
+                ).getByText(text)
+            ).toBeInTheDocument()
+            expect(
+                within(
+                    await screen.findByTestId('federalAuthorities')
+                ).getByText(text)
+            ).toBeInTheDocument()
+
+            //Rate detail summary section
+            expect(
+                within(await screen.findByTestId('ratePrograms')).getByText(
+                    text
+                )
+            ).toBeInTheDocument()
+            expect(
+                within(await screen.findByTestId('rateType')).getByText(text)
+            ).toBeInTheDocument()
+            expect(
+                within(await screen.findByTestId('ratingPeriod')).getByText(
+                    text
+                )
+            ).toBeInTheDocument()
+            expect(
+                within(await screen.findByTestId('dateCertified')).getByText(
+                    text
+                )
+            ).toBeInTheDocument()
+            expect(
+                within(
+                    await screen.findByTestId('rateCapitationType')
+                ).getByText(text)
+            ).toBeInTheDocument()
+            expect(
+                within(
+                    await screen.findByTestId('certifyingActuary')
+                ).getByText(text)
+            ).toBeInTheDocument()
+            expect(
+                within(
+                    await screen.findByTestId('addtlCertifyingActuary-0')
+                ).getByText(text)
+            ).toBeInTheDocument()
+            expect(
+                within(
+                    await screen.findByTestId('communicationPreference')
+                ).getByText(text)
+            ).toBeInTheDocument()
+
+            // Contact details summary section
+            expect(
+                within(await screen.findByTestId('statecontact')).getByText(
+                    text
+                )
+            ).toBeInTheDocument()
+        })
+
+        it('renders missing modified and unmodified provisions data error notifications', async () => {
+            const draftContract: Contract = mockContractPackageDraft({
+                draftRevision: {
+                    id: '123',
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                    contractName: 'MCR-0005-alvhalfhdsalfee',
+                    formData: mockContractFormData({
+                        contractType: 'AMENDMENT',
+                        modifiedBenefitsProvided: undefined,
+                        modifiedGeoAreaServed: undefined,
+                        modifiedMedicaidBeneficiaries: undefined,
+                        modifiedRiskSharingStrategy: undefined,
+                        modifiedIncentiveArrangements: undefined,
+                        modifiedWitholdAgreements: undefined,
+                        modifiedStateDirectedPayments: undefined,
+                        modifiedPassThroughPayments: undefined,
+                        modifiedPaymentsForMentalDiseaseInstitutions: undefined,
+                        modifiedMedicalLossRatioStandards: undefined,
+                        modifiedOtherFinancialPaymentIncentive: undefined,
+                        modifiedEnrollmentProcess: undefined,
+                        modifiedGrevienceAndAppeal: undefined,
+                        modifiedNetworkAdequacyStandards: undefined,
+                        modifiedLengthOfContract: undefined,
+                        modifiedNonRiskPaymentArrangements: undefined,
+                    }),
+                },
+            })
+            renderWithProviders(
+                <Routes>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_REVIEW_SUBMIT}
+                        element={<ReviewSubmitV2 />}
+                    />
+                </Routes>,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({ statusCode: 200 }),
+                            fetchContractMockSuccess({
+                                contract: draftContract,
+                            }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: '/submissions/test-abc-123/edit/review-and-submit',
+                    },
+                    featureFlags: {
+                        'link-rates': true,
+                        '438-attestation': true,
+                    },
+                }
+            )
+
+            const modifiedProvisions =
+                await screen.findByTestId('modifiedProvisions')
+            const unmodifiedProvisions = await screen.findByTestId(
+                'unmodifiedProvisions'
+            )
+
+            await waitFor(() => {
+                expect(modifiedProvisions).toBeInTheDocument()
+                expect(unmodifiedProvisions).toBeInTheDocument()
+
+                expect(
+                    within(modifiedProvisions).getByText(
+                        /You must provide this information/
+                    )
+                ).toBeInTheDocument()
+                expect(
+                    within(unmodifiedProvisions).getByText(
+                        /You must provide this information/
+                    )
+                ).toBeInTheDocument()
+            })
+        })
+
+        it('renders missing effective rating period data error notification', async () => {
+            const draftContract: Contract = mockContractPackageDraft({
+                draftRates: [
+                    {
+                        id: '123',
+                        createdAt: new Date(),
+                        updatedAt: new Date(),
+                        status: 'DRAFT',
+                        stateCode: 'MN',
+                        revisions: [],
+                        state: mockMNState(),
+                        stateNumber: 5,
+                        parentContractID: 'test-abc-123',
+                        draftRevision: {
+                            id: '123',
+                            rateID: '456',
+                            contractRevisions: [],
+                            createdAt: new Date(),
+                            updatedAt: new Date(),
+                            formData: {
+                                rateType: 'AMENDMENT',
+                                rateCapitationType: undefined,
+                                rateDocuments: [],
+                                supportingDocuments: [],
+                                rateDateStart: undefined,
+                                rateDateEnd: undefined,
+                                rateDateCertified: undefined,
+                                amendmentEffectiveDateStart: undefined,
+                                amendmentEffectiveDateEnd: undefined,
+                                deprecatedRateProgramIDs: [],
+                                rateProgramIDs: [],
+                                certifyingActuaryContacts: [],
+                                addtlActuaryContacts: [],
+                                actuaryCommunicationPreference: undefined,
+                                packagesWithSharedRateCerts: [],
+                            },
+                        },
+                    },
+                ],
+            })
+            renderWithProviders(
+                <Routes>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_REVIEW_SUBMIT}
+                        element={<ReviewSubmitV2 />}
+                    />
+                </Routes>,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({ statusCode: 200 }),
+                            fetchContractMockSuccess({
+                                contract: draftContract,
+                            }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: '/submissions/test-abc-123/edit/review-and-submit',
+                    },
+                    featureFlags: {
+                        'link-rates': true,
+                    },
+                }
+            )
+
+            const rateType = await screen.findByTestId('rateType')
+            const effectiveRatingPeriod = await screen.findByTestId(
+                'effectiveRatingPeriod'
+            )
+
+            await waitFor(() => {
+                expect(rateType).toBeInTheDocument()
+                expect(effectiveRatingPeriod).toBeInTheDocument()
+
+                expect(
+                    within(rateType).getByText(
+                        /Amendment to prior rate certification/
+                    )
+                ).toBeInTheDocument()
+                expect(
+                    within(effectiveRatingPeriod).getByText(
+                        /You must provide this information/
+                    )
+                ).toBeInTheDocument()
+            })
+        })
     })
 })

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ReviewSubmitV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ReviewSubmitV2.tsx
@@ -114,12 +114,14 @@ export const ReviewSubmitV2 = (): React.ReactElement => {
                     editNavigateTo="../type"
                     statePrograms={statePrograms}
                     isStateUser={isStateUser}
+                    explainMissingData
                 />
                 <ContractDetailsSummarySectionV2
                     contract={contract}
                     isStateUser={isStateUser}
                     editNavigateTo="../contract-details"
                     submissionName={submissionName}
+                    explainMissingData
                 />
 
                 {isContractActionAndRateCertification && (
@@ -128,6 +130,7 @@ export const ReviewSubmitV2 = (): React.ReactElement => {
                         editNavigateTo="../rate-details"
                         submissionName={submissionName}
                         statePrograms={statePrograms}
+                        explainMissingData
                     />
                 )}
 
@@ -135,6 +138,7 @@ export const ReviewSubmitV2 = (): React.ReactElement => {
                     contract={contract}
                     isStateUser={isStateUser}
                     editNavigateTo="../contacts"
+                    explainMissingData
                 />
 
                 <PageActionsContainer

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.test.tsx
@@ -135,6 +135,7 @@ describe('SubmissionTypeSummarySection', () => {
                     editNavigateTo="submission-type"
                     submissionName="MN-PMAP-0001"
                     isStateUser={true}
+                    explainMissingData
                 />
             )
         }
@@ -164,6 +165,7 @@ describe('SubmissionTypeSummarySection', () => {
                     editNavigateTo="submission-type"
                     submissionName="MN-PMAP-0001"
                     isStateUser={true}
+                    explainMissingData
                 />
             )
         }

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/SubmissionTypeSummarySectionV2.tsx
@@ -29,6 +29,7 @@ export type SubmissionTypeSummarySectionV2Props = {
     initiallySubmittedAt?: Date
     submissionName: string
     isStateUser: boolean
+    explainMissingData?: boolean
 }
 
 export const SubmissionTypeSummarySectionV2 = ({
@@ -41,6 +42,7 @@ export const SubmissionTypeSummarySectionV2 = ({
     initiallySubmittedAt,
     submissionName,
     isStateUser,
+    explainMissingData,
 }: SubmissionTypeSummarySectionV2Props): React.ReactElement => {
     const contractOrRev = contractRev ? contractRev : contract
     const contractFormData = getVisibleLatestContractFormData(
@@ -91,7 +93,7 @@ export const SubmissionTypeSummarySectionV2 = ({
                         <DataDetail
                             id="program"
                             label="Program(s)"
-                            explainMissingData={!isSubmitted}
+                            explainMissingData={explainMissingData}
                             children={programNames}
                         />
                     )}
@@ -99,7 +101,7 @@ export const SubmissionTypeSummarySectionV2 = ({
                         <DataDetail
                             id="submissionType"
                             label="Submission type"
-                            explainMissingData={!isSubmitted}
+                            explainMissingData={explainMissingData}
                             children={
                                 SubmissionTypeRecord[
                                     contractFormData.submissionType
@@ -111,7 +113,7 @@ export const SubmissionTypeSummarySectionV2 = ({
                         <DataDetail
                             id="contractType"
                             label="Contract action type"
-                            explainMissingData={!isSubmitted}
+                            explainMissingData={explainMissingData}
                             children={
                                 contractFormData.contractType
                                     ? ContractTypeRecord[
@@ -127,7 +129,7 @@ export const SubmissionTypeSummarySectionV2 = ({
                         <DataDetail
                             id="riskBasedContract"
                             label="Is this a risk based contract"
-                            explainMissingData={!isSubmitted}
+                            explainMissingData={explainMissingData}
                             children={booleanAsYesNoUserValue(
                                 contractFormData.riskBasedContract
                             )}
@@ -137,7 +139,7 @@ export const SubmissionTypeSummarySectionV2 = ({
                         <DataDetail
                             id="populationCoverage"
                             label="Which populations does this contract action cover?"
-                            explainMissingData={!isSubmitted}
+                            explainMissingData={explainMissingData}
                             children={
                                 contractFormData.populationCovered &&
                                 PopulationCoveredRecord[
@@ -155,7 +157,7 @@ export const SubmissionTypeSummarySectionV2 = ({
                             <DataDetail
                                 id="submissionDescription"
                                 label="Submission description"
-                                explainMissingData={!isSubmitted}
+                                explainMissingData={explainMissingData}
                                 children={
                                     contractFormData.submissionDescription
                                 }

--- a/services/app-web/src/pages/SubmissionSummary/V2/SubmissionSummaryV2.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/V2/SubmissionSummaryV2.tsx
@@ -126,6 +126,7 @@ export const SubmissionSummaryV2 = (): React.ReactElement => {
     }
     const isCMSUser = loggedInUser?.role === 'CMS_USER'
     const isStateUser = loggedInUser?.role === 'STATE_USER'
+    const isHelpDeskUser = loggedInUser?.role === 'HELPDESK_USER'
     const submissionStatus = contract.status
     const statePrograms = contract.state.programs
 
@@ -159,6 +160,9 @@ export const SubmissionSummaryV2 = (): React.ReactElement => {
     const editOrAddMCCRSID = contract.mccrsID
         ? 'Edit MC-CRS number'
         : 'Add MC-CRS record number'
+    const isSubmitted =
+        contract.status === 'SUBMITTED' || contract.status === 'RESUBMITTED'
+    const explainMissingData = (isHelpDeskUser || isStateUser) && !isSubmitted
 
     return (
         <div className={styles.background}>
@@ -254,6 +258,7 @@ export const SubmissionSummaryV2 = (): React.ReactElement => {
                         statePrograms={statePrograms}
                         initiallySubmittedAt={contract.initiallySubmittedAt}
                         isStateUser={isStateUser}
+                        explainMissingData={explainMissingData}
                     />
                 }
 
@@ -264,6 +269,7 @@ export const SubmissionSummaryV2 = (): React.ReactElement => {
                         isStateUser={isStateUser}
                         submissionName={name}
                         onDocumentError={handleDocumentDownloadError}
+                        explainMissingData={explainMissingData}
                     />
                 }
 
@@ -274,6 +280,7 @@ export const SubmissionSummaryV2 = (): React.ReactElement => {
                         isCMSUser={isCMSUser}
                         statePrograms={statePrograms}
                         onDocumentError={handleDocumentDownloadError}
+                        explainMissingData={explainMissingData}
                     />
                 )}
 
@@ -281,6 +288,7 @@ export const SubmissionSummaryV2 = (): React.ReactElement => {
                     <ContactsSummarySection
                         contract={contract}
                         isStateUser={isStateUser}
+                        explainMissingData={explainMissingData}
                     />
                 }
 

--- a/services/app-web/src/testHelpers/apolloMocks/contractPackageDataMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/contractPackageDataMock.ts
@@ -1455,6 +1455,154 @@ function mockContractFormData( partial?: Partial<ContractFormData>): ContractFor
     }
 }
 
+const mockEmptyDraftContractAndRate = (): Contract => mockContractPackageDraft(
+    {
+        draftRevision: {
+            __typename: 'ContractRevision',
+            submitInfo: undefined,
+            unlockInfo: undefined,
+            id: '123',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            contractName: 'MCR-0005-alvhalfhdsalfee',
+            formData: {
+                programIDs: [],
+                populationCovered: undefined,
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                submissionType: undefined,
+                riskBasedContract: undefined,
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                submissionDescription: undefined,
+                supportingDocuments: [
+                    {
+                        s3URL: 's3://bucketname/key/contractsupporting1',
+                        sha256: 'fakesha',
+                        name: 'contractSupporting1',
+                        dateAdded: new Date('01/15/2024')
+                    },
+                    {
+                        s3URL: 's3://bucketname/key/contractSupporting2',
+                        sha256: 'fakesha',
+                        name: 'contractSupporting2',
+                        dateAdded: new Date('01/13/2024')
+                    },
+                ],
+                stateContacts: [],
+                contractType: undefined,
+                contractExecutionStatus: undefined,
+                contractDocuments: [
+                    {
+                        s3URL: 's3://bucketname/one-two/one-two.png',
+                        sha256: 'fakesha',
+                        name: 'contract document',
+                        dateAdded: new Date('01/01/2024')
+                    },
+                ],
+                contractDateStart:undefined,
+                contractDateEnd: undefined,
+                managedCareEntities: [],
+                federalAuthorities: [],
+                inLieuServicesAndSettings: undefined,
+                modifiedBenefitsProvided: undefined,
+                modifiedGeoAreaServed: undefined,
+                modifiedMedicaidBeneficiaries: undefined,
+                modifiedRiskSharingStrategy: undefined,
+                modifiedIncentiveArrangements: undefined,
+                modifiedWitholdAgreements: undefined,
+                modifiedStateDirectedPayments: undefined,
+                modifiedPassThroughPayments: undefined,
+                modifiedPaymentsForMentalDiseaseInstitutions: undefined,
+                modifiedMedicalLossRatioStandards: undefined,
+                modifiedOtherFinancialPaymentIncentive: undefined,
+                modifiedEnrollmentProcess: undefined,
+                modifiedGrevienceAndAppeal: undefined,
+                modifiedNetworkAdequacyStandards: undefined,
+                modifiedLengthOfContract: undefined,
+                modifiedNonRiskPaymentArrangements: undefined,
+                statutoryRegulatoryAttestation: false,
+                statutoryRegulatoryAttestationDescription: undefined
+            }
+        },
+        draftRates: [
+            {
+                id: '123',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                status: 'DRAFT',
+                stateCode: 'MN',
+                revisions: [],
+                state: mockMNState(),
+                stateNumber: 5,
+                parentContractID: 'test-abc-123',
+                draftRevision: {
+                    id: '123',
+                    rateID: '456',
+                    contractRevisions: [],
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                    formData: {
+                        rateType: undefined,
+                        rateCapitationType: undefined,
+                        rateDocuments: [
+                            {
+                                s3URL: 's3://bucketname/key/rate',
+                                sha256: 'fakesha',
+                                name: 'rate certification',
+                                dateAdded: new Date('01/13/2024')
+                            },
+                        ],
+                        supportingDocuments: [
+                            {
+                                s3URL: 's3://bucketname/key/ratesupporting1',
+                                sha256: 'fakesha',
+                                name: 'rateSupporting1',
+                                dateAdded: new Date('01/15/2024')
+                            },
+                            {
+                                s3URL: 's3://bucketname/key/rateSupporting2',
+                                sha256: 'fakesha',
+                                name: 'rateSupporting2',
+                                dateAdded: new Date('01/13/2024')
+                            },
+                        ],
+                        rateDateStart: undefined,
+                        rateDateEnd: undefined,
+                        rateDateCertified: undefined,
+                        amendmentEffectiveDateStart: undefined,
+                        amendmentEffectiveDateEnd: undefined,
+                        deprecatedRateProgramIDs: [],
+                        rateProgramIDs: [],
+                        certifyingActuaryContacts: [
+                            {
+                                id: null,
+                                actuarialFirmOther: null,
+                                actuarialFirm: undefined,
+                                name: '',
+                                titleRole: '',
+                                email: '',
+                            },
+                        ],
+                        addtlActuaryContacts: [
+                            {
+                                id: null,
+                                actuarialFirmOther: null,
+                                actuarialFirm: undefined,
+                                name: '',
+                                titleRole: '',
+                                email: '',
+                            },
+                        ],
+                        actuaryCommunicationPreference: undefined,
+                        packagesWithSharedRateCerts: [],
+                    }
+                }
+            },
+        ],
+    }
+)
+
 export {
     mockContractPackageDraft,
     mockContractPackageSubmitted,
@@ -1462,5 +1610,6 @@ export {
     mockContractPackageUnlocked,
     mockContractFormData,
     mockContractPackageSubmittedWithRevisions,
-    mockContractPackageWithDifferentProgramsInRevisions
+    mockContractPackageWithDifferentProgramsInRevisions,
+    mockEmptyDraftContractAndRate
 }

--- a/services/app-web/src/testHelpers/apolloMocks/index.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/index.ts
@@ -39,6 +39,7 @@ export {
     mockValidUser,
     mockValidAdminUser,
     indexUsersQueryMock,
+    mockValidHelpDeskUser
 } from './userGQLMock'
 
 export {
@@ -67,7 +68,8 @@ export {
     mockContractPackageSubmitted,
     mockContractWithLinkedRateDraft,
     mockContractPackageUnlocked,
-    mockContractPackageSubmittedWithRevisions
+    mockContractPackageSubmittedWithRevisions,
+    mockEmptyDraftContractAndRate
 } from './contractPackageDataMock'
 export { rateDataMock } from './rateDataMock'
 export { fetchContractMockSuccess, updateDraftContractRatesMockSuccess } from './contractGQLMock'

--- a/services/app-web/src/testHelpers/apolloMocks/rateDataMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/rateDataMock.ts
@@ -157,11 +157,11 @@ const rateRevisionDataMock = (data?: Partial<RateRevision>): RateRevision => {
                     packageStatus: 'SUBMITTED',
                 },
             ],
-            ...data,
             __typename: 'RateFormData',
         },
         contractRevisions: [contractRevisionOnRateDataMock()],
         __typename: 'RateRevision',
+        ...data,
     }
 }
 

--- a/services/app-web/src/testHelpers/apolloMocks/userGQLMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/userGQLMock.ts
@@ -8,6 +8,7 @@ import {
     IndexUsersDocument,
     IndexUsersQuery,
     StateUser,
+    HelpdeskUser
 } from '../../gen/gqlClient'
 
 import { mockMNState } from './stateMock'
@@ -47,6 +48,18 @@ function mockValidAdminUser(userData?: Partial<AdminUser>): AdminUser {
         __typename: 'AdminUser' as const,
         id: 'bar-id',
         role: 'ADMIN_USER',
+        givenName: 'bob',
+        familyName: 'ddmas',
+        email: 'bob@dmas.mn.gov',
+        ...userData,
+    }
+}
+
+function mockValidHelpDeskUser(userData?: Partial<HelpdeskUser>): HelpdeskUser {
+    return {
+        __typename: 'HelpdeskUser' as const,
+        id: 'bar-id',
+        role: 'HELPDESK_USER',
         givenName: 'bob',
         familyName: 'ddmas',
         email: 'bob@dmas.mn.gov',
@@ -128,4 +141,5 @@ export {
     mockValidUser,
     mockValidAdminUser,
     indexUsersQueryMock,
+    mockValidHelpDeskUser
 }


### PR DESCRIPTION
## Summary
[MCR-4195](https://jiraent.cms.gov/browse/MCR-4195)

This work refactored where we are determining when to show the missing data error notification. Before this was done at each summary section with slightly different conditions. I refactored to have this be determined at the summary page component, then passed into the summary sections. 

This made more sense since we determine the notifications based on the summary page and the user, not at each summary section component.

- `ReviewSubmitV2` is only for state users and should always notify them of any missing data, not just certain sections.
- `SubmissionRevisionSummaryV2` is for viewing historical data where notifications for missing data is not important for any user because it is no longer in review. 
- `SubmissionSummaryV2` only shows missing data notification for State and Helpdesk users only when the submission is unlocked.
   - I added a test in this for State users because there is code to show this page to State users when submission is unlocked, but I'm not sure when or how a state user would get to this page when the submission is unlocked.
- CMS users should never see the missing data notification.

Other things I did:
- Fix 404 page when help desk users click on a unlocked submission on the dashboard.
- Fix some error with `rateRevisionDataMock` test helper.
- Fixed some field not showing missing data text on summary pages.
- Fixed previous submission summary showing missing data error notification.
- Showing missing data error notification to help desk users.
- Added `mockValidHelpDeskUser` helper.
- Added tests for summary pages to catch regressions.

#### Related issues

#### Screenshots

#### Test cases covered

`ReviewSubmitV2.test.ts`
- `'renders missing data error notifications for state user'`
- `'renders missing modified and unmodified provisions data error notifications'`
- `'renders missing effective rating period data error notification'`

`SubmissionRevisionSummaryV2.test.ts`
- `'does not render missing data notification for CMS users'`
- `'does not render missing data notification for Helpdesk users'`
- `'does not render missing data notification for State users'`

`SubmissionSummaryV2.test.ts`
- `'renders missing data error notifications for helpdesk user'`
- `'renders missing data error notifications for State user'`
- `'does not render missing data error notifications for CMS user'`
- `'does not render missing data error notifications on submitted submissions'`

`SingleRateSummarySection.test.ts`
- `'should not display missing field text to CMS users'`
   - Now tests all fields.
- `'should display missing field text to state users'`
   - Now tests all fields.
- `'should display missing field text to helpdesk users'`
- `'should not display missing field text on submitted rates'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

There is not a good way to manually test all the data fields in the review app. I think the best way is to locally test this by:
- Manually pass in missing data to the components.
- Load in VAL data and go though old submissions.

<!---These are developer instructions on how to test or validate the work -->
