### PR TITLE
Update security hub jira sync tool

### DIFF
--- a/.github/workflows/sechub-jira-sync.yml
+++ b/.github/workflows/sechub-jira-sync.yml
@@ -25,11 +25,10 @@ jobs:
           stage-name: prod
 
       - name: Sync Security Hub and Jira
-        uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v1.0.7
+        uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v2.0.6
         with:
           jira-token: ${{ secrets.JIRA_TOKEN }}
           jira-username: ${{ secrets.JIRA_USERNAME }}
-          jira-host: jiraent.cms.gov
           jira-project-key: 'MCR' # add issues to the 'MC-Review' project
           jira-custom-fields: '{ "customfield_10104": "32589", "customfield_10100": "MCR-2480"}' # Sprint, Epic
           jira-ignore-statuses: Done, Closed, Canceled

--- a/.github/workflows/sechub-jira-sync.yml
+++ b/.github/workflows/sechub-jira-sync.yml
@@ -31,9 +31,8 @@ jobs:
           jira-username: ${{ secrets.JIRA_USERNAME }}
           jira-host: jiraent.cms.gov
           jira-project-key: MCR # add issues to the 'MC-Review' project
-          jira-epic-key: MCR-2480 # add issues to the '[Tech Maintenance] Security Hub' epic
-          jira-custom-fields: '{ "customfield_10006": 925 }' # add issues to the 'Tech Maintenance' sprint
-          jira-ignore-statuses: Done
+          jira-custom-fields: '{ "customfield_10104": 32589, "customfield_10100": "MCR-2480"}'
+          jira-ignore-statuses: Done, Closed, Canceled
           aws-region: us-east-1
           aws-severities: CRITICAL, HIGH, MEDIUM
 

--- a/.github/workflows/sechub-jira-sync.yml
+++ b/.github/workflows/sechub-jira-sync.yml
@@ -25,13 +25,13 @@ jobs:
           stage-name: prod
 
       - name: Sync Security Hub and Jira
-        uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v2.0.5
+        uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v1.0.7
         with:
           jira-token: ${{ secrets.JIRA_TOKEN }}
           jira-username: ${{ secrets.JIRA_USERNAME }}
           jira-host: jiraent.cms.gov
           jira-project-key: 'MCR' # add issues to the 'MC-Review' project
-          jira-custom-fields: '{ "customfield_10104": "32589", "customfield_10100": "MCR-2480"}'
+          jira-custom-fields: '{ "customfield_10104": "32589", "customfield_10100": "MCR-2480"}' # Sprint, Epic
           jira-ignore-statuses: Done, Closed, Canceled
           aws-region: us-east-1
           aws-severities: CRITICAL, HIGH, MEDIUM

--- a/.github/workflows/sechub-jira-sync.yml
+++ b/.github/workflows/sechub-jira-sync.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           jira-token: ${{ secrets.JIRA_TOKEN }}
           jira-username: ${{ secrets.JIRA_USERNAME }}
-          jira-host: qmacbis.atlassian.net
+          jira-host: jiraent.cms.gov
           jira-project-key: MCR # add issues to the 'MC-Review' project
           jira-epic-key: MCR-2480 # add issues to the '[Tech Maintenance] Security Hub' epic
           jira-custom-fields: '{ "customfield_10006": 925 }' # add issues to the 'Tech Maintenance' sprint

--- a/.github/workflows/sechub-jira-sync.yml
+++ b/.github/workflows/sechub-jira-sync.yml
@@ -30,7 +30,7 @@ jobs:
           jira-token: ${{ secrets.JIRA_TOKEN }}
           jira-username: ${{ secrets.JIRA_USERNAME }}
           jira-project-key: 'MCR' # add issues to the 'MC-Review' project
-          jira-custom-fields: '{ "customfield_10104": "32589", "customfield_10100": "MCR-2480"}' # Sprint, Epic
+          jira-custom-fields: '{ "customfield_10104": 32589, "customfield_10100": "MCR-2480"}' # Sprint, Epic
           jira-ignore-statuses: Done, Closed, Canceled
           aws-region: us-east-1
           aws-severities: CRITICAL, HIGH, MEDIUM

--- a/.github/workflows/sechub-jira-sync.yml
+++ b/.github/workflows/sechub-jira-sync.yml
@@ -30,8 +30,8 @@ jobs:
           jira-token: ${{ secrets.JIRA_TOKEN }}
           jira-username: ${{ secrets.JIRA_USERNAME }}
           jira-host: jiraent.cms.gov
-          jira-project-key: MCR # add issues to the 'MC-Review' project
-          jira-custom-fields: '{ "customfield_10104": 32589, "customfield_10100": "MCR-2480"}'
+          jira-project-key: 'MCR' # add issues to the 'MC-Review' project
+          jira-custom-fields: '{ "customfield_10104": "32589", "customfield_10100": "MCR-2480"}'
           jira-ignore-statuses: Done, Closed, Canceled
           aws-region: us-east-1
           aws-severities: CRITICAL, HIGH, MEDIUM


### PR DESCRIPTION
## Summary

We have been given credentials to move this over to Jira Enterprise finally. The credentials have been updated and this is a minor fix to the action.

#### Related issues
https://jiraent.cms.gov/browse/MCR-3877
