### PR TITLE
Security Finding: Disallow user creation on val/prod

### DIFF
--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -59,6 +59,9 @@ resources:
         - Fn::Equals:
             - ${sls:stage}
             - 'prod'
+        - Fn::Equals:
+            - ${sls:stage}
+            - 'mtsecfindingusers'
   Resources:
     CognitoUserPool:
       Type: AWS::Cognito::UserPool

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -51,11 +51,24 @@ resources:
         - Fn::Equals:
             - ''
             - ${self:custom.sesSourceEmailAddress}
+    IsValOrProd:
+      Fn::Or:
+        - Fn::Equals:
+            - ${sls:stage}
+            - 'val'
+        - Fn::Equals:
+            - ${sls:stage}
+            - 'prod'
   Resources:
     CognitoUserPool:
       Type: AWS::Cognito::UserPool
       Properties:
         UserPoolName: ${sls:stage}-user-pool
+        AdminCreateUserConfig:
+          AllowAdminCreateUserOnly: !If
+            - IsValOrProd
+            - true
+            - false
         UsernameAttributes:
           - email
         AutoVerifiedAttributes:


### PR DESCRIPTION
## Summary

The pen testing team was able to get a user signup through in val, although it had no privileges to do anything. This remediates their finding by disabling the Cognito IDP signup in val and prod environments. 

I was able to confirm that user signup was allowed in my review branch, which gave me a confirmation code to my signup email address:
<img width="758" alt="Screenshot 2024-09-17 at 4 20 08 PM" src="https://github.com/user-attachments/assets/8de5cc5d-82b6-4b5a-b89f-2bce27d4fcb5">

I then added my branch's environment to the CloudFormation check to disable this, which worked as expected:

```
An error occurred (NotAuthorizedException) when calling the SignUp operation: SignUp is not permitted for this user pool
```

I'm not really sure we can test this in any other way prior to merging, but we can confirm in val once it promotes.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4430


