### PR TITLE
Fix: runtime 3.12 not available

### DIFF
--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -11,7 +11,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: python3.12
+  runtime: python3.11
   region: us-east-1
   iam:
     role:


### PR DESCRIPTION
## Summary

MacRae just saw a warning for an unavailable runtime in the `postgres` service's CI deploy. This puts it to the available version.