### PR TITLE
Downcase file extensions uploaded with ALLCAPS

### DIFF
--- a/services/app-web/src/components/FileUpload/FileUpload.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.tsx
@@ -174,18 +174,7 @@ export const FileUpload = ({
     const asyncS3Upload = (files: File[] | File) => {
         const upload = async (file: File) => {
             const sha = (await calculateSHA256(file)) || ''
-
-            // Create a new File object with downcased extension
-            // This will catch things like .PDF or .DOCX
-            const fileNameParts = file.name.split('.')
-            const extension = fileNameParts.pop()
-            const newFileName =
-                fileNameParts.join('.') +
-                '.' +
-                (extension ? extension.toLowerCase() : '')
-            const newFile = new File([file], newFileName, { type: file.type })
-
-            uploadFile(newFile)
+            uploadFile(file)
                 .then((data) => {
                     setFileItems((prevItems) => {
                         const newItems = [...prevItems]

--- a/services/app-web/src/components/FileUpload/FileUpload.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.tsx
@@ -174,7 +174,18 @@ export const FileUpload = ({
     const asyncS3Upload = (files: File[] | File) => {
         const upload = async (file: File) => {
             const sha = (await calculateSHA256(file)) || ''
-            uploadFile(file)
+
+            // Create a new File object with downcased extension
+            // This will catch things like .PDF or .DOCX
+            const fileNameParts = file.name.split('.')
+            const extension = fileNameParts.pop()
+            const newFileName =
+                fileNameParts.join('.') +
+                '.' +
+                (extension ? extension.toLowerCase() : '')
+            const newFile = new File([file], newFileName, { type: file.type })
+
+            uploadFile(newFile)
                 .then((data) => {
                     setFileItems((prevItems) => {
                         const newItems = [...prevItems]

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -39,7 +39,6 @@ function assertIsS3PutError(val: unknown): asserts val is s3PutError {
 
 // MAIN
 // TODO clarify what gets3URL versus getURL are doing
-
 function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
     return {
         uploadFile: async (
@@ -47,7 +46,7 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
             bucket: BucketShortName
         ): Promise<string | S3Error> => {
             const uuid = uuidv4()
-            const ext = file.name.split('.').pop()
+            const ext = file.name.split('.').pop()?.toLowerCase() || ''
             //encode file names and decoding done in bulk_downloads.ts
             const fileName = encodeURIComponent(file.name)
             try {


### PR DESCRIPTION
## Summary

A user attempted to upload a document with an extension of `.PDF`. Turns out that s3 file extension policies are case-sensitive. This downcases the extension on every file upload before sending it to s3.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4375

