### PR TITLE
Disable Apollo Browser and introspection queries in val 

### DIFF
--- a/services/app-api/src/handlers/apollo_gql.ts
+++ b/services/app-api/src/handlers/apollo_gql.ts
@@ -349,10 +349,12 @@ async function initializeGQLHandler(): Promise<Handler> {
 
     // Configure Apollo sandbox plugin
     let plugins = []
-    if (stageName === 'prod') {
+    let introspectionAllowed = false // sets if we allow introspection queries
+    if (stageName === 'prod' || stageName === 'val') {
         plugins = [ApolloServerPluginLandingPageDisabled()]
     } else {
         plugins = [ApolloServerPluginLandingPageLocalDefault({ embed: true })]
+        introspectionAllowed = true
     }
 
     // Hard coding this for now, next job is to run this config to this app.
@@ -437,6 +439,7 @@ async function initializeGQLHandler(): Promise<Handler> {
         resolvers,
         context: contextForRequest,
         plugins,
+        introspection: introspectionAllowed,
     })
 
     const handler = server.createHandler({

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -2,7 +2,7 @@ import React, { Fragment, useEffect, useState } from 'react'
 import { useLocation, Navigate } from 'react-router'
 import { Route, Routes } from 'react-router-dom'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
-import {  idmRedirectURL } from '../../pages/Auth/cognitoAuth'
+import { idmRedirectURL } from '../../pages/Auth/cognitoAuth'
 import { assertNever, AuthModeType } from '../../common-code/config'
 import { PageTitlesRecord, RoutesRecord, RouteT } from '../../constants/routes'
 import { getRouteName } from '../../routeHelpers'
@@ -150,7 +150,7 @@ const StateUserRoutes = ({
                     element={<SubmissionRevisionSummary />}
                 />
                 {UniversalRoutes}
-                {stageName !== 'prod' && (
+                {(stageName === 'dev' || stageName === 'local') && (
                     <Route
                         path={RoutesRecord.GRAPHQL_EXPLORER}
                         element={<GraphQLExplorer />}
@@ -238,10 +238,7 @@ const CMSUserRoutes = ({
                         element={<GraphQLExplorer />}
                     />
                 )}
-                <Route
-                    path={RoutesRecord.MCR_SETTINGS}
-                    element={<Settings />}
-                >
+                <Route path={RoutesRecord.MCR_SETTINGS} element={<Settings />}>
                     <Route
                         index
                         element={
@@ -266,9 +263,9 @@ const CMSUserRoutes = ({
                     />
                 </Route>
                 <Route
-                        path={RoutesRecord.EDIT_STATE_ASSIGNMENTS}
-                        element={<EditStateAssign />}
-                    />
+                    path={RoutesRecord.EDIT_STATE_ASSIGNMENTS}
+                    element={<EditStateAssign />}
+                />
                 <Route
                     path={RoutesRecord.SETTINGS}
                     // Until we update the helpdesk documentation for the /mc-review-settings route, we are keeping this
@@ -310,9 +307,7 @@ export const AppRoutes = ({
     authMode: AuthModeType
     setAlert?: React.Dispatch<React.ReactElement>
 }): React.ReactElement => {
-    const {
-        loggedInUser,
-    } = useAuth()
+    const { loggedInUser } = useAuth()
     const { pathname } = useLocation()
     const [redirectPath, setRedirectPath] = useLocalStorage(
         'LOGIN_REDIRECT',


### PR DESCRIPTION
## Summary

We were asked to disable the Apollo browser and introspection queries on the Val environment for security compliance. This does the thing.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4431
