### PR TITLE
Bump container for cypress in promote

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -238,11 +238,10 @@ jobs:
     needs: [promote-app-prod]
     runs-on: ubuntu-20.04
     container:
-      image: cypress/browsers:node16.17.0-chrome106
+      image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
       options: --user 1001
     strategy:
       fail-fast: false
-
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

When landing the `pnpm` work we got a failure in the cypress promote action due to an outdated container. This just bumps that container to match what we have in review apps.


