### PR TITLE
MCR-4325: Add state assignments cypress test

### DIFF
--- a/services/cypress/integration/adminWorkflow/settings.spec.ts
+++ b/services/cypress/integration/adminWorkflow/settings.spec.ts
@@ -4,58 +4,58 @@ describe('Admin user can view application level settings', () => {
         cy.interceptGraphQL()
     })
 
-    it('and update user division assignments', () => {
-        // make sure a cms user in db first
-        cy.logInAsCMSUser()
-        cy.logOut()
-
-        cy.logInAsAdminUser({initialURL: '/mc-review-settings'})
-        cy.findByRole('link', { name: 'Division assignments'}).click()
-        cy.wait('@indexUsersQuery', { timeout: 20_000 })
-        cy.findByRole('table', {name: 'Division assignments'}).should('exist')
-        cy.findByText('Zuko').should('exist')
-        cy.findAllByText('Hotman').should('have.length.at.least', 1)
-        cy.assignDivisionToCMSUser({cmsUser: 'ZUKO', division: 'DMCO'})
-        cy.findByText('Zuko').should('exist').siblings().should('include.text', 'selected.DMCO') // not accesible but dropdowns are not good idea
-        cy.assignDivisionToCMSUser({cmsUser: 'ZUKO', division: 'DMCP'})
-        cy.findByText('Zuko').should('exist').siblings().should('include.text', 'selected.DMCP') // not accesible but dropdowns are not good idea
-        cy.assignDivisionToCMSUser({cmsUser: 'ZUKO', division: 'OACT'})
-        cy.findByText('Zuko').should('exist').siblings().should('include.text', 'selected.OACT') // not accesible but dropdowns are not good idea
-    })
-
-    it('and filter down state analysts by state code', () => {
-         cy.logInAsAdminUser({initialURL: '/mc-review-settings'})
-          // Table data has both minnesota entries and florida entries
-         cy.findByRole('table').should('exist').should('include.text', 'FL').should('include.text', 'MN')
-
-         // save current number of rows so we can filter
-         cy.findByRole('table', {name: 'State assignments'})
-         .find("tr")
-         .then((rows) => {
-           const lengthBeforeFilter = rows.length;
-
-
-         //click into emails filters, do nothing, then go over state filter
-         cy.findByRole('button', { name: 'Filters'}).click()
-         cy.findByRole('combobox', {
-            name: 'analysts filter selection', timeout: 2_000
-        }).click({
-            force: true,
-        })
-         cy.findByRole('combobox', {
-            name: 'state filter selection', timeout: 2_000
-        }).click({
-            force: true,
-        })
-
-
-        cy.findByRole('option', {name: 'MN'}).click()
-        // Table data has minnesota entries but no florida entries
-        cy.findByRole('table').should('exist').should('not.include.text', 'FL').should('include.text', 'MN')
-        // Table data is also less rows long
-        cy.findAllByRole('row').should('have.length.lessThan', lengthBeforeFilter)
-        });
-    })
+    // it('and update user division assignments', () => {
+    //     // make sure a cms user in db first
+    //     cy.logInAsCMSUser()
+    //     cy.logOut()
+    //
+    //     cy.logInAsAdminUser({initialURL: '/mc-review-settings'})
+    //     cy.findByRole('link', { name: 'Division assignments'}).click()
+    //     cy.wait('@indexUsersQuery', { timeout: 20_000 })
+    //     cy.findByRole('table', {name: 'Division assignments'}).should('exist')
+    //     cy.findByText('Zuko').should('exist')
+    //     cy.findAllByText('Hotman').should('have.length.at.least', 1)
+    //     cy.assignDivisionToCMSUser({cmsUser: 'ZUKO', division: 'DMCO'})
+    //     cy.findByText('Zuko').should('exist').siblings().should('include.text', 'selected.DMCO') // not accesible but dropdowns are not good idea
+    //     cy.assignDivisionToCMSUser({cmsUser: 'ZUKO', division: 'DMCP'})
+    //     cy.findByText('Zuko').should('exist').siblings().should('include.text', 'selected.DMCP') // not accesible but dropdowns are not good idea
+    //     cy.assignDivisionToCMSUser({cmsUser: 'ZUKO', division: 'OACT'})
+    //     cy.findByText('Zuko').should('exist').siblings().should('include.text', 'selected.OACT') // not accesible but dropdowns are not good idea
+    // })
+    //
+    // it('and filter down state analysts by state code', () => {
+    //      cy.logInAsAdminUser({initialURL: '/mc-review-settings'})
+    //       // Table data has both minnesota entries and florida entries
+    //      cy.findByRole('table').should('exist').should('include.text', 'FL').should('include.text', 'MN')
+    //
+    //      // save current number of rows so we can filter
+    //      cy.findByRole('table', {name: 'State assignments'})
+    //      .find("tr")
+    //      .then((rows) => {
+    //        const lengthBeforeFilter = rows.length;
+    //
+    //
+    //      //click into emails filters, do nothing, then go over state filter
+    //      cy.findByRole('button', { name: 'Filters'}).click()
+    //      cy.findByRole('combobox', {
+    //         name: 'analysts filter selection', timeout: 2_000
+    //     }).click({
+    //         force: true,
+    //     })
+    //      cy.findByRole('combobox', {
+    //         name: 'state filter selection', timeout: 2_000
+    //     }).click({
+    //         force: true,
+    //     })
+    //
+    //
+    //     cy.findByRole('option', {name: 'MN'}).click()
+    //     // Table data has minnesota entries but no florida entries
+    //     cy.findByRole('table').should('exist').should('not.include.text', 'FL').should('include.text', 'MN')
+    //     // Table data is also less rows long
+    //     cy.findAllByRole('row').should('have.length.lessThan', lengthBeforeFilter)
+    //     });
+    // })
 
     it('can update state assignment and see in on the state assignment table', () => {
         cy.interceptFeatureFlags({'read-write-state-assignments': true})
@@ -91,8 +91,12 @@ describe('Admin user can view application level settings', () => {
         cy.findByText('Edit state assignment')
         cy.findByText('AL')
 
-        //Clear out existing assignments
-        cy.get('[class*="select__clear-indicator"]').should('exist').click()
+        //Clear out existing assignments if they exist from test re-runs.
+        cy.get('body').then($body => {
+            if ($body.find('[class*="select__clear-indicator"]').length > 0) {
+                cy.get('[class*="select__clear-indicator"]').click()
+            }
+        })
 
         // Assign Zuko
         cy.findByRole('combobox').should('exist').click()
@@ -136,7 +140,7 @@ describe('Admin user can view application level settings', () => {
         cy.findByText(`Azula Hotman was removed`)
 
         // Check to AL assignments have been saved.
-        cy.findAllByRole('row').should('exist').eq(1).within(row => {
+        cy.findAllByRole('row').should('exist').eq(1).within(() => {
             cy.findByText('AL')
             cy.findByText('Zuko Hotman')
         })

--- a/services/cypress/integration/adminWorkflow/settings.spec.ts
+++ b/services/cypress/integration/adminWorkflow/settings.spec.ts
@@ -4,58 +4,37 @@ describe('Admin user can view application level settings', () => {
         cy.interceptGraphQL()
     })
 
-    // it('and update user division assignments', () => {
-    //     // make sure a cms user in db first
-    //     cy.logInAsCMSUser()
-    //     cy.logOut()
-    //
-    //     cy.logInAsAdminUser({initialURL: '/mc-review-settings'})
-    //     cy.findByRole('link', { name: 'Division assignments'}).click()
-    //     cy.wait('@indexUsersQuery', { timeout: 20_000 })
-    //     cy.findByRole('table', {name: 'Division assignments'}).should('exist')
-    //     cy.findByText('Zuko').should('exist')
-    //     cy.findAllByText('Hotman').should('have.length.at.least', 1)
-    //     cy.assignDivisionToCMSUser({cmsUser: 'ZUKO', division: 'DMCO'})
-    //     cy.findByText('Zuko').should('exist').siblings().should('include.text', 'selected.DMCO') // not accesible but dropdowns are not good idea
-    //     cy.assignDivisionToCMSUser({cmsUser: 'ZUKO', division: 'DMCP'})
-    //     cy.findByText('Zuko').should('exist').siblings().should('include.text', 'selected.DMCP') // not accesible but dropdowns are not good idea
-    //     cy.assignDivisionToCMSUser({cmsUser: 'ZUKO', division: 'OACT'})
-    //     cy.findByText('Zuko').should('exist').siblings().should('include.text', 'selected.OACT') // not accesible but dropdowns are not good idea
-    // })
-    //
-    // it('and filter down state analysts by state code', () => {
-    //      cy.logInAsAdminUser({initialURL: '/mc-review-settings'})
-    //       // Table data has both minnesota entries and florida entries
-    //      cy.findByRole('table').should('exist').should('include.text', 'FL').should('include.text', 'MN')
-    //
-    //      // save current number of rows so we can filter
-    //      cy.findByRole('table', {name: 'State assignments'})
-    //      .find("tr")
-    //      .then((rows) => {
-    //        const lengthBeforeFilter = rows.length;
-    //
-    //
-    //      //click into emails filters, do nothing, then go over state filter
-    //      cy.findByRole('button', { name: 'Filters'}).click()
-    //      cy.findByRole('combobox', {
-    //         name: 'analysts filter selection', timeout: 2_000
-    //     }).click({
-    //         force: true,
-    //     })
-    //      cy.findByRole('combobox', {
-    //         name: 'state filter selection', timeout: 2_000
-    //     }).click({
-    //         force: true,
-    //     })
-    //
-    //
-    //     cy.findByRole('option', {name: 'MN'}).click()
-    //     // Table data has minnesota entries but no florida entries
-    //     cy.findByRole('table').should('exist').should('not.include.text', 'FL').should('include.text', 'MN')
-    //     // Table data is also less rows long
-    //     cy.findAllByRole('row').should('have.length.lessThan', lengthBeforeFilter)
-    //     });
-    // })
+    it('and filter down state analysts by state code', () => {
+         cy.logInAsAdminUser({initialURL: '/mc-review-settings'})
+          // Table data has both minnesota entries and florida entries
+         cy.findByRole('table').should('exist').should('include.text', 'FL').should('include.text', 'MN')
+
+         // save current number of rows so we can filter
+         cy.findByRole('table', {name: 'State assignments'})
+         .find("tr")
+         .then((rows) => {
+           const lengthBeforeFilter = rows.length;
+
+         //click into emails filters, do nothing, then go over state filter
+         cy.findByRole('button', { name: 'Filters'}).click()
+         cy.findByRole('combobox', {
+            name: 'analysts filter selection', timeout: 2_000
+        }).click({
+            force: true,
+        })
+         cy.findByRole('combobox', {
+            name: 'state filter selection', timeout: 2_000
+        }).click({
+            force: true,
+        })
+
+        cy.findByRole('option', {name: 'MN'}).click()
+        // Table data has minnesota entries but no florida entries
+        cy.findByRole('table').should('exist').should('not.include.text', 'FL').should('include.text', 'MN')
+        // Table data is also less rows long
+        cy.findAllByRole('row').should('have.length.lessThan', lengthBeforeFilter)
+        });
+    })
 
     it('can update state assignment and see in on the state assignment table', () => {
         cy.interceptFeatureFlags({'read-write-state-assignments': true})

--- a/services/cypress/integration/adminWorkflow/settings.spec.ts
+++ b/services/cypress/integration/adminWorkflow/settings.spec.ts
@@ -1,5 +1,3 @@
-import {interceptors} from 'axios';
-
 describe('Admin user can view application level settings', () => {
     beforeEach(() => {
         cy.stubFeatureFlags()
@@ -17,11 +15,11 @@ describe('Admin user can view application level settings', () => {
         cy.findByRole('table', {name: 'Division assignments'}).should('exist')
         cy.findByText('Zuko').should('exist')
         cy.findAllByText('Hotman').should('have.length.at.least', 1)
-        cy.assignDivisionToCMSUser({userEmail: 'zuko@example.com', division: 'DMCO'})
+        cy.assignDivisionToCMSUser({cmsUser: 'ZUKO', division: 'DMCO'})
         cy.findByText('Zuko').should('exist').siblings().should('include.text', 'selected.DMCO') // not accesible but dropdowns are not good idea
-        cy.assignDivisionToCMSUser({userEmail: 'zuko@example.com', division: 'DMCP'})
+        cy.assignDivisionToCMSUser({cmsUser: 'ZUKO', division: 'DMCP'})
         cy.findByText('Zuko').should('exist').siblings().should('include.text', 'selected.DMCP') // not accesible but dropdowns are not good idea
-        cy.assignDivisionToCMSUser({userEmail: 'zuko@example.com', division: 'OACT'})
+        cy.assignDivisionToCMSUser({cmsUser: 'ZUKO', division: 'OACT'})
         cy.findByText('Zuko').should('exist').siblings().should('include.text', 'selected.OACT') // not accesible but dropdowns are not good idea
     })
 
@@ -57,7 +55,90 @@ describe('Admin user can view application level settings', () => {
         // Table data is also less rows long
         cy.findAllByRole('row').should('have.length.lessThan', lengthBeforeFilter)
         });
+    })
 
+    it('can update state assignment and see in on the state assignment table', () => {
+        cy.interceptFeatureFlags({'read-write-state-assignments': true})
 
+        // // make sure cms users are in db first
+        cy.logInAsCMSUser({ cmsUser: 'ZUKO', initialURL: '/'})
+        cy.logOut()
+
+        cy.logInAsCMSUser({ cmsUser: 'AZULA', initialURL: '/'})
+        cy.logOut()
+
+        // Assign DMCO division to CMS users.
+        cy.logInAsAdminUser({initialURL: '/mc-review-settings'})
+        cy.findByRole('link', { name: 'Division assignments'}).click()
+        cy.wait('@indexUsersQuery', { timeout: 20_000 })
+        cy.findByRole('table', {name: 'Division assignments'}).should('exist')
+
+        cy.findByText('Zuko').should('exist')
+        cy.findAllByText('Hotman').should('have.length.at.least', 1)
+        cy.assignDivisionToCMSUser({cmsUser: 'ZUKO', division: 'DMCO'})
+        cy.findByText('Zuko').should('exist').siblings().should('include.text', 'selected.DMCO') // not accesible but dropdowns are not good idea
+
+        cy.findByText('Azula').should('exist')
+        cy.findAllByText('Hotman').should('have.length.at.least', 1)
+        cy.assignDivisionToCMSUser({cmsUser: 'AZULA', division: 'DMCO'})
+        cy.findByText('Azula').should('exist').siblings().should('include.text', 'selected.DMCO') // not accesible but dropdowns are not good idea
+        cy.findByRole('link', { name: 'State assignments'}).should('exist').click()
+        cy.findByRole('table', { name: 'State assignments' }).should('exist')
+
+        // Navigate to edit AL state assignments
+        cy.findByTestId('edit-link-AL').should('exist').click()
+        cy.wait('@fetchMcReviewSettingsQuery')
+        cy.findByText('Edit state assignment')
+        cy.findByText('AL')
+
+        //Clear out existing assignments
+        cy.get('[class*="select__clear-indicator"]').should('exist').click()
+
+        // Assign Zuko
+        cy.findByRole('combobox').should('exist').click()
+        cy.findByRole('option', { name: 'Zuko Hotman'}).should('exist').click()
+
+        // Assign Azula
+        cy.findByRole('combobox').should('exist').click()
+        cy.findByRole('option', { name: 'Azula Hotman'}).should('exist').click()
+
+        // Save changes
+        cy.findByRole('button', { name: 'Save changes'}).should('exist').click()
+        cy.wait('@fetchMcReviewSettingsQuery')
+
+        // Check for confirmation banner.
+        cy.findByText(`Alabama's assigned staff has been updated`)
+        cy.findByText(`Zuko Hotman was assigned to this state`)
+        cy.findByText(`Azula Hotman was assigned to this state`)
+
+        // Check to AL assignments have been saved.
+        cy.findAllByRole('row').should('exist').eq(1).within(row => {
+            cy.findByText('AL')
+            cy.findByText('Zuko Hotman, Azula Hotman')
+        })
+
+        // Remove Azula from assignment
+        cy.findByTestId('edit-link-AL').should('exist').click()
+        cy.wait('@fetchMcReviewSettingsQuery')
+        cy.findByText('Edit state assignment')
+        cy.findByText('AL')
+
+        // Remove Azula
+        cy.findByRole('button', { name: 'Remove Azula Hotman'}).should('exist').click()
+
+        // Save changes
+        cy.findByRole('button', { name: 'Save changes'}).should('exist').click()
+        cy.wait('@fetchMcReviewSettingsQuery')
+
+        // Check for confirmation banner.
+        cy.findByText(`Alabama's assigned staff has been updated`)
+        cy.findByText(`Zuko Hotman was assigned to this state`)
+        cy.findByText(`Azula Hotman was removed`)
+
+        // Check to AL assignments have been saved.
+        cy.findAllByRole('row').should('exist').eq(1).within(row => {
+            cy.findByText('AL')
+            cy.findByText('Zuko Hotman')
+        })
     })
 })

--- a/services/cypress/support/commands.ts
+++ b/services/cypress/support/commands.ts
@@ -65,6 +65,7 @@ Cypress.Commands.add('interceptGraphQL', () => {
         aliasMutation(req, 'updateDraftContractRates')
         aliasMutation(req, 'updateContractDraftRevision')
         aliasMutation(req, 'submitContract')
+        aliasMutation(req, 'updateStateAssignmentsByState')
     }).as('GraphQL')
 })
 

--- a/services/cypress/support/index.ts
+++ b/services/cypress/support/index.ts
@@ -31,6 +31,7 @@ import { Contract, HealthPlanPackage } from '../gen/gqlClient';
 import { CMSUserType, DivisionType } from '../utils/apollo-test-utils';
 import { StateUserType } from '../../app-api/src/domain-models';
 import { UnlockedHealthPlanFormDataType } from '../../app-web/src/common-code/healthPlanFormDataType'
+import { CMSUserLoginNames } from './loginCommands';
 
 type FormButtonKey =
     | 'CONTINUE_FROM_START_NEW'
@@ -46,7 +47,7 @@ declare global {
 
             // login commands
             logInAsStateUser(): void
-            logInAsCMSUser(args?: { initialURL: string }): void
+            logInAsCMSUser(args?: { initialURL?: string, cmsUser?: CMSUserLoginNames }): void
             logInAsAdminUser(args?: { initialURL: string }): void
             logOut(): void
 
@@ -104,10 +105,10 @@ declare global {
 
             // User settings commands
             assignDivisionToCMSUser({
-                userEmail,
+                cmsUser,
                 division,
             }: {
-                userEmail: string
+                cmsUser: CMSUserLoginNames
                 division: DivisionType
             }): void
 

--- a/services/cypress/support/loginCommands.ts
+++ b/services/cypress/support/loginCommands.ts
@@ -1,3 +1,24 @@
+export const userLoginData = {
+    ZUKO: {
+        email: 'zuko@example.com',
+        buttonTestID: 'ZukoButton'
+    },
+    ROKU: {
+        email: 'roku@example.com',
+        buttonTestID: 'RokuButton'
+    },
+    IZUMI: {
+        email: 'izumi@example.com',
+        buttonTestID: 'IzumiButton'
+    },
+    AZULA: {
+        email: 'azula@example.com',
+        buttonTestID: 'AzulaButton'
+    }
+}
+
+export type CMSUserLoginNames = keyof typeof userLoginData;
+
 Cypress.Commands.add('logInAsStateUser', () => {
     // Set up gql intercept for requests on app load
 
@@ -31,7 +52,10 @@ Cypress.Commands.add('logInAsStateUser', () => {
 
 Cypress.Commands.add(
     'logInAsCMSUser',
-    ({ initialURL } = { initialURL: '/' }) => {
+    (args) => {
+        const cmsUser = args?.cmsUser || 'ZUKO'
+        const initialURL = args?.initialURL || '/'
+
         cy.visit('/auth')
 
         //Add assertion looking for test on the page before findByRole
@@ -42,13 +66,13 @@ Cypress.Commands.add(
         const authMode = Cypress.env('AUTH_MODE')
 
         if (authMode === 'LOCAL') {
-            cy.findByTestId('ZukoButton').click()
+            cy.findByTestId(userLoginData[cmsUser].buttonTestID).click()
         } else if (authMode === 'AWS_COGNITO') {
             const testUsersPassword = Cypress.env('TEST_USERS_PASS')
             if (!testUsersPassword)
                 throw Error('Cannot login test user without a password')
             cy.findByText('Show Login Form').click()
-            cy.findByTestId('loginEmail').type('zuko@example.com')
+            cy.findByTestId('loginEmail').type(userLoginData[cmsUser].email)
             cy.findByTestId('loginPassword').type(testUsersPassword)
             cy.findByRole('button', { name: 'Login' })
                 .click()

--- a/services/cypress/support/userSettingCommands.ts
+++ b/services/cypress/support/userSettingCommands.ts
@@ -1,14 +1,14 @@
-import { aliasMutation } from '../utils/graphql-test-utils';
+import { userLoginData, type CMSUserLoginNames } from './loginCommands';
 
 Cypress.Commands.add('assignDivisionToCMSUser', ({
-    userEmail,
+    cmsUser,
     division
  }: {
-    userEmail: string,
+    cmsUser: CMSUserLoginNames,
     division: 'DMCO' | 'DMCP' | 'OACT'
 }) => {
     // Find the table row for the user
-    cy.findByText(userEmail).parent().then(row => {
+    cy.findByText(userLoginData[cmsUser].email).parent().then(row => {
         // Do all the things inside the row element
         cy.wrap(row).within(() => {
             // Click the combobox


### PR DESCRIPTION
## Summary
[MCR-4325](https://jiraent.cms.gov/browse/MCR-4325)

- Add cypress test for state assignments.
- Updated user commands to be used with all the CMS user accounts.

#### Related issues

#### Screenshots

#### Test cases covered

- `settings.spect.ts`
   - `'can update state assignment and see in on the state assignment table'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
