### PR TITLE
Add host to security hub

### DIFF
--- a/.github/workflows/sechub-jira-sync.yml
+++ b/.github/workflows/sechub-jira-sync.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           jira-token: ${{ secrets.JIRA_TOKEN }}
           jira-username: ${{ secrets.JIRA_USERNAME }}
+          jira-host: jiraent.cms.gov
           jira-project-key: 'MCR' # add issues to the 'MC-Review' project
           jira-custom-fields: '{ "customfield_10104": 32589, "customfield_10100": "MCR-2480"}' # Sprint, Epic
           jira-ignore-statuses: Done, Closed, Canceled


### PR DESCRIPTION
## Summary
The latest dependabot PR to update security hub tool actually broke it, as a value became required in this latest release. `jira-host` would previously default to `jiraent.cms.gov` but it looks like it no longer does.

This adds the value to the config.

