### PR TITLE
MCR-4258: Hide missing data text for linked rates

### DIFF
--- a/services/app-web/src/pages/StateSubmission/RateDetails/LinkedRateSummary.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/LinkedRateSummary.tsx
@@ -1,7 +1,6 @@
 import { formatCalendarDate } from '../../../common-code/dateHelpers'
 import {
     DataDetail,
-    DataDetailMissingField,
     DoubleColumnGrid,
     SectionCard,
     UploadedDocumentsTable,
@@ -45,14 +44,12 @@ export const LinkedRateSummary = ({
                         id="ratingPeriod"
                         label="Rating period"
                         children={
-                            rateForm.rateDateStart && rateForm.rateDateEnd ? (
+                            rateForm.rateDateStart && rateForm.rateDateEnd && (
                                 `${formatCalendarDate(
                                     rateForm?.rateDateStart
                                 )} to ${formatCalendarDate(
                                     rateForm?.rateDateEnd
                                 )}`
-                            ) : (
-                                <DataDetailMissingField />
                             )
                         }
                     />

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/RateDetailsSummarySection.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/RateDetailsSummarySection.test.tsx
@@ -407,6 +407,38 @@ describe('RateDetailsSummarySection', () => {
         ).not.toBeInTheDocument()
     })
 
+    it('does not render explain missing data text for a linked rate', async () => {
+        const statePrograms = mockMNState().programs
+        const contract = mockContractWithLinkedRateDraft()
+        contract.draftRates![0].revisions[0].formData.rateDateStart = null
+        contract.draftRates![0].revisions[0].formData.rateDateEnd = null
+        contract.draftRates![0].revisions[0].formData.rateDateCertified = null
+        contract.draftRates![0].revisions[0].formData.rateCapitationType = null
+        contract.draftRates![0].revisions[0].formData.amendmentEffectiveDateEnd = null
+        contract.draftRates![0].revisions[0].formData.amendmentEffectiveDateStart = null
+        contract.draftRates![0].revisions[0].formData.rateCapitationType = null
+        contract.draftRates![0].revisions[0].formData.certifyingActuaryContacts = []
+        contract.draftRates![0].revisions[0].formData.actuaryCommunicationPreference = null
+
+        await waitFor(() => {
+            renderWithProviders(
+                <RateDetailsSummarySection
+                    contract={contract}
+                    submissionName="MN-MSHO-0003"
+                    statePrograms={statePrograms}
+                    editNavigateTo="/edit"
+                />,
+                {
+                    apolloProvider: apolloProviderStateUser,
+                }
+            )
+        })
+
+        expect(
+            screen.queryByText('You must provide this information')
+        ).not.toBeInTheDocument()
+    })
+
     it('renders the deprecated rate programs when no rate programs present on last submitted version of rate shown to state user editing draft contract with linked rates', async () => {
         const statePrograms = mockMNState().programs
         const contract = mockContractWithLinkedRateDraft()

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/RateDetailsSummarySection.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React, { useState } from 'react'
 import { DataDetail } from '../../../components/DataDetail'
 import { SectionHeader } from '../../../components/SectionHeader'
@@ -344,8 +345,10 @@ export const RateDetailsSummarySection = ({
                                           id="rateType"
                                           label="Rate certification type"
                                           explainMissingData={
-                                              explainMissingData
-                                          }
+                                            isLinkedRate
+                                                ? false
+                                                : explainMissingData
+                                        }
                                           children={rateCertificationType(rate)}
                                       />
                                       <DataDetail
@@ -357,8 +360,10 @@ export const RateDetailsSummarySection = ({
                                                   : 'Rating period'
                                           }
                                           explainMissingData={
-                                              explainMissingData
-                                          }
+                                            isLinkedRate
+                                                ? false
+                                                : explainMissingData
+                                        }
                                           children={formatDatePeriod(
                                               rateFormData.rateDateStart,
                                               rateFormData.rateDateEnd
@@ -372,8 +377,10 @@ export const RateDetailsSummarySection = ({
                                                   : 'Date certified'
                                           }
                                           explainMissingData={
-                                              explainMissingData
-                                          }
+                                            isLinkedRate
+                                                ? false
+                                                : explainMissingData
+                                        }
                                           children={formatCalendarDate(
                                               rateFormData.rateDateCertified
                                           )}
@@ -383,8 +390,10 @@ export const RateDetailsSummarySection = ({
                                               id="effectiveRatingPeriod"
                                               label="Rate amendment effective dates"
                                               explainMissingData={
-                                                  explainMissingData
-                                              }
+                                                isLinkedRate
+                                                    ? false
+                                                    : explainMissingData
+                                            }
                                               children={formatDatePeriod(
                                                   rateFormData.amendmentEffectiveDateStart,
                                                   rateFormData.amendmentEffectiveDateEnd
@@ -395,16 +404,20 @@ export const RateDetailsSummarySection = ({
                                           id="rateCapitationType"
                                           label="Does the actuary certify capitation rates specific to each rate cell or a rate range?"
                                           explainMissingData={
-                                              explainMissingData
-                                          }
+                                            isLinkedRate
+                                                ? false
+                                                : explainMissingData
+                                        }
                                           children={rateCapitationType(rate)}
                                       />
                                       <DataDetail
                                           id="certifyingActuary"
                                           label="Certifying actuary"
                                           explainMissingData={
-                                              explainMissingData
-                                          }
+                                            isLinkedRate
+                                                ? false
+                                                : explainMissingData
+                                        }
                                           children={
                                               validateActuary(
                                                   rateFormData
@@ -426,7 +439,9 @@ export const RateDetailsSummarySection = ({
                                                   id={`addtlCertifyingActuary-${addtlContactIndex}`}
                                                   label="Certifying actuary"
                                                   explainMissingData={
-                                                      explainMissingData
+                                                    isLinkedRate
+                                                        ? false
+                                                        : explainMissingData
                                                   }
                                                   children={
                                                       validateActuary(
@@ -451,7 +466,9 @@ export const RateDetailsSummarySection = ({
                                               ]
                                           }
                                           explainMissingData={
-                                              explainMissingData
+                                            isLinkedRate
+                                                ? false
+                                                : explainMissingData
                                           }
                                       />
                                   </DoubleColumnGrid>


### PR DESCRIPTION
## Summary

This PR updates the RateDetailsSummarySection to ensure no missing data error validations display for a linked rate and it updates the linkedRatesSummary (that appears on the RateDetails page) to not display missing data error either

#### Related issues

https://jiraent.cms.gov/browse/MCR-4258

#### Screenshots

**BEFORE**

<img width="624" alt="Screenshot 2024-07-16 at 4 10 43 PM" src="https://github.com/user-attachments/assets/d73a12d6-e93c-4af7-8a71-98ee0cad59fe">

<img width="782" alt="Screenshot 2024-07-16 at 4 11 47 PM" src="https://github.com/user-attachments/assets/056b3337-c201-4b41-a00a-3fa0f4599028">


AFTER

<img width="730" alt="Screenshot 2024-07-17 at 11 16 48 AM" src="https://github.com/user-attachments/assets/aa2d7957-be49-404c-9a81-b4713b497149">
<img width="813" alt="Screenshot 2024-07-17 at 11 24 02 AM" src="https://github.com/user-attachments/assets/bd8e8f58-20ad-4999-b001-50458064fe76">



#### Test cases covered

- RateDetailsSummarySection - checks that missing data text doesn't appear for a draft linked rate

## QA guidance

- create and submit a contract with one rate (Rate A) submission
- go in through db functions and remove a required field from Rate A(make start date added empty, for example)
- create a new contract and rate submission that has Rate A as a linked rate
- go to review and submit page
- no validation errors should appear
