### PR TITLE
MCR-4410 & MCR-3757 fix show more text on banners

### DIFF
--- a/services/app-web/src/components/FormContainer/FormContainer.module.scss
+++ b/services/app-web/src/components/FormContainer/FormContainer.module.scss
@@ -6,3 +6,8 @@
     display: flex;
     flex-direction: column;
 }
+
+.notificationContainer {
+    max-width: custom.$mcr-container-standard-width-fixed;
+    padding: 2rem 0;
+}

--- a/services/app-web/src/components/FormContainer/FormNotificationContainer.tsx
+++ b/services/app-web/src/components/FormContainer/FormNotificationContainer.tsx
@@ -1,0 +1,21 @@
+import classnames from 'classnames'
+import styles from './FormContainer.module.scss'
+import { GridContainer } from '@trussworks/react-uswds'
+
+type NotificationContainerProps = {
+    testID?: string
+    children: React.ReactNode & JSX.IntrinsicElements['div']
+    className?: string
+}
+export const FormNotificationContainer = (
+    props: NotificationContainerProps
+): React.ReactElement => {
+    const { testID, className, children } = props
+
+    const classes = classnames(styles.notificationContainer, className)
+    return (
+        <GridContainer data-testid={testID} className={classes}>
+            {children}
+        </GridContainer>
+    )
+}

--- a/services/app-web/src/components/FormContainer/index.ts
+++ b/services/app-web/src/components/FormContainer/index.ts
@@ -1,0 +1,2 @@
+export { FormContainer} from './FormContainer'
+export { FormNotificationContainer } from './FormNotificationContainer'

--- a/services/app-web/src/components/index.ts
+++ b/services/app-web/src/components/index.ts
@@ -85,3 +85,5 @@ export { InlineDocumentWarning } from './DocumentWarning'
 export { SectionCard } from './SectionCard'
 
 export { NavLinkWithLogging, LinkWithLogging, ReactRouterLinkWithLogging, ButtonWithLogging } from './TealiumLogging'
+
+export { FormContainer, FormNotificationContainer} from './FormContainer'

--- a/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
@@ -27,6 +27,7 @@ import { RoutesRecord } from '../../../constants'
 import {
     ButtonWithLogging,
     DynamicStepIndicator,
+    FormNotificationContainer,
     SectionCard,
 } from '../../../components'
 import { FormContainer } from '../../../components/FormContainer/FormContainer'
