### PR TITLE
Syntax fix on zip lambda stage

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -231,7 +231,7 @@ functions:
           cors: true
           authorizer: aws_iam
     timeout: 30
-    memorySize: ${self:custom.lambdaMemory.${self:provider.stage}, self:custom.lambdaMemory.default}
+    memorySize: ${self:custom.lambdaMemory.${sls:stage}, self:custom.lambdaMemory.default}
 
   cleanup:
     handler: src/handlers/cleanup.main


### PR DESCRIPTION
## Summary

This fixes the syntax to expand the `stage` from PR #2723 to use the more recent `sls:stage` syntax from Serverless.

#### Related Issues
https://jiraent.cms.gov/browse/MCR-4434