### PR TITLE
MCR-4366: Remove help desk from replyToAddresses

### DIFF
--- a/services/app-api/src/emailer/emails/newPackageCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/newPackageCMSEmail.ts
@@ -92,7 +92,6 @@ export const newPackageCMSEmail = async (
     } else {
         return {
             toAddresses: reviewerEmails,
-            replyToAddresses: [config.helpDeskEmail],
             sourceEmail: config.emailSource,
             subject: `${
                 isTestEnvironment ? `[${config.stage}] ` : ''

--- a/services/app-api/src/emailer/emails/newPackageStateEmail.ts
+++ b/services/app-api/src/emailer/emails/newPackageStateEmail.ts
@@ -102,7 +102,6 @@ export const newPackageStateEmail = async (
         return {
             toAddresses: receiverEmails,
             sourceEmail: config.emailSource,
-            replyToAddresses: [config.helpDeskEmail],
             subject: `${
                 config.stage !== 'prod' ? `[${config.stage}] ` : ''
             }${packageName} was sent to CMS`,

--- a/services/app-api/src/emailer/emails/resubmitPackageCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/resubmitPackageCMSEmail.ts
@@ -73,7 +73,6 @@ export const resubmitPackageCMSEmail = async (
     } else {
         return {
             toAddresses: reviewerEmails,
-            replyToAddresses: [config.helpDeskEmail],
             sourceEmail: config.emailSource,
             subject: `${
                 isTestEnvironment ? `[${config.stage}] ` : ''

--- a/services/app-api/src/emailer/emails/resubmitPackageStateEmail.ts
+++ b/services/app-api/src/emailer/emails/resubmitPackageStateEmail.ts
@@ -69,7 +69,6 @@ export const resubmitPackageStateEmail = async (
     } else {
         return {
             toAddresses: receiverEmails,
-            replyToAddresses: [config.helpDeskEmail],
             sourceEmail: config.emailSource,
             subject: `${
                 isTestEnvironment ? `[${config.stage}] ` : ''

--- a/services/app-api/src/emailer/emails/sendQuestionCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/sendQuestionCMSEmail.ts
@@ -75,7 +75,6 @@ export const sendQuestionCMSEmail = async (
         return {
             toAddresses: receiverEmails,
             sourceEmail: config.emailSource,
-            replyToAddresses: [config.helpDeskEmail],
             subject: `${
                 config.stage !== 'prod' ? `[${config.stage}] ` : ''
             }Questions sent for ${packageName}`,

--- a/services/app-api/src/emailer/emails/sendQuestionResponseCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/sendQuestionResponseCMSEmail.ts
@@ -80,7 +80,6 @@ export const sendQuestionResponseCMSEmail = async (
         return {
             toAddresses: receiverEmails,
             sourceEmail: config.emailSource,
-            replyToAddresses: [config.helpDeskEmail],
             subject: `${
                 config.stage !== 'prod' ? `[${config.stage}] ` : ''
             }New Responses for ${packageName}`,

--- a/services/app-api/src/emailer/emails/sendQuestionResponseStateEmail.ts
+++ b/services/app-api/src/emailer/emails/sendQuestionResponseStateEmail.ts
@@ -78,7 +78,6 @@ export const sendQuestionResponseStateEmail = async (
         return {
             toAddresses: receiverEmails,
             sourceEmail: config.emailSource,
-            replyToAddresses: [config.helpDeskEmail],
             subject: `${
                 config.stage !== 'prod' ? `[${config.stage}] ` : ''
             }Response submitted to CMS for ${packageName}`,

--- a/services/app-api/src/emailer/emails/sendQuestionStateEmail.ts
+++ b/services/app-api/src/emailer/emails/sendQuestionStateEmail.ts
@@ -67,7 +67,6 @@ export const sendQuestionStateEmail = async (
         return {
             toAddresses: receiverEmails,
             sourceEmail: config.emailSource,
-            replyToAddresses: [config.helpDeskEmail],
             subject: `${
                 config.stage !== 'prod' ? `[${config.stage}] ` : ''
             }New questions about ${packageName}`,

--- a/services/app-api/src/emailer/emails/unlockContractCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/unlockContractCMSEmail.ts
@@ -68,7 +68,6 @@ export const unlockContractCMSEmail = async (
     } else {
         return {
             toAddresses: reviewerEmails,
-            replyToAddresses: [config.helpDeskEmail],
             sourceEmail: config.emailSource,
             subject: `${
                 isTestEnvironment ? `[${config.stage}] ` : ''

--- a/services/app-api/src/emailer/emails/unlockContractStateEmail.ts
+++ b/services/app-api/src/emailer/emails/unlockContractStateEmail.ts
@@ -76,7 +76,6 @@ export const unlockContractStateEmail = async (
     } else {
         return {
             toAddresses: receiverEmails,
-            replyToAddresses: [config.helpDeskEmail],
             sourceEmail: config.emailSource,
             subject: `${
                 isTestEnvironment ? `[${config.stage}] ` : ''

--- a/services/app-api/src/emailer/emails/unlockPackageCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/unlockPackageCMSEmail.ts
@@ -66,7 +66,6 @@ export const unlockPackageCMSEmail = async (
     } else {
         return {
             toAddresses: reviewerEmails,
-            replyToAddresses: [config.helpDeskEmail],
             sourceEmail: config.emailSource,
             subject: `${
                 isTestEnvironment ? `[${config.stage}] ` : ''

--- a/services/app-api/src/emailer/emails/unlockPackageStateEmail.ts
+++ b/services/app-api/src/emailer/emails/unlockPackageStateEmail.ts
@@ -72,7 +72,6 @@ export const unlockPackageStateEmail = async (
     } else {
         return {
             toAddresses: receiverEmails,
-            replyToAddresses: [config.helpDeskEmail],
             sourceEmail: config.emailSource,
             subject: `${
                 isTestEnvironment ? `[${config.stage}] ` : ''


### PR DESCRIPTION
## Summary
[MCR-4366](https://jiraent.cms.gov/browse/MCR-4366)

Removed the entire `replyToAddress` it was only the helpdesk email in there..

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
