### PR TITLE
Changes for unlockedContract type

### DIFF
--- a/services/app-api/src/domain-models/contractAndRates/contractTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/contractTypes.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { contractRevisionWithRatesSchema } from './revisionTypes'
-import { statusSchema } from './statusType'
+import { statusSchema, unlockedContractStatusSchema } from './statusType'
 import { pruneDuplicateEmails } from '../../emailer/formatters'
 import { rateSchema } from './rateTypes'
 import { contractPackageSubmissionSchema } from './packageSubmissions'
@@ -26,7 +26,7 @@ const contractSchema = z.object({
 })
 
 const unlockedContractSchema = contractSchema.extend({
-    status: z.literal('UNLOCKED'),
+    status: unlockedContractStatusSchema,
     // Since this is a contract in UNLOCKED status, there will be a draftRevision and draftRates
     draftRevision: contractRevisionWithRatesSchema,
     draftRates: z.array(rateSchema),

--- a/services/app-api/src/domain-models/contractAndRates/contractTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/contractTypes.ts
@@ -25,21 +25,11 @@ const contractSchema = z.object({
     packageSubmissions: z.array(contractPackageSubmissionSchema),
 })
 
-const unlockedContractSchema = z.object({
-    id: z.string().uuid(),
-    createdAt: z.date(),
-    updatedAt: z.date(),
-    status: statusSchema,
-    stateCode: z.string(),
-    mccrsID: z.string().optional(),
-    stateNumber: z.number().min(1),
-    // If this contract is in a DRAFT or UNLOCKED status, there will be a draftRevision and draftRates
+const unlockedContractSchema = contractSchema.extend({
+    status: z.literal('UNLOCKED'),
+    // Since this is a contract in UNLOCKED status, there will be a draftRevision and draftRates
     draftRevision: contractRevisionWithRatesSchema,
-    draftRates: z.array(rateSchema).optional(),
-    // All revisions are submitted and in reverse chronological order
-    revisions: z.array(contractRevisionWithRatesSchema),
-
-    packageSubmissions: z.array(contractPackageSubmissionSchema),
+    draftRates: z.array(rateSchema),
 })
 
 const draftContractSchema = contractSchema.extend({

--- a/services/app-api/src/domain-models/contractAndRates/statusType.ts
+++ b/services/app-api/src/domain-models/contractAndRates/statusType.ts
@@ -7,4 +7,9 @@ const statusSchema = z.union([
     z.literal('RESUBMITTED'),
 ])
 
-export { statusSchema }
+const unlockedContractStatusSchema = z.union([
+    z.literal('DRAFT'),
+    z.literal('UNLOCKED'),
+])
+
+export { statusSchema, unlockedContractStatusSchema }

--- a/services/app-api/src/postgres/contractAndRates/findRateWithHistory.test.ts
+++ b/services/app-api/src/postgres/contractAndRates/findRateWithHistory.test.ts
@@ -12,7 +12,7 @@ import { findRateWithHistory } from './findRateWithHistory'
 import { must, mockInsertContractArgs } from '../../testHelpers'
 import { mockInsertRateArgs } from '../../testHelpers/rateDataMocks'
 import { findContractWithHistory } from './findContractWithHistory'
-import type { DraftContractType } from '../../domain-models/contractAndRates/contractTypes'
+import type { UnlockedContractType } from '../../domain-models/contractAndRates/contractTypes'
 import { updateDraftContractRates } from './updateDraftContractRates'
 
 describe('findRate', () => {
@@ -210,7 +210,7 @@ describe('findRate', () => {
                 unlockedByUserID: cmsUser.id,
                 unlockReason: 'unlock for 1.1',
             })
-        ) as DraftContractType
+        ) as UnlockedContractType
         must(
             await updateDraftContractWithRates(client, {
                 contractID: unlockedContract1.id,

--- a/services/app-api/src/postgres/contractAndRates/findRateWithHistory.test.ts
+++ b/services/app-api/src/postgres/contractAndRates/findRateWithHistory.test.ts
@@ -12,7 +12,7 @@ import { findRateWithHistory } from './findRateWithHistory'
 import { must, mockInsertContractArgs } from '../../testHelpers'
 import { mockInsertRateArgs } from '../../testHelpers/rateDataMocks'
 import { findContractWithHistory } from './findContractWithHistory'
-import type { UnlockedContractType } from '../../domain-models/contractAndRates/contractTypes'
+import type { DraftContractType } from '../../domain-models/contractAndRates/contractTypes'
 import { updateDraftContractRates } from './updateDraftContractRates'
 
 describe('findRate', () => {
@@ -210,7 +210,7 @@ describe('findRate', () => {
                 unlockedByUserID: cmsUser.id,
                 unlockReason: 'unlock for 1.1',
             })
-        ) as UnlockedContractType
+        ) as DraftContractType
         must(
             await updateDraftContractWithRates(client, {
                 contractID: unlockedContract1.id,

--- a/services/app-api/src/postgres/contractAndRates/unlockContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/unlockContract.ts
@@ -260,6 +260,8 @@ async function unlockContractInTransaction(
     const unlockedContract: UnlockedContractType = {
         ...contract,
         draftRevision: contract.draftRevision,
+        draftRates: contract.draftRates ?? [],
+        status: 'UNLOCKED',
     }
     return unlockedContract
 }

--- a/services/app-api/src/resolvers/contract/unlockContract.ts
+++ b/services/app-api/src/resolvers/contract/unlockContract.ts
@@ -92,7 +92,7 @@ export function unlockContractResolver(
             unlockContractResult.status != 'UNLOCKED' &&
             unlockContractResult.status != 'DRAFT'
         ) {
-            const errMessage = `Programming Error: Got incorrect from an unlocked contract.`
+            const errMessage = `Programming Error: Got incorrect status from an unlocked contract.`
             logError('unlockContract', errMessage)
             setErrorAttributesOnActiveSpan(errMessage, span)
             throw new GraphQLError(errMessage, {

--- a/services/app-api/src/resolvers/contract/unlockContract.ts
+++ b/services/app-api/src/resolvers/contract/unlockContract.ts
@@ -88,7 +88,10 @@ export function unlockContractResolver(
                 },
             })
         }
-        if (unlockContractResult.status != 'UNLOCKED') {
+        if (
+            unlockContractResult.status != 'UNLOCKED' &&
+            unlockContractResult.status != 'DRAFT'
+        ) {
             const errMessage = `Programming Error: Got incorrect from an unlocked contract.`
             logError('unlockContract', errMessage)
             setErrorAttributesOnActiveSpan(errMessage, span)

--- a/services/app-api/src/resolvers/contract/unlockContract.ts
+++ b/services/app-api/src/resolvers/contract/unlockContract.ts
@@ -88,8 +88,8 @@ export function unlockContractResolver(
                 },
             })
         }
-        if (unlockContractResult.status === 'SUBMITTED') {
-            const errMessage = `Programming Error: Got SUBMITTED from an unlocked contract.`
+        if (unlockContractResult.status != 'UNLOCKED') {
+            const errMessage = `Programming Error: Got incorrect from an unlocked contract.`
             logError('unlockContract', errMessage)
             setErrorAttributesOnActiveSpan(errMessage, span)
             throw new GraphQLError(errMessage, {

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -809,6 +809,10 @@ enum HealthPlanPackageStatus {
     RESUBMITTED
 }
 
+enum UnlockedStatus {
+    UNLOCKED
+}
+
 """
 HealthPlanPackage is the core type for a single package submission. All the
 submission data is contained in the HealthPlanRevision type, allowing us to store
@@ -1580,7 +1584,7 @@ type UnlockedContract {
     Options are DRAFT, SUBMITTED, RESUBMITTED and UNLOCKED
     SUBMITTED and RESUBMITTED packages cannot be modified
     """
-    status: HealthPlanPackageStatus!
+    status: UnlockedStatus!
     "initiallySubmittedAt is the initial date this contract was submitted at. Is not changed by unlock or resubmission."
     initiallySubmittedAt: Date
     "stateCode is the state code (e.g. CA or TN) for the submitting state"

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -811,6 +811,7 @@ enum HealthPlanPackageStatus {
 
 enum UnlockedStatus {
     UNLOCKED
+    DRAFT
 }
 
 """


### PR DESCRIPTION
## Summary

This PR makes the minor changes that were brought up in RSP

- Restricts the status of an `UnlockedContractType` to be `UNLOCKED`
- Makes `draftRates` mandatory on the domain model 
- Uses the extend syntax on the domain model type

