### PR TITLE
MCR-4317 add admin cypress tests for Settings

### DIFF
--- a/scripts/add_cypress_test_users.ts
+++ b/scripts/add_cypress_test_users.ts
@@ -62,6 +62,7 @@ function IDMRole(role: UserRole): string {
 async function createUser({
     userPoolID,
     name,
+    familyName,
     email,
     role,
     password,
@@ -73,6 +74,7 @@ async function createUser({
     role: UserRole
     password: string
     state?: string
+    familyName?: string
 }) {
     const cognitoClient = new CognitoIdentityProviderClient({
         apiVersion: '2016-04-19',
@@ -91,7 +93,7 @@ async function createUser({
             },
             {
                 Name: 'family_name',
-                Value: 'TestLastName',
+                Value: familyName ?? 'TestLastName',
             },
             {
                 Name: 'email',
@@ -175,36 +177,42 @@ async function main() {
     const testUsers = [
         {
             name: 'Aang',
+            familyName: 'Avatar',
             email: 'aang@example.com',
             role: 'STATE_USER' as const,
             state: 'MN',
         },
         {
             name: 'Toph',
+            familyName: 'Beifong',
             email: 'toph@example.com',
             role: 'STATE_USER' as const,
             state: 'VA',
         },
         {
             name: 'Toph',
+            familyName: 'Beifong',
             email: 'toph2@example.com',
             role: 'STATE_USER' as const,
             state: 'FL',
         },
         {
             name: 'Zuko',
+            familyName: 'Hotman',
             email: 'zuko@example.com',
             role: 'CMS_USER' as const,
             state: undefined,
         },
         {
             name: 'Roku',
+            familyName: 'Hotman',
             email: 'roku@example.com',
             role: 'CMS_USER' as const,
             state: undefined,
         },
         {
             name: 'Izumi',
+            familyName: 'Hotman',
             email: 'izumi@example.com',
             role: 'CMS_USER' as const,
             state: undefined,
@@ -218,17 +226,20 @@ async function main() {
         {
             name: 'Iroh',
             email: 'iroh@example.com',
+            familyName: 'Uncle',
             role: 'ADMIN_USER' as const,
             state: undefined,
         },
         {
             name: 'Appa',
+            familyName: 'Sky Bison',
             email: 'appa@example.com',
             role: 'HELPDESK_USER' as const,
             state: undefined,
         },
         {
             name: 'Shi Tong',
+            familyName: 'Wan',
             email: 'shi-tong@example.com',
             role: 'BUSINESSOWNER_USER' as const,
             state: undefined,
@@ -241,6 +252,7 @@ async function main() {
             await createUser({
                 userPoolID,
                 name: user.name,
+                familyName: user.familyName,
                 email: user.email,
                 role: user.role,
                 password: testUserPassword,

--- a/services/app-web/src/contexts/AuthContext.tsx
+++ b/services/app-web/src/contexts/AuthContext.tsx
@@ -62,7 +62,6 @@ function AuthProvider({
     const [loginStatus, setLoginStatus] =
         useState<LoginStatusType>('LOGGED_OUT')
     const ldClient = useLDClient()
-    const navigate = useNavigate()
 
     // session expiration modal
     const [sessionIsExpiring, setSessionIsExpiring] = useState<boolean>(false)
@@ -146,7 +145,7 @@ function AuthProvider({
                     `[User auth error]: Unable to authenticate user though user seems to be logged in. Message: ${error.message}`
                 )
                 // since we have an auth request error but a potentially logged in user, we log out fully from Auth context and redirect to dashboard for clearer user experience
-                navigate(`/?session-timeout=true`)
+                window.location.href = '/?session-timeout=true'
             }
         } else if (data?.fetchCurrentUser) {
             if (!isAuthenticated) {

--- a/services/app-web/src/localAuth/LocalLogin.tsx
+++ b/services/app-web/src/localAuth/LocalLogin.tsx
@@ -72,7 +72,7 @@ const localUsers: LocalUserType[] = [
         id: 'user4',
         email: 'iroh@example.com',
         givenName: 'Iroh',
-        familyName: 'Coldstart',
+        familyName: 'Uncle',
         role: 'ADMIN_USER',
     },
     {

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -290,7 +290,6 @@ export const AppRoutes = ({
         checkIfSessionsIsAboutToExpire,
     } = useAuth()
     const { pathname } = useLocation()
-    const navigate = useNavigate()
     const ldClient = useLDClient()
     const [redirectPath, setRedirectPath] = useLocalStorage(
         'LOGIN_REDIRECT',
@@ -351,7 +350,7 @@ export const AppRoutes = ({
                         window.location.href = idmRedirectURL()
                     } else {
                         console.info('redirecting to /auth')
-                        navigate('/auth')
+                        window.location.href = '/auth'
                     }
                 } catch (err) {
                     recordJSException(
@@ -363,14 +362,13 @@ export const AppRoutes = ({
         } else {
             if (typeof redirectPath === 'string') {
                 console.info('Retrieved For Redirect: ', redirectPath)
-                navigate(redirectPath)
+                 window.location.href = redirectPath
                 setRedirectPath(null)
             }
         }
     }, [
         initialPath,
         loggedInUser,
-        navigate,
         authMode,
         redirectPath,
         setRedirectPath,

--- a/services/app-web/src/pages/Settings/CMSUsersTable/CMSUsersTable.tsx
+++ b/services/app-web/src/pages/Settings/CMSUsersTable/CMSUsersTable.tsx
@@ -144,6 +144,9 @@ function CMSUserTableWithData({
                     )
                 },
                 header: () => 'Division',
+                meta: {
+                    dataTestID: 'division-assignment',
+                },
             }),
         ]
     }, [setDivision])

--- a/services/cypress/integration/adminWorkflow/settings.spec.ts
+++ b/services/cypress/integration/adminWorkflow/settings.spec.ts
@@ -1,0 +1,61 @@
+describe('Admin user can view application level settings', () => {
+    beforeEach(() => {
+        cy.stubFeatureFlags()
+        cy.interceptGraphQL()
+    })
+
+    it('and update user division assignments', () => {
+        // make sure a cms user in db first
+        cy.logInAsCMSUser()
+        cy.logOut()
+
+        cy.logInAsAdminUser({initialURL: '/settings'})
+        cy.findByRole('tab', {name: 'CMS users'}).click()
+        cy.findByRole('table', {name: 'CMS Users'}).should('exist')
+        cy.findByText('Zuko').should('exist')
+        cy.findByText('Hotman').should('exist')
+        cy.assignDivisionToCMSUser({userEmail: 'zuko@example.com', division: 'DMCO'})
+        cy.findByText('Zuko').should('exist').siblings().should('include.text', 'selected.DMCO') // not accesible but dropdowns are not good idea
+        cy.assignDivisionToCMSUser({userEmail: 'zuko@example.com', division: 'DMCP'})
+        cy.findByText('Zuko').should('exist').siblings().should('include.text', 'selected.DMCP') // not accesible but dropdowns are not good idea
+        cy.assignDivisionToCMSUser({userEmail: 'zuko@example.com', division: 'OACT'})
+        cy.findByText('Zuko').should('exist').siblings().should('include.text', 'selected.OACT') // not accesible but dropdowns are not good idea
+
+    })
+
+    it('and filter down state analysts by state code', () => {
+         cy.logInAsAdminUser({initialURL: '/settings'})
+         cy.findByRole('tab', {name: 'State analysts'}).click()
+          // Table data has both minnesota entries and florida entries
+         cy.findByRole('table').should('exist').should('include.text', 'FL').should('include.text', 'MN')
+
+         // save current number of rows so we can filter
+         cy.findByRole('table', {name: 'Analyst emails'})
+         .find("tr")
+         .then((rows) => {
+           const lengthBeforeFilter = rows.length;
+
+
+         //click into emails filters, do nothing, then go over state filter
+         cy.findByRole('combobox', {
+            name: 'emails filter selection', timeout: 2_000
+        }).click({
+            force: true,
+        })
+         cy.findByRole('combobox', {
+            name: 'state filter selection', timeout: 2_000
+        }).click({
+            force: true,
+        })
+
+
+        cy.findByRole('option', {name: 'MN'}).click()
+        // Table data has minnesota entries but no florida entries
+        cy.findByRole('table').should('exist').should('not.include.text', 'FL').should('include.text', 'MN')
+        // Table data is also less rows long
+        cy.findAllByRole('row').should('have.length.lessThan', lengthBeforeFilter)
+        });
+
+
+    })
+})

--- a/services/cypress/utils/apollo-test-utils.ts
+++ b/services/cypress/utils/apollo-test-utils.ts
@@ -203,7 +203,7 @@ const adminUser = (): AdminUserType => ({
     id: 'user4',
     email: 'iroh@example.com',
     givenName: 'Iroh',
-    familyName: 'Coldstart',
+    familyName: 'Uncle',
     role: 'ADMIN_USER',
 })
 


### PR DESCRIPTION
## Summary
Follow on to #2578. Adds new Admin workflow Cypress tests. This helps protect against the various crash/freeze behaviors we saw on settings page this sprint (one was with users table, one was with state analysts table). 

🔍 I also made a change to the use of `navigate` in AppRoutes and AuthContext. It was failing silently - we didn't notice. A test that could have caught it breaking has been skipped since Contract and Rates API was introduced.  I found out when I tried to write an admin test that would attempt to go to /settings, login, then redirect. Using `window.location.href` directly seems to resolve the issue. 

#### Related issues
https://jiraent.cms.gov/browse/MCR-4317


#### Test cases covered
- update user division assignments
- filter down state analysts by state code

## QA guidance
If Cypress tests pass,  we can merge. The bugfix already happened for this issue - this catches up the tests. 