### PR TITLE
Add navigation event tagging

### DIFF
--- a/services/app-web/src/components/TealiumLogging/Button.tsx
+++ b/services/app-web/src/components/TealiumLogging/Button.tsx
@@ -35,7 +35,7 @@ const ButtonWithLogging = (props: ButtonWithLoggingType) => {
     }
 
     if (props.outline) {
-        buttonStyle = 'transparent'
+        buttonStyle = 'outline'
     }
 
     if (props.unstyled) {

--- a/services/app-web/src/components/TealiumLogging/Link.tsx
+++ b/services/app-web/src/components/TealiumLogging/Link.tsx
@@ -13,7 +13,7 @@ import { extractText } from './tealiamLoggingHelpers'
 type TealiumDataType = Omit<
     TealiumInternalLinkEventObject,
     'event_name' | 'link_url' | 'text'
->
+> & { event_name?: TealiumInternalLinkEventObject['event_name'] }
 
 type LinkWithLoggingType = TealiumDataType & DefaultLinkProps
 const LinkWithLogging = (props: LinkWithLoggingType) => {
@@ -34,6 +34,7 @@ const LinkWithLogging = (props: LinkWithLoggingType) => {
                     link_url: href,
                     parent_component_type,
                     parent_component_heading,
+                    event_name: props.event_name ?? 'internal_link_clicked',
                 })
                 if (onClick) {
                     onClick(e)
@@ -72,6 +73,7 @@ const NavLinkWithLogging = (props: NavLinkWithLoggingType) => {
                     link_url,
                     parent_component_type,
                     parent_component_heading,
+                    event_name: props.event_name ?? 'internal_link_clicked',
                 })
             }}
             {...rest}
@@ -106,6 +108,7 @@ const ReactRouterLinkWithLogging = (props: ReactRouterLinkWithLoggingType) => {
                     link_url,
                     parent_component_type,
                     parent_component_heading,
+                    event_name: props.event_name ?? 'internal_link_clicked',
                 })
             }}
             {...rest}

--- a/services/app-web/src/hooks/useTealium.ts
+++ b/services/app-web/src/hooks/useTealium.ts
@@ -11,7 +11,7 @@ const useTealium = (): {
         tealiumData: Omit<TealiumButtonEventObject, 'event_name'>,
     ) => void,
     logInternalLinkEvent: (
-        tealiumData: Omit<TealiumInternalLinkEventObject, 'event_name'>,
+        tealiumData: TealiumInternalLinkEventObject,
     ) => void
 } => {
     const context = React.useContext(TealiumContext)
@@ -36,16 +36,16 @@ const useTealium = (): {
     }
 
     const logInternalLinkEvent = (
-        tealiumData: Omit<TealiumInternalLinkEventObject, 'event_name'>
+        tealiumData: TealiumInternalLinkEventObject
     ) => {
         const linkData: TealiumInternalLinkEventObject = {
             ...tealiumData,
-            event_name: 'internal_link_clicked',
+            event_name: tealiumData.event_name ?? 'internal_link_clicked',
         }
         logUserEvent(linkData, pathname, loggedInUser, heading)
     }
 
-    return { logButtonEvent, logInternalLinkEvent }
+return { logButtonEvent, logInternalLinkEvent}
 }
 
 export { useTealium }

--- a/services/app-web/src/pages/RateSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.tsx
@@ -90,6 +90,7 @@ export const RateSummary = (): React.ReactElement => {
                                     ? RoutesRecord.DASHBOARD
                                     : RoutesRecord.DASHBOARD_RATES,
                         }}
+                        event_name="back_button"
                     >
                         <Icon.ArrowBack />
                         <span>&nbsp;Back to dashboard</span>

