### PR TITLE
MCR-3757: Fix expandable text for Safari

### DIFF
--- a/services/app-web/src/components/ExpandableText/ExpandableText.module.scss
+++ b/services/app-web/src/components/ExpandableText/ExpandableText.module.scss
@@ -7,7 +7,7 @@
 
 .textExpanded {
     height: auto;
-    display: -webkit-box;
+    display: block;
 }
 
 .textContracted {


### PR DESCRIPTION
## Summary
[MCR-3757](https://jiraent.cms.gov/browse/MCR-3757)

Used the wrong css display type.

#### Related issues

#### Screenshots
Safari browser
<img src="https://github.com/user-attachments/assets/e46ee09e-5f56-4df3-b8e6-6f60e9aa86da" width="500" />
<img src="https://github.com/user-attachments/assets/00ef4d67-4193-4929-b6df-8a391d6c7b39" width="500" />



#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
Test the expandable text of the banners in both Safari and Chrome ( maybe Firefox too) to check for regressions.

<!---These are developer instructions on how to test or validate the work -->
