### PR TITLE
Bump AWS Distro for OTEL layer to latest

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -74,7 +74,7 @@ provider:
     restApiId: ${self:custom.appApiGatewayId}
     restApiRootResourceId: ${self:custom.appApiGatewayRootResourceId}
   layers:
-    - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:3
+    - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:4
   iam:
     role:
       path: ${ssm:/configuration/iam/path, "/"}
@@ -206,7 +206,7 @@ functions:
       subnetIds: ${self:custom.privateSubnets}
     layers:
       - !Ref PrismaClientEngineLambdaLayer
-      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:3
+      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:4
 
   migrate:
     handler: src/handlers/postgres_migrate.main
@@ -217,7 +217,7 @@ functions:
       subnetIds: ${self:custom.privateSubnets}
     layers:
       - !Ref PrismaClientMigrationLambdaLayer
-      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:3
+      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:4
 
   zip_keys:
     handler: src/handlers/bulk_download.main
@@ -234,7 +234,7 @@ functions:
     events:
       - schedule: cron(0 14 ? * MON-FRI *)
     layers:
-      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:3
+      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:4
 
 resources:
   Resources:

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -110,7 +110,7 @@ functions:
     ephemeralStorageSize: 1024
     layers:
       - !Ref ClamAvLambdaLayer
-      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:3
+      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:4
     vpc:
       securityGroupIds: ${self:custom.sgId}
       subnetIds: ${self:custom.privateSubnets}
@@ -128,7 +128,7 @@ functions:
     maximumRetryAttempts: 0
     layers:
       - !Ref ClamAvLambdaLayer
-      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:3
+      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:4
     environment:
       stage: ${sls:stage}
       AUDIT_BUCKET_NAME: !Ref DocumentUploadsBucket
@@ -148,7 +148,7 @@ functions:
     maximumRetryAttempts: 0
     layers:
       - !Ref ClamAvLambdaLayer
-      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:3
+      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:4
     environment:
       stage: ${sls:stage}
       AUDIT_BUCKET_NAME: !Ref DocumentUploadsBucket


### PR DESCRIPTION
## Summary

The lambda layer that AWS provides for OTEL tooling has had a minor version bump. This brings us in line with the 0.40 OTEL collector.