@@ -202,7 +203,7 @@ const Contacts = ({
 
     return (
         <>
-            <div>
+            <FormNotificationContainer>
                 <DynamicStepIndicator
                     formPages={activeFormPages(draftSubmission)}
                     currentFormPage={currentRoute}
@@ -212,7 +213,7 @@ const Contacts = ({
                     unlockedInfo={unlockInfo}
                     showPageErrorMessage={showPageErrorMessage ?? false}
                 />
-            </div>
+            </FormNotificationContainer>
             <FormContainer id="Contacts">
                 <Formik
                     initialValues={contactsInitialValues}

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -24,6 +24,7 @@ import {
     DynamicStepIndicator,
     LinkWithLogging,
     ReactRouterLinkWithLogging,
+    FormNotificationContainer,
 } from '../../../components'
 import {
     formatForForm,
@@ -81,10 +82,7 @@ import {
     StatutoryRegulatoryAttestationQuestion,
 } from '../../../constants/statutoryRegulatoryAttestation'
 import { FormContainer } from '../../../components/FormContainer/FormContainer'
-import {
-    useCurrentRoute,
-    useRouteParams,
-} from '../../../hooks'
+import { useCurrentRoute, useRouteParams } from '../../../hooks'
 import { useAuth } from '../../../contexts/AuthContext'
 import { ErrorOrLoadingPage } from '../ErrorOrLoadingPage'
 import { PageBannerAlerts } from '../PageBannerAlerts'
@@ -524,7 +522,7 @@ export const ContractDetails = ({
 
     return (
         <>
-            <div>
+            <FormNotificationContainer>
                 <DynamicStepIndicator
                     formPages={activeFormPages(
                         draftSubmission.draftRevision.formData
@@ -536,7 +534,7 @@ export const ContractDetails = ({
                     unlockedInfo={draftSubmission.draftRevision.unlockInfo}
                     showPageErrorMessage={showPageErrorMessage ?? false}
                 />
-            </div>
+            </FormNotificationContainer>
             <FormContainer id="ContactDetails">
                 <Formik
                     initialValues={contractDetailsInitialValues}

--- a/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
+++ b/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
@@ -26,7 +26,11 @@ import {
     useRouteParams,
 } from '../../../hooks'
 import { ErrorOrLoadingPage } from '../ErrorOrLoadingPage'
-import { DynamicStepIndicator, LinkWithLogging } from '../../../components'
+import {
+    DynamicStepIndicator,
+    FormNotificationContainer,
+    LinkWithLogging,
+} from '../../../components'
 import { PageBannerAlerts } from '../PageBannerAlerts'
 import { useErrorSummary } from '../../../hooks/useErrorSummary'
 
@@ -249,7 +253,7 @@ export const Documents = (): React.ReactElement => {
 
     return (
         <>
-            <div>
+            <FormNotificationContainer>
                 <DynamicStepIndicator
                     formPages={activeFormPages(draftSubmission)}
                     currentFormPage={currentRoute}
@@ -259,7 +263,7 @@ export const Documents = (): React.ReactElement => {
                     unlockedInfo={unlockInfo}
                     showPageErrorMessage={showPageErrorMessage ?? false}
                 />
-            </div>
+            </FormNotificationContainer>
             <FormContainer id="Documents">
                 <UswdsForm
                     className={classNames(

--- a/services/app-web/src/pages/StateSubmission/PageBannerAlerts.tsx
+++ b/services/app-web/src/pages/StateSubmission/PageBannerAlerts.tsx
@@ -4,7 +4,6 @@ import {
     SubmissionUnlockedBanner,
 } from '../../components'
 import { UpdateInformation, User } from '../../gen/gqlClient'
-import styles from './StateSubmissionForm.module.scss'
 
 const PageBannerAlerts = ({
     showPageErrorMessage,
@@ -26,7 +25,6 @@ const PageBannerAlerts = ({
             )}
             {unlockedInfo && (
                 <SubmissionUnlockedBanner
-                    className={styles.banner}
                     loggedInUser={loggedInUser}
                     unlockedInfo={unlockedInfo}
                 />

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -8,6 +8,7 @@ import {
     ButtonWithLogging,
     DynamicStepIndicator,
     ErrorSummary,
+    FormNotificationContainer,
     SectionCard,
 } from '../../../../components'
 import { RateDetailsFormSchema } from '../RateDetailsSchema'
@@ -373,7 +374,7 @@ const RateDetails = ({
 
     return (
         <>
-            <div>
+            <FormNotificationContainer>
                 {!displayAsStandaloneRate && (
                     <DynamicStepIndicator
                         formPages={STATE_SUBMISSION_FORM_ROUTES}
@@ -392,7 +393,7 @@ const RateDetails = ({
                         showPageErrorMessage={showAPIErrorBanner}
                     />
                 )}
-            </div>
+            </FormNotificationContainer>
 
             <Formik
                 initialValues={initialValues}

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ReviewSubmitV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ReviewSubmitV2.tsx
@@ -26,7 +26,7 @@ import { useFetchContractQuery } from '../../../../../gen/gqlClient'
 import { ErrorForbiddenPage } from '../../../../Errors/ErrorForbiddenPage'
 import { Error404 } from '../../../../Errors/Error404Page'
 import { GenericErrorPage } from '../../../../Errors/GenericErrorPage'
-import { Loading } from '../../../../../components'
+import { Loading, FormNotificationContainer } from '../../../../../components'
 import { PageBannerAlerts } from '../../../PageBannerAlerts'
 import { packageName } from '../../../../../common-code/healthPlanFormDataType'
 import { usePage } from '../../../../../contexts/PageContext'
@@ -101,7 +101,7 @@ export const ReviewSubmit = (): React.ReactElement => {
         ) || ''
     return (
         <>
-            <div>
+            <FormNotificationContainer>
                 <DynamicStepIndicator
                     formPages={activeFormPages(contractFormData)}
                     currentFormPage="SUBMISSIONS_REVIEW_SUBMIT"
@@ -111,7 +111,7 @@ export const ReviewSubmit = (): React.ReactElement => {
                     unlockedInfo={contract.draftRevision?.unlockInfo}
                     showPageErrorMessage={false}
                 />
-            </div>
+            </FormNotificationContainer>
             <GridContainer className={styles.reviewSectionWrapper}>
                 <SubmissionTypeSummarySection
                     contract={contract}

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
@@ -13,6 +13,7 @@ import {
     FieldRadio,
     FieldTextarea,
     FieldYesNo,
+    FormNotificationContainer,
     PoliteErrorMessage,
     ReactRouterLinkWithLogging,
 } from '../../../components'
@@ -357,7 +358,7 @@ export const SubmissionType = ({
 
     return (
         <>
-            <div>
+            <FormNotificationContainer>
                 <DynamicStepIndicator
                     formPages={
                         draftSubmission
@@ -373,7 +374,7 @@ export const SubmissionType = ({
                     unlockedInfo={draftSubmission?.draftRevision.unlockInfo}
                     showPageErrorMessage={showPageErrorMessage ?? false}
                 />
-            </div>
+            </FormNotificationContainer>
             <FormContainer id="SubmissionType">
                 <Formik
                     initialValues={submissionTypeInitialValues}


### PR DESCRIPTION
## Summary
[MCR-4410](https://jiraent.cms.gov/browse/MCR-4410)
We moved banners outside the grid containers that set a max width. The banners `show more` text needs to have a max width in order for it to know when to clamp long strings.

This fix places both the step indicator and the page banners inside it's own grid container,`FormNotificationContainer`.

A good refactor is to move the step indicator and page banners to the `StateSubmissionForm` component, but for now we need to get this merged in so that users can continue their work.

[MCR-3757](https://jiraent.cms.gov/browse/MCR-3757)
I did not see this happen, but included it anyways to review that it is no longer an issue. This was created last year in November so changes in the project since then may have fixed this. 

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
