### PR TITLE
Unblock settings page usage

### DIFF
--- a/services/app-web/src/hooks/useTealium.ts
+++ b/services/app-web/src/hooks/useTealium.ts
@@ -17,9 +17,10 @@ const useTealium = (): {
     const context = React.useContext(TealiumContext)
 
     if (context === undefined) {
-        const error = new Error('useTealium can only be used within an Tealium Provider')
-        recordJSException(error)
-        throw error
+        return {
+            logButtonEvent: () => {console.warn('cannot logButtonEven - Tealium Provider not loaded')},
+            logInternalLinkEvent:  () => {console.warn('cannot logLinkEvent- Tealium Provider not loaded')}
+        }
     }
 
     const { pathname, loggedInUser, heading, logUserEvent } = context

--- a/services/app-web/src/pages/Settings/EmailSettingsTables/EmailAnalystsTable.tsx
+++ b/services/app-web/src/pages/Settings/EmailSettingsTables/EmailAnalystsTable.tsx
@@ -47,7 +47,7 @@ const EmailAnalystsTable = ({
     )
 
     const reactTable = useReactTable({
-        data: analysts.sort((a, b) =>
+        data: Array.from(analysts).sort((a, b) =>
             a['stateCode'] > b['stateCode'] ? -1 : 1
         ),
         filterFns: {


### PR DESCRIPTION
## Summary

Settings page started to crash on load. Looks like  mutable array was causing crash - throwing a type a error `0 is read only" for trying to alter state analysts array.

Other notes
- will look into an eslint role for this next
- will also write basic E2E test for settings page load
- I changed the error state for tealium because on full page crash that error was getting thrown multiple times and it floods the console. Not helpful. 

#### Related issues
https://jiraent.cms.gov/browse/MCR-4317

#### Test cases covered
No new tests yet, will be next PR

## QA guidance
Log is as admin user and navigate to /settings. Try to change an existing users division assignment.  Before the crash happened as soon as you hit the setting page.
