### PR TITLE
update state analyst by state

### DIFF
--- a/services/app-api/src/postgres/postgresErrors.ts
+++ b/services/app-api/src/postgres/postgresErrors.ts
@@ -13,7 +13,7 @@ class UserInputPostgresError extends Error {
     constructor(message: string) {
         super(message)
 
-        Object.setPrototypeOf(this, NotFoundError.prototype)
+        Object.setPrototypeOf(this, UserInputPostgresError.prototype)
     }
 }
 

--- a/services/app-api/src/postgres/postgresStore.ts
+++ b/services/app-api/src/postgres/postgresStore.ts
@@ -59,6 +59,7 @@ import type { UnlockRateArgsType } from './contractAndRates/unlockRate'
 import { findRateWithHistory } from './contractAndRates/findRateWithHistory'
 import { updateDraftContractRates } from './contractAndRates/updateDraftContractRates'
 import type { UpdateDraftContractRatesArgsType } from './contractAndRates/updateDraftContractRates'
+import { updateStateAssignedUsers } from './state/updateStateAssignedUsers'
 
 type Store = {
     findPrograms: (
@@ -78,6 +79,12 @@ type Store = {
 
     insertManyUsers: (
         users: InsertUserArgsType[]
+    ) => Promise<UserType[] | Error>
+
+    updateStateAssignedUsers: (
+        idOfUserPerformingUpdate: string,
+        stateCode: StateCodeType,
+        assignedUserIDs: string[]
     ) => Promise<UserType[] | Error>
 
     updateCmsUserProperties: (
@@ -174,6 +181,17 @@ function NewPostgresStore(client: PrismaClient): Store {
                 idOfUserPerformingUpdate,
                 divisionAssignment,
                 description
+            ),
+        updateStateAssignedUsers: (
+            idOfUserPerformingUpdate,
+            stateCode,
+            assignedUserIDs
+        ) =>
+            updateStateAssignedUsers(
+                client,
+                idOfUserPerformingUpdate,
+                stateCode,
+                assignedUserIDs
             ),
         findStatePrograms: findStatePrograms,
         findAllSupportedStates: () => findAllSupportedStates(client),

--- a/services/app-api/src/postgres/state/updateStateAssignedUsers.ts
+++ b/services/app-api/src/postgres/state/updateStateAssignedUsers.ts
@@ -41,6 +41,11 @@ async function updateStateAssignedUsersInTransaction(
         },
     })
 
+    if (previousUsers.length !== assignedUserIDs.length) {
+        const badUserMessage = `Some assigned user IDs do not exist or are duplicative`
+        return new UserInputPostgresError(badUserMessage)
+    }
+
     const nonCMSUsers = previousUsers.filter(
         (u) => !['CMS_USER', 'CMS_APPROVER_USER'].includes(u.role)
     )
@@ -116,11 +121,6 @@ async function updateStateAssignedUsersInTransaction(
 
         return users
     } catch (err) {
-        if (err.code === 'P2025') {
-            // this is because an ID doesn't exist in the db. This can only be a user ID b/c we've multiple times validated the StateCode
-            const invalidUserIDMsg = `Attempted to assign non existing users to the state`
-            return new UserInputPostgresError(invalidUserIDMsg)
-        }
         return err
     }
 }

--- a/services/app-api/src/postgres/state/updateStateAssignedUsers.ts
+++ b/services/app-api/src/postgres/state/updateStateAssignedUsers.ts
@@ -1,0 +1,155 @@
+import { AuditAction } from '@prisma/client'
+import type { PrismaClient } from '@prisma/client'
+import type { StateCodeType } from '../../common-code/healthPlanFormDataType'
+import type { UserType } from '../../domain-models'
+import { NotFoundError, UserInputPostgresError } from '../postgresErrors'
+import type { PrismaTransactionType } from '../prismaTypes'
+import { parseDomainUsersFromPrismaUsers } from '../user/prismaDomainUser'
+
+async function updateStateAssignedUsersInTransaction(
+    tx: PrismaTransactionType,
+    idOfUserPerformingUpdate: string,
+    stateCode: StateCodeType,
+    assignedUserIDs: string[]
+): Promise<UserType[] | Error> {
+    // get the state
+    const state = await tx.state.findUnique({
+        where: {
+            stateCode: stateCode,
+        },
+        include: {
+            assignedCMSUsers: {
+                include: {
+                    stateAssignments: true,
+                },
+            },
+        },
+    })
+
+    if (!state) {
+        return new NotFoundError('no state with code ' + stateCode)
+    }
+
+    const previousUsers = await tx.user.findMany({
+        where: {
+            id: {
+                in: assignedUserIDs,
+            },
+        },
+        include: {
+            stateAssignments: true,
+        },
+    })
+
+    const nonCMSUsers = previousUsers.filter(
+        (u) => !['CMS_USER', 'CMS_APPROVER_USER'].includes(u.role)
+    )
+    if (nonCMSUsers.length > 0) {
+        const badUserMessage = `Attempted to assign non-cms-users to a state: [${nonCMSUsers.map((u) => u.id)}]`
+        return new UserInputPostgresError(badUserMessage)
+    }
+
+    // find all previously assigned users no longer assigned
+    const removedUsers = state.assignedCMSUsers.filter(
+        (u) => !assignedUserIDs.includes(u.id)
+    )
+
+    // find newly assigned users
+    const newlyAssignedUsers = previousUsers.filter(
+        (u) => !state.assignedCMSUsers.find((au) => au.id === u.id)
+    )
+
+    // set links in state
+    try {
+        const updatedState = await tx.state.update({
+            where: {
+                stateCode: stateCode,
+            },
+            data: {
+                assignedCMSUsers: {
+                    set: assignedUserIDs.map((id) => ({ id: id })),
+                },
+            },
+            include: {
+                assignedCMSUsers: {
+                    include: {
+                        stateAssignments: true,
+                    },
+                },
+            },
+        })
+
+        // set audit table for all affected users
+        interface UserAuditStub {
+            modifiedUserID: string
+            previousValue: string
+        }
+
+        const modifiedUsers: UserAuditStub[] = []
+        modifiedUsers.push(
+            ...removedUsers.map((r) => ({
+                modifiedUserID: r.id,
+                previousValue: JSON.stringify(r.stateAssignments),
+            }))
+        )
+        modifiedUsers.push(
+            ...newlyAssignedUsers.map((r) => ({
+                modifiedUserID: r.id,
+                previousValue: JSON.stringify(r.stateAssignments),
+            }))
+        )
+
+        await tx.userAudit.createMany({
+            data: modifiedUsers.map((u) => ({
+                modifiedUserId: u.modifiedUserID,
+                updatedByUserId: idOfUserPerformingUpdate,
+                action: AuditAction.CHANGED_STATE_ASSIGNMENT,
+                description: 'updated state assignments',
+                priorValue: u.previousValue,
+            })),
+        })
+
+        // convert users.
+        const users = parseDomainUsersFromPrismaUsers(
+            updatedState.assignedCMSUsers
+        )
+
+        return users
+    } catch (err) {
+        if (err.code === 'P2025') {
+            // this is because an ID doesn't exist in the db. This can only be a user ID b/c we've multiple times validated the StateCode
+            const invalidUserIDMsg = `Attempted to assign non existing users to the state`
+            return new UserInputPostgresError(invalidUserIDMsg)
+        }
+        return err
+    }
+}
+
+async function updateStateAssignedUsers(
+    client: PrismaClient,
+    idOfUserPerformingUpdate: string,
+    stateCode: StateCodeType,
+    assignedUserIDs: string[]
+): Promise<UserType[] | Error> {
+    try {
+        const txRes = client.$transaction((tx) => {
+            const result = updateStateAssignedUsersInTransaction(
+                tx,
+                idOfUserPerformingUpdate,
+                stateCode,
+                assignedUserIDs
+            )
+
+            if (result instanceof Error) {
+                throw result
+            }
+
+            return result
+        })
+        return txRes
+    } catch (err) {
+        return err
+    }
+}
+
+export { updateStateAssignedUsers }

--- a/services/app-api/src/resolvers/configureResolvers.ts
+++ b/services/app-api/src/resolvers/configureResolvers.ts
@@ -52,6 +52,7 @@ import { createContract } from './contract/createContract'
 import { updateContractDraftRevision } from './contract/updateContractDraftRevision'
 import { withdrawAndReplaceRedundantRateResolver } from './contract/withdrawAndReplaceRedundantRate'
 import { fetchMcReviewSettings } from './settings'
+import { updateStateAssignmentsByState } from './user/updateStateAssignmentsByState'
 
 export function configureResolvers(
     store: Store,
@@ -123,6 +124,7 @@ export function configureResolvers(
                 withdrawAndReplaceRedundantRateResolver(store),
             updateDivisionAssignment: updateDivisionAssignment(store),
             updateStateAssignment: updateStateAssignment(store),
+            updateStateAssignmentsByState: updateStateAssignmentsByState(store),
             createQuestion: createQuestionResolver(
                 store,
                 emailParameterStore,

--- a/services/app-api/src/resolvers/user/updateStateAssignment.test.ts
+++ b/services/app-api/src/resolvers/user/updateStateAssignment.test.ts
@@ -79,7 +79,7 @@ const unauthorizedUserTests = [
 
 describe.each(authorizedUserTests)(
     'updateStateAssignment as $userType tests',
-    ({ mockUser, userType }) => {
+    ({ mockUser }) => {
         // setup a user in the db for us to modify
         const mockTestCMSUser = (): InsertUserArgsType => ({
             userID: uuidv4(),
@@ -208,7 +208,7 @@ describe.each(authorizedUserTests)(
             })
 
             expect(assertAnError(updateResUndefined).message).toContain(
-                'cannot update state assignments with no assignments'
+                'Variable "$input" got invalid value'
             )
             expect(assertAnErrorCode(updateResUndefined)).toBe('BAD_USER_INPUT')
             expect(
@@ -226,12 +226,12 @@ describe.each(authorizedUserTests)(
             })
 
             expect(assertAnError(updateResNull).message).toContain(
-                'cannot update state assignments with no assignments'
+                'Variable "$input" got invalid value'
             )
             expect(assertAnErrorCode(updateResNull)).toBe('BAD_USER_INPUT')
             expect(
                 assertAnErrorExtensions(updateResNull).argumentValues
-            ).toBeNull()
+            ).toBeUndefined()
         })
         it('returns an error with invalid state codes', async () => {
             const prismaClient = await sharedTestPrismaClient()

--- a/services/app-api/src/resolvers/user/updateStateAssignmentsByState.test.ts
+++ b/services/app-api/src/resolvers/user/updateStateAssignmentsByState.test.ts
@@ -1,0 +1,448 @@
+import {
+    testAdminUser,
+    testBusinessOwnerUser,
+    testCMSApproverUser,
+    testCMSUser,
+    testHelpdeskUser,
+    testStateUser,
+} from '../../testHelpers/userHelpers'
+import { v4 as uuidv4 } from 'uuid'
+import type { InsertUserArgsType } from '../../postgres'
+import { NewPostgresStore } from '../../postgres'
+import { sharedTestPrismaClient } from '../../testHelpers/storeHelpers'
+import UPDATE_STATE_ASSIGNMENTS_BY_STATE from '../../../../app-graphql/src/mutations/updateStateAssignmentsByState.graphql'
+import INDEX_USERS from '../../../../app-graphql/src/queries/indexUsers.graphql'
+import { constructTestPostgresServer } from '../../testHelpers/gqlHelpers'
+import type { User, UserEdge } from '../../gen/gqlServer'
+import {
+    assertAnError,
+    assertAnErrorCode,
+    assertAnErrorExtensions,
+} from '../../testHelpers'
+
+const authorizedUserTests = [
+    {
+        userType: 'ADMIN user',
+        mockUser: testAdminUser(),
+    },
+    {
+        userType: 'DMCO CMS user',
+        mockUser: testCMSUser({
+            divisionAssignment: 'DMCO',
+        }),
+    },
+    {
+        userType: 'DMCO CMS approver user',
+        mockUser: testCMSApproverUser({
+            divisionAssignment: 'DMCO',
+        }),
+    },
+    {
+        userType: 'Business owner user',
+        mockUser: testBusinessOwnerUser(),
+    },
+    {
+        userType: 'Helpdesk user',
+        mockUser: testHelpdeskUser(),
+    },
+    {
+        userType: 'OACT CMS user',
+        mockUser: testCMSUser({
+            divisionAssignment: 'OACT',
+        }),
+    },
+    {
+        userType: 'DMCP CMS user',
+        mockUser: testCMSUser({
+            divisionAssignment: 'DMCP',
+        }),
+    },
+    {
+        userType: 'DMCP CMS approver user',
+        mockUser: testCMSApproverUser({
+            divisionAssignment: 'DMCP',
+        }),
+    },
+    {
+        userType: 'OACT CMS approver user',
+        mockUser: testCMSApproverUser({
+            divisionAssignment: 'OACT',
+        }),
+    },
+]
+
+const unauthorizedUserTests = [
+    {
+        userType: 'State user',
+        mockUser: testStateUser(),
+    },
+]
+
+describe.each(authorizedUserTests)(
+    'updateStateAssignmentByState as $userType tests',
+    ({ mockUser }) => {
+        // setup a user in the db for us to modify
+        const mockTestCMSUser = (): InsertUserArgsType => ({
+            userID: uuidv4(),
+            ...testCMSUser({
+                id: uuidv4(),
+                divisionAssignment: 'OACT',
+            }),
+        })
+
+        const mockTestStateUser = (): InsertUserArgsType => ({
+            userID: uuidv4(),
+            ...testStateUser({
+                id: uuidv4(),
+            }),
+        })
+
+        it(`allows update state assignments`, async () => {
+            const prismaClient = await sharedTestPrismaClient()
+            const postgresStore = NewPostgresStore(prismaClient)
+
+            const newUser = await postgresStore.insertUser(mockTestCMSUser())
+            const secondUser = await postgresStore.insertUser(mockTestCMSUser())
+            const thirdUser = await postgresStore.insertUser(mockTestCMSUser())
+
+            if (
+                newUser instanceof Error ||
+                secondUser instanceof Error ||
+                thirdUser instanceof Error
+            ) {
+                throw new Error('no user')
+            }
+
+            const server = await constructTestPostgresServer({
+                store: postgresStore,
+                context: {
+                    user: mockUser,
+                },
+            })
+
+            const updateRes = await server.executeOperation({
+                query: UPDATE_STATE_ASSIGNMENTS_BY_STATE,
+                variables: {
+                    input: {
+                        stateCode: 'CA',
+                        assignedUsers: [newUser.id],
+                    },
+                },
+            })
+
+            expect(updateRes.data).toBeDefined()
+            expect(updateRes.errors).toBeUndefined()
+
+            if (!updateRes.data) {
+                throw new Error('no data')
+            }
+
+            const users =
+                updateRes.data.updateStateAssignmentsByState.assignedUsers
+            expect(users).toHaveLength(1)
+            const user = users[0]
+            expect(user.id).toBe(newUser.id)
+            expect(user.stateAssignments[0].code).toBe('CA')
+            expect(user.divisionAssignment).toBe('OACT')
+
+            // change the value and see if it updates
+            const updateRes2 = await server.executeOperation({
+                query: UPDATE_STATE_ASSIGNMENTS_BY_STATE,
+                variables: {
+                    input: {
+                        stateCode: 'CA',
+                        assignedUsers: [secondUser.id, thirdUser.id],
+                    },
+                },
+            })
+
+            expect(updateRes2.data).toBeDefined()
+            expect(updateRes2.errors).toBeUndefined()
+
+            if (!updateRes2.data) {
+                throw new Error('no data')
+            }
+
+            const users2 =
+                updateRes2.data.updateStateAssignmentsByState.assignedUsers
+            expect(users2).toHaveLength(2)
+
+            const updateRes3 = await server.executeOperation({
+                query: UPDATE_STATE_ASSIGNMENTS_BY_STATE,
+                variables: {
+                    input: {
+                        stateCode: 'NC',
+                        assignedUsers: [secondUser.id],
+                    },
+                },
+            })
+
+            expect(updateRes3.data).toBeDefined()
+            expect(updateRes3.errors).toBeUndefined()
+
+            const allUsersQuery = await server.executeOperation({
+                query: INDEX_USERS,
+                variables: {},
+            })
+
+            expect(allUsersQuery.data).toBeDefined()
+            expect(allUsersQuery.errors).toBeUndefined()
+
+            if (!allUsersQuery.data) {
+                throw new Error('no data')
+            }
+
+            const theseUserIDs = [newUser.id, secondUser.id, thirdUser.id]
+            const theseUsers = allUsersQuery.data.indexUsers.edges
+                .map((e: UserEdge) => e.node)
+                .filter((n: User) => theseUserIDs.includes(n.id))
+
+            const firstUserFound = theseUsers.find(
+                (u: User) => u.id === newUser.id
+            )
+            const secondUserFound = theseUsers.find(
+                (u: User) => u.id === secondUser.id
+            )
+            const thirdUserFound = theseUsers.find(
+                (u: User) => u.id === thirdUser.id
+            )
+
+            expect(firstUserFound.stateAssignments).toHaveLength(0)
+            expect(secondUserFound.stateAssignments).toHaveLength(2)
+            expect(thirdUserFound.stateAssignments).toHaveLength(1)
+
+            // finally, check the audit table.
+            const allAudits = await prismaClient.userAudit.findMany({
+                where: {
+                    modifiedUserId: {
+                        in: [newUser.id, secondUser.id, thirdUser.id],
+                    },
+                },
+                orderBy: {
+                    createdAt: 'asc',
+                },
+            })
+            expect(allAudits).toHaveLength(5)
+
+            // 1, add, remove
+            const firstAudits = allAudits.filter(
+                (a) => a.modifiedUserId === newUser.id
+            )
+            expect(firstAudits).toHaveLength(2)
+            expect(firstAudits[0].priorValue).toBe('[]')
+            if (!firstAudits[1].priorValue) {
+                throw new Error('no Prior')
+            }
+            const priorJSON = firstAudits[1].priorValue
+            let firstPriorVal = null
+            if (typeof priorJSON === 'string') {
+                firstPriorVal = JSON.parse(priorJSON)
+            } else {
+                throw new Error('got back a weird type from JSON')
+            }
+            expect(firstPriorVal).toHaveLength(1)
+            expect(firstPriorVal[0].stateCode).toBe('CA')
+            // 2, add, add
+            const secondAudits = allAudits.filter(
+                (a) => a.modifiedUserId === secondUser.id
+            )
+            expect(secondAudits).toHaveLength(2)
+            expect(secondAudits[0].priorValue).toBe('[]')
+            expect(secondAudits[1].priorValue).not.toBe('[]')
+            // 3, add
+            const thirdAudits = allAudits.filter(
+                (a) => a.modifiedUserId === thirdUser.id
+            )
+            expect(thirdAudits).toHaveLength(1)
+            expect(thirdAudits[0].priorValue).toBe('[]')
+        })
+        it('errors if state assignments are empty, undefined, or null', async () => {
+            const prismaClient = await sharedTestPrismaClient()
+            const postgresStore = NewPostgresStore(prismaClient)
+
+            const newUser = await postgresStore.insertUser(mockTestCMSUser())
+
+            if (newUser instanceof Error) {
+                throw newUser
+            }
+
+            const server = await constructTestPostgresServer({
+                store: postgresStore,
+                context: {
+                    user: mockUser,
+                },
+            })
+
+            const updateResEmpty = await server.executeOperation({
+                query: UPDATE_STATE_ASSIGNMENTS_BY_STATE,
+                variables: {
+                    input: {
+                        stateCode: 'CA',
+                        assignedUsers: [],
+                    },
+                },
+            })
+
+            expect(assertAnError(updateResEmpty).message).toContain(
+                'cannot update state assignments with no assignments'
+            )
+            expect(assertAnErrorCode(updateResEmpty)).toBe('BAD_USER_INPUT')
+            expect(
+                assertAnErrorExtensions(updateResEmpty).argumentValues
+            ).toEqual([])
+
+            const updateResUndefined = await server.executeOperation({
+                query: UPDATE_STATE_ASSIGNMENTS_BY_STATE,
+                variables: {
+                    input: {
+                        stateCode: 'CA',
+                        assignedUsers: undefined,
+                    },
+                },
+            })
+
+            expect(assertAnError(updateResUndefined).message).toContain(
+                'Variable "$input" got invalid value'
+            )
+            expect(assertAnErrorCode(updateResUndefined)).toBe('BAD_USER_INPUT')
+
+            const updateResNull = await server.executeOperation({
+                query: UPDATE_STATE_ASSIGNMENTS_BY_STATE,
+                variables: {
+                    input: {
+                        stateCode: 'CA',
+                        assignedUsers: null,
+                    },
+                },
+            })
+
+            expect(assertAnError(updateResNull).message).toContain(
+                'Variable "$input" got invalid value'
+            )
+            expect(assertAnErrorCode(updateResNull)).toBe('BAD_USER_INPUT')
+        })
+        it('returns an error with invalid state code', async () => {
+            const prismaClient = await sharedTestPrismaClient()
+            const postgresStore = NewPostgresStore(prismaClient)
+
+            const newUser = await postgresStore.insertUser(mockTestCMSUser())
+
+            if (newUser instanceof Error) {
+                throw newUser
+            }
+
+            const server = await constructTestPostgresServer({
+                store: postgresStore,
+                context: {
+                    user: mockUser,
+                },
+            })
+
+            const updateRes = await server.executeOperation({
+                query: UPDATE_STATE_ASSIGNMENTS_BY_STATE,
+                variables: {
+                    input: {
+                        stateCode: 'XX',
+                        assignedUsers: [newUser.id],
+                    },
+                },
+            })
+
+            expect(assertAnError(updateRes).message).toContain(
+                'cannot update state assignments for invalid state'
+            )
+            expect(assertAnErrorCode(updateRes)).toBe('BAD_USER_INPUT')
+            expect(assertAnErrorExtensions(updateRes).argumentValues).toBe('XX')
+        })
+        it('errors if the target is not a CMS user', async () => {
+            const prismaClient = await sharedTestPrismaClient()
+            const postgresStore = NewPostgresStore(prismaClient)
+            const server = await constructTestPostgresServer({
+                store: postgresStore,
+                context: {
+                    user: mockUser,
+                },
+            })
+
+            const newStateUser =
+                await postgresStore.insertUser(mockTestStateUser())
+
+            if (newStateUser instanceof Error) {
+                throw newStateUser
+            }
+
+            const updateRes = await server.executeOperation({
+                query: UPDATE_STATE_ASSIGNMENTS_BY_STATE,
+                variables: {
+                    input: {
+                        stateCode: 'CA',
+                        assignedUsers: [newStateUser.id],
+                    },
+                },
+            })
+
+            expect(updateRes.errors).toBeDefined()
+
+            expect(assertAnError(updateRes).message).toContain(
+                'Attempted to assign non-cms-users to a state'
+            )
+            expect(assertAnErrorCode(updateRes)).toBe('BAD_USER_INPUT')
+        })
+        it('errors if the userID doesnt exist', async () => {
+            const prismaClient = await sharedTestPrismaClient()
+            const postgresStore = NewPostgresStore(prismaClient)
+            const server = await constructTestPostgresServer({
+                store: postgresStore,
+                context: {
+                    user: mockUser,
+                },
+            })
+
+            const updateRes = await server.executeOperation({
+                query: UPDATE_STATE_ASSIGNMENTS_BY_STATE,
+                variables: {
+                    input: {
+                        stateCode: 'CA',
+                        assignedUsers: ['not-existing-user-id'],
+                    },
+                },
+            })
+
+            expect(assertAnError(updateRes).message).toContain(
+                'Attempted to assign non existing users to the state'
+            )
+            expect(assertAnErrorCode(updateRes)).toBe('BAD_USER_INPUT')
+        })
+    }
+)
+
+describe.each(unauthorizedUserTests)(
+    'updateStateAssignment as $userType tests',
+    ({ mockUser, userType }) => {
+        it(`errors if called by a ${userType}`, async () => {
+            const prismaClient = await sharedTestPrismaClient()
+            const postgresStore = NewPostgresStore(prismaClient)
+            const server = await constructTestPostgresServer({
+                store: postgresStore,
+                context: {
+                    user: mockUser,
+                },
+            })
+
+            const updateRes = await server.executeOperation({
+                query: UPDATE_STATE_ASSIGNMENTS_BY_STATE,
+                variables: {
+                    input: {
+                        stateCode: 'CA',
+                        assignedUsers: ['not-existing-user-id'],
+                    },
+                },
+            })
+
+            expect(assertAnError(updateRes).message).toContain(
+                'user not authorized to modify assignments'
+            )
+            expect(assertAnErrorCode(updateRes)).toBe('FORBIDDEN')
+        })
+    }
+)

--- a/services/app-api/src/resolvers/user/updateStateAssignmentsByState.ts
+++ b/services/app-api/src/resolvers/user/updateStateAssignmentsByState.ts
@@ -86,7 +86,7 @@ export function updateStateAssignmentsByState(
                 throw new UserInputError(errMsg, {
                     argumentName: 'assignedUsers',
                     argumentValues: assignedUsers,
-                    cause: 'USERS_ARE_NOT_STATE_USERS',
+                    cause: 'BAD_ASSIGNED_USERS',
                 })
             }
 

--- a/services/app-api/src/resolvers/user/updateStateAssignmentsByState.ts
+++ b/services/app-api/src/resolvers/user/updateStateAssignmentsByState.ts
@@ -1,0 +1,109 @@
+import type { Store } from '../../postgres'
+import { UserInputPostgresError } from '../../postgres'
+import type { MutationResolvers } from '../../gen/gqlServer'
+import {
+    setErrorAttributesOnActiveSpan,
+    setResolverDetailsOnActiveSpan,
+} from '../attributeHelper'
+import { logError } from '../../logger'
+import { ForbiddenError, UserInputError } from 'apollo-server-lambda'
+import { hasAdminPermissions, hasCMSPermissions } from '../../domain-models'
+import { isValidStateCode } from '../../common-code/healthPlanFormDataType'
+import { NotFoundError } from '../../postgres'
+import { GraphQLError } from 'graphql/index'
+
+export function updateStateAssignmentsByState(
+    store: Store
+): MutationResolvers['updateStateAssignmentsByState'] {
+    return async (_parent, { input }, context) => {
+        const { user: currentUser, ctx, tracer } = context
+        const span = tracer?.startSpan('updateStateAssignmentsByState', {}, ctx)
+        setResolverDetailsOnActiveSpan(
+            'updateStateAssignmentsByState',
+            currentUser,
+            span
+        )
+
+        // Only Admin and all CMS users can call this resolver
+        if (
+            !hasAdminPermissions(currentUser) &&
+            !hasCMSPermissions(currentUser)
+        ) {
+            const msg = 'user not authorized to modify assignments'
+            logError('updateStateAssignmentsByState', msg)
+            setErrorAttributesOnActiveSpan(msg, span)
+            throw new ForbiddenError(msg, {
+                cause: 'NOT_AUTHORIZED',
+            })
+        }
+
+        const { stateCode, assignedUsers } = input
+
+        if (!isValidStateCode(stateCode)) {
+            const errMsg = 'cannot update state assignments for invalid state'
+            logError('updateStateAssignmentsByState', errMsg)
+            setErrorAttributesOnActiveSpan(errMsg, span)
+            throw new UserInputError(errMsg, {
+                argumentName: 'stateCode',
+                argumentValues: stateCode,
+                cause: 'INVALID_STATE_CODE',
+            })
+        }
+
+        if (assignedUsers.length === 0) {
+            const msg = 'cannot update state assignments with no assignments'
+            logError('updateStateAssignmentsByState', msg)
+            setErrorAttributesOnActiveSpan(msg, span)
+            throw new UserInputError(msg, {
+                argumentName: 'assignedUsers',
+                argumentValues: assignedUsers,
+                cause: 'NO_ASSIGNED_USERS',
+            })
+        }
+
+        const result = await store.updateStateAssignedUsers(
+            currentUser.id,
+            stateCode,
+            assignedUsers
+        )
+
+        if (result instanceof Error) {
+            if (result instanceof NotFoundError) {
+                const errMsg = 'state does not exist'
+                logError('updateStateAssignmentsByState', errMsg)
+                setErrorAttributesOnActiveSpan(errMsg, span)
+                throw new UserInputError(errMsg, {
+                    argumentName: 'stateCode',
+                    argumentValues: stateCode,
+                    cause: 'STATE_DOES_NOT_EXIST',
+                })
+            }
+
+            if (result instanceof UserInputPostgresError) {
+                const errMsg = result.message
+                logError('updateStateAssignmentsByState', errMsg)
+                setErrorAttributesOnActiveSpan(errMsg, span)
+                throw new UserInputError(errMsg, {
+                    argumentName: 'assignedUsers',
+                    argumentValues: assignedUsers,
+                    cause: 'USERS_ARE_NOT_STATE_USERS',
+                })
+            }
+
+            const errMsg = `Issue assigning states to user. Message: ${result.message}`
+            logError('updateStateAssignmentsByState', errMsg)
+            setErrorAttributesOnActiveSpan(errMsg, span)
+            throw new GraphQLError(errMsg, {
+                extensions: {
+                    code: 'INTERNAL_SERVER_ERROR',
+                    cause: 'DB_ERROR',
+                },
+            })
+        }
+
+        return {
+            stateCode,
+            assignedUsers: result,
+        }
+    }
+}

--- a/services/app-api/src/testHelpers/storeHelpers.ts
+++ b/services/app-api/src/testHelpers/storeHelpers.ts
@@ -97,6 +97,9 @@ function mockStoreThatErrors(): Store {
         updateDraftContract: async (_args) => {
             return genericError
         },
+        updateStateAssignedUsers: async (_args) => {
+            return genericError
+        },
         findAllContractsWithHistoryByState: async (_ID) => {
             return genericError
         },

--- a/services/app-graphql/src/mutations/updateStateAssignmentsByState.graphql
+++ b/services/app-graphql/src/mutations/updateStateAssignmentsByState.graphql
@@ -1,0 +1,44 @@
+mutation updateStateAssignmentsByState($input: UpdateStateAssignmentsByStateInput!) {
+    updateStateAssignmentsByState(input: $input) {
+        stateCode
+        assignedUsers {
+            __typename
+            ... on CMSUser {
+                id
+                email
+                role
+                familyName
+                givenName
+                stateAssignments {
+                    code
+                    name
+                    programs {
+                        id
+                        name
+                        fullName
+                        isRateProgram
+                    }
+                }
+                divisionAssignment
+            }
+            ... on CMSApproverUser {
+                id
+                email
+                role
+                familyName
+                givenName
+                stateAssignments {
+                    code
+                    name
+                    programs {
+                        id
+                        name
+                        fullName
+                        isRateProgram
+                    }
+                }
+                divisionAssignment
+            }
+        }
+    }
+}

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -358,6 +358,22 @@ type Mutation {
     updateStateAssignment(input: UpdateStateAssignmentInput!): UpdateCMSUserPayload!
 
     """
+    updateStateAssignmentByState updates which CMSUsers are assigned to a given state.
+
+    This can only be called by an AdminUser or a DMCO CMS user.
+    The cmsUserID must be a CMSUser's id, not a state user
+
+    Errors:
+    - ForbiddenError:
+    - A non AdminUser called this
+    - A non DMCO CMS user called this
+    - UserInputError
+    - cmsUserID was not a CMSUser's ID
+    - stateCodes included an invalid state code
+    """
+    updateStateAssignmentsByState(input: UpdateStateAssignmentsByStateInput!): UpdateStateAssignmentsByStatePayload!
+
+    """
     createQuestion creates a new Question for the given HealthPlanPackage
     A CMS User can add text to a note field and append a document to their question
     They can also specify a due date, and specify rate IDs that are associated with the question
@@ -753,7 +769,19 @@ input UpdateDivisionAssignmentInput {
 input UpdateStateAssignmentInput {
     cmsUserID: ID!
     "stateAssignments is an array of stateCodes (e.g. ['CA', 'NM', 'TN'])"
-    stateAssignments: [String!]
+    stateAssignments: [String!]!
+}
+
+input UpdateStateAssignmentsByStateInput {
+    stateCode: ID!
+    "stateAssignments is an array of userIDs (uuids)"
+    assignedUsers: [String!]!
+}
+
+type UpdateStateAssignmentsByStatePayload {
+    stateCode: ID!
+    "stateAssignments is an array of userIDs (uuids)"
+    assignedUsers: [CMSUsersUnion!]!
 }
 
 type UpdateCMSUserPayload {


### PR DESCRIPTION
## Summary

This PR adds a new API for updating state analysts by the whole state instead of updating the states assigned to a single user. The UI works this way so the API should work this way. 

#### Related issues

#### Screenshots

#### Test cases covered

Wrote new API tests

## QA guidance

API isn't being hit yet so can't really validate it manually
