### PR TITLE
Historic rate programs still appear on previous submission and rate summary pages

### DIFF
--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
@@ -61,6 +61,7 @@ describe('SingleRateSummarySection', () => {
                 name: 'Rates this rate certification covers',
             })
         ).toBeInTheDocument()
+        // this is a deprecated field but should still show if present on summary page
         expect(
             screen.getByRole('definition', {
                 name: 'Programs this rate certification covers',

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -271,11 +271,11 @@ export const SingleRateSummarySection = ({
                 <dl>
                     <DoubleColumnGrid>
                         {formData.deprecatedRateProgramIDs.length > 0 &&
-                            isSubmitted && (
+                            isSubmittedOrCMSUser && (
                                 <DataDetail
                                     id="historicRatePrograms"
                                     label="Programs this rate certification covers"
-                                    explainMissingData={explainMissingData}
+                                    explainMissingData={false} // this is a deprecated field, we never need to explain if its missing
                                     children={ratePrograms(
                                         formData,
                                         statePrograms,

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.test.tsx
@@ -5,12 +5,16 @@ import {
     mockMNState,
     fetchCurrentUserMock,
     mockValidCMSUser,
+    mockContractPackageSubmittedWithRevisions,
+    mockValidStateUser,
+    mockContractPackageUnlocked,
 } from '../../../../../testHelpers/apolloMocks'
 import { renderWithProviders } from '../../../../../testHelpers/jestHelpers'
 import { RateDetailsSummarySectionV2 as RateDetailsSummarySection } from './RateDetailsSummarySectionV2'
 import { Rate } from '../../../../../gen/gqlClient'
 import { testS3Client } from '../../../../../testHelpers/s3Helpers'
 import { ActuaryCommunicationRecord } from '../../../../../constants'
+import * as usePreviousSubmission from '../../../../../hooks/usePreviousSubmission'
 
 describe('RateDetailsSummarySection', () => {
     const draftContract = mockContractPackageDraft()
@@ -130,11 +134,19 @@ describe('RateDetailsSummarySection', () => {
         ]
     }
 
-    const apolloProvider = {
+    const apolloProviderCMSUser = {
         mocks: [
             fetchCurrentUserMock({
                 statusCode: 200,
                 user: mockValidCMSUser(),
+            }),
+        ],
+    }
+    const apolloProviderStateUser = {
+        mocks: [
+            fetchCurrentUserMock({
+                statusCode: 200,
+                user: mockValidStateUser(),
             }),
         ],
     }
@@ -150,7 +162,7 @@ describe('RateDetailsSummarySection', () => {
                 statePrograms={statePrograms}
             />,
             {
-                apolloProvider,
+                apolloProvider: apolloProviderCMSUser,
             }
         )
 
@@ -173,7 +185,7 @@ describe('RateDetailsSummarySection', () => {
                 statePrograms={statePrograms}
             />,
             {
-                apolloProvider,
+                apolloProvider: apolloProviderCMSUser,
             }
         )
 
@@ -208,7 +220,7 @@ describe('RateDetailsSummarySection', () => {
                 statePrograms={statePrograms}
             />,
             {
-                apolloProvider,
+                apolloProvider: apolloProviderCMSUser,
             }
         )
         expect(
@@ -251,7 +263,7 @@ describe('RateDetailsSummarySection', () => {
                     statePrograms={statePrograms}
                 />,
                 {
-                    apolloProvider,
+                    apolloProvider: apolloProviderCMSUser,
                 }
             )
         })
@@ -286,7 +298,7 @@ describe('RateDetailsSummarySection', () => {
                         statePrograms={statePrograms}
                     />,
                     {
-                        apolloProvider,
+                        apolloProvider: apolloProviderCMSUser,
                     }
                 )
             }
@@ -313,7 +325,7 @@ describe('RateDetailsSummarySection', () => {
                     statePrograms={statePrograms}
                 />,
                 {
-                    apolloProvider,
+                    apolloProvider: apolloProviderCMSUser,
                 }
             )
         })
@@ -351,7 +363,7 @@ describe('RateDetailsSummarySection', () => {
                     statePrograms={statePrograms}
                 />,
                 {
-                    apolloProvider,
+                    apolloProvider: apolloProviderCMSUser,
                 }
             )
         })
@@ -376,7 +388,7 @@ describe('RateDetailsSummarySection', () => {
                     statePrograms={statePrograms}
                 />,
                 {
-                    apolloProvider,
+                    apolloProvider: apolloProviderCMSUser,
                 }
             )
         })
@@ -437,7 +449,7 @@ describe('RateDetailsSummarySection', () => {
                         statePrograms={statePrograms}
                     />,
                     {
-                        apolloProvider,
+                        apolloProvider: apolloProviderCMSUser,
                     }
                 )
             }
@@ -513,7 +525,7 @@ describe('RateDetailsSummarySection', () => {
                         statePrograms={statePrograms}
                     />,
                     {
-                        apolloProvider,
+                        apolloProvider: apolloProviderCMSUser,
                     }
                 )
             }
@@ -526,6 +538,10 @@ describe('RateDetailsSummarySection', () => {
     })
 
     it('does not render download all button when on previous submission', async () => {
+        jest.spyOn(
+            usePreviousSubmission,
+            'usePreviousSubmission'
+        ).mockReturnValue(true)
         await waitFor(() =>
             renderWithProviders(
                 <RateDetailsSummarySection
@@ -534,7 +550,7 @@ describe('RateDetailsSummarySection', () => {
                     statePrograms={statePrograms}
                 />,
                 {
-                    apolloProvider,
+                    apolloProvider: apolloProviderCMSUser,
                 }
             )
         )
@@ -555,7 +571,7 @@ describe('RateDetailsSummarySection', () => {
                 statePrograms={statePrograms}
             />,
             {
-                apolloProvider,
+                apolloProvider: apolloProviderCMSUser,
             }
         )
         expect(
@@ -586,7 +602,7 @@ describe('RateDetailsSummarySection', () => {
                     statePrograms={statePrograms}
                 />,
                 {
-                    apolloProvider,
+                    apolloProvider: apolloProviderCMSUser,
                 }
             )
         }
@@ -621,7 +637,7 @@ describe('RateDetailsSummarySection', () => {
                     statePrograms={statePrograms}
                 />,
                 {
-                    apolloProvider,
+                    apolloProvider: apolloProviderCMSUser,
                 }
             )
         }
@@ -644,7 +660,7 @@ describe('RateDetailsSummarySection', () => {
                 statePrograms={statePrograms}
             />,
             {
-                apolloProvider,
+                apolloProvider: apolloProviderCMSUser,
             }
         )
         const programList = screen.getAllByRole('definition', {
@@ -667,7 +683,7 @@ describe('RateDetailsSummarySection', () => {
                 statePrograms={statePrograms}
             />,
             {
-                apolloProvider,
+                apolloProvider: apolloProviderCMSUser,
             }
         )
         const certType = screen.getAllByRole('definition', {
@@ -689,7 +705,7 @@ describe('RateDetailsSummarySection', () => {
                 statePrograms={statePrograms}
             />,
             {
-                apolloProvider,
+                apolloProvider: apolloProviderCMSUser,
             }
         )
         await waitFor(() => {
@@ -721,7 +737,7 @@ describe('RateDetailsSummarySection', () => {
                 statePrograms={statePrograms}
             />,
             {
-                apolloProvider,
+                apolloProvider: apolloProviderCMSUser,
             }
         )
         await waitFor(() => {
@@ -766,7 +782,7 @@ describe('RateDetailsSummarySection', () => {
                 statePrograms={statePrograms}
             />,
             {
-                apolloProvider,
+                apolloProvider: apolloProviderCMSUser,
             }
         )
 
@@ -800,7 +816,7 @@ describe('RateDetailsSummarySection', () => {
                 statePrograms={statePrograms}
             />,
             {
-                apolloProvider,
+                apolloProvider: apolloProviderCMSUser,
             }
         )
         await waitFor(() => {
@@ -851,7 +867,7 @@ describe('RateDetailsSummarySection', () => {
                 statePrograms={statePrograms}
             />,
             {
-                apolloProvider,
+                apolloProvider: apolloProviderCMSUser,
             }
         )
         await waitFor(() => {
@@ -895,7 +911,7 @@ describe('RateDetailsSummarySection', () => {
                 statePrograms={statePrograms}
             />,
             {
-                apolloProvider,
+                apolloProvider: apolloProviderCMSUser,
             }
         )
         await waitFor(() => {
@@ -911,7 +927,7 @@ describe('RateDetailsSummarySection', () => {
         })
     })
 
-    it('displays missing info text for unlocked submissions with only historic rate program ids', async () => {
+    it('displays missing info text for state users on unlocked submissions with only historic rate program ids', async () => {
         const draftContract = mockContractPackageDraft()
         if (
             draftContract.draftRevision &&
@@ -933,7 +949,7 @@ describe('RateDetailsSummarySection', () => {
                 explainMissingData
             />,
             {
-                apolloProvider,
+                apolloProvider: apolloProviderStateUser,
             }
         )
         await waitFor(() => {
@@ -964,7 +980,7 @@ describe('RateDetailsSummarySection', () => {
             />,
             {
                 s3Provider,
-                apolloProvider,
+                apolloProvider: apolloProviderCMSUser,
             }
         )
 
@@ -973,5 +989,85 @@ describe('RateDetailsSummarySection', () => {
                 screen.getByText('Rate document download is unavailable')
             ).toBeInTheDocument()
         })
+    })
+    it('displays deprecated fields on previous submissions viewed by state users', async () => {
+        jest.spyOn(
+            usePreviousSubmission,
+            'usePreviousSubmission'
+        ).mockReturnValue(true)
+        const draftContract = mockContractPackageSubmittedWithRevisions()
+        draftContract.packageSubmissions[0].rateRevisions[0].formData.deprecatedRateProgramIDs =
+            [statePrograms[1].id]
+        draftContract.packageSubmissions[0].rateRevisions[0].formData.rateProgramIDs =
+            []
+
+        renderWithProviders(
+            <RateDetailsSummarySection
+                contract={draftContract}
+                editNavigateTo="rate-details"
+                submissionName="MN-PMAP-0001"
+                statePrograms={statePrograms}
+                explainMissingData
+            />,
+            {
+                apolloProvider: apolloProviderStateUser,
+            }
+        )
+
+        expect(
+            screen.findByText('Programs this rate certification covers')
+        ).toBeTruthy()
+    })
+
+    it('displays deprecated fields on unlocked submissions for CMS users', async () => {
+        const contract = mockContractPackageUnlocked()
+
+        renderWithProviders(
+            <RateDetailsSummarySection
+                contract={contract}
+                editNavigateTo="rate-details"
+                submissionName="MN-PMAP-0001"
+                statePrograms={statePrograms}
+            />,
+            {
+                apolloProvider: apolloProviderCMSUser,
+            }
+        )
+
+        expect(
+            screen.findByText('Programs this rate certification covers')
+        ).toBeTruthy()
+    })
+    it('does not display deprecated fields on unlocked submissions for state users', async () => {
+        const draftContract = mockContractPackageDraft()
+        if (
+            draftContract.draftRevision &&
+            draftContract.draftRates &&
+            draftContract.draftRates[0].draftRevision
+        ) {
+            draftContract.draftRates[0].draftRevision.formData.deprecatedRateProgramIDs =
+                [statePrograms[0].id]
+            draftContract.draftRates[0].draftRevision.formData.rateProgramIDs =
+                []
+            draftContract.status = 'UNLOCKED'
+            draftContract.draftRates[0].status = 'UNLOCKED'
+        }
+
+        renderWithProviders(
+            <RateDetailsSummarySection
+                contract={draftContract}
+                editNavigateTo="rate-details"
+                submissionName="MN-PMAP-0001"
+                statePrograms={statePrograms}
+                explainMissingData
+            />,
+            {
+                apolloProvider: apolloProviderStateUser,
+            }
+        )
+
+        expect(
+            screen.queryByText('Programs this rate certification covers')
+        ).toBeNull()
     })
 })

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
@@ -94,6 +94,7 @@ export const RateDetailsSummarySectionV2 = ({
     const rates = rateRevs
         ? rateRevs
         : getVisibleLatestRateRevisions(contract, isEditing)
+
     const lastSubmittedDate =
         getLastContractSubmission(contract)?.submitInfo.updatedAt ?? null
 
@@ -284,12 +285,12 @@ export const RateDetailsSummarySectionV2 = ({
                                   <DoubleColumnGrid>
                                       {rateFormData.deprecatedRateProgramIDs
                                           .length > 0 &&
-                                          isSubmitted && (
+                                          isSubmittedOrCMSUser && (
                                               <DataDetail
                                                   id="historicRatePrograms"
                                                   label="Programs this rate certification covers"
                                                   explainMissingData={
-                                                      explainMissingData
+                                                      false // this is a deprecated field, we never need to explain if its missing
                                                   }
                                                   children={ratePrograms(
                                                       rate,

--- a/services/app-web/src/testHelpers/apolloMocks/contractPackageDataMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/contractPackageDataMock.ts
@@ -1181,7 +1181,7 @@ function mockContractPackageUnlocked(
                         amendmentEffectiveDateStart: new Date(),
                         amendmentEffectiveDateEnd: new Date(),
                         rateProgramIDs: ['abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce'],
-                        deprecatedRateProgramIDs: [],
+                        deprecatedRateProgramIDs: ['d95394e5-44d1-45df-8151-1cc1ee66f10'],
                         certifyingActuaryContacts: [
                             {
                                 actuarialFirm: 'DELOITTE',
@@ -1360,7 +1360,7 @@ function mockContractPackageUnlocked(
                         amendmentEffectiveDateStart: new Date(),
                         amendmentEffectiveDateEnd: new Date(),
                         rateProgramIDs: ['abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce'],
-                        deprecatedRateProgramIDs: [],
+                        deprecatedRateProgramIDs: ['ea16a6c0-5fc6-4df8-adac-c627e76660ab'],
                         certifyingActuaryContacts: [
                             {
                                 actuarialFirm: 'DELOITTE',


### PR DESCRIPTION
## Summary
We should still display that old rate programs field and its data
- on previous submission revision page
- on the CMS visible standalone rate summary page
- on the CMS visible submissions summary page 

The only time when this historical data field is hidden is for state users looking at review and submit and starting to edit that unlocked rate.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4206

#### Screenshots

#### Test cases covered
- does not display deprecated fields on unlocked submissions for state users
- displays deprecated fields on previous submissions viewed by state users
-  displays deprecated fields on unlocked submissions for CMS users


## QA guidance
- to evaluate this look at submission that uses the old rate programs field. probably have to use historic data  to achieve this
