### PR TITLE
MCR-4285 & MCR-4128: page redirection fixes

### DIFF
--- a/services/app-web/src/hooks/useHealthPlanPackageForm.ts
+++ b/services/app-web/src/hooks/useHealthPlanPackageForm.ts
@@ -1,8 +1,14 @@
 import { useState, useEffect} from 'react'
 import { usePage } from "../contexts/PageContext"
 import { useStatePrograms } from './useStatePrograms'
-import { useFetchHealthPlanPackageWrapper } from '../gqlHelpers'
-import { CreateHealthPlanPackageInput, HealthPlanPackage, UpdateInformation, useCreateHealthPlanPackageMutation, useUpdateHealthPlanFormDataMutation } from '../gen/gqlClient'
+import { useFetchHealthPlanPackageWrapper} from '../gqlHelpers'
+import {
+    CreateHealthPlanPackageInput,
+    HealthPlanPackage,
+    UpdateInformation,
+    useCreateHealthPlanPackageMutation,
+    useUpdateHealthPlanFormDataMutation
+} from '../gen/gqlClient'
 import { UnlockedHealthPlanFormDataType, packageName } from '../common-code/healthPlanFormDataType'
 import { domainToBase64 } from '../common-code/proto/healthPlanFormDataProto'
 import { recordJSException } from '../otelHelpers'
