### PR TITLE
MCR-4279: prevent oact from getting emails about non risked based contracts

### DIFF
--- a/services/app-api/src/emailer/emails/newPackageCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/newPackageCMSEmail.test.ts
@@ -805,6 +805,31 @@ test('does not include oactEmails on contract only submission', async () => {
     })
 })
 
+test('does not include oactEmails on non risked based contract', async () => {
+    const sub = mockContractAndRatesFormData()
+    sub.riskBasedContract = false
+    const statePrograms = mockMNState().programs
+    const template = await newPackageCMSEmail(
+        sub,
+        testEmailConfig(),
+        [],
+        statePrograms
+    )
+
+    if (template instanceof Error) {
+        throw template
+    }
+
+    const ratesReviewerEmails = [...testEmailConfig().oactEmails]
+    ratesReviewerEmails.forEach((emailAddress) => {
+        expect(template).toEqual(
+            expect.objectContaining({
+                toAddresses: expect.not.arrayContaining([emailAddress]),
+            })
+        )
+    })
+})
+
 test('CHIP contract only submission does include state specific analysts emails', async () => {
     const sub = mockContractOnlyFormData({
         stateCode: 'MS',

--- a/services/app-api/src/emailer/emails/newPackageCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/newPackageCMSEmail.test.ts
@@ -41,6 +41,7 @@ test('to addresses list includes review team email addresses', async () => {
 
 test('to addresses list includes OACT and DMCP group emails for contract and rate package', async () => {
     const sub = mockContractAndRatesFormData()
+    sub.riskBasedContract = true
     const statePrograms = mockMNState().programs
     const template = await newPackageCMSEmail(
         sub,
@@ -699,6 +700,7 @@ test('includes state specific analyst on contract only submission', async () => 
 
 test('includes state specific analyst on contract and rate submission', async () => {
     const sub = mockContractAndRatesFormData()
+    sub.riskBasedContract = true
     const testStateAnalystEmails = testStateAnalystsEmails
     const statePrograms = mockMNState().programs
     const template = await newPackageCMSEmail(
@@ -750,8 +752,10 @@ test('does not include state specific analyst on contract and rate submission', 
     })
 })
 
-test('includes oactEmails on contract and rate submission', async () => {
+test('includes oactEmails on contract and rate submission for a risked based contract', async () => {
     const sub = mockContractAndRatesFormData()
+    // ensure oact will be notified
+    sub.riskBasedContract = true
     const statePrograms = mockMNState().programs
     const template = await newPackageCMSEmail(
         sub,

--- a/services/app-api/src/emailer/emails/resubmitPackageCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/resubmitPackageCMSEmail.test.ts
@@ -304,9 +304,10 @@ describe('with rates', () => {
         )
     })
     test('to addresses list includes DMCP and OACT group emails for contract and rate package', async () => {
-        submission.riskBasedContract = true
+        const sub = submission
+        sub.riskBasedContract = true
         const template = await resubmitPackageCMSEmail(
-            submission,
+            sub,
             resubmitData,
             testEmailConfig(),
             testStateAnalystEmails,
@@ -343,6 +344,32 @@ describe('with rates', () => {
         })
     })
 
+    it('does not include oactEmails for non risked based contract', async () => {
+        const sub = submission
+        sub.riskBasedContract = false
+        const template = await resubmitPackageCMSEmail(
+            submission,
+            resubmitData,
+            testEmailConfig(),
+            testStateAnalystEmails,
+            defaultStatePrograms
+        )
+
+        if (template instanceof Error) {
+            console.error(template)
+            return
+        }
+
+        const ratesReviewerEmails = [...testEmailConfig().oactEmails]
+        ratesReviewerEmails.forEach((emailAddress) => {
+            expect(template).toEqual(
+                expect.objectContaining({
+                    toAddresses: expect.not.arrayContaining([emailAddress]),
+                })
+            )
+        })
+    })
+
     test('to addresses list does not include help addresses', async () => {
         const template = await resubmitPackageCMSEmail(
             submission,
@@ -374,8 +401,10 @@ describe('with rates', () => {
     })
 
     it('includes state specific analysts emails on contract and rate resubmission email', async () => {
+        const sub = submission
+        sub.riskBasedContract = true
         const template = await resubmitPackageCMSEmail(
-            submission,
+            sub,
             resubmitData,
             testEmailConfig(),
             testStateAnalystEmails,

--- a/services/app-api/src/emailer/emails/resubmitPackageCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/resubmitPackageCMSEmail.test.ts
@@ -304,6 +304,7 @@ describe('with rates', () => {
         )
     })
     test('to addresses list includes DMCP and OACT group emails for contract and rate package', async () => {
+        submission.riskBasedContract = true
         const template = await resubmitPackageCMSEmail(
             submission,
             resubmitData,

--- a/services/app-api/src/emailer/emails/sendQuestionCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/sendQuestionCMSEmail.test.ts
@@ -68,6 +68,7 @@ test('to addresses list only includes state analyst when a DMCO user submits a q
 
 test('to addresses list includes state analyst and OACT group emails when an OACT user submits a question', async () => {
     const sub = mockContractRev()
+    sub.formData.riskBasedContract = true
     const defaultStatePrograms = mockMNState().programs
     const oactUser: CMSUserType = {
         ...cmsUser,

--- a/services/app-api/src/emailer/emails/sendQuestionCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/sendQuestionCMSEmail.ts
@@ -23,7 +23,10 @@ export const sendQuestionCMSEmail = async (
     let receiverEmails = [...stateAnalystsEmails, ...config.devReviewTeamEmails]
     if (newQuestion.addedBy.divisionAssignment === 'DMCP') {
         receiverEmails.push(...config.dmcpReviewEmails)
-    } else if (newQuestion.addedBy.divisionAssignment === 'OACT') {
+    } else if (
+        newQuestion.addedBy.divisionAssignment === 'OACT' &&
+        contractRev.formData.riskBasedContract
+    ) {
         receiverEmails.push(...config.oactEmails)
     }
     receiverEmails = pruneDuplicateEmails(receiverEmails)

--- a/services/app-api/src/emailer/emails/sendQuestionResponseCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/sendQuestionResponseCMSEmail.test.ts
@@ -20,6 +20,7 @@ const dmcpUser = testCMSUser({
     divisionAssignment: 'DMCP',
 })
 const contractRev = mockContractRev()
+contractRev.formData.riskBasedContract = true
 const defaultMNStatePrograms = mockMNState().programs
 const questions = [
     mockQuestionAndResponses({

--- a/services/app-api/src/emailer/emails/sendQuestionResponseCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/sendQuestionResponseCMSEmail.ts
@@ -36,7 +36,7 @@ export const sendQuestionResponseCMSEmail = async (
     let receiverEmails = [...stateAnalystsEmails, ...config.devReviewTeamEmails]
     if (division === 'DMCP') {
         receiverEmails.push(...config.dmcpReviewEmails)
-    } else if (division === 'OACT') {
+    } else if (division === 'OACT' && contractRev.formData.riskBasedContract) {
         receiverEmails.push(...config.oactEmails)
     }
     receiverEmails = pruneDuplicateEmails(receiverEmails)

--- a/services/app-api/src/emailer/emails/unlockContractCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/unlockContractCMSEmail.test.ts
@@ -298,7 +298,7 @@ describe('unlockPackageCMSEmail', () => {
     })
     test('to addresses list includes DMCP and OACT emails for contract and rate package', async () => {
         const sub = mockContractRev()
-
+        sub.formData.riskBasedContract = true
         const template = await unlockContractCMSEmail(
             sub,
             unlockData,
@@ -394,7 +394,7 @@ describe('unlockPackageCMSEmail', () => {
     })
     test('includes correct toAddresses in contract and rate submission unlock', async () => {
         const sub = mockContractRev()
-
+        sub.formData.riskBasedContract = true
         const template = await unlockContractCMSEmail(
             sub,
             unlockData,
@@ -464,6 +464,36 @@ describe('unlockPackageCMSEmail', () => {
             formData: {
                 ...mockedContract.formData,
                 submissionType: 'CONTRACT_ONLY',
+            },
+        })
+
+        const template = await unlockContractCMSEmail(
+            sub,
+            unlockData,
+            testEmailConfig(),
+            [],
+            defaultStatePrograms
+        )
+
+        if (template instanceof Error) {
+            throw template
+        }
+
+        const ratesReviewerEmails = [...testEmailConfig().oactEmails]
+        ratesReviewerEmails.forEach((emailAddress) => {
+            expect(template).toEqual(
+                expect.objectContaining({
+                    toAddresses: expect.not.arrayContaining([emailAddress]),
+                })
+            )
+        })
+    })
+    test('does not include oactEmails on non risked based submission unlock', async () => {
+        const mockedContract = mockContractRev()
+        const sub = mockContractRev({
+            formData: {
+                ...mockedContract.formData,
+                submissionType: 'CONTRACT_AND_RATES',
             },
         })
 

--- a/services/app-api/src/emailer/emails/unlockPackageCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/unlockPackageCMSEmail.test.ts
@@ -305,6 +305,8 @@ describe('unlockPackageCMSEmail', () => {
         )
     })
     test('to addresses list includes DMCP and OACT emails for contract and rate package', async () => {
+        // set riskedBasedContract to true so that OACT is emailed
+        sub.riskBasedContract = true
         const template = await unlockPackageCMSEmail(
             sub,
             unlockData,
@@ -395,6 +397,8 @@ describe('unlockPackageCMSEmail', () => {
         })
     })
     test('includes correct toAddresses in contract and rate submission unlock', async () => {
+        // set riskedBasedContract to true so that OACT is emailed
+        sub.riskBasedContract = true
         const template = await unlockPackageCMSEmail(
             sub,
             unlockData,

--- a/services/app-api/src/emailer/emails/unlockPackageCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/unlockPackageCMSEmail.test.ts
@@ -305,10 +305,11 @@ describe('unlockPackageCMSEmail', () => {
         )
     })
     test('to addresses list includes DMCP and OACT emails for contract and rate package', async () => {
+        const submission = sub
         // set riskedBasedContract to true so that OACT is emailed
-        sub.riskBasedContract = true
+        submission.riskBasedContract = true
         const template = await unlockPackageCMSEmail(
-            sub,
+            submission,
             unlockData,
             testEmailConfig(),
             testStateAnalystEmails,
@@ -343,6 +344,31 @@ describe('unlockPackageCMSEmail', () => {
                 })
             )
         })
+    })
+
+    test('do not send OACT emails for non risked based contract', async () => {
+        const submission = sub
+        // set riskedBasedContract to true so that OACT is emailed
+        submission.riskBasedContract = false
+        const template = await unlockPackageCMSEmail(
+            submission,
+            unlockData,
+            testEmailConfig(),
+            testStateAnalystEmails,
+            defaultStatePrograms
+        )
+
+        if (template instanceof Error) {
+            throw template
+        }
+
+        expect(template).toEqual(
+            expect.objectContaining({
+                toAddresses: expect.not.arrayContaining([
+                    testEmailConfig().oactEmails,
+                ]),
+            })
+        )
     })
 
     test('to addresses list does not include help addresses', async () => {

--- a/services/app-api/src/emailer/templateHelpers.test.ts
+++ b/services/app-api/src/emailer/templateHelpers.test.ts
@@ -18,6 +18,8 @@ import type { EmailConfiguration, StateAnalystsEmails } from './emailer'
 import type { ProgramType } from '../domain-models'
 
 describe('generateCMSReviewerEmails', () => {
+    const sub = mockUnlockedContractAndRatesFormData()
+    sub.riskBasedContract = true
     const contractOnlyWithValidRateData: {
         submission: UnlockedHealthPlanFormDataType
         emailConfig: EmailConfiguration
@@ -37,7 +39,7 @@ describe('generateCMSReviewerEmails', () => {
             ],
         },
         {
-            submission: mockUnlockedContractAndRatesFormData(),
+            submission: sub,
             emailConfig: testEmailConfig(),
             stateAnalystsEmails: testStateAnalystsEmails,
             testDescription: 'contract and rates submission',

--- a/services/app-api/src/emailer/templateHelpers.ts
+++ b/services/app-api/src/emailer/templateHelpers.ts
@@ -156,8 +156,11 @@ const generateCMSReviewerEmailsForContract = (
             ...config.devReviewTeamEmails,
             ...stateAnalystsEmails,
             ...dmcpSubmissionEmails,
-            ...oactEmails,
         ]
+
+        if (contractFormData.riskBasedContract) {
+            reviewers = [...reviewers, ...oactEmails]
+        }
     }
 
     //Remove OACT and DMCP emails from CHIP or State of PR submissions

--- a/services/app-api/src/emailer/templateHelpers.ts
+++ b/services/app-api/src/emailer/templateHelpers.ts
@@ -210,8 +210,10 @@ const generateCMSReviewerEmails = (
             ...config.devReviewTeamEmails,
             ...stateAnalystsEmails,
             ...dmcpSubmissionEmails,
-            ...oactEmails,
         ]
+        if (pkg.riskBasedContract) {
+            reviewers = [...reviewers, ...oactEmails]
+        }
     }
 
     //Remove OACT and DMCP emails from CHIP or State of PR submissions

--- a/services/app-api/src/resolvers/healthPlanPackage/unlockHealthPlanPackage.test.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/unlockHealthPlanPackage.test.ts
@@ -767,7 +767,6 @@ describe(`Tests unlockHealthPlanPackage`, () => {
         const cmsEmails = [
             ...config.devReviewTeamEmails,
             ...stateAnalystsEmails,
-            ...config.oactEmails,
         ]
 
         // email subject line is correct for CMS email

--- a/services/app-api/src/resolvers/healthPlanPackage/unlockHealthPlanPackage.test.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/unlockHealthPlanPackage.test.ts
@@ -729,8 +729,10 @@ describe(`Tests unlockHealthPlanPackage`, () => {
         const stateServer = await constructTestPostgresServer()
 
         // First, create a new submitted submission
-        const stateSubmission =
-            await createAndSubmitTestHealthPlanPackage(stateServer)
+        const stateSubmission = await createAndSubmitTestHealthPlanPackage(
+            stateServer,
+            { riskBasedContract: true }
+        )
 
         const cmsServer = await constructTestPostgresServer({
             context: {
@@ -767,6 +769,7 @@ describe(`Tests unlockHealthPlanPackage`, () => {
         const cmsEmails = [
             ...config.devReviewTeamEmails,
             ...stateAnalystsEmails,
+            ...config.oactEmails,
         ]
 
         // email subject line is correct for CMS email

--- a/services/app-api/src/resolvers/questionResponse/createQuestionResponse.test.ts
+++ b/services/app-api/src/resolvers/questionResponse/createQuestionResponse.test.ts
@@ -145,9 +145,10 @@ describe('createQuestionResponse', () => {
             emailer: mockEmailer,
         })
 
-        const submittedPkg =
-            await createAndSubmitTestHealthPlanPackage(stateServer)
-
+        const submittedPkg = await createAndSubmitTestHealthPlanPackage(
+            stateServer,
+            { riskBasedContract: true }
+        )
         const formData = latestFormData(submittedPkg)
 
         const createdQuestion = await createTestQuestion(cmsServer, formData.id)

--- a/services/app-web/src/pages/Settings/EmailSettingsTables/EmailSettingsTables.tsx
+++ b/services/app-web/src/pages/Settings/EmailSettingsTables/EmailSettingsTables.tsx
@@ -91,7 +91,7 @@ const EmailGeneralTable = ({ config }: { config: EmailConfiguration }) => {
                         <td>OACT division emails</td>
                         <td>
                             Contract and rate submissions; excluding CHIP
-                            programs and PR state
+                            programs, PR state and non risked based contraction
                         </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
## Summary

If a contract is not risk based than OACT shouldn't be notified about it

#### Related issues

https://jiraent.cms.gov/browse/MCR-4279

#### Test cases covered

Updated existing test to use a risked based contract if expecting oact to receive emails

## QA guidance

Submit a risked based contract, in review app. OACT should not be notified
