### PR TITLE
MCR-2501: Update copy on settings page

### DIFF
--- a/services/app-web/src/pages/QuestionResponse/QuestionResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponse.tsx
@@ -2,12 +2,7 @@ import { useEffect } from 'react'
 import { GridContainer } from '@trussworks/react-uswds'
 import styles from './QuestionResponse.module.scss'
 
-import {
-    Loading,
-    SectionHeader,
-    NavLinkWithLogging,
-    LinkWithLogging,
-} from '../../components'
+import { Loading, SectionHeader, NavLinkWithLogging } from '../../components'
 import { useLocation, useOutletContext } from 'react-router-dom'
 import { usePage } from '../../contexts/PageContext'
 import { SideNavOutletContextType } from '../SubmissionSideNav/SubmissionSideNav'
@@ -17,7 +12,6 @@ import {
 } from '../../components/Banner'
 import { QATable, QuestionData, Division } from './QATable/QATable'
 import { CmsUser, QuestionEdge, StateUser } from '../../gen/gqlClient'
-import { useStringConstants } from '../../hooks/useStringConstants'
 import { GenericErrorPage } from '../Errors/GenericErrorPage'
 import { hasCMSUserPermissions } from '../../gqlHelpers'
 import { ContactSupportLink } from '../../components/ErrorAlert/ContactSupportLink'
@@ -134,7 +128,8 @@ export const QuestionResponse = () => {
                             <span>
                                 You must be assigned to a division in order to
                                 ask questions about a submission. Please&nbsp;
-                                <ContactSupportLink />&nbsp;to add your division.
+                                <ContactSupportLink />
+                                &nbsp;to add your division.
                             </span>
                         }
                     />

--- a/services/app-web/src/pages/Settings/Settings.test.tsx
+++ b/services/app-web/src/pages/Settings/Settings.test.tsx
@@ -126,10 +126,10 @@ const commonSettingPageTest = async () => {
     expect(tableRowsDivision).toHaveLength(2)
     // Check the table headers
     expect(
-        screen.getByRole('columnheader', { name: 'Family Name' })
+        screen.getByRole('columnheader', { name: 'Last name' })
     ).toBeInTheDocument()
     expect(
-        screen.getByRole('columnheader', { name: 'Given Name' })
+        screen.getByRole('columnheader', { name: 'First name' })
     ).toBeInTheDocument()
     expect(
         screen.getByRole('columnheader', { name: 'Email' })

--- a/services/app-web/src/pages/Settings/SettingsTables/DivisionAssignmentTable.tsx
+++ b/services/app-web/src/pages/Settings/SettingsTables/DivisionAssignmentTable.tsx
@@ -114,12 +114,12 @@ function CMSUserTableWithData({
             columnHelper.accessor('familyName', {
                 id: 'familyName',
                 cell: (info) => info.getValue(),
-                header: 'Family Name',
+                header: 'Last name',
             }),
             columnHelper.accessor('givenName', {
                 id: 'givenName',
                 cell: (info) => info.getValue(),
-                header: 'Given Name',
+                header: 'First name',
             }),
             columnHelper.accessor('email', {
                 id: 'email',


### PR DESCRIPTION
## Summary
[MCR-2501](https://jiraent.cms.gov/browse/MCR-2501)
- On Division assignments tab (formally CMS users):
   - Change Family Name to Last name
   - Change Given Name to First name
   - All first and last name entries should be in sentence case
- On the State assignments tab (formally state analysts):
   - Page header should be in sentence case State assignments
   - Update page description to say “Below is a list of the DMCO staff assigned to states.”
   - Add space after comma between emails


#### Related issues

#### Screenshots
![Screenshot 2024-09-13 at 6 47 31 PM](https://github.com/user-attachments/assets/e4ba8509-b482-4648-98d7-4ddaed0d1c0c)

![Screenshot 2024-09-13 at 6 51 53 PM](https://github.com/user-attachments/assets/526fdf06-f2d8-4f3b-8643-8fa93a6fd13e)


#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
