### PR TITLE
MCR-4150: Do not display withdrawn rates on rates dashboard.

### DIFF
--- a/services/app-graphql/src/queries/indexRates.graphql
+++ b/services/app-graphql/src/queries/indexRates.graphql
@@ -19,6 +19,11 @@ query indexRates {
                     }
                 }
                 status
+                withdrawInfo {
+                    updatedAt
+                    updatedReason
+                    updatedBy
+                }
                 initiallySubmittedAt
                 parentContractID
 

--- a/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsDashboard.test.tsx
+++ b/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsDashboard.test.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../testHelpers/apolloMocks'
 import { indexRatesMockSuccess } from '../../../testHelpers/apolloMocks'
 import { screen, waitFor } from '@testing-library/react'
+import { Rate } from '../../../gen/gqlClient'
 
 describe('RateReviewsDashboard', () => {
     describe.each(iterableCmsUsersMockData)(

--- a/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsDashboard.test.tsx
+++ b/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsDashboard.test.tsx
@@ -4,6 +4,7 @@ import {
     fetchCurrentUserMock,
     indexRatesMockFailure,
     iterableCmsUsersMockData,
+    rateDataMock,
 } from '../../../testHelpers/apolloMocks'
 import { indexRatesMockSuccess } from '../../../testHelpers/apolloMocks'
 import { screen, waitFor } from '@testing-library/react'
@@ -36,6 +37,57 @@ describe('RateReviewsDashboard', () => {
                 // Expect 3 rates to be displayed
                 expect(
                     screen.getByText('Displaying 3 of 3 rate reviews')
+                ).toBeInTheDocument()
+            })
+
+            it('renders dashboard without withdrawn rates', async () => {
+                const rates: Rate[] = [
+                    { ...rateDataMock(), id: 'test-id-123', stateNumber: 3 },
+                    {
+                        ...rateDataMock(),
+                        id: 'test-id-124-withdrawn',
+                        stateNumber: 2,
+                        withdrawInfo: {
+                            updatedAt: new Date(),
+                            updatedBy: 'admin@example.com',
+                            updatedReason: 'retreat!',
+                        },
+                    },
+                    {
+                        ...rateDataMock(),
+                        id: 'test-id-125-withdrawn',
+                        stateNumber: 2,
+                        withdrawInfo: {
+                            updatedAt: new Date(),
+                            updatedBy: 'admin@example.com',
+                            updatedReason: 'retreat!',
+                        },
+                    },
+                    { ...rateDataMock(), id: 'test-id-126', stateNumber: 1 },
+                ]
+                renderWithProviders(<RateReviewsDashboard />, {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                statusCode: 200,
+                                user: mockUser(),
+                            }),
+                            indexRatesMockSuccess(rates),
+                        ],
+                    },
+                })
+
+                // Wait for accordion and table components to load on page
+                await waitFor(() => {
+                    expect(
+                        screen.queryByTestId('accordion')
+                    ).toBeInTheDocument()
+                    expect(screen.queryByTestId('table')).toBeInTheDocument()
+                })
+
+                // Expect 2 rates to be displayed
+                expect(
+                    screen.getByText('Displaying 2 of 2 rate reviews')
                 ).toBeInTheDocument()
             })
 

--- a/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsDashboard.tsx
+++ b/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsDashboard.tsx
@@ -21,6 +21,10 @@ const RateReviewsDashboard = (): React.ReactElement => {
     data?.indexRates.edges
         .map((edge) => edge.node)
         .forEach((rate) => {
+            // Skip rates that have been withdrawn
+            if (rate.withdrawInfo) {
+                return
+            }
             const currentRevision = rate.revisions[0]
 
             // Set rate display data - could be based on either current or previous revision depending on status


### PR DESCRIPTION
## Summary
[MCR-4150](https://jiraent.cms.gov/browse/MCR-4150)

- Rates dashboard will skip rates with `withdrawInfo`.

#### Related issues

#### Screenshots

#### Test cases covered

- `RateReviewsDashboard.test.ts`
   - `'renders dashboard without withdrawn rates'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

The UI to withdraw a rate is not implemented yet, but this is a small task and it can be verified with tests. We can merge this in, but we should wait for acceptance testing until MCR-4152 and the issue found with the withdraw API have been merged. See this Slack [thread](https://cmsgov.slack.com/archives/C014CRU197U/p1723131423175859) for more information.

For reviewing this PR, I think making sure the code and test are good. Please comment if you think that would not be sufficient to approve this.

<!---These are developer instructions on how to test or validate the work -->
