### PR TITLE
Add sts:AssumeRole to DSO metrics role

### DIFF
--- a/.github/workflows/send-dso-metrics.yml
+++ b/.github/workflows/send-dso-metrics.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           aws-account-id: ${{ secrets.PROD_AWS_ACCOUNT_ID }}
           oidc-role: ${{ steps.format-oidc-role-arn.outputs.arn }}
-          github-access-token: ${{ secrets.GITHUB_ACCESS_TOKEN }}
+          github-access-token: ${{ secrets.GITHUB_TOKEN }}
           scan-config: |
             events:  # a list of event specifications such as the following one
             - type: deploy 

--- a/services/github-oidc/serverless.yml
+++ b/services/github-oidc/serverless.yml
@@ -111,7 +111,7 @@ resources:
               Resource: '*'
             - Effect: Allow
               Action: 'sts:AssumeRole'
-              Resource: 'arn:aws:iam::${AWS::AccountId}:role/delegatedadmin/developer/ct-cmcs-mac-fc-dso-metrics-report-events-role'
+              Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:role/delegatedadmin/developer/ct-cmcs-mac-fc-dso-metrics-report-events-role'
         Roles: [!Ref 'GitHubActionsServiceRole']
     GitHubActionsServiceRole:
       Type: AWS::IAM::Role

--- a/services/github-oidc/serverless.yml
+++ b/services/github-oidc/serverless.yml
@@ -109,6 +109,9 @@ resources:
             - Effect: Allow
               Action: ${param:githubActionsAllowedAwsActions}
               Resource: '*'
+            - Effect: Allow
+              Action: 'sts:AssumeRole'
+              Resource: 'arn:aws:iam::${AWS::AccountId}:role/delegatedadmin/developer/ct-cmcs-mac-fc-dso-metrics-report-events-role'
         Roles: [!Ref 'GitHubActionsServiceRole']
     GitHubActionsServiceRole:
       Type: AWS::IAM::Role


### PR DESCRIPTION
## Summary

This adds permissions for the role to be assumed for DSO metrics. I tested this with a manual change and it worked fine.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4248
