### PR TITLE
Fix local uploads service

### DIFF
--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -71,6 +71,11 @@ custom:
       - offline
     ssm:
       '/configuration/iam/full_permissions_boundary_policy': 'arn:aws:iam::local:policy/local/developer-boundary-policy'
+      '/configuration/default/vpc/id': 'offline'
+      '/configuration/default/vpc/sg/id': 'offline'
+      '/configuration/default/vpc/subnets/private/a/id': 'offline'
+      '/configuration/default/vpc/subnets/private/b/id': 'offline'
+      '/configuration/default/vpc/subnets/private/c/id': 'offline'
   s3:
     # address: 127.0.0.1 # this started defaulting to ipv6 which prevented tests from connecting
     # when vhostBuckets are enabled all non-localhost hostnames are re-written as buckets

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -76,6 +76,7 @@ custom:
       '/configuration/default/vpc/subnets/private/a/id': 'offline'
       '/configuration/default/vpc/subnets/private/b/id': 'offline'
       '/configuration/default/vpc/subnets/private/c/id': 'offline'
+      '/configuration/default/vpc/subnets/public/a/id': 'offline'
   s3:
     # address: 127.0.0.1 # this started defaulting to ipv6 which prevented tests from connecting
     # when vhostBuckets are enabled all non-localhost hostnames are re-written as buckets


### PR DESCRIPTION
## Summary
The local offline service for `uploads` is failing to start. It was missing a few entries to mock out ssm values for local dev environments.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4220
