### PR TITLE
Run lint-staged from pnpm

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -15,4 +15,4 @@ done
 git diff --staged --name-only -z | grep -zv 'pnpm-lock.yaml' | xargs -0 detect-secrets-hook
 
 # Run "precommit" in all pnpm workspaces 
-npx lint-staged --allow-empty
+pnpm lint-staged --allow-empty


### PR DESCRIPTION
## Summary
This updates running our linters from `npx` to using `pnpm` directly. I'll also say that I'm not sure that this will change much, as I personally wasn't seeing any of the issues that Hana or Pearl were seeing with linters not running locally in pre-commit. But running from pnpm does work and is recommended since we're using it now.

I originally intended to include a CI step for linting, but there are more failures than I had thought. Here is a follow on ticket and explanation of what I found: https://jiraent.cms.gov/browse/MCR-4391

#### Related issues
https://jiraent.cms.gov/browse/MCR-4390
