### PR TITLE
MCR-4262: cms and admin see link to email settings in header

### DIFF
--- a/services/app-web/src/components/Header/Header.module.scss
+++ b/services/app-web/src/components/Header/Header.module.scss
@@ -1,25 +1,123 @@
 @use '../../styles/custom.scss' as custom;
 @use '../../styles/uswdsImports.scss' as uswds;
 
-.userInfo {
-    font-weight: uswds.font-weight('light');
-    padding: 0 1rem;
+// This is to override all the styles in USWDS classes.
+@mixin override-uswds-nav {
+    font-weight: uswds.font-weight('light') !important;
+    font-size: 1rem !important;
+    line-height: 1.15rem !important;
     color: custom.$mcr-foundation-white;
+}
 
-    button,
-    a {
-        color: custom.$mcr-foundation-white;
+// Override the USWDS classes to match our own styling.
+.primaryNav {
+    background-color: transparent !important;
 
-        &:hover,
-        &:active,
-        &:visited {
-            color: custom.$mcr-foundation-white;
+    button {
+        padding-top: 0 !important;
+        padding-bottom: 0 !important;
+        padding-left: 0 !important;
+        background-color: custom.$mcr-cmsblue-base !important;
+
+        &:hover {
+            color: custom.$mcr-foundation-white !important;
+        }
+        span::after {
+            background-color: white !important;
+        }
+    }
+
+    ul {
+        li > * {
+            @include override-uswds-nav;
         }
     }
 }
 
+.headerItemsContainer {
+    display: flex;
+    flex-wrap: wrap;
+    @include override-uswds-nav;
+
+    a {
+        text-decoration: underline !important;
+        color: custom.$mcr-foundation-white !important;
+        padding: 0 !important;
+        &:hover,
+        &:active,
+        &:visited {
+            color: custom.$mcr-foundation-white !important;
+            background-color: transparent !important;
+        }
+    }
+}
+
+.subMenuContainer {
+    position: relative;
+    margin-bottom: 0 !important;
+
+    ul {
+        position: absolute !important;
+        right: 0 !important;
+        margin-top: 1.5rem !important;
+        width: fit-content;
+        background-color: custom.$mcr-cmsblue-base !important;
+
+        > li {
+            & + li {
+                margin-top: 1.3rem !important;
+            }
+        }
+    }
+}
+
+.signOutButton {
+    text-decoration: underline !important;
+}
+
 .divider {
     padding: 0 1rem;
+    color: custom.$mcr-foundation-white;
+}
+
+@media (min-width: 63px) and (max-width: 1023px) {
+    .divider {
+        display: none;
+    }
+
+    .headerItemsContainer {
+        display: flex;
+        flex-wrap: wrap;
+        flex-direction: column;
+        justify-content: space-between;
+        padding-top: 1rem;
+        padding-bottom: 1rem;
+
+        li {
+            border-top: none !important;
+            margin-top: 1rem;
+            margin-bottom: 1rem;
+        }
+    }
+
+    .primaryNav {
+        ul {
+            margin-top: unset !important;
+        }
+        a:hover {
+            background-color: transparent !important;
+        }
+    }
+
+    .subMenuContainer {
+        ul {
+            margin-top: 0.5rem !important;
+            padding: 1rem;
+            li {
+                margin: 0;
+            }
+        }
+    }
 }
 
 .landingPageHeading {

--- a/services/app-web/src/components/Header/Header.test.tsx
+++ b/services/app-web/src/components/Header/Header.test.tsx
@@ -110,8 +110,19 @@ describe('Header', () => {
             })
 
             await waitFor(() => {
+                const yourAccountButton = screen.getByRole('button', {
+                    name: 'Your account',
+                })
+                expect(
+                    screen.getByRole('link', { name: 'MC-Review settings' })
+                ).toBeInTheDocument()
+                expect(yourAccountButton).toBeInTheDocument()
+                void userEvent.click(yourAccountButton)
+            })
+
+            await waitFor(() => {
                 const signOutButton = screen.getByRole('button', {
-                    name: /Sign out/i,
+                    name: 'Sign out',
                 })
                 expect(signOutButton).toBeInTheDocument()
             })
@@ -132,8 +143,19 @@ describe('Header', () => {
             })
 
             await waitFor(() => {
+                const yourAccountButton = screen.getByRole('button', {
+                    name: 'Your account',
+                })
+                expect(
+                    screen.getByRole('link', { name: 'MC-Review settings' })
+                ).toBeInTheDocument()
+                expect(yourAccountButton).toBeInTheDocument()
+                void userEvent.click(yourAccountButton)
+            })
+
+            await waitFor(() => {
                 const signOutButton = screen.getByRole('button', {
-                    name: /Sign out/i,
+                    name: 'Sign out',
                 })
                 expect(signOutButton).toBeInTheDocument()
                 void userEvent.click(signOutButton)
@@ -161,10 +183,20 @@ describe('Header', () => {
             )
 
             await waitFor(() => {
-                const signOutButton = screen.getByRole('button', {
-                    name: /Sign out/i,
+                const yourAccountButton = screen.getByRole('button', {
+                    name: 'Your account',
                 })
+                expect(
+                    screen.getByRole('link', { name: 'MC-Review settings' })
+                ).toBeInTheDocument()
+                expect(yourAccountButton).toBeInTheDocument()
+                void userEvent.click(yourAccountButton)
+            })
 
+            await waitFor(() => {
+                const signOutButton = screen.getByRole('button', {
+                    name: 'Sign out',
+                })
                 expect(signOutButton).toBeInTheDocument()
                 void userEvent.click(signOutButton)
             })

--- a/services/app-web/src/components/Header/Header.test.tsx
+++ b/services/app-web/src/components/Header/Header.test.tsx
@@ -1,6 +1,4 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-
 import * as CognitoAuthApi from '../../pages/Auth/cognitoAuth'
 import { renderWithProviders } from '../../testHelpers/jestHelpers'
 import { fetchCurrentUserMock } from '../../testHelpers/apolloMocks'
@@ -48,12 +46,14 @@ describe('Header', () => {
         })
 
         it('redirects when signin Link is clicked', async () => {
-            renderWithProviders(<Header authMode={'AWS_COGNITO'} />)
+            const { user } = renderWithProviders(
+                <Header authMode={'AWS_COGNITO'} />
+            )
             await waitFor(() => {
                 const signInButton = screen.getByRole('link', {
                     name: /Sign In/i,
                 })
-                void userEvent.click(signInButton)
+                void user.click(signInButton)
                 expect(signInButton).toHaveAttribute('href', '/auth')
             })
         })
@@ -103,11 +103,14 @@ describe('Header', () => {
         })
 
         it('displays sign out button', async () => {
-            renderWithProviders(<Header authMode={'AWS_COGNITO'} />, {
-                apolloProvider: {
-                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                },
-            })
+            const { user } = renderWithProviders(
+                <Header authMode={'AWS_COGNITO'} />,
+                {
+                    apolloProvider: {
+                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                    },
+                }
+            )
 
             await waitFor(() => {
                 const yourAccountButton = screen.getByRole('button', {
@@ -117,7 +120,7 @@ describe('Header', () => {
                     screen.getByRole('link', { name: 'MC-Review settings' })
                 ).toBeInTheDocument()
                 expect(yourAccountButton).toBeInTheDocument()
-                void userEvent.click(yourAccountButton)
+                void user.click(yourAccountButton)
             })
 
             await waitFor(() => {
@@ -133,14 +136,17 @@ describe('Header', () => {
                 .spyOn(CognitoAuthApi, 'signOut')
                 .mockResolvedValue(null)
 
-            renderWithProviders(<Header authMode={'AWS_COGNITO'} />, {
-                apolloProvider: {
-                    mocks: [
-                        fetchCurrentUserMock({ statusCode: 200 }),
-                        fetchCurrentUserMock({ statusCode: 403 }),
-                    ],
-                },
-            })
+            const { user } = renderWithProviders(
+                <Header authMode={'AWS_COGNITO'} />,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({ statusCode: 200 }),
+                            fetchCurrentUserMock({ statusCode: 403 }),
+                        ],
+                    },
+                }
+            )
 
             await waitFor(() => {
                 const yourAccountButton = screen.getByRole('button', {
@@ -150,7 +156,7 @@ describe('Header', () => {
                     screen.getByRole('link', { name: 'MC-Review settings' })
                 ).toBeInTheDocument()
                 expect(yourAccountButton).toBeInTheDocument()
-                void userEvent.click(yourAccountButton)
+                void user.click(yourAccountButton)
             })
 
             await waitFor(() => {
@@ -158,7 +164,7 @@ describe('Header', () => {
                     name: 'Sign out',
                 })
                 expect(signOutButton).toBeInTheDocument()
-                void userEvent.click(signOutButton)
+                void user.click(signOutButton)
             })
 
             await waitFor(() => expect(spy).toHaveBeenCalledTimes(1))
@@ -170,7 +176,7 @@ describe('Header', () => {
                 .mockRejectedValue('This logout failed!')
             const mockAlert = vi.fn()
 
-            renderWithProviders(
+            const { user } = renderWithProviders(
                 <Header authMode={'AWS_COGNITO'} setAlert={mockAlert} />,
                 {
                     apolloProvider: {
@@ -190,7 +196,7 @@ describe('Header', () => {
                     screen.getByRole('link', { name: 'MC-Review settings' })
                 ).toBeInTheDocument()
                 expect(yourAccountButton).toBeInTheDocument()
-                void userEvent.click(yourAccountButton)
+                void user.click(yourAccountButton)
             })
 
             await waitFor(() => {
@@ -198,7 +204,7 @@ describe('Header', () => {
                     name: 'Sign out',
                 })
                 expect(signOutButton).toBeInTheDocument()
-                void userEvent.click(signOutButton)
+                void user.click(signOutButton)
             })
 
             await waitFor(() => expect(spy).toHaveBeenCalledTimes(1))

--- a/services/app-web/src/components/Header/Header.test.tsx
+++ b/services/app-web/src/components/Header/Header.test.tsx
@@ -1,7 +1,11 @@
 import { screen, waitFor } from '@testing-library/react'
 import * as CognitoAuthApi from '../../pages/Auth/cognitoAuth'
 import { renderWithProviders } from '../../testHelpers/jestHelpers'
-import { fetchCurrentUserMock } from '../../testHelpers/apolloMocks'
+import {
+    fetchCurrentUserMock,
+    iterableAdminUsersMockData,
+    iterableCmsUsersMockData,
+} from '../../testHelpers/apolloMocks'
 import { Header } from './Header'
 
 describe('Header', () => {
@@ -116,9 +120,6 @@ describe('Header', () => {
                 const yourAccountButton = screen.getByRole('button', {
                     name: 'Your account',
                 })
-                expect(
-                    screen.getByRole('link', { name: 'MC-Review settings' })
-                ).toBeInTheDocument()
                 expect(yourAccountButton).toBeInTheDocument()
                 void user.click(yourAccountButton)
             })
@@ -152,9 +153,6 @@ describe('Header', () => {
                 const yourAccountButton = screen.getByRole('button', {
                     name: 'Your account',
                 })
-                expect(
-                    screen.getByRole('link', { name: 'MC-Review settings' })
-                ).toBeInTheDocument()
                 expect(yourAccountButton).toBeInTheDocument()
                 void user.click(yourAccountButton)
             })
@@ -192,9 +190,6 @@ describe('Header', () => {
                 const yourAccountButton = screen.getByRole('button', {
                     name: 'Your account',
                 })
-                expect(
-                    screen.getByRole('link', { name: 'MC-Review settings' })
-                ).toBeInTheDocument()
                 expect(yourAccountButton).toBeInTheDocument()
                 void user.click(yourAccountButton)
             })
@@ -210,5 +205,62 @@ describe('Header', () => {
             await waitFor(() => expect(spy).toHaveBeenCalledTimes(1))
             await waitFor(() => expect(mockAlert).toHaveBeenCalled())
         })
+
+        it('does not render MC-review settings link for State users', async () => {
+            renderWithProviders(<Header authMode={'AWS_COGNITO'} />, {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            statusCode: 200,
+                        }),
+                    ],
+                },
+            })
+
+            await waitFor(() => {
+                const yourAccountButton = screen.getByRole('button', {
+                    name: 'Your account',
+                })
+                expect(yourAccountButton).toBeInTheDocument()
+            })
+
+            expect(
+                screen.queryByRole('link', { name: 'MC-Review settings' })
+            ).toBeNull()
+        })
     })
 })
+
+const adminAndCmsUsers = [
+    ...iterableAdminUsersMockData,
+    ...iterableCmsUsersMockData,
+]
+
+describe.each(adminAndCmsUsers)(
+    'Admin and CMS users tests',
+    ({ mockUser, userRole }) => {
+        it('renders MC-review settings link for $userRole', async () => {
+            renderWithProviders(<Header authMode={'AWS_COGNITO'} />, {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockUser(),
+                            statusCode: 200,
+                        }),
+                    ],
+                },
+            })
+
+            await waitFor(() => {
+                const yourAccountButton = screen.getByRole('button', {
+                    name: 'Your account',
+                })
+                expect(yourAccountButton).toBeInTheDocument()
+            })
+
+            expect(
+                screen.getByRole('link', { name: 'MC-Review settings' })
+            ).toBeInTheDocument()
+        })
+    }
+)

--- a/services/app-web/src/components/Header/UserLoginInfo/UserLoginInfo.tsx
+++ b/services/app-web/src/components/Header/UserLoginInfo/UserLoginInfo.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 
-import { LoginStatusType } from '../../../contexts/AuthContext'
+import { LoginStatusType, useAuth } from '../../../contexts/AuthContext'
 import { User } from '../../../gen/gqlClient'
 import { idmRedirectURL } from '../../../pages/Auth/cognitoAuth'
 import { AuthModeType } from '../../../common-code/config'
@@ -27,6 +27,10 @@ const LoggedInUserInfo = (
     const stringConstants = useStringConstants()
     const [isOpen, setIsOpen] = useState(false)
     const { logButtonEvent } = useTealium()
+    const { loggedInUser } = useAuth()
+
+    const isStateUser = loggedInUser?.role === 'STATE_USER'
+
     const onToggle = (): void => {
         logButtonEvent({
             text: 'Your account',
@@ -52,19 +56,23 @@ const LoggedInUserInfo = (
             </span>
             <nav className={`${styles.primaryNav}`}>
                 <ul className={'usa-nav__primary usa-accordion'}>
-                    <li className={`usa-nav__primary-item`}>
-                        <NavLinkWithLogging
-                            to={'/mc-review-settings'}
-                            variant="unstyled"
-                        >
-                            MC-Review settings
-                        </NavLinkWithLogging>
-                    </li>
-                    <li aria-hidden className={`usa-nav__primary-item`}>
-                        <span aria-hidden className={styles.divider}>
-                            |
-                        </span>
-                    </li>
+                    {!isStateUser && (
+                        <>
+                            <li className={`usa-nav__primary-item`}>
+                                <NavLinkWithLogging
+                                    to={'/mc-review-settings'}
+                                    variant="unstyled"
+                                >
+                                    MC-Review settings
+                                </NavLinkWithLogging>
+                            </li>
+                            <li aria-hidden className={`usa-nav__primary-item`}>
+                                <span aria-hidden className={styles.divider}>
+                                    |
+                                </span>
+                            </li>
+                        </>
+                    )}
                     <li
                         className={`usa-nav__primary-item ${styles.subMenuContainer}`}
                     >

--- a/services/app-web/src/components/Header/UserLoginInfo/UserLoginInfo.tsx
+++ b/services/app-web/src/components/Header/UserLoginInfo/UserLoginInfo.tsx
@@ -39,19 +39,6 @@ const LoggedInUserInfo = (
         })
     }
 
-    const testMenuItems = [
-        <span key="email">{user.email}</span>,
-        <ButtonWithLogging
-            type="button"
-            unstyled
-            parent_component_type="constant header"
-            onClick={logout}
-            className={styles.signOutButton}
-        >
-            Sign out
-        </ButtonWithLogging>,
-    ]
-
     return (
         <div className={styles.headerItemsContainer}>
             <div>
@@ -94,7 +81,18 @@ const LoggedInUserInfo = (
                             />
                             <Menu
                                 key="one"
-                                items={testMenuItems}
+                                items={[
+                                    <span key="email">{user.email}</span>,
+                                    <ButtonWithLogging
+                                        type="button"
+                                        unstyled
+                                        parent_component_type="constant header"
+                                        onClick={logout}
+                                        className={styles.signOutButton}
+                                    >
+                                        Sign out
+                                    </ButtonWithLogging>,
+                                ]}
                                 isOpen={isOpen}
                                 id="accountDropDown"
                             />

--- a/services/app-web/src/components/Header/UserLoginInfo/UserLoginInfo.tsx
+++ b/services/app-web/src/components/Header/UserLoginInfo/UserLoginInfo.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import { LoginStatusType } from '../../../contexts/AuthContext'
 import { User } from '../../../gen/gqlClient'
@@ -13,6 +13,8 @@ import {
     ButtonWithLogging,
 } from '../../../components'
 import { ContactSupportLink } from '../../ErrorAlert/ContactSupportLink'
+import { NavDropDownButton, Menu } from '@trussworks/react-uswds'
+import { useTealium } from '../../../hooks'
 
 type LogoutHandlerT = (
     e: React.MouseEvent<HTMLButtonElement, MouseEvent>
@@ -23,22 +25,83 @@ const LoggedInUserInfo = (
     logout: LogoutHandlerT
 ): React.ReactElement => {
     const stringConstants = useStringConstants()
-    return (
-        <div className={styles.userInfo}>
-            <span>Contact </span>
-            <ContactSupportLink alternateText={stringConstants.MAIL_TO_SUPPORT} />
-            <span className={styles.divider}>|</span>
-            <span>{user.email}</span>
-            <span className={styles.divider}>|</span>
+    const [isOpen, setIsOpen] = useState(false)
+    const { logButtonEvent } = useTealium()
+    const onToggle = (): void => {
+        logButtonEvent({
+            text: 'Your account',
+            button_type: 'button',
+            button_style: 'unstyled',
+            parent_component_type: 'constant header',
+        })
+        setIsOpen((prevIsOpen) => {
+            return !prevIsOpen
+        })
+    }
 
-            <ButtonWithLogging
-                type="button"
-                unstyled
-                parent_component_type="constant header"
-                onClick={logout}
-            >
-                Sign out
-            </ButtonWithLogging>
+    const testMenuItems = [
+        <span key="email">{user.email}</span>,
+        <ButtonWithLogging
+            type="button"
+            unstyled
+            parent_component_type="constant header"
+            onClick={logout}
+            className={styles.signOutButton}
+        >
+            Sign out
+        </ButtonWithLogging>,
+    ]
+
+    return (
+        <div className={styles.headerItemsContainer}>
+            <div>
+                <span>Contact </span>
+                <ContactSupportLink
+                    alternateText={stringConstants.MAIL_TO_SUPPORT}
+                />
+            </div>
+            <span aria-hidden className={styles.divider}>
+                |
+            </span>
+            <nav className={`${styles.primaryNav}`}>
+                <ul className={'usa-nav__primary usa-accordion'}>
+                    <li className={`usa-nav__primary-item`}>
+                        <NavLinkWithLogging
+                            to={'/mc-review-settings'}
+                            variant="unstyled"
+                        >
+                            MC-Review settings
+                        </NavLinkWithLogging>
+                    </li>
+                    <li aria-hidden className={`usa-nav__primary-item`}>
+                        <span aria-hidden className={styles.divider}>
+                            |
+                        </span>
+                    </li>
+                    <li
+                        className={`usa-nav__primary-item ${styles.subMenuContainer}`}
+                    >
+                        <>
+                            <NavDropDownButton
+                                key="testItemOne"
+                                label="Your account"
+                                menuId="accountDropDown"
+                                className={styles.headerSignOutButton}
+                                isOpen={isOpen}
+                                onToggle={(): void => {
+                                    onToggle()
+                                }}
+                            />
+                            <Menu
+                                key="one"
+                                items={testMenuItems}
+                                isOpen={isOpen}
+                                id="accountDropDown"
+                            />
+                        </>
+                    </li>
+                </ul>
+            </nav>
         </div>
     )
 }

--- a/services/cypress/integration/stateWorkflow/login/login.spec.ts
+++ b/services/cypress/integration/stateWorkflow/login/login.spec.ts
@@ -3,14 +3,25 @@ describe('login', () => {
         cy.stubFeatureFlags()
         cy.interceptGraphQL()
     })
-    it('can log in and log out as expected', () => {
+    it('can log in and log out as expected without accessibility violations', () => {
         cy.logInAsStateUser()
 
         cy.url().should('eq', Cypress.config().baseUrl + '/dashboard/submissions')
+        cy.findByRole('button', { name: 'Your account' }).should('exist').click()
+
+        cy.injectAxe()
+        cy.checkA11yWithWcag22aa()
+
         cy.findByRole('button', { name: /Sign out/i }).safeClick()
+
+        cy.injectAxe()
+        cy.checkA11yWithWcag22aa()
 
         cy.location('pathname').should('eq', '/')
         cy.findByRole('link', { name: /Sign In/i }).should('exist')
+
+        cy.injectAxe()
+        cy.checkA11yWithWcag22aa()
     })
 
     it('can log in and see personal dashboard for their state', () => {

--- a/services/cypress/integration/stateWorkflow/login/login.spec.ts
+++ b/services/cypress/integration/stateWorkflow/login/login.spec.ts
@@ -13,10 +13,6 @@ describe('login', () => {
         cy.checkA11yWithWcag22aa()
 
         cy.findByRole('button', { name: /Sign out/i }).safeClick()
-
-        cy.injectAxe()
-        cy.checkA11yWithWcag22aa()
-
         cy.location('pathname').should('eq', '/')
         cy.findByRole('link', { name: /Sign In/i }).should('exist')
 

--- a/services/cypress/support/loginCommands.ts
+++ b/services/cypress/support/loginCommands.ts
@@ -134,6 +134,7 @@ Cypress.Commands.add(
 )
 
 Cypress.Commands.add('logOut', () => {
+    cy.findByRole('button', { name: 'Your account' }).should('exist').click()
     cy.findByRole('button', { name: 'Sign out' }).should('exist').click()
     cy.findByText(
         'Medicaid and CHIP Managed Care Reporting and Review System',


### PR DESCRIPTION
## Summary
[MCR-4262](https://jiraent.cms.gov/browse/MCR-4262)

ACs:
- If I am logged in as a CMS user or an Admin then I see an "MC-Review settings" link in the header
- If I click on the link then I am directed to /mc-review-settings 
- Place user email and sign out button under a `Your account` dropdown.

Other things
- Placed `MC-Review settings` link and the `Your account` dropdown into a `nav` element
- Fixed the `nav` section for small screens
- Update `login.spec.ts` to also check for accessibility violations. (It actually found a mistake I made when I ran the test!)

#### Related issues

#### Screenshots

#### Test cases covered

`login.spec.ts`
- `'can log in and log out as expected without accessibility violations'`
<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