@@ -21,169 +27,164 @@ type  UseHealthPlanPackageForm = {
     updateDraft: (
         input: UnlockedHealthPlanFormDataType
     ) => Promise<HealthPlanPackage | Error>
-    createDraft: (
-        input: CreateHealthPlanPackageInput
-    ) => Promise<HealthPlanPackage | Error>
+    createDraft: (input: CreateHealthPlanPackageInput) => Promise<HealthPlanPackage | Error>
     documentDateLookupTable?: DocumentDateLookupTableType
-   interimState?:  InterimState,
-   submissionName?: string
+    interimState?:  InterimState
+    submissionName?: string
 }
 // This hook is for use on form pages still relying on the old HealthPlanPackage APIS and domain model types
 // This is intentionally throwaway code that replicates logic formally in StateSubmissionForm
 // PLease delete and remove this file when HealthPlanPackage is fully out of the Form
 
 const useHealthPlanPackageForm = (packageID?: string): UseHealthPlanPackageForm => {
-     // Set up defaults for the return value for hook
-     let interimState: UseHealthPlanPackageForm['interimState'] = undefined // enum to determine what Interim UI should override form page
-     let previousDocuments: UseHealthPlanPackageForm['previousDocuments'] = [] // used for document upload tables
-     let draftSubmission: UseHealthPlanPackageForm['draftSubmission'] = undefined // form data from current package revision, used to load form
-     let unlockInfo: UseHealthPlanPackageForm['unlockInfo'] = undefined
-     let documentDateLookupTable = undefined
-     const [showPageErrorMessage, setShowPageErrorMessage] = useState<
-     boolean | string
- >(false) // string is a custom error message, defaults to generic of true
+    // Set up defaults for the return value for hook
+    let interimState: UseHealthPlanPackageForm['interimState'] = undefined // enum to determine what Interim UI should override form page
+    let previousDocuments: UseHealthPlanPackageForm['previousDocuments'] = [] // used for document upload tables
+    let draftSubmission: UseHealthPlanPackageForm['draftSubmission'] = undefined // form data from current package revision, used to load form
+    let unlockInfo: UseHealthPlanPackageForm['unlockInfo'] = undefined
+    let documentDateLookupTable = undefined
+    const [showPageErrorMessage, setShowPageErrorMessage] = useState<boolean | string>(false) // string is a custom error message, defaults to generic of true
     const { updateHeading } = usePage()
-    const [pkgNameForHeading, setPkgNameForHeading] = useState<
-    string | undefined
->(undefined)
+    const [pkgNameForHeading, setPkgNameForHeading] = useState<string | undefined>(undefined)
 
-useEffect(() => {
-    updateHeading({ customHeading: pkgNameForHeading })
-}, [pkgNameForHeading, updateHeading])
+    useEffect(() => {
+        updateHeading({ customHeading: pkgNameForHeading })
+    }, [pkgNameForHeading, updateHeading])
 
-const statePrograms = useStatePrograms()
+    const statePrograms = useStatePrograms()
 
-const { result: fetchResult } = useFetchHealthPlanPackageWrapper(packageID ?? 'new-draft', packageID? false: true)
-const [createFormData] = useCreateHealthPlanPackageMutation()
+    const { result: fetchResult } = useFetchHealthPlanPackageWrapper(packageID ?? 'new-draft',packageID? false: true)
+    const [createFormData] = useCreateHealthPlanPackageMutation()
 
-const createDraft: UseHealthPlanPackageForm['createDraft']  = async (
-    input: CreateHealthPlanPackageInput
-): Promise<HealthPlanPackage | Error> => {
-    setShowPageErrorMessage(false)
-    const {populationCovered,programIDs,riskBasedContract, submissionType, submissionDescription, contractType} = input
-    if(populationCovered === undefined || contractType === undefined) {
-        return new Error('wrong')
-    }
-    try {
-        const createResult = await createFormData({
-            variables: {
-                input: {
-                    populationCovered,
-                    programIDs,
-                    riskBasedContract,
-                    submissionType,
-                    submissionDescription,
-                    contractType,
-            },
-        }})
-        const createdSubmission: HealthPlanPackage | undefined =
-            createResult?.data?.createHealthPlanPackage.pkg
-
-        if (!createdSubmission) {
-            setShowPageErrorMessage(true)
-            console.info('Failed to update form data', createResult)
-            recordJSException(
-                `StateSubmissionForm: Apollo error reported. Error message: Failed to create form data ${createResult}`
-            )
-            return new Error('Failed to create form data')
+    const createDraft: UseHealthPlanPackageForm['createDraft']  = async (
+        input: CreateHealthPlanPackageInput
+    ): Promise<HealthPlanPackage | Error> => {
+        setShowPageErrorMessage(false)
+        const {populationCovered,programIDs,riskBasedContract, submissionType, submissionDescription, contractType} = input
+        if(populationCovered === undefined || contractType === undefined) {
+            return new Error('wrong')
         }
-
-        return createdSubmission
-    } catch (serverError) {
-        setShowPageErrorMessage(true)
-        recordJSException(
-            `StateSubmissionForm: Apollo error reported. Error message: ${serverError.message}`
-        )
-        return new Error(serverError)
-    }
-}
-const [updateFormData] = useUpdateHealthPlanFormDataMutation()
-
-const updateDraft: UseHealthPlanPackageForm['updateDraft']  = async (
-    input: UnlockedHealthPlanFormDataType
-): Promise<HealthPlanPackage | Error> => {
-    const base64Draft = domainToBase64(input)
-
-    setShowPageErrorMessage(false)
-    try {
-        const updateResult = await updateFormData({
-            variables: {
-                input: {
-                    pkgID: pkg.id,
-                    healthPlanFormData: base64Draft,
+        try {
+            const createResult = await createFormData({
+                variables: {
+                    input: {
+                        populationCovered,
+                        programIDs,
+                        riskBasedContract,
+                        submissionType,
+                        submissionDescription,
+                        contractType,
                 },
-            },
-        })
-        const updatedSubmission: HealthPlanPackage | undefined =
-            updateResult?.data?.updateHealthPlanFormData.pkg
+            }})
+            const createdSubmission: HealthPlanPackage | undefined =
+                createResult?.data?.createHealthPlanPackage.pkg
 
-        if (!updatedSubmission) {
+            if (!createdSubmission) {
+                setShowPageErrorMessage(true)
+                console.info('Failed to update form data', createResult)
+                recordJSException(
+                    `StateSubmissionForm: Apollo error reported. Error message: Failed to create form data ${createResult}`
+                )
+                return new Error('Failed to create form data')
+            }
+
+            return createdSubmission
+        } catch (serverError) {
             setShowPageErrorMessage(true)
-            console.info('Failed to update form data', updateResult)
             recordJSException(
-                `StateSubmissionForm: Apollo error reported. Error message: Failed to update form data ${updateResult}`
+                `StateSubmissionForm: Apollo error reported. Error message: ${serverError.message}`
             )
-            return new Error('Failed to update form data')
-        }
-
-        return updatedSubmission
-    } catch (serverError) {
-        setShowPageErrorMessage(true)
-        recordJSException(
-            `StateSubmissionForm: Apollo error reported. Error message: ${serverError.message}`
-        )
-        return new Error(serverError)
-    }
-}
-
-if (fetchResult.status === 'LOADING') {
-    interimState = 'LOADING'
-    return {interimState, createDraft, updateDraft, showPageErrorMessage }
-}
-
-if (fetchResult.status === 'ERROR') {
-    const err = fetchResult.error
-    if (err instanceof ApolloError){
-        handleApolloError(err, true)
-        if (err.graphQLErrors[0]?.extensions?.code === 'NOT_FOUND') {
-                interimState = 'NOT_FOUND'
-                return {interimState,createDraft, updateDraft,  showPageErrorMessage }
+            return new Error(serverError)
         }
     }
-    if (err.name !== 'SKIPPED') {
-        recordJSException(err)
-        interimState = 'GENERIC_ERROR'// api failure or protobuf decode failure
-        return { interimState,  createDraft, updateDraft,  showPageErrorMessage}
+    const [updateFormData] = useUpdateHealthPlanFormDataMutation()
+
+    const updateDraft: UseHealthPlanPackageForm['updateDraft']  = async (
+        input: UnlockedHealthPlanFormDataType
+    ): Promise<HealthPlanPackage | Error> => {
+        const base64Draft = domainToBase64(input)
+
+        setShowPageErrorMessage(false)
+        try {
+            const updateResult = await updateFormData({
+                variables: {
+                    input: {
+                        pkgID: pkg.id,
+                        healthPlanFormData: base64Draft,
+                    },
+                },
+            })
+            const updatedSubmission: HealthPlanPackage | undefined =
+                updateResult?.data?.updateHealthPlanFormData.pkg
+
+            if (!updatedSubmission) {
+                setShowPageErrorMessage(true)
+                console.info('Failed to update form data', updateResult)
+                recordJSException(
+                    `StateSubmissionForm: Apollo error reported. Error message: Failed to update form data ${updateResult}`
+                )
+                return new Error('Failed to update form data')
+            }
+
+            return updatedSubmission
+        } catch (serverError) {
+            setShowPageErrorMessage(true)
+            recordJSException(
+                `StateSubmissionForm: Apollo error reported. Error message: ${serverError.message}`
+            )
+            return new Error(serverError)
+        }
     }
-    return {interimState: undefined, createDraft, updateDraft,  showPageErrorMessage}
 
-}
+    if (fetchResult.status === 'LOADING') {
+        interimState = 'LOADING'
+        return {interimState, createDraft, updateDraft, showPageErrorMessage }
+    }
 
-const { data, revisionsLookup } = fetchResult
-const pkg = data.fetchHealthPlanPackage.pkg
+    if (fetchResult.status === 'ERROR') {
+        const err = fetchResult.error
+        if (err instanceof ApolloError){
+            handleApolloError(err, true)
+            if (err.graphQLErrors[0]?.extensions?.code === 'NOT_FOUND') {
+                    interimState = 'NOT_FOUND'
+                    return {interimState,createDraft, updateDraft,  showPageErrorMessage }
+            }
+        }
+        if (err.name !== 'SKIPPED') {
+            recordJSException(err)
+            interimState = 'GENERIC_ERROR'// api failure or protobuf decode failure
+            return { interimState,  createDraft, updateDraft,  showPageErrorMessage}
+        }
+        return {interimState: undefined, createDraft, updateDraft,  showPageErrorMessage}
 
-// pull out the latest revision and document lookups
-const latestRevision = pkg.revisions[0].node
-const formDataFromLatestRevision =
-    revisionsLookup[latestRevision.id].formData
-const documentDates = makeDocumentDateTable(revisionsLookup)
-const documentLists = makeDocumentS3KeyLookup(revisionsLookup)
-previousDocuments = documentLists.previousDocuments
-// if we've gotten back a submitted revision, it can't be edited
-if (formDataFromLatestRevision.status !== 'DRAFT') {
- interimState = 'INVALID_STATUS'
- return {createDraft, updateDraft,  showPageErrorMessage}
-}
+    }
 
-const submissionName = packageName(
-    formDataFromLatestRevision.stateCode,
-    formDataFromLatestRevision.stateNumber,
-    formDataFromLatestRevision.programIDs,
-    statePrograms
-)
-if (pkgNameForHeading !== submissionName) {
-    setPkgNameForHeading(submissionName)
-}
+    const { data, revisionsLookup } = fetchResult
+    const pkg = data.fetchHealthPlanPackage.pkg
+
+    // pull out the latest revision and document lookups
+    const latestRevision = pkg.revisions[0].node
+    const formDataFromLatestRevision =
+        revisionsLookup[latestRevision.id].formData
+    const documentDates = makeDocumentDateTable(revisionsLookup)
+    const documentLists = makeDocumentS3KeyLookup(revisionsLookup)
+    previousDocuments = documentLists.previousDocuments
+
+    // if we've gotten back a submitted revision, it can't be edited
+    if (formDataFromLatestRevision.status !== 'DRAFT') {
+        interimState = 'INVALID_STATUS'
+        return {createDraft, updateDraft,  showPageErrorMessage}
+    }
+
+    const submissionName = packageName(
+        formDataFromLatestRevision.stateCode,
+        formDataFromLatestRevision.stateNumber,
+        formDataFromLatestRevision.programIDs,
+        statePrograms
+    )
+    if (pkgNameForHeading !== submissionName) {
+        setPkgNameForHeading(submissionName)
+    }
 
     // set up data to return
     draftSubmission = formDataFromLatestRevision

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponse.tsx
@@ -18,6 +18,7 @@ import {
 import { QATable, QuestionData, Division } from './QATable/QATable'
 import { CmsUser, QuestionEdge, StateUser } from '../../gen/gqlClient'
 import { useStringConstants } from '../../hooks/useStringConstants'
+import { GenericErrorPage } from '../Errors/GenericErrorPage'
 
 type divisionQuestionDataType = {
     division: Division
@@ -79,6 +80,10 @@ export const QuestionResponse = () => {
                 <Loading />
             </GridContainer>
         )
+    }
+
+    if (pkg.status === 'DRAFT') {
+        return <GenericErrorPage />
     }
 
     const isCMSUser = user?.role === 'CMS_USER'

--- a/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadQuestions.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadQuestions.tsx
@@ -27,13 +27,14 @@ import { usePage } from '../../../contexts/PageContext'
 import { Breadcrumbs } from '../../../components/Breadcrumbs/Breadcrumbs'
 import { createQuestionWrapper } from '../../../gqlHelpers/mutationWrappersForUserFriendlyErrors'
 import { RoutesRecord } from '../../../constants'
+import { GenericErrorPage } from '../../Errors/GenericErrorPage'
 
 export const UploadQuestions = () => {
     // router context
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     const { division, id } = useParams<{ division: string; id: string }>()
     const navigate = useNavigate()
-    const { packageName } = useOutletContext<SideNavOutletContextType>()
+    const { packageName, pkg } = useOutletContext<SideNavOutletContextType>()
 
     // api
     const [createQuestion, { loading: apiLoading, error: apiError }] =
@@ -45,6 +46,10 @@ export const UploadQuestions = () => {
     useEffect(() => {
         updateHeading({ customHeading: `${packageName} Add questions` })
     }, [packageName, updateHeading])
+
+    if (pkg.status === 'DRAFT') {
+        return <GenericErrorPage />
+    }
 
     // component specific support
     const { handleDeleteFile, handleUploadFile, handleScanFile } = useS3()

--- a/services/app-web/src/pages/QuestionResponse/UploadResponse/UploadResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadResponse/UploadResponse.tsx
@@ -28,6 +28,7 @@ import { SideNavOutletContextType } from '../../SubmissionSideNav/SubmissionSide
 import { Breadcrumbs } from '../../../components/Breadcrumbs/Breadcrumbs'
 import { createResponseWrapper } from '../../../gqlHelpers/mutationWrappersForUserFriendlyErrors'
 import { RoutesRecord } from '../../../constants'
+import { GenericErrorPage } from '../../Errors/GenericErrorPage'
 
 export const UploadResponse = () => {
     // router context
@@ -46,10 +47,14 @@ export const UploadResponse = () => {
     // page level state
     const [shouldValidate, setShouldValidate] = React.useState(false)
     const { updateHeading } = usePage()
-    const { packageName } = useOutletContext<SideNavOutletContextType>()
+    const { packageName, pkg } = useOutletContext<SideNavOutletContextType>()
     useEffect(() => {
         updateHeading({ customHeading: packageName })
     }, [packageName, updateHeading])
+
+    if (pkg.status === 'DRAFT') {
+        return <GenericErrorPage />
+    }
 
     // component specific support
     const { handleDeleteFile, handleUploadFile, handleScanFile } = useS3()

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
@@ -1,6 +1,12 @@
 import React from 'react'
 
-import { Routes, Route } from 'react-router-dom'
+import {
+    Routes,
+    Route,
+    useOutletContext,
+    Navigate,
+    generatePath,
+} from 'react-router-dom'
 
 import { Error404 } from '../Errors/Error404Page'
 
@@ -20,9 +26,22 @@ import { UnlockedHealthPlanFormDataType } from '../../common-code/healthPlanForm
 import { ContractFormData } from '../../gen/gqlClient'
 import { RateDetails } from './RateDetails'
 import styles from './StateSubmissionForm.module.scss'
+import { SideNavOutletContextType } from '../SubmissionSideNav/SubmissionSideNav'
 
 // Can move this AppRoutes on future pass - leaving it here now to make diff clear
 export const StateSubmissionForm = (): React.ReactElement => {
+    const { pkg } = useOutletContext<SideNavOutletContextType>()
+
+    if (pkg.status === 'RESUBMITTED' || pkg.status === 'SUBMITTED') {
+        return (
+            <Navigate
+                to={generatePath(RoutesRecord.SUBMISSIONS_SUMMARY, {
+                    id: pkg.id,
+                })}
+            />
+        )
+    }
+
     return (
         <div
             data-testid="state-submission-form-page"


### PR DESCRIPTION
## Summary
[MCR-4285](https://jiraent.cms.gov/browse/MCR-4285)
[MCR-4128](https://jiraent.cms.gov/browse/MCR-4128)

- State users viewing the submission summary page:
   - When the submission is a `draft`, the user is redirected to the submission type page
   - When the submission is `unlocked`, the user is redirected to the review and submit page
- Submission form pages
   - When a submission is submitted or resubmitted, form pages will redirect users to the summary page.
- Q&A pages
   - When a submission is a `draft`, the user is redirected to a generic error page.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