--- a/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
@@ -388,7 +388,7 @@ const Contacts = ({
                                                             logButtonEvent({
                                                                 text: 'Add another state contact',
                                                                 button_style:
-                                                                    'transparent',
+                                                                    'outline',
                                                                 button_type:
                                                                     'button',
                                                                 parent_component_type:

--- a/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
@@ -171,6 +171,7 @@ export const SubmissionSideNav = () => {
                                     pathname:
                                         RoutesRecord.DASHBOARD_SUBMISSIONS,
                                 }}
+                                event_name="back_button"
                             >
                                 <Icon.ArrowBack />
                                 {loggedInUser?.__typename === 'StateUser' ? (
@@ -195,6 +196,7 @@ export const SubmissionSideNav = () => {
                                             ? STATE_SUBMISSION_FORM_ROUTES
                                             : 'SUBMISSIONS_SUMMARY'
                                     )}
+                                    event_name="navigation_clicked"
                                 >
                                     {isStateUser &&
                                     submissionStatus === 'UNLOCKED'
@@ -206,6 +208,7 @@ export const SubmissionSideNav = () => {
                                     className={isSelectedLink(
                                         'SUBMISSIONS_QUESTIONS_AND_ANSWERS'
                                     )}
+                                    event_name="navigation_clicked"
                                 >
                                     Q&A
                                 </NavLinkWithLogging>,

--- a/services/app-web/src/pages/SubmissionSummary/V2/SubmissionSummaryV2.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/V2/SubmissionSummaryV2.tsx
@@ -203,6 +203,7 @@ export const SubmissionSummary = (): React.ReactElement => {
                         to={{
                             pathname: RoutesRecord.DASHBOARD_SUBMISSIONS,
                         }}
+                        event_name="back_button"
                     >
                         <Icon.ArrowBack />
                         {loggedInUser?.__typename === 'StateUser' ? (

--- a/services/app-web/src/tealium/constants.ts
+++ b/services/app-web/src/tealium/constants.ts
@@ -1,0 +1,52 @@
+import { RouteT } from "../constants"
+
+const TEALIUM_SUBSECTION_BY_ROUTE: Partial<Record<RouteT| 'UNKNOWN_ROUTE', string>> = {
+    SUBMISSIONS_TYPE: 'submission edit',
+    SUBMISSIONS_CONTRACT_DETAILS: 'submission edit',
+    SUBMISSIONS_RATE_DETAILS: 'submission edit',
+    SUBMISSIONS_CONTACTS: 'submission edit',
+    SUBMISSIONS_DOCUMENTS: 'submission edit',
+    SUBMISSIONS_REVIEW_SUBMIT: 'submission edit',
+    SUBMISSIONS_SUMMARY: 'submission summary',
+    SUBMISSIONS_REVISION: 'submission summary',
+    SUBMISSIONS_QUESTIONS_AND_ANSWERS: 'submission summary',
+    SUBMISSIONS_MCCRSID: 'submission cms edit',
+    SUBMISSIONS_UPLOAD_QUESTION: 'questions',
+    SUBMISSIONS_UPLOAD_RESPONSE: 'responses',
+}
+
+
+const TEALIUM_CONTENT_TYPE_BY_ROUTE: Record<RouteT | 'UNKNOWN_ROUTE', string> = {
+    ROOT: 'homepage',
+    AUTH: 'login',
+    DASHBOARD: 'table',
+    DASHBOARD_SUBMISSIONS: 'table',
+    DASHBOARD_RATES: 'table',
+    HELP: 'glossary',
+    GRAPHQL_EXPLORER: 'dev',
+    API_ACCESS: 'dev',
+    SETTINGS: 'table',
+    RATES_SUMMARY: 'summary',
+    RATE_EDIT: 'form',
+    SUBMISSIONS: 'form',
+    SUBMISSIONS_NEW: 'form',
+    SUBMISSIONS_EDIT_TOP_LEVEL: 'form',
+    SUBMISSIONS_TYPE: 'form',
+    SUBMISSIONS_CONTRACT_DETAILS: 'form',
+    SUBMISSIONS_RATE_DETAILS: 'form',
+    SUBMISSIONS_CONTACTS: 'form',
+    SUBMISSIONS_DOCUMENTS: 'form',
+    SUBMISSIONS_REVIEW_SUBMIT: 'form',
+    SUBMISSIONS_SUMMARY: 'summary',
+    SUBMISSIONS_REVISION: 'summary',
+    SUBMISSIONS_QUESTIONS_AND_ANSWERS: 'summary',
+    SUBMISSIONS_MCCRSID: 'form',
+    SUBMISSIONS_UPLOAD_QUESTION: 'form',
+    SUBMISSIONS_UPLOAD_RESPONSE: 'form',
+    UNKNOWN_ROUTE: '404',
+}
+
+export {
+    TEALIUM_CONTENT_TYPE_BY_ROUTE,
+    TEALIUM_SUBSECTION_BY_ROUTE
+}

--- a/services/app-web/src/tealium/index.ts
+++ b/services/app-web/src/tealium/index.ts
@@ -1,6 +1,5 @@
 export {
     tealiumClient,
-    CONTENT_TYPE_BY_ROUTE,
     devTealiumClient
 } from './tealium'
 
@@ -8,6 +7,11 @@ export {
     getTealiumPageName,
     getTealiumEnv
 } from './tealiumHelpers'
+
+export {
+    TEALIUM_CONTENT_TYPE_BY_ROUTE,
+    TEALIUM_SUBSECTION_BY_ROUTE
+} from './constants'
 
 export type {
     TealiumLinkDataObject,

--- a/services/app-web/src/tealium/tealiumHelpers.ts
+++ b/services/app-web/src/tealium/tealiumHelpers.ts
@@ -44,16 +44,15 @@ const getTealiumPageName = ({
     switch (route) {
         case 'ROOT':
             if (!user) {
-                return formatPageName({ title: 'Landing' })
-            } else if (user.__typename === 'CMSUser') {
-                return formatPageName({ heading, title: 'CMS Dashboard' })
+                return formatPageName({ title: 'Home' })
             } else if (user.__typename === 'StateUser') {
                 return formatPageName({
                     heading,
                     title: 'State dashboard',
                 })
+            } else {
+                return formatPageName({ heading, title: 'CMS Dashboard' })
             }
-            return formatPageName({ heading, title: PageTitlesRecord[route] })
         case 'DASHBOARD_SUBMISSIONS' || 'DASHBOARD_RATES':
             if (user && user.__typename === 'CMSUser') {
                 return formatPageName({ title: 'CMS Dashboard' })


### PR DESCRIPTION
## Summary

Narrow in work from #2543 for navigation links specifically

- Address missing fields from[ Blast analytics tagging strategy doc](https://confluence.cms.gov/pages/viewpage.action?spaceKey=BLSTANALYT&title=mc-review.onemac.cms.gov+-+Tagging+Strategy)
- Use dashboard or homepage rather than "root" as the page name for the `/` url and dashboards
- Add more granular `event_name` types by allowing that value to be set in nav links. This allows distinct loggined for navigation clicked versus back button versus internal link clicked

#### Related issues
https://jiraent.cms.gov/browse/MCR-4219


#### Screenshots
n/a

#### Test cases covered
n/a we dont unit test analytiucs

## QA guidance
This work with be QA/ed by Blast in product -  code reviewers can just skim change high level