### PR TITLE
MCR-4302: Fix GraphQL explorer tool

### DIFF
--- a/services/app-web/src/pages/GraphQLExplorer/GraphQLExplorer.tsx
+++ b/services/app-web/src/pages/GraphQLExplorer/GraphQLExplorer.tsx
@@ -6,6 +6,7 @@ import { FetchCurrentUserDocument } from '../../gen/gqlClient'
 import { fakeAmplifyFetch } from '../../api'
 
 import schema from '../../gen/schema.graphql'
+import { print } from 'graphql'
 
 export const GraphQLExplorer = () => {
     const stageName = import.meta.env.VITE_APP_STAGE_NAME
@@ -36,7 +37,7 @@ export const GraphQLExplorer = () => {
             <ApolloExplorer
                 className={styles.explorer}
                 endpointUrl={'/graphql'}
-                schema={schema}
+                schema={print(schema)}
                 initialState={{
                     displayOptions: {
                         docsPanelState: 'open',

--- a/services/app-web/src/pages/GraphQLExplorer/GraphQLExplorer.tsx
+++ b/services/app-web/src/pages/GraphQLExplorer/GraphQLExplorer.tsx
@@ -4,9 +4,9 @@ import { useAuth } from '../../contexts/AuthContext'
 import { GenericErrorPage } from '../Errors/GenericErrorPage'
 import { FetchCurrentUserDocument } from '../../gen/gqlClient'
 import { fakeAmplifyFetch } from '../../api'
+import { print } from 'graphql'
 
 import schema from '../../gen/schema.graphql'
-import { print } from 'graphql'
 
 export const GraphQLExplorer = () => {
     const stageName = import.meta.env.VITE_APP_STAGE_NAME


### PR DESCRIPTION
## Summary
[MCR-4302](https://jiraent.cms.gov/browse/MCR-4302)

In our vite.config.ts we are using `'vite-plugin-graphql-loader'` to load our GraphQL schema. The output is a `DocumentNode` which I think differred from when we used webpack which outputted a string. The `ApolloExplorer` component only takes an `IntrospectionQuery` or `SDLstring` for the schema. So the fix here is to convert the document node into the `SDLstring` using `print()` from `graphql` library.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
