### PR TITLE
Fix flaky unit test in ContractDetails.tsx

### DIFF
--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
@@ -72,7 +72,7 @@ describe('ContractDetails', () => {
         ).not.toBeInTheDocument()
         const requiredLabels = await screen.findAllByText('Required')
         expect(requiredLabels).toHaveLength(6)
-        const optionalLabels = screen.queryAllByText('Optional')
+        const optionalLabels = await screen.findAllByText('Optional')
         expect(optionalLabels).toHaveLength(1)
     })
 


### PR DESCRIPTION
## Summary

I believe the assertion looking for `Optional` text was happening before the page was re-rendered from the feature flag and showing the element with the `Optional` text. Changing the method to `findAllByText` allows time for re-rendering.

#### Related issues

#### Screenshots

#### Test cases covered

`ContractDetails.test.tsx`
- `'displays correct form guidance'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
