### PR TITLE
Fix updateDraftContractRates resolver to check for concurrent update

### DIFF
--- a/services/app-api/src/resolvers/contract/submitContract.test.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.test.ts
@@ -497,9 +497,9 @@ describe('submitContract', () => {
             'Unlock A.0'
         )
         const a0FormData = latestFormData(unlockedA0Pkg)
-        const unlockedA0Contract = await fetchTestContract(stateServer, AID)
         a0FormData.submissionDescription = 'DESC A1'
         await updateTestHealthPlanFormData(stateServer, a0FormData)
+        const unlockedA0Contract = await fetchTestContract(stateServer, AID)
         const a0RatesUpdates =
             updateRatesInputFromDraftContract(unlockedA0Contract)
         expect(a0RatesUpdates.updatedRates[0].rateID).toBe(OneID)
@@ -595,10 +595,11 @@ describe('submitContract', () => {
             'Unlock B.0'
         )
         const b0FormData = latestFormData(unlockedB0Pkg)
-        const unlockedB0Contract = await fetchTestContract(stateServer, BID)
 
         b0FormData.submissionDescription = 'DESC B1'
         await updateTestHealthPlanFormData(stateServer, b0FormData)
+
+        const unlockedB0Contract = await fetchTestContract(stateServer, BID)
         const b0RatesUpdates =
             updateRatesInputFromDraftContract(unlockedB0Contract)
         expect(b0RatesUpdates.updatedRates[0].type).toBe('UPDATE')
@@ -644,10 +645,11 @@ describe('submitContract', () => {
             'Unlock C.0'
         )
         const c0FormData = latestFormData(unlockedC0Pkg)
-        const unlockedC0Contract = await fetchTestContract(stateServer, CID)
-
         c0FormData.submissionDescription = 'DESC C1'
         await updateTestHealthPlanFormData(stateServer, c0FormData)
+
+        const unlockedC0Contract = await fetchTestContract(stateServer, CID)
+
         const c0RatesUpdates =
             updateRatesInputFromDraftContract(unlockedC0Contract)
         expect(c0RatesUpdates.updatedRates[0].type).toBe('LINK')
@@ -973,12 +975,14 @@ describe('submitContract', () => {
             'Unlock A.0'
         )
         const a0FormData = latestFormData(unlockedA0Pkg)
-        const unlockedA0Contract = await fetchTestContract(stateServer, AID)
         a0FormData.submissionDescription = 'DESC A1'
         a0FormData.contractDocuments.push(dummyDoc('c2'))
         a0FormData.documents.push(dummyDoc('s2'))
 
         await updateTestHealthPlanFormData(stateServer, a0FormData)
+
+        const unlockedA0Contract = await fetchTestContract(stateServer, AID)
+
         const a0RatesUpdates =
             updateRatesInputFromDraftContract(unlockedA0Contract)
         expect(a0RatesUpdates.updatedRates[0].rateID).toBe(OneID)

--- a/services/app-api/src/resolvers/rate/fetchRate.test.ts
+++ b/services/app-api/src/resolvers/rate/fetchRate.test.ts
@@ -376,12 +376,13 @@ describe('fetchRate', () => {
             'Unlock A.0'
         )
         const a0FormData = latestFormData(unlockedA0Pkg)
-        const unlockedA0Contract = await fetchTestContract(stateServer, AID)
         a0FormData.submissionDescription = 'DESC A1'
         a0FormData.contractDocuments.push(dummyDoc('c2'))
         a0FormData.documents.push(dummyDoc('s2'))
 
         await updateTestHealthPlanFormData(stateServer, a0FormData)
+
+        const unlockedA0Contract = await fetchTestContract(stateServer, AID)
         const a0RatesUpdates =
             updateRatesInputFromDraftContract(unlockedA0Contract)
         expect(a0RatesUpdates.updatedRates[0].rateID).toBe(OneID)

--- a/services/app-api/src/testHelpers/gqlRateHelpers.ts
+++ b/services/app-api/src/testHelpers/gqlRateHelpers.ts
@@ -210,6 +210,7 @@ function addNewRateToRateInput(
 
     return {
         contractID: input.contractID,
+        lastSeenUpdatedAt: input.lastSeenUpdatedAt,
         updatedRates: [
             ...input.updatedRates,
             {
@@ -238,6 +239,7 @@ function addLinkedRateToRateInput(
 ): UpdateDraftContractRatesInput {
     return {
         contractID: input.contractID,
+        lastSeenUpdatedAt: input.lastSeenUpdatedAt,
         updatedRates: [
             ...input.updatedRates,
             {
@@ -327,6 +329,8 @@ function updateRatesInputFromDraftContract(
 
     return {
         contractID: contract.id,
+        lastSeenUpdatedAt:
+            contract.draftRevision?.updatedAt || contract.updatedAt,
         updatedRates: rateInputs,
     }
 }
@@ -334,6 +338,7 @@ function updateRatesInputFromDraftContract(
 const createTestDraftRateOnContract = async (
     server: ApolloServer,
     contractID: string,
+    lastSeenUpdatedAt: Date,
     rateData?: RateFormDataInput
 ): Promise<Contract> => {
     if (!rateData) {
@@ -345,6 +350,7 @@ const createTestDraftRateOnContract = async (
         variables: {
             input: {
                 contractID,
+                lastSeenUpdatedAt: lastSeenUpdatedAt,
                 updatedRates: [
                     {
                         type: 'CREATE',
@@ -368,6 +374,7 @@ const createTestDraftRateOnContract = async (
 const updateTestDraftRateOnContract = async (
     server: ApolloServer,
     contractID: string,
+    lastSeenUpdatedAt: Date,
     rateID: string,
     rateData?: RateFormDataInput
 ): Promise<Contract> => {
@@ -380,6 +387,7 @@ const updateTestDraftRateOnContract = async (
         variables: {
             input: {
                 contractID,
+                lastSeenUpdatedAt,
                 updatedRates: [
                     {
                         type: 'UPDATE',

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -1326,6 +1326,8 @@ input UpdateContractRateInput {
 
 input UpdateDraftContractRatesInput {
     contractID: ID!
+    "date the contracts draft revision was last updated at"
+    lastSeenUpdatedAt: DateTime!
     """
     updatedRates contains ALL the existing rates associated with this contract.
     This includes rates that were previously linked or previously created (LINK & UPDATE)

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -1326,7 +1326,7 @@ input UpdateContractRateInput {
 
 input UpdateDraftContractRatesInput {
     contractID: ID!
-    "date the contracts draft revision was last updated at"
+    "The updatedAt of the contract draft revision at the time this mutation. This is used for optimistic concurrency control"
     lastSeenUpdatedAt: DateTime!
     """
     updatedRates contains ALL the existing rates associated with this contract.

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.test.tsx
@@ -35,6 +35,10 @@ import { Rate } from '../../../../gen/gqlClient'
 
 describe('RateDetailsV2', () => {
     /* eslint-disable jest/no-disabled-tests, jest/expect-expect */
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
     describe.skip('handles edit  of a single rate', () => {
         it('renders without errors', async () => {
             const rateID = 'test-abc-123'

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -166,9 +166,8 @@ const RateDetailsV2 = ({
               .rateCertificationName
         : fetchContractData?.fetchContract.contract?.draftRevision?.contractName
     if (pageHeading) updateHeading({ customHeading: pageHeading })
-    const [updateDraftContractRates, { error: updateContractError }] =
-        useUpdateDraftContractRatesMutation()
-    const [submitRate, { error: submitRateError }] = useSubmitRateMutation()
+    const [updateDraftContractRates] = useUpdateDraftContractRatesMutation()
+    const [submitRate] = useSubmitRateMutation()
 
     // Set up data for form. Either based on contract API (for multi rate) or rates API (for edit and submit of standalone rate)
     const contract = fetchContractData?.fetchContract.contract
@@ -176,8 +175,6 @@ const RateDetailsV2 = ({
     const ratesFromContract = contract?.draftRates
     const initialRequestLoading = fetchContractLoading || fetchRateLoading
     const initialRequestError = fetchContractError || fetchRateError
-    const submitRequestError = updateContractError || submitRateError
-    const apiError = initialRequestError || submitRequestError
     const previousDocuments: string[] = []
 
     // Set up initial rate form values for Formik
@@ -209,9 +206,11 @@ const RateDetailsV2 = ({
         return <ErrorOrLoadingPage state="LOADING" />
     }
 
-    if (apiError) {
+    if (initialRequestError) {
         return (
-            <ErrorOrLoadingPage state={handleAndReturnErrorState(apiError)} />
+            <ErrorOrLoadingPage
+                state={handleAndReturnErrorState(initialRequestError)}
+            />
         )
     }
     // Redirect if in standalone rate workflow and rate not editable

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -172,6 +172,7 @@ const RateDetailsV2 = ({
 
     // Set up data for form. Either based on contract API (for multi rate) or rates API (for edit and submit of standalone rate)
     const contract = fetchContractData?.fetchContract.contract
+    const contractDraftRevision = contract?.draftRevision
     const ratesFromContract = contract?.draftRates
     const initialRequestLoading = fetchContractLoading || fetchRateLoading
     const initialRequestError = fetchContractError || fetchRateError
@@ -284,6 +285,7 @@ const RateDetailsV2 = ({
                     variables: {
                         input: {
                             contractID: id ?? 'no-id',
+                            lastSeenUpdatedAt: contractDraftRevision?.updatedAt,
                             updatedRates,
                         },
                     },

--- a/services/app-web/src/testHelpers/apolloMocks/contractGQLMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/contractGQLMock.ts
@@ -40,6 +40,7 @@ const updateDraftContractRatesMockSuccess = ({
     const contractData = mockContractPackageDraft(contract)
     const contractInput = {
         contractID: contractData.id,
+        lastSeenUpdatedAt: contractData.draftRevision?.updatedAt,
         updatedRates: [
             {
                 formData: {

--- a/services/app-web/src/testHelpers/apolloMocks/contractPackageDataMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/contractPackageDataMock.ts
@@ -180,8 +180,8 @@ function mockContractPackageDraft(
             submitInfo: undefined,
             unlockInfo: undefined,
             id: '123',
-            createdAt: new Date(),
-            updatedAt: new Date(),
+            createdAt: new Date('01/01/2023'),
+            updatedAt: new Date('11/01/2023'),
             contractName: 'MCR-0005-alvhalfhdsalfee',
             formData: mockContractFormData(partial?.draftRevision?.formData)
         },
@@ -285,8 +285,8 @@ function mockContractWithLinkedRateDraft(
             submitInfo: undefined,
             unlockInfo: undefined,
             id: '123',
-            createdAt: new Date(),
-            updatedAt: new Date(),
+            createdAt: new Date('01/01/2023'),
+            updatedAt: new Date('11/01/2023'),
             contractName: 'MCR-0005-alvhalfhdsalfss',
             formData: {
                 programIDs: ['abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce'],

--- a/services/cypress/integration/cmsWorkflow/rateReview.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/rateReview.spec.ts
@@ -1,28 +1,10 @@
-import { HealthPlanFormDataType, packageName } from "../../../app-web/src/common-code/healthPlanFormDataType"
-import { base64ToDomain } from "../../../app-web/src/common-code/proto/healthPlanFormDataProto"
-import { HealthPlanPackage } from "../../gen/gqlClient"
-import { cmsUser, minnesotaStatePrograms, stateUser } from "../../utils/apollo-test-utils"
+import { cmsUser, stateUser } from "../../utils/apollo-test-utils"
 
 describe('CMS user can view rate reviews', () => {
     beforeEach(() => {
         cy.stubFeatureFlags()
         cy.interceptGraphQL()
     })
-    // By default return lastest revision
-    const getFormData = (pkg: HealthPlanPackage, indx = 0): HealthPlanFormDataType => {
-        const latestRevision = pkg.revisions[indx].node
-        if (!latestRevision) {
-            throw new Error('no revisions found for package' + pkg.id)
-        }
-
-        const unwrapResult = base64ToDomain(latestRevision.formDataProto)
-        if (unwrapResult instanceof Error) {
-            throw unwrapResult
-        }
-
-        return unwrapResult
-    }
-
 
     it('and navigate to a specific rate from the rates dashboard', () => {
           cy.apiAssignDivisionToCMSUser(cmsUser(), 'DMCO').then(() => {

--- a/services/cypress/integration/cmsWorkflow/rateReview.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/rateReview.spec.ts
@@ -30,7 +30,6 @@ describe('CMS user can view rate reviews', () => {
             // Create a new contract and rates submission with two attached rates
             cy.apiCreateAndSubmitContractWithRates(stateUser()).then(
                 (contract) => {
-
                     const latestSubmission = contract.packageSubmissions[0]
 
                     const rate1 = latestSubmission.rateRevisions[0]

--- a/services/cypress/integration/stateWorkflow/questionResponse/questionResponse.spec.ts
+++ b/services/cypress/integration/stateWorkflow/questionResponse/questionResponse.spec.ts
@@ -14,15 +14,15 @@ describe('Q&A', () => {
         cy.apiAssignDivisionToCMSUser(cmsUser(), 'DMCO').then(() => {
             // Create a new submission
             cy.apiCreateAndSubmitContractOnlySubmission(stateUser()).then(
-                (pkg) => {
+                (contract) => {
                     // Log in as CMS user and upload question
                     cy.logInAsCMSUser({
-                        initialURL: `/submissions/${pkg.id}/question-and-answers`,
+                        initialURL: `/submissions/${contract.id}/question-and-answers`,
                     })
 
                     cy.url({ timeout: 10_000 }).should(
                         'contain',
-                        `${pkg.id}/question-and-answers`
+                        `${contract.id}/question-and-answers`
                     )
 
                     cy.findByRole('link', {
@@ -49,7 +49,7 @@ describe('Q&A', () => {
 
                     cy.logInAsStateUser()
 
-                    cy.visit(`/submissions/${pkg.id}`)
+                    cy.visit(`/submissions/${contract.id}`)
 
                     cy.findByTestId('submission-summary').should('exist')
                     cy.findByRole('link', {
@@ -60,7 +60,7 @@ describe('Q&A', () => {
                     cy.findByRole('link', { name: /Q&A/ }).click()
                     cy.url({ timeout: 10_000 }).should(
                         'contain',
-                        `${pkg.id}/question-and-answers`
+                        `${contract.id}/question-and-answers`
                     )
 
                     // Make sure Heading is correct with 'Upload questions' in addition to submission name

--- a/services/cypress/support/apiCommands.ts
+++ b/services/cypress/support/apiCommands.ts
@@ -35,7 +35,6 @@ const createAndSubmitContractOnlyPackage = async (
 
     const draftContract = newContract.data.createContract.contract
     const draftRevision = draftContract.draftRevision
-    delete draftRevision.formData.__typename
     const updateFormData = contractFormData({
         submissionType: 'CONTRACT_ONLY'
     })
@@ -77,7 +76,6 @@ const createAndSubmitContractWithRates = async (
 
     const draftContract = newContract.data.createContract.contract
     const draftRevision = draftContract.draftRevision
-    delete draftRevision.formData.__typename
     const updateFormData = contractFormData({
         submissionType: 'CONTRACT_AND_RATES'
     })
@@ -97,7 +95,6 @@ const createAndSubmitContractWithRates = async (
 
     const updatedDraftRevision = updatedContract.data.updateContractDraftRevision.contract.draftRevision
 
-    // Using new API to create child rates
     const updateDraftContractRatesInput: UpdateDraftContractRatesInput = {
         contractID: draftContract.id,
         lastSeenUpdatedAt: updatedDraftRevision.updatedAt,

--- a/services/cypress/support/apiCommands.ts
+++ b/services/cypress/support/apiCommands.ts
@@ -1,8 +1,4 @@
 import {
-    CreateHealthPlanPackageDocument,
-    HealthPlanPackage,
-    SubmitHealthPlanPackageDocument,
-    UpdateHealthPlanFormDataDocument,
     IndexUsersDocument,
     UserEdge,
     User,
@@ -10,112 +6,102 @@ import {
     FetchCurrentUserDocument,
     UpdateDraftContractRatesDocument,
     UpdateDraftContractRatesInput,
-    Contract, SubmitContractDocument,
+    Contract,
+    SubmitContractDocument,
+    CreateContractDocument,
+    UpdateContractDraftRevisionDocument,
+    UpdateContractDraftRevisionInput,
 } from '../gen/gqlClient'
-import {
-    domainToBase64,
-    base64ToDomain,
-} from '../../app-web/src/common-code/proto/healthPlanFormDataProto'
 import {
     apolloClientWrapper,
     DivisionType,
     adminUser,
-    contractOnlyData,
-    contractAndRatesData,
     newSubmissionInput,
     rateFormData,
+    contractFormData,
     CMSUserType, minnesotaStatePrograms,
 } from '../utils/apollo-test-utils'
 import { ApolloClient, DocumentNode, NormalizedCacheObject } from '@apollo/client'
-import {UnlockedHealthPlanFormDataType} from 'app-web/src/common-code/healthPlanFormDataType';
 
 const createAndSubmitContractOnlyPackage = async (
     apolloClient: ApolloClient<NormalizedCacheObject>
-): Promise<HealthPlanPackage> => {
-    const newSubmission = await apolloClient.mutate({
-        mutation: CreateHealthPlanPackageDocument,
+): Promise<Contract> => {
+    const newContract = await apolloClient.mutate({
+        mutation: CreateContractDocument,
         variables: {
             input: newSubmissionInput(),
-        },
+        }
     })
 
-    const pkg = newSubmission.data.createHealthPlanPackage.pkg
-    const revision = pkg.revisions[0].node
+    const draftContract = newContract.data.createContract.contract
+    const draftRevision = draftContract.draftRevision
+    delete draftRevision.formData.__typename
+    const updateFormData = contractFormData({
+        submissionType: 'CONTRACT_ONLY'
+    })
 
-    const formData = base64ToDomain(revision.formDataProto)
-    if (formData instanceof Error) {
-        throw new Error(formData.message)
+    const updateContractDraftRevisionInput: UpdateContractDraftRevisionInput = {
+        contractID: draftContract.id,
+        lastSeenUpdatedAt: draftRevision.updatedAt,
+        formData: updateFormData
     }
 
-    const fullFormData = {
-        ...formData,
-        ...contractOnlyData(),
-    }
-
-    const formDataProto = domainToBase64(fullFormData as UnlockedHealthPlanFormDataType)
-
-    await apolloClient.mutate({
-        mutation: UpdateHealthPlanFormDataDocument,
+    const updatedContract = await apolloClient.mutate({
+        mutation: UpdateContractDraftRevisionDocument,
         variables: {
-            input: {
-                healthPlanFormData: formDataProto,
-                pkgID: pkg.id,
-            },
-        },
+            input: updateContractDraftRevisionInput
+        }
     })
 
     const submission = await apolloClient.mutate({
-        mutation: SubmitHealthPlanPackageDocument,
+        mutation: SubmitContractDocument,
         variables: {
             input: {
-                pkgID: pkg.id,
-                submittedReason: 'Submit package for Q&A Tests',
+                contractID: draftContract.id,
             },
         },
     })
 
-    return submission.data.submitHealthPlanPackage.pkg
+    return submission.data.submitContract.contract
 }
 
 const createAndSubmitContractWithRates = async (
     apolloClient: ApolloClient<NormalizedCacheObject>
 ): Promise<Contract> => {
-    const newSubmission1 = await apolloClient.mutate({
-        mutation: CreateHealthPlanPackageDocument,
-        variables: {
-            input: newSubmissionInput({submissionType: 'CONTRACT_AND_RATES'}),
-        },
-    })
-    const pkg1 = newSubmission1.data.createHealthPlanPackage.pkg
-    const pkg1FirstRev = pkg1.revisions[0].node
 
-    const formData1 = base64ToDomain(pkg1FirstRev.formDataProto)
-    if (formData1 instanceof Error) {
-        throw new Error(formData1.message)
+    const newContract = await apolloClient.mutate({
+        mutation: CreateContractDocument,
+        variables: {
+            input: newSubmissionInput(),
+        }
+    })
+
+    const draftContract = newContract.data.createContract.contract
+    const draftRevision = draftContract.draftRevision
+    delete draftRevision.formData.__typename
+    const updateFormData = contractFormData({
+        submissionType: 'CONTRACT_AND_RATES'
+    })
+
+    const updateContractDraftRevisionInput: UpdateContractDraftRevisionInput = {
+        contractID: draftContract.id,
+        lastSeenUpdatedAt: draftRevision.updatedAt,
+        formData: updateFormData
     }
 
-    const fullFormData1: UnlockedHealthPlanFormDataType = {
-        ...formData1,
-        ...contractAndRatesData(),
-        status: 'DRAFT',
-        rateInfos: []
-    }
-
-    const formDataProto = domainToBase64(fullFormData1 as UnlockedHealthPlanFormDataType)
-
-    await apolloClient.mutate({
-        mutation: UpdateHealthPlanFormDataDocument,
+    const updatedContract = await apolloClient.mutate({
+        mutation: UpdateContractDraftRevisionDocument,
         variables: {
-            input: {
-                healthPlanFormData: formDataProto,
-                pkgID: pkg1.id,
-            },
-        },
+            input: updateContractDraftRevisionInput
+        }
     })
+
+    const updatedDraftRevision = updatedContract.data.updateContractDraftRevision.contract.draftRevision
 
     // Using new API to create child rates
     const updateDraftContractRatesInput: UpdateDraftContractRatesInput = {
-        contractID: pkg1.id,
+        contractID: draftContract.id,
+        lastSeenUpdatedAt: updatedDraftRevision.updatedAt,
         updatedRates: [
             {
                 formData: rateFormData({
@@ -151,7 +137,7 @@ const createAndSubmitContractWithRates = async (
         mutation: SubmitContractDocument,
         variables: {
             input: {
-                contractID: pkg1.id,
+                contractID: draftContract.id,
             },
         },
     })
@@ -206,7 +192,7 @@ const seedUserIntoDB = async (
 
 Cypress.Commands.add(
     'apiCreateAndSubmitContractOnlySubmission',
-    (stateUser): Cypress.Chainable<HealthPlanPackage> =>
+    (stateUser): Cypress.Chainable<Contract> =>
         cy.task<DocumentNode>('readGraphQLSchema').then((schema) =>
             apolloClientWrapper(
                 schema,

--- a/services/cypress/support/apiCommands.ts
+++ b/services/cypress/support/apiCommands.ts
@@ -46,7 +46,7 @@ const createAndSubmitContractOnlyPackage = async (
         formData: updateFormData
     }
 
-    const updatedContract = await apolloClient.mutate({
+    await apolloClient.mutate({
         mutation: UpdateContractDraftRevisionDocument,
         variables: {
             input: updateContractDraftRevisionInput
@@ -68,7 +68,6 @@ const createAndSubmitContractOnlyPackage = async (
 const createAndSubmitContractWithRates = async (
     apolloClient: ApolloClient<NormalizedCacheObject>
 ): Promise<Contract> => {
-
     const newContract = await apolloClient.mutate({
         mutation: CreateContractDocument,
         variables: {

--- a/services/cypress/support/index.ts
+++ b/services/cypress/support/index.ts
@@ -104,7 +104,7 @@ declare global {
                 division: DivisionType
             }): void
 
-            apiCreateAndSubmitContractOnlySubmission(stateUser: StateUserType): Cypress.Chainable<HealthPlanPackage>
+            apiCreateAndSubmitContractOnlySubmission(stateUser: StateUserType): Cypress.Chainable<Contract>
             apiCreateAndSubmitContractWithRates(stateUser: StateUserType): Cypress.Chainable<Contract>
             apiAssignDivisionToCMSUser(cmsUser: CMSUserType, division: DivisionType): Cypress.Chainable<void>
 

--- a/services/cypress/utils/apollo-test-utils.ts
+++ b/services/cypress/utils/apollo-test-utils.ts
@@ -1,5 +1,4 @@
 import { AxiosResponse } from 'axios'
-import { v4 as uuidv4 } from 'uuid'
 import {
     ApolloClient,
     DocumentNode,
@@ -8,13 +7,9 @@ import {
     NormalizedCacheObject,
 } from '@apollo/client'
 import { Amplify, Auth as AmplifyAuth, API } from 'aws-amplify'
-import { UnlockedHealthPlanFormDataType } from '../../app-web/src/common-code/healthPlanFormDataType'
 import {
     RateFormDataInput,
-    Contract,
-    ContractFormData,
-    UpdateContractDraftRevisionInput,
-    ContractDraftRevisionFormDataInput
+    ContractFormData, CreateContractInput,
 } from '../gen/gqlClient';
 
 type StateUserType = {
@@ -74,146 +69,6 @@ const minnesotaStatePrograms = [
         "isRateProgram": false
     }
 ]
-
-const contractOnlyData = (): Partial<UnlockedHealthPlanFormDataType> => ({
-    stateCode: 'MN',
-    stateContacts: [
-        {
-            name: 'Name',
-            titleRole: 'Title',
-            email: 'example@example.com',
-        },
-    ],
-    addtlActuaryContacts: [],
-    documents: [],
-    contractExecutionStatus: 'EXECUTED' as const,
-    contractDocuments: [
-        {
-            name: 'Contract Cert.pdf',
-            s3URL: 's3://local-uploads/1684382956834-Contract Cert.pdf/Contract Cert.pdf',
-            sha256: 'abc123',
-        },
-    ],
-    contractDateStart: new Date('2023-05-01T00:00:00.000Z'),
-    contractDateEnd: new Date('2023-05-31T00:00:00.000Z'),
-    contractAmendmentInfo: {
-        modifiedProvisions: {
-            inLieuServicesAndSettings: false,
-            modifiedRiskSharingStrategy: false,
-            modifiedIncentiveArrangements: false,
-            modifiedWitholdAgreements: false,
-            modifiedStateDirectedPayments: false,
-            modifiedPassThroughPayments: false,
-            modifiedPaymentsForMentalDiseaseInstitutions: false,
-            modifiedNonRiskPaymentArrangements: false,
-        },
-    },
-    managedCareEntities: ['MCO'],
-    federalAuthorities: ['STATE_PLAN'],
-    rateInfos: [],
-    statutoryRegulatoryAttestation: true,
-    programIDs: [minnesotaStatePrograms[0].id]
-})
-
-const contractAndRatesData = (): Partial<UnlockedHealthPlanFormDataType>=> ({
-    stateCode: 'MN',
-    stateContacts: [
-        {
-            name: 'Name',
-            titleRole: 'Title',
-            email: 'example@example.com',
-        },
-    ],
-    addtlActuaryContacts: [],
-    documents: [],
-    contractExecutionStatus: 'EXECUTED' as const,
-    contractDocuments: [
-        {
-            name: 'Contract Cert.pdf',
-            s3URL: 's3://local-uploads/1684382956834-Contract Cert.pdf/Contract Cert.pdf',
-            sha256: 'abc123',
-        },
-    ],
-    contractDateStart: new Date('2023-05-01T00:00:00.000Z'),
-    contractDateEnd: new Date('2023-05-31T00:00:00.000Z'),
-    contractAmendmentInfo: {
-        modifiedProvisions: {
-            inLieuServicesAndSettings: false,
-            modifiedRiskSharingStrategy: false,
-            modifiedIncentiveArrangements: false,
-            modifiedWitholdAgreements: false,
-            modifiedStateDirectedPayments: false,
-            modifiedPassThroughPayments: false,
-            modifiedPaymentsForMentalDiseaseInstitutions: false,
-            modifiedNonRiskPaymentArrangements: false,
-        },
-    },
-    managedCareEntities: ['MCO'],
-    federalAuthorities: ['STATE_PLAN'],
-    rateInfos:[
-        {
-            id: uuidv4(),
-            rateType: 'NEW' as const,
-            rateDateStart: new Date(Date.UTC(2025, 5, 1)),
-            rateDateEnd: new Date(Date.UTC(2026, 4, 30)),
-            rateDateCertified: new Date(Date.UTC(2025, 3, 15)),
-            rateDocuments: [
-                {
-                    name: 'rate1Document1.pdf',
-                    s3URL: 's3://bucketname/key/rate1Document1.pdf',
-                    sha256: 'fakesha',
-                },
-            ],
-            supportingDocuments: [   {
-                name: 'rate1SupportingDocument1.pdf',
-                s3URL: 's3://bucketname/key/rate1SupportingDocument1.pdf',
-                sha256: 'fakesha',
-            }],
-            rateProgramIDs: [minnesotaStatePrograms[0].id],
-            actuaryContacts: [
-                {
-                    name: 'actuary1',
-                    titleRole: 'test title',
-                    email: 'email@example.com',
-                    actuarialFirm: 'MERCER' as const,
-                    actuarialFirmOther: '',
-                },
-            ],
-            actuaryCommunicationPreference: 'OACT_TO_ACTUARY' as const,
-            packagesWithSharedRateCerts: [],
-        },
-            {
-                id: uuidv4(),
-                rateType: 'NEW' as const,
-                rateDateStart: new Date(Date.UTC(2030, 5, 1)),
-                rateDateEnd: new Date(Date.UTC(2036, 4, 30)),
-                rateDateCertified: new Date(Date.UTC(2035, 3, 15)),
-                rateDocuments: [
-                    {
-                        name: 'rate2Document1.pdf',
-                        s3URL: 's3://bucketname/key/rate2Document1.pdf',
-                        sha256: 'fakesha',
-                    },
-                ],
-                supportingDocuments: [],
-                rateProgramIDs: [minnesotaStatePrograms[0].id],
-                actuaryContacts: [
-                    {
-                        name: 'actuary2',
-                        titleRole: 'test title',
-                        email: 'email@example.com',
-                        actuarialFirm: 'MERCER' as const,
-                        actuarialFirmOther: '',
-                    },
-                ],
-                actuaryCommunicationPreference: 'OACT_TO_ACTUARY' as const,
-                packagesWithSharedRateCerts: [],
-            },
-    ],
-    statutoryRegulatoryAttestation: false,
-    statutoryRegulatoryAttestationDescription: 'No compliance',
-    programIDs: [minnesotaStatePrograms[0].id]
-})
 
 const contractFormData = (overrides?: Partial<ContractFormData>): ContractFormData => ({
     programIDs: [minnesotaStatePrograms[0].id],
@@ -299,7 +154,7 @@ const rateFormData = (data?: Partial<RateFormDataInput>): RateFormDataInput => (
     ...data
 })
 
-const newSubmissionInput = (overrides?: Partial<UnlockedHealthPlanFormDataType> ): Partial<UnlockedHealthPlanFormDataType> => {
+const newSubmissionInput = (overrides?: Partial<CreateContractInput> ): Partial<CreateContractInput> => {
     return Object.assign(
         {
             populationCovered: 'MEDICAID',
@@ -311,7 +166,7 @@ const newSubmissionInput = (overrides?: Partial<UnlockedHealthPlanFormDataType> 
         },
         overrides
     )
-    }
+}
 
 const stateUser = ():StateUserType => ({
     id: 'user1',
@@ -524,8 +379,6 @@ const apolloClientWrapper = async <T>(
 
 export {
     apolloClientWrapper,
-    contractOnlyData,
-    contractAndRatesData,
     newSubmissionInput,
     cmsUser,
     adminUser,

--- a/services/cypress/utils/apollo-test-utils.ts
+++ b/services/cypress/utils/apollo-test-utils.ts
@@ -9,7 +9,13 @@ import {
 } from '@apollo/client'
 import { Amplify, Auth as AmplifyAuth, API } from 'aws-amplify'
 import { UnlockedHealthPlanFormDataType } from '../../app-web/src/common-code/healthPlanFormDataType'
-import { RateFormDataInput } from '../gen/gqlClient';
+import {
+    RateFormDataInput,
+    Contract,
+    ContractFormData,
+    UpdateContractDraftRevisionInput,
+    ContractDraftRevisionFormDataInput
+} from '../gen/gqlClient';
 
 type StateUserType = {
     id: string
@@ -207,6 +213,56 @@ const contractAndRatesData = (): Partial<UnlockedHealthPlanFormDataType>=> ({
     statutoryRegulatoryAttestation: false,
     statutoryRegulatoryAttestationDescription: 'No compliance',
     programIDs: [minnesotaStatePrograms[0].id]
+})
+
+const contractFormData = (overrides?: Partial<ContractFormData>): ContractFormData => ({
+    programIDs: [minnesotaStatePrograms[0].id],
+    populationCovered: 'MEDICAID',
+    submissionType: 'CONTRACT_ONLY',
+    riskBasedContract: false,
+    submissionDescription: 'A submission description',
+    stateContacts: [
+        {
+            name: 'Name',
+            titleRole: 'Title',
+            email: 'example@example.com',
+        },
+    ],
+    supportingDocuments: [],
+    contractType: 'BASE',
+    contractExecutionStatus: 'EXECUTED',
+    contractDocuments: [
+        {
+            name: 'Contract Cert.pdf',
+            s3URL: 's3://local-uploads/1684382956834-Contract Cert.pdf/Contract Cert.pdf',
+            sha256: 'abc123',
+        },
+    ],
+    contractDateStart: '2023-05-01',
+    contractDateEnd: '2024-05-31',
+    managedCareEntities: ['MCO'],
+    federalAuthorities: ['STATE_PLAN'],
+    inLieuServicesAndSettings: true,
+    modifiedBenefitsProvided: true,
+    modifiedGeoAreaServed: true,
+    modifiedMedicaidBeneficiaries: true,
+    modifiedRiskSharingStrategy: true,
+    modifiedIncentiveArrangements: true,
+    modifiedWitholdAgreements: true,
+    modifiedStateDirectedPayments: true,
+    modifiedPassThroughPayments: false,
+    modifiedPaymentsForMentalDiseaseInstitutions: false,
+    modifiedMedicalLossRatioStandards: false,
+    modifiedOtherFinancialPaymentIncentive: false,
+    modifiedEnrollmentProcess: false,
+    modifiedGrevienceAndAppeal: false,
+    modifiedNetworkAdequacyStandards: true,
+    modifiedLengthOfContract: true,
+    modifiedNonRiskPaymentArrangements: true,
+    statutoryRegulatoryAttestation: false,
+    statutoryRegulatoryAttestationDescription: 'No compliance',
+    ...overrides,
+
 })
 
 const rateFormData = (data?: Partial<RateFormDataInput>): RateFormDataInput => ({
@@ -475,6 +531,7 @@ export {
     adminUser,
     stateUser,
     rateFormData,
+    contractFormData,
     minnesotaStatePrograms
 }
 export type {


### PR DESCRIPTION
## Summary

- Adds a check in `updateDraftContractRates` for optimistic concurrency control. The mutation takes an extra input field `lastSeenUpdatedAt` from `contract.draftRevision.updatedAt` to compare with the  same draft revisions `updatedAt` in the DB to prevent newer changes being overwritten by stale data.
- I also went ahead and updated all the api commands in Cypress to only use the new API's and remove all references to HPP.

#### Related issues

#### Screenshots

#### Test cases covered
`updateDraftContractRates.test.ts`
- `'errors on concurrent updates'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
- With the `link-rates` feature flag on.
- Open two windows with the same draft contract and rates submission
- On the first the window:
   - Continue with the form until the Rate details page
- On the second window:
   - Continue with the form until the Rate details page
   - Make a change to the rate.
   - Continue to the Contacts page
- Back on the first window, attempt to continue to Contacts page.
- You will encounter a system error banner.
 
<!---These are developer instructions on how to test or validate the work -->
