### PR TITLE
MCR-4130: Design fixes for Replace Rate btn

### DIFF
--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionSummarySection.module.scss
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionSummarySection.module.scss
@@ -99,9 +99,13 @@
     h3 {
         max-width: 70%;
     }
+
+    a {
+        margin-right: 0;
+    }
 }
 
-.certifyingActuaryDetail { 
+.certifyingActuaryDetail {
     margin-bottom: uswds.units(4);
 
     @include uswds.at-media(tablet) {

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/RateDetailsSummarySection.tsx
@@ -270,9 +270,10 @@ export const RateDetailsSummarySection = ({
         isPreviousSubmission,
     ])
 
-    const replaceRateClass = classnames({
-        [styles.replaceRateWrapper]: isAdminUser,
-    })
+    const replaceRateClass = (isLinkedRate: boolean) =>
+        classnames({
+            [styles.replaceRateWrapper]: isAdminUser && !isLinkedRate,
+        })
 
     return (
         <SectionCard id="rateDetails" className={styles.summarySection}>
@@ -315,7 +316,7 @@ export const RateDetailsSummarySection = ({
                               id={`rate-details-${rateRev.id}`}
                               key={rateRev.id}
                           >
-                              <div className={replaceRateClass}>
+                              <div className={replaceRateClass(isLinkedRate)}>
                                   <h3
                                       aria-label={`Rate ID: ${rateFormData.rateCertificationName}`}
                                       className={styles.rateName}


### PR DESCRIPTION
## Summary

This PR addresses feedback on [ticket](https://jiraent.cms.gov/browse/MCR-4130):

- Replace rate button is 32px from the right of the border box
- When replace rate button isn't on the page, prevent unnecessary wrapping of the rate name


#### Related issues
https://jiraent.cms.gov/browse/MCR-4130

#### Screenshots
<img width="984" alt="Screenshot 2024-07-25 at 4 13 00 PM" src="https://github.com/user-attachments/assets/33d3698c-4d0b-49c7-a133-07a98e46b900">
<img width="879" alt="Screenshot 2024-07-25 at 4 13 23 PM" src="https://github.com/user-attachments/assets/5078ea10-2729-4c77-a421-2f917591499c">
<img width="431" alt="Screenshot 2024-07-25 at 4 17 27 PM" src="https://github.com/user-attachments/assets/5cd12afd-ed47-4971-9768-4ea8b50c10ba">


#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

View submissions as an admin issue with a non linked rate. should see the replace rate button is properly positioned

On a submission summary that doesn't have the replace rate button (viewed by a non admin user or a linked rate), ensure there's no unneeded wrapping happening on the rate name
