### PR TITLE
Bump lambda environment's memory in prod

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -64,6 +64,9 @@ custom:
     - ${ssm:/configuration/${sls:stage}/vpc/subnets/private/a/id, ssm:/configuration/default/vpc/subnets/private/a/id}
     - ${ssm:/configuration/${sls:stage}/vpc/subnets/private/b/id, ssm:/configuration/default/vpc/subnets/private/b/id}
     - ${ssm:/configuration/${sls:stage}/vpc/subnets/private/c/id, ssm:/configuration/default/vpc/subnets/private/c/id}
+  lambdaMemory:
+    prod: 4096
+    default: 1024
 
 provider:
   name: aws
@@ -227,7 +230,8 @@ functions:
           method: post
           cors: true
           authorizer: aws_iam
-    timeout: 30 # zipping large amount of files hits default time out of 6 seconds
+    timeout: 30
+    memorySize: ${self:custom.lambdaMemory.${self:provider.stage}, self:custom.lambdaMemory.default}
 
   cleanup:
     handler: src/handlers/cleanup.main


### PR DESCRIPTION
## Summary

This increases the memory for the lambda zip function in prod, in order to speed up the processing of files. This fixes an issue where a user is attempting to view a submission that has a large amount of files and the zip function is hitting the max runtime of 30s in AWS Lambda.
