### PR TITLE
Move git reference for CI back to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -271,7 +271,7 @@ jobs:
 
   deploy-infra:
     needs: [begin-deployment, build-clamav-layer]
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@mt-lerna-remove
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name}}
@@ -298,7 +298,7 @@ jobs:
       needs.api-unit-tests.result == 'success' &&
       needs.build-prisma-client-lambda-layer.result == 'success' &&
       needs.begin-deployment.result == 'success'
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@mt-lerna-remove
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name }}

--- a/scripts/get-changed-services/index.ts
+++ b/scripts/get-changed-services/index.ts
@@ -8,7 +8,7 @@ const owner = 'Enterprise-CMCS'
 const repo = 'managed-care-review'
 
 async function main() {
-    // get our service names from lerna
+    // get our service names from pnpm
     const listOfServices = getAllServicesFromPnpm()
     if (listOfServices instanceof Error) {
         console.error('Failed to get service list from pnpm', listOfServices)
@@ -86,7 +86,7 @@ async function main() {
 
     console.info('All services: ' + listOfServices)
     console.info('Jobs we can skip from GHA: ' + jobsToSkip)
-    console.info('Changed services from lerna: ' + pnpmChangedServices)
+    console.info('Changed services from pnpm: ' + pnpmChangedServices)
     console.info('Jobs to rerun: ' + jobsToRun)
 
     core.setOutput('changed-services', jobsToRun)


### PR DESCRIPTION
## Summary
This just cleans up the last PR merge that needed to use a branch name for CI scripts. Moves it back to main. Also there were a couple comments that still mentioned lerna.

