### PR TITLE
Fix promote for vite_app_auth_mode

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -307,7 +307,7 @@ jobs:
       needs.api-unit-tests.result == 'success' &&
       needs.build-prisma-client-lambda-layer.result == 'success' &&
       needs.begin-deployment.result == 'success'
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@mt-use-vite
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -171,9 +171,9 @@ jobs:
       app_version: ${{ needs.unit-tests.outputs.app-version }}
       changed_services: ${{ needs.unit-tests.outputs.changed-services}}
       aws_default_region: ${{ vars.AWS_DEFAULT_REGION }}
+      vite_app_auth_mode: IDM
     secrets:
       aws_account_id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
-      react_app_auth_mode: IDM
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
 
   promote-infra-val:
@@ -198,9 +198,9 @@ jobs:
       app_version: ${{ needs.unit-tests.outputs.app-version }}
       changed_services: ${{ needs.unit-tests.outputs.changed-services}}
       aws_default_region: ${{ vars.AWS_DEFAULT_REGION }}
+      vite_app_auth_mode: IDM
     secrets:
       aws_account_id: ${{ secrets.VAL_AWS_ACCOUNT_ID }}
-      react_app_auth_mode: IDM
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
 
   promote-infra-prod:
@@ -225,9 +225,9 @@ jobs:
       app_version: ${{ needs.unit-tests.outputs.app-version }}
       changed_services: ${{ needs.unit-tests.outputs.changed-services}}
       aws_default_region: ${{ vars.AWS_DEFAULT_REGION }}
+      vite_app_auth_mode: IDM
     secrets:
       aws_account_id: ${{ secrets.PROD_AWS_ACCOUNT_ID }}
-      react_app_auth_mode: IDM
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
 
   cypress-prod:


### PR DESCRIPTION
## Summary

In the Vite PR there was a missing config value for `vite_app_auth_mode`. This fixes that and also moves the `deploy.yml` back to `main`.

#### Related issues
https://jiraent.cms.gov/browse/MCR-1797