### PR TITLE
Add vite proxy configs to deal with LD CORS

### DIFF
--- a/services/app-api/src/handlers/apollo_gql.ts
+++ b/services/app-api/src/handlers/apollo_gql.ts
@@ -337,7 +337,7 @@ async function initializeGQLHandler(): Promise<Handler> {
 
     // Wait for initialization. On initialization failure default to offlineLDService and close ldClient.
     try {
-        await ldClient.waitForInitialization()
+        await ldClient.waitForInitialization({ timeout: 10 })
         launchDarkly = ldService(ldClient)
     } catch (err) {
         console.error(

--- a/services/app-web/package.json
+++ b/services/app-web/package.json
@@ -106,7 +106,7 @@
         "jotai": "^2.2.1",
         "jotai-location": "^0.5.1",
         "jsdom": "^24.1.0",
-        "launchdarkly-react-client-sdk": "^3.0.10",
+        "launchdarkly-react-client-sdk": "^3.3.2",
         "path-browserify": "^1.0.1",
         "qs": "^6.11.0",
         "react": "^18.2.0",

--- a/services/app-web/src/index.tsx
+++ b/services/app-web/src/index.tsx
@@ -60,7 +60,7 @@ Amplify.configure({
     },
 })
 
-const authMode = import.meta.env.VITE_APP_AUTH_MODE
+const authMode: string = import.meta.env.VITE_APP_AUTH_MODE
 assertIsAuthMode(authMode)
 const cache = new InMemoryCache({
     typePolicies: {
@@ -151,10 +151,19 @@ if (ldClientId === undefined) {
     const LDProvider = await asyncWithLDProvider({
         clientSideID: ldClientId,
         options: {
-            bootstrap: 'localStorage',
-            baseUrl: 'https://clientsdk.launchdarkly.us',
-            streamUrl: 'https://clientstream.launchdarkly.us',
-            eventsUrl: 'https://events.launchdarkly.us',
+            bootstrap: 'localStorage' as const,
+            baseUrl:
+                authMode === 'LOCAL'
+                    ? '/ld-clientsdk'
+                    : 'https://clientsdk.launchdarkly.us',
+            streamUrl:
+                authMode === 'LOCAL'
+                    ? '/ld-clientstream'
+                    : 'https://clientstream.launchdarkly.us',
+            eventsUrl:
+                authMode === 'LOCAL'
+                    ? '/ld-events'
+                    : 'https://events.launchdarkly.us',
         },
     })
 

--- a/services/app-web/src/index.tsx
+++ b/services/app-web/src/index.tsx
@@ -151,7 +151,7 @@ if (ldClientId === undefined) {
     const LDProvider = await asyncWithLDProvider({
         clientSideID: ldClientId,
         options: {
-            bootstrap: 'localStorage' as const,
+            bootstrap: 'localStorage',
             baseUrl:
                 authMode === 'LOCAL'
                     ? '/ld-clientsdk'

--- a/services/app-web/src/react-app-env.d.ts
+++ b/services/app-web/src/react-app-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="react-scripts" />

--- a/services/app-web/vite.config.ts
+++ b/services/app-web/vite.config.ts
@@ -10,6 +10,7 @@ import path from 'path'
 
 export default defineConfig(() => ({
     base: '/',
+    sourcemap: true,
     plugins: [
         react(),
         svgr({
@@ -28,6 +29,43 @@ export default defineConfig(() => ({
         open: true,
         port: 3000,
         host: '127.0.0.1',
+        cors: {
+            origin: '*',
+            preflightContinue: true,
+            methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+        },
+        proxy: {
+            '/ld-clientsdk': {
+                target: 'https://clientsdk.launchdarkly.us',
+                changeOrigin: true,
+                rewrite: (path) => path.replace(/^\/ld-clientsdk/, ''),
+                configure: (proxy, _options) => {
+                    proxy.on('proxyReq', (proxyReq, req, res) => {
+                        proxyReq.setHeader('Origin', 'http://localhost:3000')
+                    })
+                },
+            },
+            '/ld-clientstream': {
+                target: 'https://clientstream.launchdarkly.us',
+                changeOrigin: true,
+                rewrite: (path) => path.replace(/^\/ld-clientstream/, ''),
+                configure: (proxy, _options) => {
+                    proxy.on('proxyReq', (proxyReq, req, res) => {
+                        proxyReq.setHeader('Origin', 'http://localhost:3000')
+                    })
+                },
+            },
+            '/ld-events': {
+                target: 'https://events.launchdarkly.us',
+                changeOrigin: true,
+                rewrite: (path) => path.replace(/^\/ld-events/, ''),
+                configure: (proxy, _options) => {
+                    proxy.on('proxyReq', (proxyReq, req, res) => {
+                        proxyReq.setHeader('Origin', 'http://localhost:3000')
+                    })
+                },
+            },
+        },
     },
     define: {
         global: 'globalThis',
@@ -49,9 +87,11 @@ export default defineConfig(() => ({
     css: {
         preprocessorOptions: {
             scss: {
-                includePaths: [path.resolve(__dirname, '../../node_modules/uswds/dist')]
-            }
-        }
+                includePaths: [
+                    path.resolve(__dirname, '../../node_modules/uswds/dist'),
+                ],
+            },
+        },
     },
     test: {
         environment: 'jsdom',

--- a/yarn.lock
+++ b/yarn.lock
@@ -18860,10 +18860,10 @@ launchdarkly-js-sdk-common@5.2.0:
     fast-deep-equal "^2.0.1"
     uuid "^8.0.0"
 
-launchdarkly-react-client-sdk@^3.0.10:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/launchdarkly-react-client-sdk/-/launchdarkly-react-client-sdk-3.2.0.tgz#815812780f1fa7569cc72ea7d504b3ddc95324ea"
-  integrity sha512-PomUDVMv4/imEtz+2vR3w0v9NAtq4QWu6c3wXQbWv+xOuLH4RSaLHHbt1avrRWLC1tWCl2vrWA6HqVL6c5Dm8w==
+launchdarkly-react-client-sdk@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/launchdarkly-react-client-sdk/-/launchdarkly-react-client-sdk-3.3.2.tgz#b934f556d85ab9c6457744ddeb2ba581b440342c"
+  integrity sha512-Cusw0aB+L65FceGQQ77IFhKZT+J+NezDtmahhI/LtK/Da2YhlbSmxhInSLdf325e3Umj0+foDIOkFt/OOFmQsQ==
   dependencies:
     hoist-non-react-statics "^3.3.2"
     launchdarkly-js-client-sdk "^3.3.0"


### PR DESCRIPTION
## Summary

Since merging the CRA -> Vite refactor, LaunchDarkly has been throwing cors errors in local dev. This adds some LD proxies that will get CORS checks to succeed. 

#### Related issues
https://jiraent.cms.gov/browse/MCR-4298
