### PR TITLE
Fix cypress bin cache location

### DIFF
--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -31,7 +31,7 @@ runs:
       with:
         path: |
           ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          /github/home/.cache/Cypress
+          ~/.cache/Cypress
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-store-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -492,6 +492,7 @@ jobs:
         id: cypress
         uses: cypress-io/github-action@v6
         with:
+          install: false
           config: baseUrl=${{ needs.finishing-prep.outputs.application-endpoint }}
           record: true
           parallel: true


### PR DESCRIPTION
## Summary

The `promote` task started throwing errors on the last Cypress step after we merged in the pnpm change. It turns out in `promote` we had `install: false` set, which caused the action to not find the binary at that point (I'm not sure why it completed on my initial merge/promote, but then started failing on subsequent promotes). 

This updates the cache location to include the relative `~` dir expansion. The reason for this is that in VMs the path for the cache is in `/github/home/.cache/Cypress` whereas in containers it is in `/root/.cache/Cypress`. I've also set `install: false` in review app deploys to save a little time now that this works properly.

