### PR TITLE
avscan service: check if there is an error value before logging

### DIFF
--- a/services/uploads/src/deps/clamAV/clamAV.ts
+++ b/services/uploads/src/deps/clamAV/clamAV.ts
@@ -192,9 +192,15 @@ function scanForInfectedFiles(
             pathToScan,
         ])
 
-        console.info('stderror', avResult.stderr && avResult.stderr.toString())
-        console.info('stdout', avResult.stdout && avResult.stdout.toString())
-        console.info('err', avResult.error)
+        if (avResult.stderr) {
+            console.info('stderror', avResult.stderr.toString())
+        }
+        if (avResult.stdout) {
+            console.info('stdout', avResult.stdout.toString())
+        }
+        if (avResult.error) {
+            console.error('error', avResult.error)
+        }
 
         // Exit status 1 means file is infected
         if (avResult.status === 1) {


### PR DESCRIPTION
## Summary

I was looking around our cloudwatch logs for MCR-4354 and noticed a lot of `err undefined` in the logs. Looking at the code this seems normal, we were logging if there was something in `avResult.error` -- which usually is `undefined`. Just added checks here so that we don't see a bunch of `err undefined` in the logs thinking we're missing something.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4354