### PR TITLE
fix: Pull Tealium change off prod, keep on lower env

### DIFF
--- a/services/app-web/src/tealium/tealium.ts
+++ b/services/app-web/src/tealium/tealium.ts
@@ -202,6 +202,7 @@ type TealiumClientType = {
 }
 
 const tealiumClient = (tealiumEnv: Omit<TealiumEnv, 'dev'>): TealiumClientType => {
+    const tealiumHostname = (tealiumEnv == 'prod') ? 'tags.tiqcdn.com' : 'tealium-tags.cms.gov'
     return {
         initializeTealium: () => {
             // Suppress automatic page views for SPA
@@ -212,7 +213,7 @@ const tealiumClient = (tealiumEnv: Omit<TealiumEnv, 'dev'>): TealiumClientType =
 
             // Load utag.sync.js - add to head element - SYNC load from src
             const initializeTagManagerSnippet = createScript({
-                src: `https://tealium-tags.cms.gov/utag/cmsgov/${tealiumProfile}/${tealiumEnv}/utag.sync.js`,
+                src: `https://${tealiumHostname}/utag/cmsgov/${tealiumProfile}/${tealiumEnv}/utag.sync.js`,
                 id: 'tealium-load-tags-sync',
             })
             if (document.getElementById(initializeTagManagerSnippet.id) === null) {
@@ -224,7 +225,7 @@ const tealiumClient = (tealiumEnv: Omit<TealiumEnv, 'dev'>): TealiumClientType =
                 t = 'cmsgov/${tealiumProfile}'
                 e = '${tealiumEnv}'
                 a = '/' + t + '/' + e + '/utag.js'
-                l = '//tealium-tags.cms.gov/utag' + a
+                l = '//${tealiumHostname}/utag' + a
                 i = document
                 u = 'script'
                 m = i.createElement(u)


### PR DESCRIPTION
## Summary
Follow on to #2739 - I realized they instructed us **not** to deploy to prod yet, only to lower environments. Makes sense, I see that the new script isn't working in prod when I look in the console. Bringing back the old script for prod.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4458

#### Screenshots

#### Test cases covered
This will be tested after deploy 