### PR TITLE
MCR-4222: CMS and States see withdrawn label on Rate Summary Page

### DIFF
--- a/services/app-web/src/components/Banner/RateWithdrawnBanner/RateWithdrawnBanner.tsx
+++ b/services/app-web/src/components/Banner/RateWithdrawnBanner/RateWithdrawnBanner.tsx
@@ -1,0 +1,50 @@
+import { UpdateInformation } from '../../../gen/gqlClient'
+import React from 'react'
+import { Alert } from '@trussworks/react-uswds'
+import styles from '../Banner.module.scss'
+import { dayjs } from '../../../common-code/dateHelpers'
+import { ExpandableText } from '../../ExpandableText'
+
+export type RateWithdrawnProps = {
+    withdrawInfo: UpdateInformation
+}
+export const RateWithdrawnBanner = ({
+    withdrawInfo,
+    className,
+}: RateWithdrawnProps &
+    React.HTMLAttributes<HTMLDivElement>): React.ReactElement => {
+    const { updatedAt, updatedReason } = withdrawInfo
+
+    return (
+        <Alert
+            role="alert"
+            type="info"
+            heading="Withdrawn Rate"
+            headingLevel="h4"
+            validation={true}
+            data-testid="rateWithdrawnBanner"
+            className={className}
+        >
+            <div className={styles.bannerBodyText}>
+                <p className="usa-alert__text">
+                    <b>Withdrawn by:&nbsp;</b>
+                    Administrator
+                </p>
+                <p className="usa-alert__text">
+                    <b>Withdrawn on:&nbsp;</b>
+                    {dayjs
+                        .utc(updatedAt)
+                        .tz('America/New_York')
+                        .format('MM/DD/YY h:mma')}
+                    &nbsp;ET
+                </p>
+                <ExpandableText>
+                    <>
+                        <b>Reason for withdrawing the rate:&nbsp;</b>
+                        {updatedReason}
+                    </>
+                </ExpandableText>
+            </div>
+        </Alert>
+    )
+}

--- a/services/app-web/src/components/Banner/RateWithdrawnBanner/RateWithdrawnBanner.tsx
+++ b/services/app-web/src/components/Banner/RateWithdrawnBanner/RateWithdrawnBanner.tsx
@@ -27,8 +27,7 @@ export const RateWithdrawnBanner = ({
         >
             <div className={styles.bannerBodyText}>
                 <p className="usa-alert__text">
-                    <b>Withdrawn by:&nbsp;</b>
-                    Administrator
+                    <b>Withdrawn by:&nbsp;</b>Administrator
                 </p>
                 <p className="usa-alert__text">
                     <b>Withdrawn on:&nbsp;</b>

--- a/services/app-web/src/components/Banner/index.ts
+++ b/services/app-web/src/components/Banner/index.ts
@@ -5,3 +5,4 @@ export { GenericApiErrorBanner } from './GenericApiErrorBanner/GenericApiErrorBa
 export { QuestionResponseSubmitBanner } from './QuestionResponseSubmitBanner'
 export { UserAccountWarningBanner } from './UserAccountWarningBanner/UserAccountWarningBanner'
 export { DocumentWarningBanner } from './DocumentWarningBanner/DocumentWarningBanner'
+export { RateWithdrawnBanner } from './RateWithdrawnBanner/RateWithdrawnBanner'

--- a/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
@@ -47,6 +47,47 @@ describe('RateSummary', () => {
                 ).toBeInTheDocument()
             })
 
+            it('displays withdrawn banner on a withdrawn rate', async () => {
+                renderWithProviders(wrapInRoutes(<RateSummary />), {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                user: mockUser(),
+                                statusCode: 200,
+                            }),
+                            fetchRateMockSuccess({
+                                id: '1337',
+                                withdrawInfo: {
+                                    updatedAt: new Date('2024-01-01'),
+                                    updatedBy: 'admin@example.com',
+                                    updatedReason: 'This rate was withdrawn',
+                                },
+                            }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: '/rates/1337',
+                    },
+                    featureFlags: { 'rate-edit-unlock': true },
+                })
+
+                await waitFor(() => {
+                    expect(
+                        screen.queryByTestId('rate-summary')
+                    ).toBeInTheDocument()
+                })
+
+                expect(
+                    await screen.findByText(
+                        'Rates this rate certification covers'
+                    )
+                ).toBeInTheDocument()
+
+                expect(
+                    screen.getByTestId('rateWithdrawnBanner')
+                ).toBeInTheDocument()
+            })
+
             it('renders document download warning banner when download fails', async () => {
                 const error = vi
                     .spyOn(console, 'error')
@@ -146,6 +187,43 @@ describe('RateSummary', () => {
 
             expect(
                 await screen.findByText('Rates this rate certification covers')
+            ).toBeInTheDocument()
+        })
+
+        it('displays withdrawn banner on a withdrawn rate', async () => {
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidStateUser(),
+                            statusCode: 200,
+                        }),
+                        fetchRateMockSuccess({
+                            id: '1337',
+                            withdrawInfo: {
+                                updatedAt: new Date('2024-01-01'),
+                                updatedBy: 'admin@example.com',
+                                updatedReason: 'This rate was withdrawn',
+                            },
+                        }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/rates/1337',
+                },
+                featureFlags: { 'rate-edit-unlock': true },
+            })
+
+            await waitFor(() => {
+                expect(screen.queryByTestId('rate-summary')).toBeInTheDocument()
+            })
+
+            expect(
+                await screen.findByText('Rates this rate certification covers')
+            ).toBeInTheDocument()
+
+            expect(
+                screen.getByTestId('rateWithdrawnBanner')
             ).toBeInTheDocument()
         })
 

