### PR TITLE
Add mac-fc DSO metrics collection

### DIFF
--- a/.github/workflows/send-dso-metrics.yml
+++ b/.github/workflows/send-dso-metrics.yml
@@ -20,10 +20,23 @@ jobs:
           scan-config: |
             events:  # a list of event specifications such as the following one
             - type: deploy 
+            environment: prod
             name: mc-review-promote
             team: mv-review
-            environment: prod
             owner: Enterprise-CMCS
             repo: managed-care-review
             workflowfilename: promote.yml
             branch: main
+
+            - type: test
+            environment: prod
+            name: mc-review-test
+            team: mc-review
+            owner: Enterprise-CMCS
+            repo: managed-care-review
+            workflowfilename: promote.yml
+            branch: main
+            start:
+              job: unit-tests
+            end:
+              job: unit-tests

--- a/.github/workflows/send-dso-metrics.yml
+++ b/.github/workflows/send-dso-metrics.yml
@@ -20,23 +20,23 @@ jobs:
           scan-config: |
             events:  # a list of event specifications such as the following one
             - type: deploy 
-            environment: prod
-            name: mc-review-promote
-            team: mv-review
-            owner: Enterprise-CMCS
-            repo: managed-care-review
-            workflowfilename: promote.yml
-            branch: main
+              environment: prod
+              name: mc-review-promote
+              team: mv-review
+              owner: Enterprise-CMCS
+              repo: managed-care-review
+              workflowfilename: promote.yml
+              branch: main
 
             - type: test
-            environment: prod
-            name: mc-review-test
-            team: mc-review
-            owner: Enterprise-CMCS
-            repo: managed-care-review
-            workflowfilename: promote.yml
-            branch: main
-            start:
-              job: unit-tests
-            end:
-              job: unit-tests
+              environment: prod
+              name: mc-review-test
+              team: mc-review
+              owner: Enterprise-CMCS
+              repo: managed-care-review
+              workflowfilename: promote.yml
+              branch: main
+              start:
+                job: unit-tests
+              end:
+                job: unit-tests

--- a/.github/workflows/send-dso-metrics.yml
+++ b/.github/workflows/send-dso-metrics.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Send DSO events
         uses: Enterprise-CMCS/mac-fc-scan-github@v1.0.1
         with:
-          aws-account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
-          oidc-role: arn:aws:iam::${{secrets.DEV_AWS_ACCOUNT_ID }}:role/delegatedadmin/developer/professor-mac-github-oidc
+          aws-account-id: ${{ secrets.PROD_AWS_ACCOUNT_ID }}
+          oidc-role: arn:aws:iam::${{secrets.PROD_AWS_ACCOUNT_ID }}:role/delegatedadmin/developer/github-oidc-prod-ServiceRole
           github-access-token: ${{ secrets.GITHUB_ACCESS_TOKEN }}
           scan-config: |
             events:  # a list of event specifications such as the following one

--- a/.github/workflows/send-dso-metrics.yml
+++ b/.github/workflows/send-dso-metrics.yml
@@ -1,0 +1,29 @@
+name: Send DSO metrics events
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+
+permissions:
+  id-token: write
+
+jobs:
+  SendDSOEvents:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send DSO events
+        uses: Enterprise-CMCS/mac-fc-scan-github@v1.0.1
+        with:
+          aws-account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
+          oidc-role: arn:aws:iam::${{secrets.DEV_AWS_ACCOUNT_ID }}:role/delegatedadmin/developer/professor-mac-github-oidc
+          github-access-token: ${{ secrets.GITHUB_ACCESS_TOKEN }}
+          scan-config: |
+            events:  # a list of event specifications such as the following one
+            - type: deploy 
+            name: mc-review-promote
+            team: mv-review
+            environment: prod
+            owner: Enterprise-CMCS
+            repo: managed-care-review
+            workflowfilename: promote.yml
+            branch: main


### PR DESCRIPTION
## Summary

We've been asked to setup a metric export to the mac-fc backend that is collecting deploy metrics. This uses the [mac-fc-scan](https://github.com/Enterprise-CMCS/mac-fc-scan-github) action that Ben wrote and puts in just our promote metrics.

Since we can't run this to debug until it merges there likely will be follow-on PRs.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4248

