### PR TITLE
Set email replyToAddresses as empty array.

### DIFF
--- a/services/app-api/src/emailer/emails/newPackageCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/newPackageCMSEmail.ts
@@ -92,6 +92,7 @@ export const newPackageCMSEmail = async (
     } else {
         return {
             toAddresses: reviewerEmails,
+            replyToAddresses: [],
             sourceEmail: config.emailSource,
             subject: `${
                 isTestEnvironment ? `[${config.stage}] ` : ''

--- a/services/app-api/src/emailer/emails/newPackageStateEmail.ts
+++ b/services/app-api/src/emailer/emails/newPackageStateEmail.ts
@@ -101,6 +101,7 @@ export const newPackageStateEmail = async (
     } else {
         return {
             toAddresses: receiverEmails,
+            replyToAddresses: [],
             sourceEmail: config.emailSource,
             subject: `${
                 config.stage !== 'prod' ? `[${config.stage}] ` : ''

--- a/services/app-api/src/emailer/emails/resubmitPackageCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/resubmitPackageCMSEmail.ts
@@ -73,6 +73,7 @@ export const resubmitPackageCMSEmail = async (
     } else {
         return {
             toAddresses: reviewerEmails,
+            replyToAddresses: [],
             sourceEmail: config.emailSource,
             subject: `${
                 isTestEnvironment ? `[${config.stage}] ` : ''

--- a/services/app-api/src/emailer/emails/resubmitPackageStateEmail.ts
+++ b/services/app-api/src/emailer/emails/resubmitPackageStateEmail.ts
@@ -69,6 +69,7 @@ export const resubmitPackageStateEmail = async (
     } else {
         return {
             toAddresses: receiverEmails,
+            replyToAddresses: [],
             sourceEmail: config.emailSource,
             subject: `${
                 isTestEnvironment ? `[${config.stage}] ` : ''

--- a/services/app-api/src/emailer/emails/sendQuestionCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/sendQuestionCMSEmail.ts
@@ -74,6 +74,7 @@ export const sendQuestionCMSEmail = async (
     } else {
         return {
             toAddresses: receiverEmails,
+            replyToAddresses: [],
             sourceEmail: config.emailSource,
             subject: `${
                 config.stage !== 'prod' ? `[${config.stage}] ` : ''

--- a/services/app-api/src/emailer/emails/sendQuestionResponseCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/sendQuestionResponseCMSEmail.ts
@@ -79,6 +79,7 @@ export const sendQuestionResponseCMSEmail = async (
     } else {
         return {
             toAddresses: receiverEmails,
+            replyToAddresses: [],
             sourceEmail: config.emailSource,
             subject: `${
                 config.stage !== 'prod' ? `[${config.stage}] ` : ''

--- a/services/app-api/src/emailer/emails/sendQuestionResponseStateEmail.ts
+++ b/services/app-api/src/emailer/emails/sendQuestionResponseStateEmail.ts
@@ -77,6 +77,7 @@ export const sendQuestionResponseStateEmail = async (
     } else {
         return {
             toAddresses: receiverEmails,
+            replyToAddresses: [],
             sourceEmail: config.emailSource,
             subject: `${
                 config.stage !== 'prod' ? `[${config.stage}] ` : ''

--- a/services/app-api/src/emailer/emails/sendQuestionStateEmail.ts
+++ b/services/app-api/src/emailer/emails/sendQuestionStateEmail.ts
@@ -66,6 +66,7 @@ export const sendQuestionStateEmail = async (
     } else {
         return {
             toAddresses: receiverEmails,
+            replyToAddresses: [],
             sourceEmail: config.emailSource,
             subject: `${
                 config.stage !== 'prod' ? `[${config.stage}] ` : ''

--- a/services/app-api/src/emailer/emails/unlockContractCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/unlockContractCMSEmail.ts
@@ -77,6 +77,7 @@ export const unlockContractCMSEmail = async (
     } else {
         return {
             toAddresses: reviewerEmails,
+            replyToAddresses: [],
             sourceEmail: config.emailSource,
             subject: `${
                 isTestEnvironment ? `[${config.stage}] ` : ''

--- a/services/app-api/src/emailer/emails/unlockContractStateEmail.ts
+++ b/services/app-api/src/emailer/emails/unlockContractStateEmail.ts
@@ -89,6 +89,7 @@ export const unlockContractStateEmail = async (
     } else {
         return {
             toAddresses: receiverEmails,
+            replyToAddresses: [],
             sourceEmail: config.emailSource,
             subject: `${
                 isTestEnvironment ? `[${config.stage}] ` : ''

--- a/services/app-api/src/emailer/emails/unlockPackageCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/unlockPackageCMSEmail.ts
@@ -66,6 +66,7 @@ export const unlockPackageCMSEmail = async (
     } else {
         return {
             toAddresses: reviewerEmails,
+            replyToAddresses: [],
             sourceEmail: config.emailSource,
             subject: `${
                 isTestEnvironment ? `[${config.stage}] ` : ''

--- a/services/app-api/src/emailer/emails/unlockPackageStateEmail.ts
+++ b/services/app-api/src/emailer/emails/unlockPackageStateEmail.ts
@@ -72,6 +72,7 @@ export const unlockPackageStateEmail = async (
     } else {
         return {
             toAddresses: receiverEmails,
+            replyToAddresses: [],
             sourceEmail: config.emailSource,
             subject: `${
                 isTestEnvironment ? `[${config.stage}] ` : ''


### PR DESCRIPTION
## Summary
[MCR-4366](https://jiraent.cms.gov/browse/MCR-4366)

Lets try setting `replyToAddresses` in the emailer as empty array. I think it would have the same result as not including the property at all. 

I believe [AWS SES ](https://docs.aws.amazon.com/ses/latest/dg/send-email-concepts-email-format.html)defaults the `replyTo` of emails as the sender when we don't specify the `replyToAddresses` in the emailer.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
