### PR TITLE
MCR-4199 Adjust NEW tag logic for same date submission and previous revisions

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
@@ -164,37 +164,8 @@ function rateFormDataToDomainModel(
         rateID: rateRevision.rateID,
         rateType: rateRevision.rateType ?? undefined,
         rateCapitationType: rateRevision.rateCapitationType ?? undefined,
-        rateDocuments: rateRevision.rateDocuments
-            ? rateRevision.rateDocuments.map((doc) => {
-                  const dateAdded =
-                      previousRevision &&
-                      previousRevision.rateDocuments.includes(doc)
-                          ? previousRevision.submitInfo?.updatedAt
-                          : rateRevision.updatedAt
-
-                  return {
-                      name: doc.name,
-                      s3URL: doc.s3URL,
-                      sha256: doc.sha256,
-                      dateAdded: dateAdded ?? rateRevision.updatedAt,
-                  }
-              })
-            : [],
-        supportingDocuments: rateRevision.supportingDocuments
-            ? rateRevision.supportingDocuments.map((doc) => {
-                  const dateAdded =
-                      previousRevision &&
-                      previousRevision.supportingDocuments.includes(doc)
-                          ? previousRevision.submitInfo?.updatedAt
-                          : rateRevision.updatedAt
-                  return {
-                      name: doc.name,
-                      s3URL: doc.s3URL,
-                      sha256: doc.sha256,
-                      dateAdded: dateAdded ?? rateRevision.updatedAt,
-                  }
-              })
-            : [],
+        rateDocuments: rateRevision.rateDocuments ?? [],
+        supportingDocuments: rateRevision.supportingDocuments ?? [],
         rateDateStart: rateRevision.rateDateStart ?? undefined,
         rateDateEnd: rateRevision.rateDateEnd ?? undefined,
         rateDateCertified: rateRevision.rateDateCertified ?? undefined,
@@ -256,7 +227,6 @@ function setDateAddedForContractRevisions(
     contractRevs: ContractRevisionType[]
 ) {
     const firstSeenDate: { [sha: string]: Date } = {}
-
     for (const contractRev of contractRevs) {
         const sinceDate = contractRev.submitInfo?.updatedAt
         if (!sinceDate) break
@@ -270,6 +240,7 @@ function setDateAddedForContractRevisions(
             if (!firstSeenDate[doc.sha256]) {
                 firstSeenDate[doc.sha256] = sinceDate
             }
+
             doc.dateAdded = firstSeenDate[doc.sha256]
         }
     }
@@ -371,39 +342,10 @@ function contractFormDataToDomainModel(
                   email: contact.email ?? undefined,
               }))
             : [],
-        supportingDocuments: contractRevision.supportingDocuments
-            ? contractRevision.supportingDocuments.map((doc) => {
-                  const dateAdded =
-                      previousRevision &&
-                      previousRevision.supportingDocuments.includes(doc)
-                          ? previousRevision.submitInfo?.updatedAt
-                          : contractRevision.updatedAt
-
-                  return {
-                      name: doc.name,
-                      s3URL: doc.s3URL,
-                      sha256: doc.sha256 ?? undefined,
-                      dateAdded: dateAdded ?? contractRevision.updatedAt,
-                  }
-              })
-            : [],
+        supportingDocuments: contractRevision.supportingDocuments ?? [],
         contractExecutionStatus:
             contractRevision.contractExecutionStatus ?? undefined,
-        contractDocuments: contractRevision.contractDocuments
-            ? contractRevision.contractDocuments.map((doc) => {
-                  const dateAdded =
-                      previousRevision &&
-                      previousRevision.contractDocuments.includes(doc)
-                          ? previousRevision.submitInfo?.updatedAt
-                          : contractRevision.updatedAt
-                  return {
-                      name: doc.name,
-                      s3URL: doc.s3URL,
-                      sha256: doc.sha256 ?? undefined,
-                      dateAdded: dateAdded ?? contractRevision.updatedAt,
-                  }
-              })
-            : [],
+        contractDocuments: contractRevision.contractDocuments ?? [],
         contractDateStart: contractRevision.contractDateStart ?? undefined,
         contractDateEnd: contractRevision.contractDateEnd ?? undefined,
         managedCareEntities: contractRevision.managedCareEntities ?? undefined,

