### PR TITLE
MRC-4244: Bug fix for Showing an error on a submitted rate

### DIFF
--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { screen, waitFor, within } from '@testing-library/react'
 import {
     mockContractPackageDraft,
@@ -398,6 +399,75 @@ describe('RateDetailsSummarySection', () => {
                 name: 'Programs this rate certification covers',
             })
         ).not.toBeInTheDocument()
+    })
+
+    it('renders the deprecated rate programs when present on a locked historic linked rate', async () => {
+        const statePrograms = mockMNState().programs
+        const contract = mockContractPackageDraft()
+        contract.draftRates![0].draftRevision!.formData.deprecatedRateProgramIDs =
+            [statePrograms[0].id]
+        contract.draftRates![0].draftRevision!.formData.rateProgramIDs = []
+        contract.draftRates![0].draftRevision!.submitInfo = {
+            updatedAt: new Date('01/02/2024'),
+            updatedBy: 'zuko@example.com',
+            updatedReason: 'initial submission',
+        }
+        contract.draftRates![0].parentContractID = contract.id
+        contract.draftRates![0].draftRevision!.unlockInfo = null
+        await waitFor(() => {
+            renderWithProviders(
+                <RateDetailsSummarySection
+                    contract={contract}
+                    submissionName="MN-MSHO-0003"
+                    statePrograms={statePrograms}
+                    editNavigateTo="/edit"
+                />,
+                {
+                    apolloProvider: apolloProviderCMSUser,
+                }
+            )
+        })
+
+        expect(
+            screen.queryByRole('definition', {
+                name: 'Programs this rate certification covers',
+            })
+        ).toBeInTheDocument()
+
+        expect(
+            screen.queryByRole('definition', {
+                name: 'Rates this rate certification covers',
+            })
+        ).not.toBeInTheDocument()
+    })
+
+    it('does not render the deprecated rate programs when present on an unlocked historic linked rate', async () => {
+        const statePrograms = mockMNState().programs
+        const contract = mockContractPackageSubmitted()
+        await waitFor(() => {
+            renderWithProviders(
+                <RateDetailsSummarySection
+                    contract={contract}
+                    submissionName="MN-MSHO-0003"
+                    statePrograms={statePrograms}
+                />,
+                {
+                    apolloProvider: apolloProviderCMSUser,
+                }
+            )
+        })
+
+        expect(
+            screen.queryByRole('definition', {
+                name: 'Programs this rate certification covers',
+            })
+        ).not.toBeInTheDocument()
+
+        expect(
+            screen.queryByRole('definition', {
+                name: 'Rates this rate certification covers',
+            })
+        ).toBeInTheDocument()
     })
 
     it('renders supporting rates docs when they exist', async () => {

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.test.tsx
@@ -441,7 +441,7 @@ describe('RateDetailsSummarySection', () => {
         ).not.toBeInTheDocument()
     })
 
-    it('does not render the deprecated rate programs when present on an unlocked historic linked rate', async () => {
+    it('does not render the deprecated rate programs when rate programs present on an submitted linked rate', async () => {
         const statePrograms = mockMNState().programs
         const contract = mockContractPackageSubmitted()
         await waitFor(() => {

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
@@ -294,29 +294,47 @@ export const RateDetailsSummarySectionV2 = ({
                               </h3>
                               <dl>
                                   <DoubleColumnGrid>
-                                      {rateFormData.deprecatedRateProgramIDs
+                                      {((rateFormData.deprecatedRateProgramIDs
                                           .length > 0 &&
-                                          isSubmittedOrCMSUser && (
-                                              <DataDetail
-                                                  id="historicRatePrograms"
-                                                  label="Programs this rate certification covers"
-                                                  explainMissingData={
-                                                      false // this is a deprecated field, we never need to explain if its missing
-                                                  }
-                                                  children={ratePrograms(
-                                                      rate,
-                                                      true
-                                                  )}
-                                              />
-                                          )}
-                                      <DataDetail
-                                          id="ratePrograms"
-                                          label="Rates this rate certification covers"
-                                          explainMissingData={
-                                              explainMissingData
-                                          }
-                                          children={ratePrograms(rate, false)}
-                                      />
+                                          isSubmittedOrCMSUser) ||
+                                          (rateFormData.deprecatedRateProgramIDs
+                                              .length > 0 &&
+                                              rateFormData.rateProgramIDs
+                                                  .length === 0 &&
+                                              !rate.unlockInfo &&
+                                              rate.submitInfo)) && (
+                                          <DataDetail
+                                              id="historicRatePrograms"
+                                              label="Programs this rate certification covers"
+                                              explainMissingData={
+                                                  false // this is a deprecated field, we never need to explain if its missing
+                                              }
+                                              children={ratePrograms(
+                                                  rate,
+                                                  true
+                                              )}
+                                          />
+                                      )}
+                                      {!(
+                                          rateFormData.deprecatedRateProgramIDs
+                                              .length > 0 &&
+                                          rateFormData.rateProgramIDs.length ===
+                                              0 &&
+                                          !rate.unlockInfo &&
+                                          rate.submitInfo
+                                      ) && (
+                                          <DataDetail
+                                              id="ratePrograms"
+                                              label="Rates this rate certification covers"
+                                              explainMissingData={
+                                                  explainMissingData
+                                              }
+                                              children={ratePrograms(
+                                                  rate,
+                                                  false
+                                              )}
+                                          />
+                                      )}
                                       <DataDetail
                                           id="rateType"
                                           label="Rate certification type"

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/RateDetailsSummarySectionV2.tsx
@@ -278,6 +278,10 @@ export const RateDetailsSummarySectionV2 = ({
             {rates && rates.length > 0
                 ? rates.map((rate, rateIndex) => {
                       const rateFormData = getRateFormData(rate)
+                      const hasDeprecatedRatePrograms =
+                          rateFormData.deprecatedRateProgramIDs.length > 0
+                      const hasNoRatePrograms =
+                          rateFormData.rateProgramIDs.length === 0
                       if (!rateFormData) {
                           return <GenericErrorPage />
                       }
@@ -294,13 +298,10 @@ export const RateDetailsSummarySectionV2 = ({
                               </h3>
                               <dl>
                                   <DoubleColumnGrid>
-                                      {((rateFormData.deprecatedRateProgramIDs
-                                          .length > 0 &&
+                                      {((hasDeprecatedRatePrograms &&
                                           isSubmittedOrCMSUser) ||
-                                          (rateFormData.deprecatedRateProgramIDs
-                                              .length > 0 &&
-                                              rateFormData.rateProgramIDs
-                                                  .length === 0 &&
+                                          (hasDeprecatedRatePrograms &&
+                                              hasNoRatePrograms &&
                                               !rate.unlockInfo &&
                                               rate.submitInfo)) && (
                                           <DataDetail
@@ -316,10 +317,8 @@ export const RateDetailsSummarySectionV2 = ({
                                           />
                                       )}
                                       {!(
-                                          rateFormData.deprecatedRateProgramIDs
-                                              .length > 0 &&
-                                          rateFormData.rateProgramIDs.length ===
-                                              0 &&
+                                          hasDeprecatedRatePrograms &&
+                                          hasNoRatePrograms &&
                                           !rate.unlockInfo &&
                                           rate.submitInfo
                                       ) && (


### PR DESCRIPTION
## Summary
To replicate:

1. Create a new submission

2. Select "contract action and rate certification" and fill out form

3. On the Rate details page link a rate certification that was submitted prior to when the rate name enhancement feature went live.
4. Click continue and fill out the rest of the submission
5. When you arrive at the Review and submit page...

Current behavior:
The Rate details will flag an error validation on the field  "Rates this rate certification covers" and prevent a submission, despite the rate being locked. 

Expected behavior:

We will not flag an error validation on a locked linked rate.

Displays the historic 'Programs this rate covers' if the linked rate is locked and historic

#### Related issues

#### Screenshots

**BEFORE**
<img width="563" alt="Screenshot 2024-07-03 at 10 02 45 AM" src="https://github.com/Enterprise-CMCS/managed-care-review/assets/67110378/6041e67d-dd1c-4be0-8e6e-80faec5bce4e">

**AFTER**
<img width="758" alt="Screenshot 2024-07-03 at 10 57 09 AM" src="https://github.com/Enterprise-CMCS/managed-care-review/assets/67110378/3c631d6e-bf1b-4671-a875-08df66406026">

#### Test cases covered

- Displays the old field for historic rates
- Renders the new field on unlocked rate

## QA guidance

I pulled down prod data to test this locally 
