### PR TITLE
fix: cypress checkbox behavior - swap .safeClick to .check to handle the USWDS checkbox

### DIFF
--- a/services/cypress/support/stateSubmissionFormCommands.ts
+++ b/services/cypress/support/stateSubmissionFormCommands.ts
@@ -103,7 +103,7 @@ Cypress.Commands.add('fillOutBaseContractDetails', () => {
     cy.findByText('No, the contract does not fully comply with all applicable requirements').click()
 
     cy.findByRole('textbox', {name: 'Provide a brief description of any contractual or operational non-compliance, including regulatory citations and expected timeframe for remediation'})
-        .type('Non compliance explanation')
+        .type('Non compliance explanation - base contract')
 
     cy.findByText('Fully executed').click()
     cy.findAllByLabelText('Start date', {timeout: 2000})
@@ -116,8 +116,8 @@ Cypress.Commands.add('fillOutBaseContractDetails', () => {
         .findByTestId('date-picker-external-input')
         .type('03/31/2025')
         .blur()
-    cy.findByLabelText('Managed Care Organization (MCO)').safeClick()
-    cy.findByLabelText('1932(a) State Plan Authority').safeClick()
+    cy.findByLabelText('Managed Care Organization (MCO)').check({force: true})
+    cy.findByLabelText('1932(a) State Plan Authority').check({force: true})
     cy.findByTestId('file-input-input').attachFile(
         'documents/trussel-guide.pdf'
     )
@@ -183,7 +183,7 @@ Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
     // Contract 438 attestation question
     cy.findByText('No, the contract does not fully comply with all applicable requirements').click()
     cy.findByRole('textbox', {name: 'Provide a brief description of any contractual or operational non-compliance, including regulatory citations and expected timeframe for remediation'})
-        .type('Non compliance explanation')
+        .type('Non compliance explanation - amendment')
 
     cy.findByText('Unexecuted by some or all parties').click()
 
@@ -196,8 +196,8 @@ Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
         .findByTestId('date-picker-external-input')
         .type('03/31/2025')
         .blur()
-    cy.findByLabelText('Managed Care Organization (MCO)').safeClick()
-    cy.findByLabelText('1932(a) State Plan Authority').safeClick()
+    cy.findByLabelText('Managed Care Organization (MCO)').check({force: true})
+    cy.findByLabelText('1932(a) State Plan Authority').check({force: true})
 
     // fill out the yes/nos
     cy.findByText('In Lieu-of Services and Settings (ILOSs) in accordance with 42 CFR § 438.3(e)(2)')


### PR DESCRIPTION
## Summary
We have a [recurrent issue on cypress runs](https://cloud.cypress.io/projects/tt5hbz/analytics/top-failures/3147a9e3-7bad-840a-b997-e16de99e4069-d020e680-9e8f-88c8-fdc7-eef74f64d75a) yesterday and today. Trying  a different way of selecting checkbox items in Cypress to see if it helps.

#### Related issues
n/a 

#### Screenshots
Screenshot of the app at the point of  cypress failures is below.  The faliures happen from within an existing state submission form helper which had been working fine... up until this week. 

The errors are for the two checkbox fields (managed care entities and federal authorities). Re-runs show these checkbox fields register as clicked and can be seen visually as selected in cypress re-runs intiially.  However, a few commands later, the selections disappear and the checkbox uncheck itself. This causes the update form API request to fail because when there's missing fields in the form, the form does not submit but instead prompts user to fix missing fields.

<img width="435" alt="Screenshot 2024-07-19 at 4 27 34 PM" src="https://github.com/user-attachments/assets/149a2c13-d905-4c95-ba8d-faad230f7bf4">


## QA guidance

If Cypress passes we would have to merge this see if it makes any difference with this class of flake. 