--- a/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
@@ -10,6 +10,7 @@ import { RateSummary } from './RateSummary'
 import { RoutesRecord } from '../../constants'
 import { Route, Routes } from 'react-router-dom'
 import { RateEdit } from '../RateEdit/RateEdit'
+import { dayjs } from '../../common-code/dateHelpers'
 
 // Wrap test component in some top level routes to allow getParams to be tested
 const wrapInRoutes = (children: React.ReactNode) => {
@@ -60,7 +61,8 @@ describe('RateSummary', () => {
                                 withdrawInfo: {
                                     updatedAt: new Date('2024-01-01'),
                                     updatedBy: 'admin@example.com',
-                                    updatedReason: 'This rate was withdrawn',
+                                    updatedReason:
+                                        'Admin as withdrawn this rate.',
                                 },
                             }),
                         ],
@@ -83,8 +85,20 @@ describe('RateSummary', () => {
                     )
                 ).toBeInTheDocument()
 
+                expect(screen.getByRole('alert')).toHaveClass('usa-alert--info')
                 expect(
                     screen.getByTestId('rateWithdrawnBanner')
+                ).toHaveTextContent(/Withdrawn by: Administrator/)
+                expect(
+                    screen.getByText(
+                        `${dayjs
+                            .utc(new Date('2024-01-01'))
+                            .tz('America/New_York')
+                            .format('MM/DD/YY h:mma')} ET`
+                    )
+                ).toBeInTheDocument()
+                expect(
+                    screen.getByText('Admin as withdrawn this rate.')
                 ).toBeInTheDocument()
             })
 
@@ -203,7 +217,7 @@ describe('RateSummary', () => {
                             withdrawInfo: {
                                 updatedAt: new Date('2024-01-01'),
                                 updatedBy: 'admin@example.com',
-                                updatedReason: 'This rate was withdrawn',
+                                updatedReason: 'Admin as withdrawn this rate.',
                             },
                         }),
                     ],
@@ -222,8 +236,20 @@ describe('RateSummary', () => {
                 await screen.findByText('Rates this rate certification covers')
             ).toBeInTheDocument()
 
+            expect(screen.getByRole('alert')).toHaveClass('usa-alert--info')
+            expect(screen.getByTestId('rateWithdrawnBanner')).toHaveTextContent(
+                /Withdrawn by: Administrator/
+            )
             expect(
-                screen.getByTestId('rateWithdrawnBanner')
+                screen.getByText(
+                    `${dayjs
+                        .utc(new Date('2024-01-01'))
+                        .tz('America/New_York')
+                        .format('MM/DD/YY h:mma')} ET`
+                )
+            ).toBeInTheDocument()
+            expect(
+                screen.getByText('Admin as withdrawn this rate.')
             ).toBeInTheDocument()
         })
 

--- a/services/app-web/src/pages/RateSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.tsx
@@ -11,6 +11,7 @@ import { SingleRateSummarySection } from '../../components/SubmissionSummarySect
 import { useAuth } from '../../contexts/AuthContext'
 import { ErrorForbiddenPage } from '../Errors/ErrorForbiddenPage'
 import { Error404 } from '../Errors/Error404Page'
+import { RateWithdrawnBanner } from '../../components/Banner'
 
 export const RateSummary = (): React.ReactElement => {
     // Page level state
@@ -39,6 +40,7 @@ export const RateSummary = (): React.ReactElement => {
 
     const rate = data?.fetchRate.rate
     const currentRateRev = rate?.revisions[0]
+    const withdrawInfo = rate?.withdrawInfo
 
     if (loading) {
         return (
@@ -81,6 +83,13 @@ export const RateSummary = (): React.ReactElement => {
                 data-testid="rate-summary"
                 className={styles.container}
             >
+                {withdrawInfo && (
+                    <RateWithdrawnBanner
+                        withdrawInfo={withdrawInfo}
+                        className={styles.banner}
+                    />
+                )}
+
                 <div>
                     <NavLinkWithLogging
                         //TODO: Will have to remove this conditional once the rate dashboard is made available to state users


### PR DESCRIPTION
## Summary
[MCR-4222](https://jiraent.cms.gov/browse/MCR-4222)

- Add new `RateWithdrawnBanner` component
- Add the withdrawn banner to the Rate summary page.


#### Related issues

#### Screenshots

#### Test cases covered

`RateSummary.test.ts`
-`'displays withdrawn banner on a withdrawn rate'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

QA here is to make sure the test and code look ok, here is a screen shot from local of the UI. Without some of the other redundant rate tickets we can get a rate into that state in this review app

![Screenshot 2024-08-08 at 4 52 29 PM](https://github.com/user-attachments/assets/ad0e0a49-5573-4b98-806d-65bca9f874b6)


<!---These are developer instructions on how to test or validate the work -->
