### PR TITLE
Add environment to DSO metrics action

### DIFF
--- a/.github/workflows/send-dso-metrics.yml
+++ b/.github/workflows/send-dso-metrics.yml
@@ -30,7 +30,7 @@ jobs:
             - type: deploy 
               environment: prod
               name: mc-review-promote
-              team: mv-review
+              team: mc-review
               owner: Enterprise-CMCS
               repo: managed-care-review
               workflowfilename: promote.yml

--- a/.github/workflows/send-dso-metrics.yml
+++ b/.github/workflows/send-dso-metrics.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   SendDSOEvents:
     runs-on: ubuntu-latest
+    environment: prod
     steps:
       - name: Format OIDC role ARN
         shell: bash


### PR DESCRIPTION
## Summary
This adds the environment specifier for the DSO metrics action. The last merge is still having issues expanding the AWS ID, which is marked as a prod secret in our config it looks like.

#### Related Issues
https://jiraent.cms.gov/browse/MCR-4248
