### PR TITLE
Enhance some S3 bucket policies for Security Hub

### DIFF
--- a/services/infra-api/serverless.yml
+++ b/services/infra-api/serverless.yml
@@ -129,6 +129,24 @@ resources:
           ServerSideEncryptionConfiguration:
             - ServerSideEncryptionByDefault:
                 SSEAlgorithm: AES256
+    S3FirehoseEventsBucketPolicy:
+      Type: AWS::S3::BucketPolicy
+      Condition: CreateNRInfraMonitoring
+      Properties:
+        Bucket: !Ref S3FirehoseEventsBucket
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Sid: ForceSSLOnlyAccess
+              Effect: Deny
+              Principal: '*'
+              Action: 's3:*'
+              Resource:
+                - !Sub arn:aws:s3:::newrelic-firehose-${sls:stage}-${AWS::AccountId}
+                - !Sub arn:aws:s3:::newrelic-firehose-${sls:stage}-${AWS::AccountId}/*
+              Condition:
+                Bool:
+                  aws:SecureTransport: false
 
     FirehoseStreamToNewRelic:
       Type: AWS::KinesisFirehose::DeliveryStream

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -160,6 +160,34 @@ resources:
       Properties:
         BucketName: !Sub ${self:service}-${sls:stage}-postgres-infra-scripts
         AccessControl: Private
+        PublicAccessBlockConfiguration:
+          BlockPublicAcls: true
+          BlockPublicPolicy: true
+          IgnorePublicAcls: true
+          RestrictPublicBuckets: true
+        BucketEncryption:
+          ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256
+
+    PostgresVMScriptsBucketPolicy:
+      Type: AWS::S3::BucketPolicy
+      Condition: IsDevValProd
+      Properties:
+        Bucket: !Ref PostgresVMScriptsBucket
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Sid: ForceSSLOnlyAccess
+              Effect: Deny
+              Principal: '*'
+              Action: 's3:*'
+              Resource:
+                - !Sub arn:aws:s3:::${self:service}-${sls:stage}-postgres-infra-scripts
+                - !Sub arn:aws:s3:::${self:service}-${sls:stage}-postgres-infra-scripts/*
+              Condition:
+                Bool:
+                  aws:SecureTransport: false
 
     PostgresVM:
       Type: 'AWS::EC2::Instance'


### PR DESCRIPTION
## Summary

This adds some additional bucket policies to a couple s3 buckets that we have for configuration. It should force SSL to make the security hub alerts go away.

This isn't something we can see in review apps, as these buckets and policies are only deployed in dev/val/prod, so we'll have to verify once it merges.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4239
https://jiraent.cms.gov/browse/MCR-4238
