### PR TITLE
Announce state on edit links for screenreader

### DIFF
--- a/services/app-web/src/pages/Settings/Settings.test.tsx
+++ b/services/app-web/src/pages/Settings/Settings.test.tsx
@@ -302,6 +302,8 @@ describe.each(combinedAuthorizedUsers)(
             ).toBeInTheDocument()
             expect(within(tableAnalysts).getByText('MN')).toBeInTheDocument()
             expect(within(tableAnalysts).getByText('OH')).toBeInTheDocument()
+            expect(within(tableAnalysts).getByRole('link', {name: 'Edit Minnesota'})).toBeInTheDocument()
+            expect(within(tableAnalysts).getByRole('link', {name: 'Edit Ohio'})).toBeInTheDocument()
 
             await commonSettingPageTest()
         })

--- a/services/app-web/src/pages/Settings/Settings.test.tsx
+++ b/services/app-web/src/pages/Settings/Settings.test.tsx
@@ -302,6 +302,8 @@ describe.each(combinedAuthorizedUsers)(
             ).toBeInTheDocument()
             expect(within(tableAnalysts).getByText('MN')).toBeInTheDocument()
             expect(within(tableAnalysts).getByText('OH')).toBeInTheDocument()
+            expect(within(tableAnalysts).getByLabelText('Ohio')).toBeInTheDocument()
+            expect(within(tableAnalysts).getByLabelText('Minnesota')).toBeInTheDocument()
             expect(within(tableAnalysts).getByRole('link', {name: 'Edit Minnesota'})).toBeInTheDocument()
             expect(within(tableAnalysts).getByRole('link', {name: 'Edit Ohio'})).toBeInTheDocument()
 

--- a/services/app-web/src/pages/Settings/SettingsCells/SettingsCells.tsx
+++ b/services/app-web/src/pages/Settings/SettingsCells/SettingsCells.tsx
@@ -10,11 +10,12 @@ const formatUserName = (user: AnalystDisplayType) => `${user.givenName} ${user.f
 const formatEmailsFromUsers = (arr?: AnalystDisplayType[]) => (arr ? arr.map(analyst => analyst.email).join(', ') : 'NOT DEFINED')
 const formatUserNamesFromUsers = (arr?: AnalystDisplayType[]) =>  (arr ? arr.map(analyst => formatUserName(analyst)).join(', ') : '')
 
-const EditLink = ({ url, rowID }: { url: string; rowID: string }) => {
+const EditLink = ({ url, rowID, fieldName }: { url: string; rowID: string, fieldName: string }) => {
     return (
         <NavLinkWithLogging
             key={rowID}
             to={url}
+            aria-label={`Edit ${fieldName}`}
             data-testid={`edit-link-${rowID}`}
         >
             Edit

--- a/services/app-web/src/pages/Settings/SettingsTables/StateAssignmentTable.tsx
+++ b/services/app-web/src/pages/Settings/SettingsTables/StateAssignmentTable.tsx
@@ -137,6 +137,7 @@ const StateAssignmentTable = () => {
                     <EditLink
                         rowID={info.row.original.stateCode}
                         url={info.getValue()}
+                        fieldName={info.row.original.stateName}
                     />
                 ),
             }),

--- a/services/app-web/src/pages/Settings/SettingsTables/StateAssignmentTable.tsx
+++ b/services/app-web/src/pages/Settings/SettingsTables/StateAssignmentTable.tsx
@@ -118,7 +118,7 @@ const StateAssignmentTable = () => {
             columnHelper.accessor('stateCode', {
                 id: 'stateCode',
                 header: 'State',
-                cell: (info) => info.getValue(),
+                cell: (info) => <span aria-label={info.row.original.stateName}>{info.getValue()}</span>,
                 filterFn: `arrIncludesSome`,
             }),
             columnHelper.accessor('analysts', {


### PR DESCRIPTION
## Summary
Add on PR for [MCR-4266](https://jiraent.cms.gov/browse/MCR-4266) after JAWS testing

#### Related issues
[MCR-4266](https://jiraent.cms.gov/browse/MCR-4266) 

#### Screenshots
n/a

#### Test cases covered
Added test case for links having clearer names - should be "Edit Minnesota" not just "Edit"

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
check screenreader announcement on table row