### PR TITLE
[MCR-4130] Prevent wrapping of rate name on previous submissions

### DIFF
--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/RateDetailsSummarySection.tsx
@@ -272,7 +272,8 @@ export const RateDetailsSummarySection = ({
 
     const replaceRateClass = (isLinkedRate: boolean) =>
         classnames({
-            [styles.replaceRateWrapper]: isAdminUser && !isLinkedRate,
+            [styles.replaceRateWrapper]:
+                isAdminUser && !isLinkedRate && !isPreviousSubmission,
         })
 
     return (


### PR DESCRIPTION
## Summary

This is a design fix PR that prevents rate name from wrapping when viewing a previous revision 

#### Related issues

#### Screenshots
BEFORE FIX
<img width="858" alt="Screenshot 2024-07-30 at 2 00 51 PM" src="https://github.com/user-attachments/assets/142c9722-248a-4545-a7e3-cba9a4807a12">


AFTER FIX
<img width="932" alt="Screenshot 2024-07-30 at 1 57 11 PM" src="https://github.com/user-attachments/assets/3076c390-782b-4613-8b76-326382c62604">



## QA guidance

- Sign in as an admin
- View a contract and rate submission that has been resubmitted
- Click the 'view previous submission' link in the change history section
- The rate details section shouldn't have unnecessary wrapping on the rate name 
