### PR TITLE
MCR-4264 Add actual edit links to dashbaord

### DIFF
--- a/services/app-web/src/pages/Settings/EditStateAssign/EditStateAssign.tsx
+++ b/services/app-web/src/pages/Settings/EditStateAssign/EditStateAssign.tsx
@@ -40,7 +40,7 @@ export const EditStateAssign = (): React.ReactElement => {
     const [_editStateAssignment, { loading: editLoading, error: editError }] =
         useUpdateStateAssignmentMutation()
 
-    if(!isValidStateCode(stateCode)){
+    if(!isValidStateCode(stateCode.toUpperCase())){
         return <Error404/>
     }
 

--- a/services/app-web/src/pages/Settings/Settings.test.tsx
+++ b/services/app-web/src/pages/Settings/Settings.test.tsx
@@ -88,7 +88,7 @@ const commonSettingPageTest = async () => {
     // Check the table headers
     expect(
         within(tableAnalysts).getByRole('columnheader', {
-            name: 'Inbox',
+            name: 'Assigned DMCO staff',
         })
     ).toBeInTheDocument()
     expect(

--- a/services/app-web/src/pages/Settings/Settings.tsx
+++ b/services/app-web/src/pages/Settings/Settings.tsx
@@ -43,6 +43,7 @@ const mapStateAnalystsFromParamStore = (
         ? stateAnalysts.map((sa) => ({
               emails: sa.emails,
               stateCode: sa.stateCode,
+              editLink: `/mc-review-settings/state-assignments/${sa.stateCode.toUpperCase()}/edit`
           }))
         : []
 }
@@ -67,6 +68,7 @@ const mapStateAnalystFromDB = (
         ? stateAssignments.map((state) => ({
               stateCode: state.stateCode,
               emails: state.assignedCMSUsers.map((user) => user.email),
+            editLink: `/mc-review-settings/state-assignments/${state.stateCode.toUpperCase()}/edit`
           }))
         : []
 }

--- a/services/app-web/src/pages/Settings/SettingsCells/SettingsCells.tsx
+++ b/services/app-web/src/pages/Settings/SettingsCells/SettingsCells.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { NavLinkWithLogging } from '../../../components'
+
+
+// This is a file contains settings cell components and formatters that will be used across the settings pages
+
+const formatEmails = (arr?: string[]) =>
+    arr ? arr.join(', ') : 'NOT DEFINED'
+
+const EditLink = ({url, rowID} : {url: string, rowID: string}) => {
+    return (<NavLinkWithLogging
+                key={rowID}
+                to={url}
+                data-testid={`edit-link-${rowID}`}
+            >
+                Edit
+            </NavLinkWithLogging>
+    )
+}
+export{ EditLink, formatEmails}

--- a/services/app-web/src/pages/Settings/SettingsTables/StateAssignmentTable.tsx
+++ b/services/app-web/src/pages/Settings/SettingsTables/StateAssignmentTable.tsx
@@ -91,7 +91,7 @@ const StateAssignmentTable = () => {
             }),
             columnHelper.accessor('emails', {
                 id: 'emails',
-                header: 'Assign DMCO staff',
+                header: 'Assigned DMCO staff',
                 cell: (info) => formatEmails(info.getValue()),
                 filterFn: `arrIncludesSome`,
             }),

--- a/services/app-web/src/pages/Settings/index.ts
+++ b/services/app-web/src/pages/Settings/index.ts
@@ -1,0 +1,1 @@
+export {formatEmails, EditLink} from './SettingsCells/SettingsCells'


### PR DESCRIPTION
## Summary
Forgotten AC from MCR_4264 - "edit" links are added to the analyst assignment table. Also correct column heading and the casing bug from the url work.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4264

#### Screenshots
![Screenshot 2024-09-10 at 4 52 28 PM](https://github.com/user-attachments/assets/0ceb8520-0449-42ed-bab1-ce3fd8dc2322)

#### Test cases covered
Added basic test for Edit state assignments column presence based on feature flag

## QA guidance
Make sure AC is working and is featured flagged