--- a/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
@@ -258,8 +258,8 @@ function setDateAddedForContractRevisions(
     const firstSeenDate: { [sha: string]: Date } = {}
 
     for (const contractRev of contractRevs) {
-        const sinceDate =
-            contractRev.submitInfo?.updatedAt || contractRev.updatedAt
+        const sinceDate = contractRev.submitInfo?.updatedAt
+        if (!sinceDate) break
         for (const doc of contractRev.formData.contractDocuments) {
             if (!firstSeenDate[doc.sha256]) {
                 firstSeenDate[doc.sha256] = sinceDate
@@ -275,14 +275,15 @@ function setDateAddedForContractRevisions(
     }
 }
 
-// setDateAddedForContractRevisions takes a list of contractRevs and sets dateAdded
+// setDateAddedForRateRevisions takes a list of rateRevs and sets dateAdded
 // for all documents based on when the doc first appears in the list. The contractRevs
 // should be in createdAt order.
 function setDateAddedForRateRevisions(rateRevs: RateRevisionType[]) {
     const firstSeenDate: { [sha: string]: Date } = {}
 
     for (const rateRev of rateRevs) {
-        const sinceDate = rateRev.submitInfo?.updatedAt || rateRev.updatedAt
+        const sinceDate = rateRev.submitInfo?.updatedAt
+        if (!sinceDate) break
         if (rateRev.formData.rateDocuments) {
             for (const doc of rateRev.formData.rateDocuments) {
                 if (!firstSeenDate[doc.sha256]) {

--- a/services/app-api/src/resolvers/contract/submitContract.test.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.test.ts
@@ -32,6 +32,7 @@ import {
 import { testLDService } from '../../testHelpers/launchDarklyHelpers'
 import { latestFormData } from '../../testHelpers/healthPlanPackageHelpers'
 import { sharedTestPrismaClient } from '../../testHelpers/storeHelpers'
+import dayjs from 'dayjs'
 
 describe('submitContract', () => {
     it('submits a contract', async () => {
@@ -913,9 +914,11 @@ describe('submitContract', () => {
 
         expect(contractRev.formData.contractDocuments).toHaveLength(1)
         expect(contractRev.formData.contractDocuments[0].name).toBe('docc1.pdf')
-        expect(contractRev.formData.contractDocuments[0].dateAdded).toBe(
-            '2024-01-01'
-        )
+        expect(
+            dayjs(contractRev.formData.contractDocuments[0].dateAdded).format(
+                'YYYY-DD-DD'
+            )
+        ).toBe('2024-01-01')
 
         expect(contractRev.formData.supportingDocuments).toHaveLength(1)
         expect(contractRev.formData.supportingDocuments[0].name).toBe(

--- a/services/app-api/src/resolvers/contract/submitContract.test.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.test.ts
@@ -915,30 +915,41 @@ describe('submitContract', () => {
         expect(contractRev.formData.contractDocuments).toHaveLength(1)
         expect(contractRev.formData.contractDocuments[0].name).toBe('docc1.pdf')
         expect(
-            dayjs(contractRev.formData.contractDocuments[0].dateAdded).format(
-                'YYYY-DD-DD'
-            )
+            dayjs
+                .tz(contractRev.formData.contractDocuments[0].dateAdded, 'UTC')
+                .format('YYYY-MM-DD')
         ).toBe('2024-01-01')
 
         expect(contractRev.formData.supportingDocuments).toHaveLength(1)
         expect(contractRev.formData.supportingDocuments[0].name).toBe(
             'docs1.pdf'
         )
-        expect(contractRev.formData.supportingDocuments[0].dateAdded).toBe(
-            '2024-01-01'
-        )
+        expect(
+            dayjs
+                .tz(
+                    contractRev.formData.supportingDocuments[0].dateAdded,
+                    'UTC'
+                )
+                .format('YYYY-MM-DD')
+        ).toBe('2024-01-01')
 
         const rateRev = fixSubmitA0.packageSubmissions[0].rateRevisions[0]
 
         expect(rateRev.formData.rateDocuments).toHaveLength(1)
         expect(rateRev.formData.rateDocuments[0].name).toBe('docr1.pdf')
-        expect(rateRev.formData.rateDocuments[0].dateAdded).toBe('2024-01-01')
+        expect(
+            dayjs
+                .tz(rateRev.formData.rateDocuments[0].dateAdded, 'UTC')
+                .format('YYYY-MM-DD')
+        ).toBe('2024-01-01')
 
         expect(rateRev.formData.supportingDocuments).toHaveLength(1)
         expect(rateRev.formData.supportingDocuments[0].name).toBe('docx1.pdf')
-        expect(rateRev.formData.supportingDocuments[0].dateAdded).toBe(
-            '2024-01-01'
-        )
+        expect(
+            dayjs
+                .tz(rateRev.formData.supportingDocuments[0].dateAdded, 'UTC')
+                .format('YYYY-MM-DD')
+        ).toBe('2024-01-01')
 
         // 2. Unlock and add more documents
         const unlockedA0Pkg = await unlockTestHealthPlanPackage(
@@ -995,51 +1006,83 @@ describe('submitContract', () => {
         expect(contractRevA1.formData.contractDocuments[0].name).toBe(
             'docc1.pdf'
         )
-        expect(contractRevA1.formData.contractDocuments[0].dateAdded).toBe(
-            '2024-01-01'
-        )
+        expect(
+            dayjs
+                .tz(
+                    contractRevA1.formData.contractDocuments[0].dateAdded,
+                    'UTC'
+                )
+                .format('YYYY-MM-DD')
+        ).toBe('2024-01-01')
 
         expect(contractRevA1.formData.contractDocuments[1].name).toBe(
             'docc2.pdf'
         )
-        expect(contractRevA1.formData.contractDocuments[1].dateAdded).toBe(
-            '2024-02-02'
-        )
+        expect(
+            dayjs
+                .tz(
+                    contractRevA1.formData.contractDocuments[1].dateAdded,
+                    'UTC'
+                )
+                .format('YYYY-MM-DD')
+        ).toBe('2024-02-02')
 
         expect(contractRevA1.formData.supportingDocuments).toHaveLength(2)
         expect(contractRevA1.formData.supportingDocuments[0].name).toBe(
             'docs1.pdf'
         )
-        expect(contractRevA1.formData.supportingDocuments[0].dateAdded).toBe(
-            '2024-01-01'
-        )
+        expect(
+            dayjs
+                .tz(
+                    contractRevA1.formData.supportingDocuments[0].dateAdded,
+                    'UTC'
+                )
+                .format('YYYY-MM-DD')
+        ).toBe('2024-01-01')
 
         expect(contractRevA1.formData.supportingDocuments[1].name).toBe(
             'docs2.pdf'
         )
-        expect(contractRevA1.formData.supportingDocuments[1].dateAdded).toBe(
-            '2024-02-02'
-        )
+        expect(
+            dayjs
+                .tz(
+                    contractRevA1.formData.supportingDocuments[1].dateAdded,
+                    'UTC'
+                )
+                .format('YYYY-MM-DD')
+        ).toBe('2024-02-02')
 
         const rateRevA1 = fixedContractA1.packageSubmissions[0].rateRevisions[0]
 
         expect(rateRevA1.formData.rateDocuments).toHaveLength(2)
         expect(rateRevA1.formData.rateDocuments[0].name).toBe('docr1.pdf')
-        expect(rateRevA1.formData.rateDocuments[0].dateAdded).toBe('2024-01-01')
+        expect(
+            dayjs
+                .tz(rateRevA1.formData.rateDocuments[0].dateAdded, 'UTC')
+                .format('YYYY-MM-DD')
+        ).toBe('2024-01-01')
 
         expect(rateRevA1.formData.rateDocuments[1].name).toBe('docr2.pdf')
-        expect(rateRevA1.formData.rateDocuments[1].dateAdded).toBe('2024-02-02')
+        expect(
+            dayjs
+                .tz(rateRevA1.formData.rateDocuments[1].dateAdded, 'UTC')
+                .format('YYYY-MM-DD')
+        ).toBe('2024-02-02')
 
         expect(rateRevA1.formData.supportingDocuments).toHaveLength(2)
         expect(rateRevA1.formData.supportingDocuments[0].name).toBe('docx1.pdf')
-        expect(rateRevA1.formData.supportingDocuments[0].dateAdded).toBe(
-            '2024-01-01'
-        )
+        expect(
+            dayjs
+                .tz(rateRevA1.formData.supportingDocuments[0].dateAdded, 'UTC')
+                .format('YYYY-MM-DD')
+        ).toBe('2024-01-01')
 
         expect(rateRevA1.formData.supportingDocuments[1].name).toBe('docx2.pdf')
-        expect(rateRevA1.formData.supportingDocuments[1].dateAdded).toBe(
-            '2024-02-02'
-        )
+        expect(
+            dayjs
+                .tz(rateRevA1.formData.supportingDocuments[1].dateAdded, 'UTC')
+                .format('YYYY-MM-DD')
+        ).toBe('2024-02-02')
     })
 
     it('handles unlock and editing rates', async () => {
@@ -1385,7 +1428,8 @@ describe('submitContract', () => {
         )
     })
 
-    it('tests actions from the diagram that Jason made', async () => {
+    // Find the change history diagram in contract-rate-change-history.md
+    it('tests actions from the MC-Review change diagram', async () => {
         const ldService = testLDService({
             'link-rates': true,
             'rate-edit-unlock': true,
@@ -1424,7 +1468,6 @@ describe('submitContract', () => {
             stateServer,
             S2draft
         )
-
         const S2 = await submitTestContract(
             stateServer,
             S2draftWithRateB.id,

--- a/services/app-api/src/resolvers/rate/fetchRate.test.ts
+++ b/services/app-api/src/resolvers/rate/fetchRate.test.ts
@@ -9,14 +9,25 @@ import {
 import { testCMSUser } from '../../testHelpers/userHelpers'
 import { submitTestRate, updateTestRate } from '../../testHelpers'
 import { v4 as uuidv4 } from 'uuid'
-import { addNewRateToTestContract, createSubmitAndUnlockTestRate, fetchTestRateById,  updateRatesInputFromDraftContract, updateTestDraftRatesOnContract,  } from '../../testHelpers/gqlRateHelpers'
+import {
+    addNewRateToTestContract,
+    createSubmitAndUnlockTestRate,
+    fetchTestRateById,
+    updateRatesInputFromDraftContract,
+    updateTestDraftRatesOnContract,
+} from '../../testHelpers/gqlRateHelpers'
 import { sharedTestPrismaClient } from '../../testHelpers/storeHelpers'
-import { createAndUpdateTestContractWithoutRates, fetchTestContract, submitTestContract} from '../../testHelpers/gqlContractHelpers'
+import {
+    createAndUpdateTestContractWithoutRates,
+    fetchTestContract,
+    submitTestContract,
+} from '../../testHelpers/gqlContractHelpers'
 import { latestFormData } from '../../testHelpers/healthPlanPackageHelpers'
+import dayjs from 'dayjs'
 
 describe('fetchRate', () => {
     const ldService = testLDService({
-        'rate-edit-unlock':  true,
+        'rate-edit-unlock': true,
     })
     it('returns correct revisions on resubmit when existing rate is edited', async () => {
         const cmsUser = testCMSUser()
@@ -213,7 +224,7 @@ describe('fetchRate', () => {
 
     it('returns the correct dateAdded for documents', async () => {
         const ldService = testLDService({
-            'link-rates':  true,
+            'link-rates': true,
         })
         const prismaClient = await sharedTestPrismaClient()
         const stateServer = await constructTestPostgresServer({
@@ -271,17 +282,31 @@ describe('fetchRate', () => {
 
         const fixSubmitA0 = await fetchTestRateById(stateServer, OneID)
         const rateRev = fixSubmitA0.revisions[0]
-        if (!rateRev.formData.rateDocuments || !rateRev.formData.rateDocuments[0]) throw new Error( 'something')
-            if (!rateRev.formData.supportingDocuments || !rateRev.formData.supportingDocuments[0]) throw new Error( 'something')
+        if (
+            !rateRev.formData.rateDocuments ||
+            !rateRev.formData.rateDocuments[0]
+        )
+            throw new Error('something')
+        if (
+            !rateRev.formData.supportingDocuments ||
+            !rateRev.formData.supportingDocuments[0]
+        )
+            throw new Error('something')
         expect(rateRev.formData.rateDocuments).toHaveLength(1)
         expect(rateRev.formData.rateDocuments[0].name).toBe('docr1.pdf')
-        expect(rateRev.formData.rateDocuments[0].dateAdded).toBe('2024-01-01')
+        expect(
+            dayjs(rateRev.formData.rateDocuments[0].dateAdded).format(
+                'YYYY-DD-DD'
+            )
+        ).toBe('2024-01-01')
 
         expect(rateRev.formData.supportingDocuments).toHaveLength(1)
         expect(rateRev.formData.supportingDocuments[0].name).toBe('docx1.pdf')
-        expect(rateRev.formData.supportingDocuments[0].dateAdded).toBe(
-            '2024-01-01'
-        )
+        expect(
+            dayjs(rateRev.formData.supportingDocuments[0].dateAdded).format(
+                'YYYY-DD-DD'
+            )
+        ).toBe('2024-01-01')
 
         // 2. Unlock and add more documents
         const unlockedA0Pkg = await unlockTestHealthPlanPackage(
@@ -332,8 +357,16 @@ describe('fetchRate', () => {
         const rateA1 = await fetchTestRateById(stateServer, OneID)
 
         const rateRevA1 = rateA1.revisions[0]
-        if (!rateRevA1.formData.rateDocuments || !rateRev.formData.rateDocuments[0]) throw new Error( 'something')
-        if (!rateRevA1.formData.supportingDocuments || !rateRev.formData.supportingDocuments[0]) throw new Error( 'something')
+        if (
+            !rateRevA1.formData.rateDocuments ||
+            !rateRev.formData.rateDocuments[0]
+        )
+            throw new Error('something')
+        if (
+            !rateRevA1.formData.supportingDocuments ||
+            !rateRev.formData.supportingDocuments[0]
+        )
+            throw new Error('something')
         expect(rateRevA1.formData.rateDocuments).toHaveLength(2)
         expect(rateRevA1.formData.rateDocuments[0].name).toBe('docr1.pdf')
         expect(rateRevA1.formData.rateDocuments[0].dateAdded).toBe('2024-01-01')
@@ -352,5 +385,4 @@ describe('fetchRate', () => {
             '2024-02-02'
         )
     })
-
 })

--- a/services/app-api/src/resolvers/rate/fetchRate.test.ts
+++ b/services/app-api/src/resolvers/rate/fetchRate.test.ts
@@ -295,17 +295,17 @@ describe('fetchRate', () => {
         expect(rateRev.formData.rateDocuments).toHaveLength(1)
         expect(rateRev.formData.rateDocuments[0].name).toBe('docr1.pdf')
         expect(
-            dayjs(rateRev.formData.rateDocuments[0].dateAdded).format(
-                'YYYY-DD-DD'
-            )
+            dayjs
+                .tz(rateRev.formData.rateDocuments[0].dateAdded, 'UTC')
+                .format('YYYY-MM-DD')
         ).toBe('2024-01-01')
 
         expect(rateRev.formData.supportingDocuments).toHaveLength(1)
         expect(rateRev.formData.supportingDocuments[0].name).toBe('docx1.pdf')
         expect(
-            dayjs(rateRev.formData.supportingDocuments[0].dateAdded).format(
-                'YYYY-DD-DD'
-            )
+            dayjs
+                .tz(rateRev.formData.supportingDocuments[0].dateAdded, 'UTC')
+                .format('YYYY-MM-DD')
         ).toBe('2024-01-01')
 
         // 2. Unlock and add more documents
@@ -369,20 +369,32 @@ describe('fetchRate', () => {
             throw new Error('something')
         expect(rateRevA1.formData.rateDocuments).toHaveLength(2)
         expect(rateRevA1.formData.rateDocuments[0].name).toBe('docr1.pdf')
-        expect(rateRevA1.formData.rateDocuments[0].dateAdded).toBe('2024-01-01')
+        expect(
+            dayjs
+                .tz(rateRevA1.formData.rateDocuments[0].dateAdded, 'UTC')
+                .format('YYYY-MM-DD')
+        ).toBe('2024-01-01')
 
         expect(rateRevA1.formData.rateDocuments[1].name).toBe('docr2.pdf')
-        expect(rateRevA1.formData.rateDocuments[1].dateAdded).toBe('2024-02-02')
+        expect(
+            dayjs
+                .tz(rateRevA1.formData.rateDocuments[1].dateAdded, 'UTC')
+                .format('YYYY-MM-DD')
+        ).toBe('2024-02-02')
 
         expect(rateRevA1.formData.supportingDocuments).toHaveLength(2)
         expect(rateRevA1.formData.supportingDocuments[0].name).toBe('docx1.pdf')
-        expect(rateRevA1.formData.supportingDocuments[0].dateAdded).toBe(
-            '2024-01-01'
-        )
+        expect(
+            dayjs
+                .tz(rateRevA1.formData.supportingDocuments[0].dateAdded, 'UTC')
+                .format('YYYY-MM-DD')
+        ).toBe('2024-01-01')
 
         expect(rateRevA1.formData.supportingDocuments[1].name).toBe('docx2.pdf')
-        expect(rateRevA1.formData.supportingDocuments[1].dateAdded).toBe(
-            '2024-02-02'
-        )
+        expect(
+            dayjs
+                .tz(rateRevA1.formData.supportingDocuments[1].dateAdded, 'UTC')
+                .format('YYYY-MM-DD')
+        ).toBe('2024-02-02')
     })
 })

--- a/services/app-api/src/resolvers/rate/submitRate.test.ts
+++ b/services/app-api/src/resolvers/rate/submitRate.test.ts
@@ -10,7 +10,7 @@ import SUBMIT_RATE from '../../../../app-graphql/src/mutations/submitRate.graphq
 import FETCH_RATE from '../../../../app-graphql/src/queries/fetchRate.graphql'
 import UNLOCK_RATE from '../../../../app-graphql/src/mutations/unlockRate.graphql'
 import {
-    clearDocMetadataFromRateFormData,
+    clearMetadataFromRateFormData,
     submitTestRate,
     updateTestRate,
 } from '../../testHelpers'
@@ -83,8 +83,8 @@ describe('submitRate', () => {
         // expect status to be submitted.
         expect(submittedRate.status).toBe('RESUBMITTED')
         // expect formData to be the same
-        expect(clearDocMetadataFromRateFormData(submittedRateFormData)).toEqual(
-            clearDocMetadataFromRateFormData(draftFormData)
+        expect(clearMetadataFromRateFormData(submittedRateFormData)).toEqual(
+            clearMetadataFromRateFormData(draftFormData)
         )
     })
     it('can submit rate with formData updates', async () => {
@@ -198,8 +198,8 @@ describe('submitRate', () => {
 
         // expect formData to be the same
 
-        expect(clearDocMetadataFromRateFormData(submittedRateFormData)).toEqual(
-            clearDocMetadataFromRateFormData(draftFormData)
+        expect(clearMetadataFromRateFormData(submittedRateFormData)).toEqual(
+            clearMetadataFromRateFormData(draftFormData)
         )
     })
 

--- a/services/app-api/src/resolvers/rate/submitRate.test.ts
+++ b/services/app-api/src/resolvers/rate/submitRate.test.ts
@@ -9,7 +9,11 @@ import { testStateUser, testCMSUser } from '../../testHelpers/userHelpers'
 import SUBMIT_RATE from '../../../../app-graphql/src/mutations/submitRate.graphql'
 import FETCH_RATE from '../../../../app-graphql/src/queries/fetchRate.graphql'
 import UNLOCK_RATE from '../../../../app-graphql/src/mutations/unlockRate.graphql'
-import { submitTestRate, updateTestRate } from '../../testHelpers'
+import {
+    clearDocMetadataFromRateFormData,
+    submitTestRate,
+    updateTestRate,
+} from '../../testHelpers'
 import SUBMIT_HEALTH_PLAN_PACKAGE from '../../../../app-graphql/src/mutations/submitHealthPlanPackage.graphql'
 import {
     addLinkedRateToTestContract,
@@ -79,7 +83,9 @@ describe('submitRate', () => {
         // expect status to be submitted.
         expect(submittedRate.status).toBe('RESUBMITTED')
         // expect formData to be the same
-        expect(submittedRateFormData).toEqual(draftFormData)
+        expect(clearDocMetadataFromRateFormData(submittedRateFormData)).toEqual(
+            clearDocMetadataFromRateFormData(draftFormData)
+        )
     })
     it('can submit rate with formData updates', async () => {
         const stateUser = testStateUser()
@@ -189,8 +195,12 @@ describe('submitRate', () => {
         expect(submittedRate).toBeDefined()
         // expect status to be submitted.
         expect(submittedRate.status).toBe('RESUBMITTED')
+
         // expect formData to be the same
-        expect(submittedRateFormData).toEqual(draftFormData)
+
+        expect(clearDocMetadataFromRateFormData(submittedRateFormData)).toEqual(
+            clearDocMetadataFromRateFormData(draftFormData)
+        )
     })
 
     it('returns the latest linked contracts', async () => {

--- a/services/app-api/src/testHelpers/documentHelpers.ts
+++ b/services/app-api/src/testHelpers/documentHelpers.ts
@@ -1,4 +1,8 @@
-import type { GenericDocument } from '../gen/gqlServer'
+import type {
+    ContractFormData,
+    GenericDocument,
+    RateFormData,
+} from '../gen/gqlServer'
 
 // Clear document metadata that is added by API
 // enables direct compare between document lists (created by FE and submitted by users)
@@ -12,4 +16,28 @@ const clearDocMetadata = (documents?: GenericDocument[]): GenericDocument[] => {
     })
 }
 
-export { clearDocMetadata }
+const clearDocMetadataFromContractFormData = (
+    contractForm: ContractFormData
+): ContractFormData => {
+    return {
+        ...contractForm,
+        contractDocuments: clearDocMetadata(contractForm.contractDocuments),
+        supportingDocuments: clearDocMetadata(contractForm.supportingDocuments),
+    }
+}
+
+const clearDocMetadataFromRateFormData = (
+    rateForm: RateFormData
+): RateFormData => {
+    return {
+        ...rateForm,
+        rateDocuments: clearDocMetadata(rateForm.rateDocuments),
+        supportingDocuments: clearDocMetadata(rateForm.supportingDocuments),
+    }
+}
+
+export {
+    clearDocMetadata,
+    clearDocMetadataFromRateFormData,
+    clearDocMetadataFromContractFormData,
+}

--- a/services/app-api/src/testHelpers/documentHelpers.ts
+++ b/services/app-api/src/testHelpers/documentHelpers.ts
@@ -16,7 +16,7 @@ const clearDocMetadata = (documents?: GenericDocument[]): GenericDocument[] => {
     })
 }
 
-const clearDocMetadataFromContractFormData = (
+const clearMetadataFromContractFormData = (
     contractForm: ContractFormData
 ): ContractFormData => {
     return {
@@ -26,7 +26,7 @@ const clearDocMetadataFromContractFormData = (
     }
 }
 
-const clearDocMetadataFromRateFormData = (
+const clearMetadataFromRateFormData = (
     rateForm: RateFormData
 ): RateFormData => {
     return {
@@ -38,6 +38,6 @@ const clearDocMetadataFromRateFormData = (
 
 export {
     clearDocMetadata,
-    clearDocMetadataFromRateFormData,
-    clearDocMetadataFromContractFormData,
+    clearMetadataFromRateFormData,
+    clearMetadataFromContractFormData,
 }

--- a/services/app-api/src/testHelpers/gqlRateHelpers.ts
+++ b/services/app-api/src/testHelpers/gqlRateHelpers.ts
@@ -21,6 +21,7 @@ import type { RateType } from '../domain-models'
 import type { ApolloServer } from 'apollo-server-lambda'
 import type { RateFormEditableType } from '../domain-models/contractAndRates'
 import { createAndSubmitTestContractWithRate } from './gqlContractHelpers'
+import { clearDocMetadata } from './documentHelpers'
 
 const fetchTestRateById = async (
     server: ApolloServer,
@@ -263,8 +264,8 @@ function formatRateDataForSending(
     return {
         rateType: rateFormData.rateType,
         rateCapitationType: rateFormData.rateCapitationType,
-        rateDocuments: rateFormData.rateDocuments,
-        supportingDocuments: rateFormData.supportingDocuments,
+        rateDocuments: clearDocMetadata(rateFormData.rateDocuments),
+        supportingDocuments: clearDocMetadata(rateFormData.supportingDocuments),
         rateDateStart: rateFormData.rateDateStart,
         rateDateEnd: rateFormData.rateDateEnd,
         rateDateCertified: rateFormData.rateDateCertified,

--- a/services/app-api/src/testHelpers/index.ts
+++ b/services/app-api/src/testHelpers/index.ts
@@ -38,4 +38,8 @@ export {
     // updateTestContract,
 } from './gqlContractHelpers'
 
-export { clearDocMetadata } from './documentHelpers'
+export {
+    clearDocMetadata,
+    clearDocMetadataFromContractFormData,
+    clearDocMetadataFromRateFormData,
+} from './documentHelpers'

--- a/services/app-api/src/testHelpers/index.ts
+++ b/services/app-api/src/testHelpers/index.ts
@@ -40,6 +40,6 @@ export {
 
 export {
     clearDocMetadata,
-    clearDocMetadataFromContractFormData,
-    clearDocMetadataFromRateFormData,
+    clearMetadataFromContractFormData,
+    clearMetadataFromRateFormData,
 } from './documentHelpers'

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -866,7 +866,7 @@ type GenericDocument {
     "The sha256 is a unique string representing the file, generated on the FE currently in the FileUpload component"
     sha256: String!
     "The first date this document was added to submitted package - if still an initial draft, this date is last updated, otherwise it is the submitInfo lastUpdated"
-    dateAdded: Date
+    dateAdded: DateTime
 }
 
 """
@@ -882,7 +882,7 @@ input GenericDocumentInput {
     "The sha256 is a unique string representing the file, generated on the FE currently in the FileUpload component"
     sha256: String!
      "The first date this document was added to submitted package - this is ignored on input and regenerated on return"
-    dateAdded: Date
+    dateAdded: DateTime
 }
 
 "The large overarching population of people that the program covers."

--- a/services/app-web/package.json
+++ b/services/app-web/package.json
@@ -113,7 +113,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-error-boundary": "^4.0.10",
-        "react-router-dom": "^6.5.0",
+        "react-router-dom": "^6.23.1",
         "react-select": "^5.7.7",
         "sass": "^1.49.11",
         "typescript": "^4.4.4",

--- a/services/app-web/src/common-code/dateHelpers/dayjs.ts
+++ b/services/app-web/src/common-code/dateHelpers/dayjs.ts
@@ -5,6 +5,7 @@ import timezone from 'dayjs/plugin/timezone'
 import utc from 'dayjs/plugin/utc'
 import duration from 'dayjs/plugin/duration'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
 
 dayjs.extend(utc)
 dayjs.extend(advancedFormat)
@@ -12,5 +13,6 @@ dayjs.extend(timezone)
 dayjs.extend(isLeapYear)
 dayjs.extend(duration)
 dayjs.extend(customParseFormat)
+dayjs.extend(isSameOrAfter)
 
 export { dayjs }

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.test.tsx
@@ -189,9 +189,8 @@ describe('SingleRateSummarySection', () => {
         expect(
             within(rateDocsTable).getByText(rateDoc.name)
         ).toBeInTheDocument()
-        expect(
-            within(within(rateDocsTable).getByTestId('tag')).getByText('SHARED')
-        ).toBeInTheDocument()
+        expect(within(rateDocsTable).getByText('SHARED')).toBeInTheDocument()
+        expect(within(rateDocsTable).getByText('NEW')).toBeInTheDocument()
         expect(
             within(rateDocsTable).getByText(
                 `${linkedSubmissionOne.packageName} (Draft)`

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
@@ -259,31 +259,31 @@ describe('UploadedDocumentsTable', () => {
             })
         })
     })
-    it('renders the NEW tag when a document is submitted after the last submission', async () => {
+    it('renders the NEW tag when a document is submitted after the last submission, even if same day', async () => {
         const testDocuments: GenericDocument[] = [
             {
                 s3URL: 's3://foo/bar/test-1',
                 name: 'supporting docs test 1',
                 sha256: 'fakesha',
-                dateAdded: new Date('03/25/2022'),
+                dateAdded: new Date('06/30/2024'), // this is NEW, several days later
             },
             {
                 s3URL: 's3://foo/bar/test-2',
                 name: 'supporting docs test 2',
                 sha256: 'fakesha1',
-                dateAdded: new Date('03/26/2022'),
+                dateAdded: new Date('2024-06-03T14:24:16.244Z'), // this is NEW, same day
             },
             {
                 s3URL: 's3://foo/bar/test-3',
                 name: 'supporting docs test 3',
                 sha256: 'fakesha2',
-                dateAdded: new Date('03/27/2022'),
+                dateAdded: new Date('2024-06-03T08:08:16.244Z'), // this old, from earlier same day
             },
         ]
         renderWithProviders(
             <UploadedDocumentsTable
                 documents={testDocuments}
-                previousSubmissionDate={new Date('03/26/2022')}
+                previousSubmissionDate={new Date('2024-06-03T14:24:16.244Z')}
                 caption="Contract supporting"
                 documentCategory="Contract-supporting"
                 isSupportingDocuments
@@ -301,7 +301,8 @@ describe('UploadedDocumentsTable', () => {
             }
         )
         await waitFor(() => {
-            expect(screen.getByTestId('tag')).toHaveTextContent('NEW')
+            expect(screen.getAllByTestId('tag')).toHaveLength(2)
+            expect(screen.getAllByText('NEW')).toHaveLength(2)
         })
     })
 
@@ -554,7 +555,12 @@ describe('UploadedDocumentsTable', () => {
             />,
             {
                 apolloProvider: {
-                    mocks: [fetchCurrentUserMock({ user: mockValidStateUser(), statusCode: 200 })],
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidStateUser(),
+                            statusCode: 200,
+                        }),
+                    ],
                 },
                 featureFlags: {
                     'link-rates': true,
@@ -563,7 +569,9 @@ describe('UploadedDocumentsTable', () => {
         )
 
         expect(await screen.findByTestId('tag')).toHaveTextContent('SHARED')
-        expect(await screen.findByText('Linked submissions')).toBeInTheDocument()
+        expect(
+            await screen.findByText('Linked submissions')
+        ).toBeInTheDocument()
     })
 
     it('does not render SHARED tag to state user on review submit when linked rates flag on', async () => {
@@ -610,7 +618,9 @@ describe('UploadedDocumentsTable', () => {
         )
 
         expect(await screen.findByTestId('tag')).not.toBeInTheDocument()
-        expect(await screen.queryByText('Linked submissions')).not.toBeInTheDocument()
+        expect(
+            await screen.queryByText('Linked submissions')
+        ).not.toBeInTheDocument()
     })
 
     it('does not validations when hideDynamicFeedback is set to true', async () => {

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { Link } from '@trussworks/react-uswds'
 import { NavLink } from 'react-router-dom'
-import dayjs from 'dayjs'
+import { dayjs } from '../../../common-code/dateHelpers/dayjs'
 import styles from './UploadedDocumentsTable.module.scss'
 import {
     SharedRateCertDisplay,
@@ -66,11 +66,11 @@ export const UploadedDocumentsTable = ({
         useState<DocumentWithS3Data[]>(initialDocState)
     const shouldShowEditButton = !hideDynamicFeedback && isSupportingDocuments // at this point only contract supporting documents need the inline EDIT button - this can be deleted when we move supporting docs to ContractDetails page
 
-
-    const useLinkedRates = ldClient?.variation(
-        featureFlags.LINK_RATES.flag,
-        featureFlags.LINK_RATES.defaultValue
-    ) ?? false
+    const useLinkedRates =
+        ldClient?.variation(
+            featureFlags.LINK_RATES.flag,
+            featureFlags.LINK_RATES.defaultValue
+        ) ?? false
 
     // canDisplayDateForDocument -  guards against passing in null or undefined to dayjs
     // don't display on new initial submission
@@ -88,14 +88,19 @@ export const UploadedDocumentsTable = ({
         }
 
         if (!previousSubmissionDate) {
-            return false // this document is on an initial submission or not submitted yet
+            return false // design require, don't show new tags on initial submission
         }
-        return doc.dateAdded > previousSubmissionDate
+        // compare the last submission with this documents first seen on package date (date added)
+        return dayjs(doc.dateAdded).isSameOrAfter(previousSubmissionDate)
     }
 
     // show legacy shared rates across submissions (this is feature replaced by linked rates)
     // to cms users always when data available, to state users only when linked rates flag is off
-    const showLegacySharedRatesAcross = Boolean((useLinkedRates && hideDynamicFeedback? !isStateUser: true) && (packagesWithSharedRateCerts && packagesWithSharedRateCerts.length > 0))
+    const showLegacySharedRatesAcross = Boolean(
+        (useLinkedRates && hideDynamicFeedback ? !isStateUser : true) &&
+            packagesWithSharedRateCerts &&
+            packagesWithSharedRateCerts.length > 0
+    )
 
     const borderTopGradientStyles = `borderTopLinearGradient ${styles.uploadedDocumentsTable}`
     const supportingDocsTopMarginStyles = isSupportingDocuments

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
@@ -91,7 +91,9 @@ export const UploadedDocumentsTable = ({
             return false // design require, don't show new tags on initial submission
         }
         // compare the last submission with this documents first seen on package date (date added)
-        return dayjs(doc.dateAdded).isSameOrAfter(previousSubmissionDate)
+        return dayjs(doc.dateAdded)
+            .utc()
+            .isSameOrAfter(dayjs(previousSubmissionDate).utc())
     }
 
     // show legacy shared rates across submissions (this is feature replaced by linked rates)

--- a/services/app-web/src/gqlHelpers/contractsAndRates.ts
+++ b/services/app-web/src/gqlHelpers/contractsAndRates.ts
@@ -34,7 +34,7 @@ function getVisibleLatestRateRevisions(contract: Contract, isEditing: boolean): 
                 }
                 rateRevs.push(lastRateSubmission)
             }
-        } 
+        }
         return rateRevs
     } else {
         const lastContractSubmission = getLastContractSubmission(contract)
@@ -64,6 +64,11 @@ const getLastContractSubmission = (contract: Contract): ContractPackageSubmissio
     return (contract.packageSubmissions && contract.packageSubmissions[0]) ?? undefined
 }
 
+const getPackageSubmissionAtIndex = (contract: Contract, indx: number): ContractPackageSubmission | undefined => {
+    return (contract.packageSubmissions[indx]) ?? undefined
+}
+// revisionVersion is a integer used in the URLs for previous submission - numbering the submission in order from first submitted
+const getIndexFromRevisionVersion = (contract: Contract, revisionVersion: number) => contract.packageSubmissions.length - (Number(revisionVersion) - 1)
 const getDraftRates = (contract: Contract): Rate[] | undefined => {
     return (contract.draftRates && contract.draftRates[0]) ? contract.draftRates : undefined
 }
@@ -84,4 +89,4 @@ const getActuaryFirm = (actuaryContact: ActuaryContact): string => {
     }
 }
 
-export {getDraftRates, getLastContractSubmission, getVisibleLatestContractFormData, getVisibleLatestRateRevisions, getActuaryFirm}
+export {getDraftRates, getLastContractSubmission, getVisibleLatestContractFormData, getVisibleLatestRateRevisions, getActuaryFirm, getPackageSubmissionAtIndex, getIndexFromRevisionVersion}

--- a/services/app-web/src/pages/MccrsId/MccrsId.tsx
+++ b/services/app-web/src/pages/MccrsId/MccrsId.tsx
@@ -34,13 +34,9 @@ export interface MccrsIdFormValues {
 type FormError =
     FormikErrors<MccrsIdFormValues>[keyof FormikErrors<MccrsIdFormValues>]
 
-type RouteParams = {
-    id: string
-}
-
 export const MccrsId = (): React.ReactElement => {
     const [shouldValidate, setShouldValidate] = React.useState(true)
-    const { id } = useParams<keyof RouteParams>()
+    const { id } = useParams()
     if (!id) {
         throw new Error(
             'PROGRAMMING ERROR: id param not set in state submission form.'

--- a/services/app-web/src/pages/RateSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.tsx
@@ -13,17 +13,13 @@ import { useAuth } from '../../contexts/AuthContext'
 import { ErrorForbiddenPage } from '../Errors/ErrorForbiddenPage'
 import { Error404 } from '../Errors/Error404Page'
 
-type RouteParams = {
-    id: string
-}
-
 export const RateSummary = (): React.ReactElement => {
     // Page level state
     const { loggedInUser } = useAuth()
     const { updateHeading } = usePage()
     const navigate = useNavigate()
     const [rateName, setRateName] = useState<string | undefined>(undefined)
-    const { id } = useParams<keyof RouteParams>()
+    const { id } = useParams()
     if (!id) {
         throw new Error(
             'PROGRAMMING ERROR: id param not set in state submission form.'

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContractDetailsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ContractDetailsSummarySectionV2.tsx
@@ -44,9 +44,12 @@ import {
 import { SectionCard } from '../../../../../components/SectionCard'
 import { Contract, ContractRevision } from '../../../../../gen/gqlClient'
 import {
+    getIndexFromRevisionVersion,
     getLastContractSubmission,
+    getPackageSubmissionAtIndex,
     getVisibleLatestContractFormData,
 } from '../../../../../gqlHelpers/contractsAndRates'
+import { useParams } from 'react-router-dom'
 
 export type ContractDetailsSummarySectionV2Props = {
     contract: Contract
@@ -90,6 +93,7 @@ export const ContractDetailsSummarySectionV2 = ({
     >(undefined)
     const ldClient = useLDClient()
     const { loggedInUser } = useAuth()
+    const { revisionVersion } = useParams()
     const isSubmittedOrCMSUser =
         contract.status === 'SUBMITTED' ||
         contract.status === 'RESUBMITTED' ||
@@ -170,8 +174,16 @@ export const ContractDetailsSummarySectionV2 = ({
         submissionName,
         isPreviousSubmission,
     ])
-    const lastSubmittedDate =
-        getLastContractSubmission(contract)?.submitInfo.updatedAt ?? null
+    // Calculate last submitted data for document upload tables
+    const lastSubmittedIndex = getIndexFromRevisionVersion(
+        contract,
+        Number(revisionVersion)
+    )
+    const lastSubmittedDate = isPreviousSubmission
+        ? getPackageSubmissionAtIndex(contract, lastSubmittedIndex)?.submitInfo
+              .updatedAt
+        : getLastContractSubmission(contract)?.submitInfo.updatedAt ?? null
+
     return (
         <SectionCard
             id="contractDetailsSection"

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.tsx
@@ -20,14 +20,9 @@ import { useFetchHealthPlanPackageWrapper } from '../../gqlHelpers'
 import { ApolloError } from '@apollo/client'
 import { handleApolloError } from '../../gqlHelpers/apolloErrors'
 
-type RouteParams = {
-    id: string
-    revisionVersion: string
-}
-
 export const SubmissionRevisionSummary = (): React.ReactElement => {
     // Page level state
-    const { id, revisionVersion } = useParams<keyof RouteParams>()
+    const { id, revisionVersion } = useParams()
     if (!id) {
         throw new Error(
             'PROGRAMMING ERROR: id param not set in state submission form.'

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummaryV2.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummaryV2.tsx
@@ -17,14 +17,9 @@ import {
 } from '../StateSubmission/ErrorOrLoadingPage'
 import { Error404 } from '../Errors/Error404Page'
 
-type RouteParams = {
-    id: string
-    revisionVersion: string
-}
-
 export const SubmissionRevisionSummaryV2 = (): React.ReactElement => {
     // Page level state
-    const { id, revisionVersion } = useParams<keyof RouteParams>()
+    const { id, revisionVersion } = useParams()
     if (!id) {
         throw new Error(
             'PROGRAMMING ERROR: id param not set in state submission form.'

--- a/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
@@ -41,12 +41,8 @@ export type SideNavOutletContextType = {
     user: User
 }
 
-type RouteParams = {
-    id: string
-}
-
 export const SubmissionSideNav = () => {
-    const { id } = useParams<keyof RouteParams>()
+    const { id } = useParams()
     if (!id) {
         throw new Error(
             'PROGRAMMING ERROR: id param not set in state submission form.'

--- a/services/app-web/src/testHelpers/apolloMocks/rateDataMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/rateDataMock.ts
@@ -99,7 +99,7 @@ const rateRevisionDataMock = (data?: Partial<RateRevision>): RateRevision => {
                     name: 'rate-document.pdf',
                     s3URL: 's3://bucketname/key/rate-document',
                     sha256: 'fakeSha',
-                    dateAdded: new Date()
+                    dateAdded: new Date() // new document
                 },
             ],
             supportingDocuments: [
@@ -108,7 +108,7 @@ const rateRevisionDataMock = (data?: Partial<RateRevision>): RateRevision => {
                     name: 'rate-supporting-document.pdf',
                     s3URL: 's3://bucketname/key/rate-supporting-document',
                     sha256: 'fakeSha',
-                    dateAdded: new Date()
+                    dateAdded: new Date('10/01/2023') //existing document
                 },
             ],
             rateDateStart: '2023-02-01',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8468,10 +8468,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@remix-run/router@1.15.2":
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.15.2.tgz#35726510d332ba5349c6398d13259d5da184553d"
-  integrity sha512-+Rnav+CaoTE5QJc4Jcwh5toUpnVLKYbpU6Ys0zqbakqbaLQHeglLVHPfxOiQqdNmUy5C2lXz5dwC6tQNX2JW2Q==
+"@remix-run/router@1.16.1":
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.16.1.tgz#73db3c48b975eeb06d0006481bde4f5f2d17d1cd"
+  integrity sha512-es2g3dq6Nb07iFxGk5GuHN20RwBZOsuDQN7izWIisUcv9r+d2C5jQxqmgkdebXgReWfiyUabcki6Fg77mSNrig==
 
 "@repeaterjs/repeater@^3.0.4":
   version "3.0.5"
@@ -27144,20 +27144,20 @@ react-refresh@^0.11.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
-react-router-dom@^6.5.0:
-  version "6.22.2"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.22.2.tgz#8233968a8a576f3006e5549c80f3527d2598fc9c"
-  integrity sha512-WgqxD2qySEIBPZ3w0sHH+PUAiamDeszls9tzqMPBDA1YYVucTBXLU7+gtRfcSnhe92A3glPnvSxK2dhNoAVOIQ==
+react-router-dom@^6.23.1:
+  version "6.23.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.23.1.tgz#30cbf266669693e9492aa4fc0dde2541ab02322f"
+  integrity sha512-utP+K+aSTtEdbWpC+4gxhdlPFwuEfDKq8ZrPFU65bbRJY+l706qjR7yaidBpo3MSeA/fzwbXWbKBI6ftOnP3OQ==
   dependencies:
-    "@remix-run/router" "1.15.2"
-    react-router "6.22.2"
+    "@remix-run/router" "1.16.1"
+    react-router "6.23.1"
 
-react-router@6.22.2:
-  version "6.22.2"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.22.2.tgz#27e77e4c635a5697693b922d131d773451c98a5b"
-  integrity sha512-YD3Dzprzpcq+tBMHBS822tCjnWD3iIZbTeSXMY9LPSG541EfoBGyZ3bS25KEnaZjLcmQpw2AVLkFyfgXY8uvcw==
+react-router@6.23.1:
+  version "6.23.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.23.1.tgz#d08cbdbd9d6aedc13eea6e94bc6d9b29cb1c4be9"
+  integrity sha512-fzcOaRF69uvqbbM7OhvQyBTFDVrrGlsFdS3AL+1KfIBtGETibHzi3FkoTRyiDJnWNc2VxrfvR+657ROHjaNjqQ==
   dependencies:
-    "@remix-run/router" "1.15.2"
+    "@remix-run/router" "1.16.1"
 
 react-scripts@5.0.1:
   version "5.0.1"
@@ -29408,7 +29408,16 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -29567,7 +29576,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -29580,6 +29589,13 @@ strip-ansi@^3.0.1:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -32176,7 +32192,7 @@ worker-rpc@^0.1.0:
   dependencies:
     microevent.ts "~0.1.1"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -32189,6 +32205,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Summary
The bugs here are two specific cases 
1. when submit unlock resubmit happen on same day our date added was off
2. or, when viewing previous subission pages our date added was off 

Resolved this by:
- Fix NEW tag display for same date submissions by using DateTime graphql schema type
- Fix NEW tag display for previous submissions by making sure the `lastSubmittedDate` is based on the submission preceeding the current version being displayed 
- Upgrade react-router-dom minor versions to clean up types for router params
- Use timezone aware `isSameOrAfter` date comparison function from dayjs to determine NEW tag

#### Related issues
https://jiraent.cms.gov/browse/MCR-4199

#### Test cases covered
- renders the NEW tag when a document is submitted after the last submission, even if same day

## QA guidance
- Create and resubmit a package and check new package display is correct both on the current page and on the previous summary pages that are viewed from change history 
- Remember design rules around this feature  (also written into the code) - we do not display the new tag for state users, we do not display new tag on the initial submission. 
