### PR TITLE
MCR-4024: Fix cypress tests for linked rates

### DIFF
--- a/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsTable.tsx
+++ b/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsTable.tsx
@@ -54,7 +54,7 @@ declare module '@tanstack/table-core' {
 export type RateInDashboardType = {
     id: string
     name: string
-    rateNumber: number,
+    rateNumber: number
     submittedAt: string
     updatedAt: Date
     status: HealthPlanPackageStatus
@@ -251,6 +251,7 @@ export const RateReviewsTable = ({
                         asCustom={NavLink}
                         to={rateURL(info.getValue())}
                         className={`${styles.ID}`}
+                        data-testid={`rate-link-${info.getValue().id}`}
                     >
                         {info.getValue().name}
                     </Link>
@@ -343,7 +344,7 @@ export const RateReviewsTable = ({
         ),
         initialState: {
             columnVisibility: {
-              rateNumber: isAdminUser,
+                rateNumber: isAdminUser,
             },
         },
         columns: tableColumns,
@@ -359,7 +360,6 @@ export const RateReviewsTable = ({
         getFilteredRowModel: getFilteredRowModel(),
         getSortedRowModel: getSortedRowModel(),
         getFacetedMinMaxValues: getFacetedMinMaxValues(),
-
     })
 
     const filteredRows = reactTable.getRowModel().rows

--- a/services/cypress/integration/cmsWorkflow/rateReview.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/rateReview.spec.ts
@@ -35,30 +35,20 @@ describe('CMS user can view rate reviews', () => {
 
                     const rate1 = latestSubmission.rateRevisions[0]
                     const rate2 = latestSubmission.rateRevisions[1]
-                    let rate1Name = rate1.formData.rateCertificationName
-                    let rate2Name = rate2.formData.rateCertificationName
-
-                    if (!rate1Name || !rate2Name) {
-                        throw new Error(`Unexpected error: Rate name(s) did not exist. Rate1Name: ${rate1Name}, Rate2Name: ${rate2Name}`)
-                    }
 
                     // Then check both rates in rate reviews table
                     cy.logInAsCMSUser({
                         initialURL: `/dashboard/rate-reviews`,
                     })
 
-                    // Rate names can be the same, rare in prod, but common in automated tests and manual tests.
-                    // Here were just checking to make sure the first exists in findAll.
                     cy.get('table')
-                    .findAllByRole('link', { name: rate1Name }).first()
-                    .should('exist')
+                        .findByTestId(`rate-link-${rate1.rateID}`).should('exist')
                     cy.get('table')
-                    .findAllByRole('link', { name: rate2Name }).first()
-                    .should('exist')
+                        .findByTestId(`rate-link-${rate2.rateID}`).should('exist')
 
                     // click the first rate to navigate to rate summary page
                     cy.get('table')
-                    .findAllByRole('link', { name: rate1Name }).first().click()
+                        .findByTestId(`rate-link-${rate1.rateID}`).click()
                     cy.url({ timeout: 10_000 }).should('contain',rate1.rateID)
                     cy.findByRole('heading', {
                         name: `${rate1.formData.rateCertificationName}`,

--- a/services/cypress/integration/cmsWorkflow/rateReview.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/rateReview.spec.ts
@@ -29,49 +29,54 @@ describe('CMS user can view rate reviews', () => {
 
             // Create a new contract and rates submission with two attached rates
             cy.apiCreateAndSubmitContractWithRates(stateUser()).then(
-                (pkg) => {
-                const submission = getFormData(pkg)
-                    const submissionName = packageName(
-                        pkg.stateCode,
-                        submission.stateNumber,
-                        submission.programIDs,
-                        minnesotaStatePrograms
-                    )
-                // Then check both rates in rate reviews table
-                cy.logInAsCMSUser({
-                    initialURL: `/dashboard/rate-reviews`,
-                })
-                const rate1 = submission.rateInfos[0]
-                const rate2 = submission.rateInfos[1]
-                cy.get('table')
-                .findByRole('link', { name: rate1.rateCertificationName })
-                .should('exist')
-                cy.get('table')
-                .findByRole('link', { name: rate2.rateCertificationName })
-                .should('exist')
+                (contract) => {
 
-                // click the first rate to navigate to rate summary page
-                cy.get('table')
-                .findByRole('link', { name: rate1.rateCertificationName })
-                .should('exist').click()
-                cy.url({ timeout: 10_000 }).should('contain',rate1.id)
-                cy.findByRole('heading', {
-                    name: `${rate1.rateCertificationName}`,
-                }).should('exist')
-                cy.findByText('Rate certification type').should('exist').siblings('dd').should('have.text', 'New rate certification')
-                cy.findByText('Rating period').should('exist').siblings('dd').should('have.text', '06/01/2025 to 05/30/2026')
-                cy.findByText('Date certified').should('exist').siblings('dd').should('have.text', '04/15/2025')
-                cy.findByText('Submission this rate was submitted with').should('exist').siblings('dd').should('have.text', submissionName)
-                cy.findByText('Certifying actuary').should('exist').siblings('dd').should('have.text', 'actuary1test titleemail@example.comMercer')
-                // cy.findByText('Download all rate documents').should('exist')
-                cy.findByRole('table', {
-                    name: 'Rate certification',
-                }).should('exist')
-                cy.findByText('rate1Document1.pdf').should('exist')
-                cy.findByRole('table', {
-                    name: 'Rate supporting documents',
-                }).should('exist')
+                    const latestSubmission = contract.packageSubmissions[0]
+
+                    const rate1 = latestSubmission.rateRevisions[0]
+                    const rate2 = latestSubmission.rateRevisions[1]
+                    let rate1Name = rate1.formData.rateCertificationName
+                    let rate2Name = rate2.formData.rateCertificationName
+
+                    if (!rate1Name || !rate2Name) {
+                        throw new Error(`Unexpected error: Rate name(s) did not exist. Rate1Name: ${rate1Name}, Rate2Name: ${rate2Name}`)
+                    }
+
+                    // Then check both rates in rate reviews table
+                    cy.logInAsCMSUser({
+                        initialURL: `/dashboard/rate-reviews`,
                     })
+
+                    // Rate names can be the same, rare in prod, but common in automated tests and manual tests.
+                    // Here were just checking to make sure the first exists in findAll.
+                    cy.get('table')
+                    .findAllByRole('link', { name: rate1Name }).first()
+                    .should('exist')
+                    cy.get('table')
+                    .findAllByRole('link', { name: rate2Name }).first()
+                    .should('exist')
+
+                    // click the first rate to navigate to rate summary page
+                    cy.get('table')
+                    .findAllByRole('link', { name: rate1Name }).first().click()
+                    cy.url({ timeout: 10_000 }).should('contain',rate1.rateID)
+                    cy.findByRole('heading', {
+                        name: `${rate1.formData.rateCertificationName}`,
+                    }).should('exist')
+                    cy.findByText('Rate certification type').should('exist').siblings('dd').should('have.text', 'New rate certification')
+                    cy.findByText('Rating period').should('exist').siblings('dd').should('have.text', '06/01/2025 to 05/30/2026')
+                    cy.findByText('Date certified').should('exist').siblings('dd').should('have.text', '04/15/2025')
+                    cy.findByText('Submission this rate was submitted with').should('exist').siblings('dd').should('have.text', latestSubmission.contractRevision.contractName)
+                    cy.findByText('Certifying actuary').should('exist').siblings('dd').should('have.text', 'actuary1test titleemail@example.comMercer')
+                    // cy.findByText('Download all rate documents').should('exist')
+                    cy.findByRole('table', {
+                        name: 'Rate certification',
+                    }).should('exist')
+                    cy.findByText('rate1Document1.pdf').should('exist')
+                    cy.findByRole('table', {
+                        name: 'Rate supporting documents',
+                    }).should('exist')
+                })
                 cy.findByText('rate1SupportingDocument1.pdf').should('exist')
 
                 // No document dates or other fields are undefined
@@ -83,7 +88,6 @@ describe('CMS user can view rate reviews', () => {
                 cy.url({ timeout: 10_000 }).should('contain', 'rate-reviews')
                 cy.findByText('Rate reviews').should('exist')
                 cy.get('thead').should('have.attr', 'data-testid', 'rate-reviews-table').should('be.visible') // can't put id on table itself because data attributes not passing through in react-uswds component
-
         })
     })
 })

--- a/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -461,7 +461,7 @@ describe('CMS user', () => {
         cy.interceptFeatureFlags({'link-rates': true, '438-attestation': true})
 
         // Set up a submission with linked rates
-        cy.apiCreateAndSubmitContractWithRates(stateUser()).then((pkg) => {
+        cy.apiCreateAndSubmitContractWithRates(stateUser()).then((contract) => {
             cy.logInAsStateUser()
 
             cy.startNewContractAndRatesSubmission()
@@ -473,6 +473,8 @@ describe('CMS user', () => {
             cy.fillOutLinkedRate()
             cy.navigateContractRatesFormByButtonClick('CONTINUE')
 
+            // Set link-rates to true again.
+            cy.interceptFeatureFlags({'link-rates': true, '438-attestation': true})
             cy.findByRole('heading', { level: 2, name: /Contacts/ })
             cy.fillOutStateContact()
             cy.navigateFormByButtonClick('CONTINUE')

--- a/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -1,3 +1,5 @@
+import {stateUser} from '../../utils/apollo-test-utils';
+
 describe('CMS user', () => {
     beforeEach(() => {
         cy.stubFeatureFlags()
@@ -454,6 +456,216 @@ describe('CMS user', () => {
     })
 
     // TODO AFTER LINKED RATES AND LINKED RATES CHANGE HISTORY SHIPS
-    // it('can unlock and resubmit a linked rate and change history updates')
+    it.only('can unlock and resubmit a linked rate and change history updates', () => {
+        // turn on feature flag
+        cy.interceptFeatureFlags({'link-rates': true, '438-attestation': true})
+
+        // Set up a submission with linked rates
+        cy.apiCreateAndSubmitContractWithRates(stateUser()).then((pkg) => {
+            cy.logInAsStateUser()
+
+            cy.startNewContractAndRatesSubmission()
+            cy.fillOutBaseContractDetails()
+
+            cy.navigateFormByButtonClick('CONTINUE')
+
+            cy.findByRole('heading', { level: 2, name: /Rate details/ })
+            cy.fillOutLinkedRate()
+            cy.navigateContractRatesFormByButtonClick('CONTINUE')
+
+            cy.findByRole('heading', { level: 2, name: /Contacts/ })
+            cy.fillOutStateContact()
+            cy.navigateFormByButtonClick('CONTINUE')
+
+            cy.findByRole('heading', { level: 2, name: /Supporting documents/ })
+            cy.navigateFormByButtonClick('CONTINUE')
+
+            cy.findByRole('heading', { level: 2, name: /Review and submit/ })
+
+            // Test unlock and resubmit with a linked rate submission
+            cy.location().then((fullUrl) => {
+                const reviewURL = fullUrl.toString()
+                const submissionURL = reviewURL.replace(
+                    'edit/review-and-submit',
+                    ''
+                )
+
+                // Submit, sent to dashboard
+                cy.submitStateSubmissionForm()
+
+                // Login as CMS User
+                cy.logOut()
+                cy.logInAsCMSUser({ initialURL: submissionURL })
+                cy.wait('@fetchContractQuery', { timeout: 20_000 })
+                // click on the unlock button, type in reason and confirm
+                cy.unlockSubmission()
+
+                //Unlock banner for CMS user to be present with correct data.
+                cy.findByTestId('unlockedBanner')
+                    .should('exist')
+                    .and('contain.text', 'zuko@example.com')
+                    .and('contain.text', 'Unlock submission reason.')
+                    .contains(
+                        /Unlocked on: (0?[1-9]|[12][0-9]|3[01])\/[0-9]+\/[0-9]+\s[0-9]+:[0-9]+[a-zA-Z]+ ET/i
+                    )
+                    .should('exist')
+
+                //Find unlocked submission name
+                cy.get('#submissionName', {timeout: 2_000}).then(($h2) => {
+                    //Set name to variable for later use in finding the unlocked submission
+                    const submissionName = $h2.text()
+
+                    // Login as state user
+                    cy.logOut()
+                    cy.logInAsStateUser()
+
+                    // State user sees unlocked submission - check tag then submission link
+                    cy.get('table')
+                        .should('exist')
+                        .findByText(submissionName)
+                        .parent()
+                        .siblings('[data-testid="submission-status"]')
+                        .should('have.text', 'Unlocked')
+
+                    cy.get('table')
+                        .should('exist')
+                        .findByText(submissionName)
+                        .should('have.attr', 'href')
+                        .and('include', 'review-and-submit')
+
+                    cy.navigateFormByDirectLink(reviewURL)
+                    cy.wait('@fetchContractQuery', { timeout: 20_000 })
+
+                    //Unlock banner for state user to be present with correct data.
+                    cy.findByRole('heading', {
+                        level: 2,
+                        name: /Review and submit/,
+                    })
+                    cy.findByRole('heading', {
+                        name: `Minnesota ${submissionName}`,
+                    }).should('exist')
+                    cy.findByTestId('unlockedBanner')
+                        .should('exist')
+                        .and('contain.text', 'zuko@example.com')
+                        .and('contain.text', 'Unlock submission reason.')
+                        .contains(
+                            /Unlocked on: (0?[1-9]|[12][0-9]|3[01])\/[0-9]+\/[0-9]+\s[0-9]+:[0-9]+[a-zA-Z]+ ET+/i
+                        )
+                        .should('exist')
+
+                    cy.submitStateSubmissionForm({success: true, resubmission: true})
+
+                    cy.get('table')
+                        .should('exist')
+                        .findByText(submissionName)
+                        .parent()
+                        .siblings('[data-testid="submission-status"]')
+                        .should('have.text', 'Submitted')
+
+                    cy.get('table')
+                        .findByText(submissionName)
+                        .should('have.attr', 'href')
+                        .and('not.include', 'review-and-submit')
+
+                    // Navigate to resubmitted submission and check for submission updated banner
+                    cy.get('table')
+                        .findByRole('link', { name: submissionName })
+                        .should('exist')
+                        .click()
+
+                    cy.findByTestId('updatedSubmissionBanner').should('exist')
+
+                    // Login as CMS User
+                    cy.logOut()
+                    cy.logInAsCMSUser({ initialURL: submissionURL })
+                    cy.wait('@fetchContractQuery', { timeout: 20_000 })
+
+                    //  CMS user sees resubmitted submission and active unlock button
+                    cy.findByTestId('submission-summary', {timeout: 4_000}).should('exist')
+                    cy.findByRole('button', { name: 'Unlock submission' }).should(
+                        'not.be.disabled'
+                    )
+
+                    //CMS user should not see unlock banner and should see updated submission banner
+                    cy.findByTestId('unlockedBanner').should('not.exist')
+                    cy.findByTestId('updatedSubmissionBanner').should('exist')
+
+                    //Open all change history accordion items
+                    cy.findByTestId('accordion').should('exist')
+
+                    cy.get('[data-testid^="accordionButton_"]').each((button) => {
+                        button.trigger('click')
+                        button.siblings().hasClass('usa-accordion__content') /// make sure accordion is expanded
+                    })
+
+                    //Check for view previous submission link in the initial accordion item to exist
+                    cy.findByTestId('revision-link-1').should('be.visible')
+                    cy.clickSubmissionLink('revision-link-1')
+                    //Making sure we are on SubmissionRevisionSummary page and contains version text
+                    cy.findByTestId('revision-version')
+                        .should('exist')
+                        .contains(
+                            /(0?[1-9]|[12][0-9]|3[01])\/[0-9]+\/[0-9]+\s[0-9]+:[0-9]+[a-zA-Z]+ ET version/i
+                        )
+                    //Previous submission banner should exist and able to click link to go back to current submission
+                    cy.findByTestId('previous-submission-banner').should('exist')
+                    //Navigate back to current submission using link inside banner.
+                    cy.clickSubmissionLink('currentSubmissionLink')
+                    //Make sure banner and revision version text are gone.
+                    cy.findByTestId('previous-submission-banner').should(
+                        'not.exist'
+                    )
+                    cy.findByTestId('revision-version').should('not.exist')
+
+                    // Unlock again and resubmit to test change history
+                    cy.unlockSubmission('Second Unlock')
+
+                    // Resubmit again
+                    cy.logOut()
+                    cy.logInAsStateUser()
+                    cy.navigateFormByDirectLink(reviewURL)
+                    cy.wait('@fetchContractQuery', { timeout: 20_000 })
+                    cy.findByTestId('unlockedBanner').should('exist')
+                    cy.submitStateSubmissionForm({
+                            success: true,
+                            resubmission: true,
+                            summary: 'Second resubmit'
+                        }
+                    )
+
+                    // Visit the submission url and check the history
+                    cy.navigateFormByDirectLink(submissionURL)
+                    cy.findByTestId('updatedSubmissionBanner').should('exist')
+
+                    // No document dates or other fields are undefined
+                    cy.findByText('N/A').should('not.exist')
+
+                    // Should have change history records
+                    cy.findAllByTestId('change-history-record').should('have.length', 5)
+
+                    cy.findAllByTestId('change-history-record').then(records => {
+                        // We put all the text of each record into an array
+                        const recordText = records.map((index, record) => Cypress.$(record).text())
+
+                        // Records are in reverse
+                        // Second set of unlock and resubmit
+                        expect(recordText[0]).to.contain('Changes made: Second resubmit')
+                        expect(recordText[1]).to.contain('Reason for unlock: Second Unlock')
+
+                        // First set of unlock and resubmit
+                        expect(recordText[2]).to.contain('Changes made: Resubmission summary')
+                        expect(recordText[3]).to.contain('Reason for unlock: Unlock submission reason.')
+
+                        // Test for initial submission
+                        expect(recordText[4]).to.contain('aang@example.com')
+                        expect(recordText[4]).to.contain('View past submission version')
+                        expect(recordText[4]).to.not.contain('Changes made:')
+                        expect(recordText[4]).to.not.contain('Reason for unlock:')
+
+                    })
+                })
+            })
+        })
+    })
     // it('can unlock and resubmit combination of linked and child rates as expected' )
 })

--- a/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -227,7 +227,7 @@ describe('CMS user', () => {
         })
     })
 
-    it('can unlock and resubmit child rates with linked rates flag', () => {
+    it.only('can unlock and resubmit child rates with linked rates flag', () => {
         cy.interceptFeatureFlags({"link-rates": true, '438-attestation': true})
         cy.logInAsStateUser()
 

--- a/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -461,7 +461,7 @@ describe('CMS user', () => {
         cy.interceptFeatureFlags({'link-rates': true, '438-attestation': true})
 
         // Set up a submission with linked rates
-        cy.apiCreateAndSubmitContractWithRates(stateUser()).then((contract) => {
+        cy.apiCreateAndSubmitContractWithRates(stateUser()).then(() => {
             cy.logInAsStateUser()
 
             cy.startNewContractAndRatesSubmission()
@@ -473,8 +473,6 @@ describe('CMS user', () => {
             cy.fillOutLinkedRate()
             cy.navigateContractRatesFormByButtonClick('CONTINUE')
 
-            // Set link-rates to true again.
-            cy.interceptFeatureFlags({'link-rates': true, '438-attestation': true})
             cy.findByRole('heading', { level: 2, name: /Contacts/ })
             cy.fillOutStateContact()
             cy.navigateFormByButtonClick('CONTINUE')

--- a/services/cypress/support/apiCommands.ts
+++ b/services/cypress/support/apiCommands.ts
@@ -21,7 +21,7 @@ import {
     contractAndRatesData,
     newSubmissionInput,
     rateFormData,
-    CMSUserType,
+    CMSUserType, minnesotaStatePrograms,
 } from '../utils/apollo-test-utils'
 import { ApolloClient, DocumentNode, NormalizedCacheObject } from '@apollo/client'
 import {UnlockedHealthPlanFormDataType} from 'app-web/src/common-code/healthPlanFormDataType';
@@ -115,7 +115,22 @@ const createAndSubmitContractWithRates = async (
         contractID: pkg1.id,
         updatedRates: [
             {
-                formData: rateFormData(),
+                formData: rateFormData({
+                    rateDateStart: '2025-05-01',
+                    rateDateEnd: '2026-04-30',
+                    rateDateCertified: '2025-03-15',
+                    rateProgramIDs: [minnesotaStatePrograms[0].id]
+                }),
+                rateID: undefined,
+                type: 'CREATE'
+            },
+            {
+                formData: rateFormData({
+                    rateDateStart: '2024-03-01',
+                    rateDateEnd: '2025-04-30',
+                    rateDateCertified: '2025-03-15',
+                    rateProgramIDs: [minnesotaStatePrograms[1].id]
+                }),
                 rateID: undefined,
                 type: 'CREATE'
             }

--- a/services/cypress/support/apiCommands.ts
+++ b/services/cypress/support/apiCommands.ts
@@ -10,7 +10,7 @@ import {
     FetchCurrentUserDocument,
     UpdateDraftContractRatesDocument,
     UpdateDraftContractRatesInput,
-    FetchContractDocument, FetchContractPayload, Contract,
+    Contract, SubmitContractDocument,
 } from '../gen/gqlClient'
 import {
     domainToBase64,
@@ -147,31 +147,16 @@ const createAndSubmitContractWithRates = async (
         }
     })
 
-    // We will want to replace submit with the contract API when it's made for now we will
-    // make an additional call for the contract using fetchContract.
-    await apolloClient.mutate({
-        mutation: SubmitHealthPlanPackageDocument,
+    const submission = await apolloClient.mutate({
+        mutation: SubmitContractDocument,
         variables: {
             input: {
-                pkgID: pkg1.id,
-                submittedReason: 'Submit package for Rates Dashboard tests',
+                contractID: pkg1.id,
             },
         },
     })
 
-    // We are returning Contract instead of HPP because rate names are different between the two.
-    // Instead of fixing HPP rate names, lets just use Contract since HPP will go away.
-    const submission1 = await apolloClient.query({
-        query: FetchContractDocument,
-        variables: {
-            input: {
-                contractID: pkg1.id
-            }
-        }
-    })
-
-    // Return with contract api FetchContract
-    return submission1.data.fetchContract.contract
+    return submission.data.submitContract.contract
 }
 
 

--- a/services/cypress/support/index.ts
+++ b/services/cypress/support/index.ts
@@ -26,7 +26,7 @@ import {
     FeatureFlagSettings,
 } from '../../app-web/src/common-code/featureFlags'
 import './apiCommands'
-import { HealthPlanPackage } from '../gen/gqlClient';
+import { HealthPlanPackage, Contract } from '../gen/gqlClient';
 import { CMSUserType, DivisionType } from '../utils/apollo-test-utils';
 import { StateUserType } from 'app-api/src/domain-models';
 
@@ -105,7 +105,7 @@ declare global {
             }): void
 
             apiCreateAndSubmitContractOnlySubmission(stateUser: StateUserType): Cypress.Chainable<HealthPlanPackage>
-            apiCreateAndSubmitContractWithRates(stateUser: StateUserType): Cypress.Chainable<HealthPlanPackage>
+            apiCreateAndSubmitContractWithRates(stateUser: StateUserType): Cypress.Chainable<Contract>
             apiAssignDivisionToCMSUser(cmsUser: CMSUserType, division: DivisionType): Cypress.Chainable<void>
 
             interceptGraphQL(): void

--- a/services/cypress/utils/apollo-test-utils.ts
+++ b/services/cypress/utils/apollo-test-utils.ts
@@ -216,7 +216,11 @@ const rateFormData = (data?: Partial<RateFormDataInput>): RateFormDataInput => (
             sha256: 'fakesha',
         },
     ],
-    supportingDocuments: [],
+    supportingDocuments: [   {
+        name: 'rate1SupportingDocument1.pdf',
+        s3URL: 's3://local-uploads/1684382956834-rate1SupportingDocument1.pdf/rate1SupportingDocument1.pdf',
+        sha256: 'fakesha2',
+    }],
     rateDateStart: '2025-05-01',
     rateDateEnd: '2026-04-30',
     rateDateCertified: '2025-03-15',

--- a/services/cypress/utils/apollo-test-utils.ts
+++ b/services/cypress/utils/apollo-test-utils.ts
@@ -9,6 +9,7 @@ import {
 } from '@apollo/client'
 import { Amplify, Auth as AmplifyAuth, API } from 'aws-amplify'
 import { UnlockedHealthPlanFormDataType } from '../../app-web/src/common-code/healthPlanFormDataType'
+import { RateFormDataInput } from '../gen/gqlClient';
 
 type StateUserType = {
     id: string
@@ -203,6 +204,35 @@ const contractAndRatesData = (): Partial<UnlockedHealthPlanFormDataType>=> ({
     ],
     statutoryRegulatoryAttestation: false,
     statutoryRegulatoryAttestationDescription: 'No compliance'
+})
+
+const rateFormData = (): RateFormDataInput => ({
+    rateType: 'NEW',
+    rateCapitationType: 'RATE_CELL',
+    rateDocuments: [
+        {
+            name: 'rate1Document1.pdf',
+            s3URL: 's3://local-uploads/1684382956834-rate1Document1.pdf/rate1Document1.pdf',
+            sha256: 'fakesha',
+        },
+    ],
+    supportingDocuments: [],
+    rateDateStart: '2025-05-01',
+    rateDateEnd: '2026-04-30',
+    rateDateCertified: '2025-03-15',
+    rateProgramIDs: [minnesotaStatePrograms[0].id],
+    certifyingActuaryContacts: [
+        {
+            name: 'actuary1',
+            titleRole: 'test title',
+            email: 'email@example.com',
+            actuarialFirm: 'MERCER' as const,
+            actuarialFirmOther: '',
+        },
+    ],
+    deprecatedRateProgramIDs: [],
+    addtlActuaryContacts: [],
+    actuaryCommunicationPreference: 'OACT_TO_ACTUARY' as const,
 })
 
 const newSubmissionInput = (overrides?: Partial<UnlockedHealthPlanFormDataType> ): Partial<UnlockedHealthPlanFormDataType> => {
@@ -436,6 +466,7 @@ export {
     cmsUser,
     adminUser,
     stateUser,
+    rateFormData,
     minnesotaStatePrograms
 }
 export type {

--- a/services/cypress/utils/apollo-test-utils.ts
+++ b/services/cypress/utils/apollo-test-utils.ts
@@ -42,30 +42,30 @@ type DivisionType = 'DMCO' | 'DMCP' | 'OACT'
 type UserType = StateUserType | AdminUserType | CMSUserType
 
 // programs for state used in tests
-const minnesotaStatePrograms =[
+const minnesotaStatePrograms = [
     {
         "id": "abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce",
         "fullName": "Special Needs Basic Care",
         "name": "SNBC",
-        "isRateProgram": "false"
+        "isRateProgram": false
     },
     {
         "id": "d95394e5-44d1-45df-8151-1cc1ee66f100",
         "fullName": "Prepaid Medical Assistance Program",
         "name": "PMAP",
-        "isRateProgram": "false"
+        "isRateProgram": false
     },
     {
         "id": "ea16a6c0-5fc6-4df8-adac-c627e76660ab",
         "fullName": "Minnesota Senior Care Plus ",
         "name": "MSC+",
-        "isRateProgram": "false"
+        "isRateProgram": false
     },
     {
         "id": "3fd36500-bf2c-47bc-80e8-e7aa417184c5",
         "fullName": "Minnesota Senior Health Options",
         "name": "MSHO",
-        "isRateProgram": "false"
+        "isRateProgram": false
     }
 ]
 

--- a/services/cypress/utils/apollo-test-utils.ts
+++ b/services/cypress/utils/apollo-test-utils.ts
@@ -206,7 +206,7 @@ const contractAndRatesData = (): Partial<UnlockedHealthPlanFormDataType>=> ({
     statutoryRegulatoryAttestationDescription: 'No compliance'
 })
 
-const rateFormData = (): RateFormDataInput => ({
+const rateFormData = (data?: Partial<RateFormDataInput>): RateFormDataInput => ({
     rateType: 'NEW',
     rateCapitationType: 'RATE_CELL',
     rateDocuments: [
@@ -233,6 +233,7 @@ const rateFormData = (): RateFormDataInput => ({
     deprecatedRateProgramIDs: [],
     addtlActuaryContacts: [],
     actuaryCommunicationPreference: 'OACT_TO_ACTUARY' as const,
+    ...data
 })
 
 const newSubmissionInput = (overrides?: Partial<UnlockedHealthPlanFormDataType> ): Partial<UnlockedHealthPlanFormDataType> => {

--- a/services/cypress/utils/apollo-test-utils.ts
+++ b/services/cypress/utils/apollo-test-utils.ts
@@ -69,7 +69,8 @@ const minnesotaStatePrograms = [
     }
 ]
 
-const contractOnlyData = (): Partial<UnlockedHealthPlanFormDataType>=> ({
+const contractOnlyData = (): Partial<UnlockedHealthPlanFormDataType> => ({
+    stateCode: 'MN',
     stateContacts: [
         {
             name: 'Name',
@@ -104,7 +105,8 @@ const contractOnlyData = (): Partial<UnlockedHealthPlanFormDataType>=> ({
     managedCareEntities: ['MCO'],
     federalAuthorities: ['STATE_PLAN'],
     rateInfos: [],
-    statutoryRegulatoryAttestation: true
+    statutoryRegulatoryAttestation: true,
+    programIDs: [minnesotaStatePrograms[0].id]
 })
 
 const contractAndRatesData = (): Partial<UnlockedHealthPlanFormDataType>=> ({
@@ -203,7 +205,8 @@ const contractAndRatesData = (): Partial<UnlockedHealthPlanFormDataType>=> ({
             },
     ],
     statutoryRegulatoryAttestation: false,
-    statutoryRegulatoryAttestationDescription: 'No compliance'
+    statutoryRegulatoryAttestationDescription: 'No compliance',
+    programIDs: [minnesotaStatePrograms[0].id]
 })
 
 const rateFormData = (data?: Partial<RateFormDataInput>): RateFormDataInput => ({


### PR DESCRIPTION
## Summary
[MCR-4024](https://jiraent.cms.gov/browse/MCR-4024)

- Added a new cypress test `'can unlock and resubmit a linked rate and change history updates'` in `unlockResubmit.spec`
- Updated `createAndSubmitContractWithRates` to use the new Contract and Rate API.
   - The function did not work using the HPP API to create rates, not sure how `rateReview.spec` even passed in other branches. 
   - Instead of trying to fix it with the old API, I updated it to use the new rates API.
   - I'm also returning `Contract` instead of `HealthPlanPackage`. 
      - This is because rate names differ between them and instead of updating HPP to match rate name formats today, I just switched to using `Contract` instead. 
      - This made `rateReview.spec` fail because it was looking for HPP rate names, but the rates were made using new Rate API with the new name format.
- Updated `rateReview.spec` to use `Contract` instead of HPP and update the tests now that rate names are less unique using the new rate name format.
- Fixed `fillOutLinkedRate` to look for the first rate option.
- Fixed `minnesotaStatePrograms` to use booleans for `isRateProgram` instead of string
   - Maybe this was causing `createAndSubmitContractWithRates` to fail.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

If it passes CI it should be good, but you could pull down and run both tests in local.

<!---These are developer instructions on how to test or validate the work -->
