### PR TITLE
MCR-4450: Update rate resolver to return questions field

### DIFF
--- a/services/app-api/src/domain-models/QuestionsType.ts
+++ b/services/app-api/src/domain-models/QuestionsType.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { cmsUserSchema } from './UserType'
+import { cmsUsersUnionSchema } from './UserType'
 import { questionResponseType } from './QuestionResponseType'
 import { divisionType } from './DivisionType'
 
@@ -12,7 +12,7 @@ const document = z.object({
 const commonQuestionSchema = z.object({
     id: z.string().uuid(),
     createdAt: z.date(),
-    addedBy: cmsUserSchema,
+    addedBy: cmsUsersUnionSchema,
     division: divisionType, // DMCO, DMCP, OACT
     documents: z.array(document),
     responses: z.array(questionResponseType),
@@ -30,15 +30,30 @@ const questionEdge = z.object({
     node: question,
 })
 
+const rateQuestionEdge = z.object({
+    node: rateQuestion,
+})
+
 const questionList = z.object({
     totalCount: z.number(),
     edges: z.array(questionEdge),
+})
+
+const rateQuestionList = z.object({
+    totalCount: z.number(),
+    edges: z.array(rateQuestionEdge),
 })
 
 const indexQuestionsPayload = z.object({
     DMCOQuestions: questionList,
     DMCPQuestions: questionList,
     OACTQuestions: questionList,
+})
+
+const indexRateQuestionsPayload = z.object({
+    DMCOQuestions: rateQuestionList,
+    DMCPQuestions: rateQuestionList,
+    OACTQuestions: rateQuestionList,
 })
 
 const createQuestionPayload = z.object({
@@ -71,6 +86,8 @@ type QuestionList = z.infer<typeof questionList>
 
 type Document = z.infer<typeof document>
 
+type IndexRateQuestionsPayload = z.infer<typeof indexRateQuestionsPayload>
+
 export type {
     IndexQuestionsPayload,
     CreateQuestionPayload,
@@ -80,6 +97,7 @@ export type {
     QuestionList,
     RateQuestionType,
     CreateRateQuestionInputType,
+    IndexRateQuestionsPayload,
 }
 
 export {

--- a/services/app-api/src/domain-models/UserType.ts
+++ b/services/app-api/src/domain-models/UserType.ts
@@ -44,6 +44,8 @@ const cmsApproverUserSchema = baseUserSchema.extend({
     divisionAssignment: divisionType.optional(),
 })
 
+const cmsUsersUnionSchema = z.union([cmsUserSchema, cmsApproverUserSchema])
+
 const adminUserSchema = baseUserSchema.extend({
     role: z.literal(userRolesSchema.enum.ADMIN_USER),
 })
@@ -68,7 +70,7 @@ type CMSUserType = z.infer<typeof cmsUserSchema>
 
 type CMSApproverUserType = z.infer<typeof cmsApproverUserSchema>
 
-type CMSUsersUnionType = CMSUserType | CMSApproverUserType
+type CMSUsersUnionType = z.infer<typeof cmsUsersUnionSchema>
 
 type BaseUserType = z.infer<typeof baseUserSchema>
 
@@ -87,4 +89,10 @@ export type {
     BaseUserType,
 }
 
-export { cmsUserSchema, stateUserSchema, userRolesSchema, baseUserSchema }
+export {
+    cmsUserSchema,
+    stateUserSchema,
+    userRolesSchema,
+    baseUserSchema,
+    cmsUsersUnionSchema,
+}

--- a/services/app-api/src/domain-models/index.ts
+++ b/services/app-api/src/domain-models/index.ts
@@ -71,6 +71,7 @@ export type {
     QuestionList,
     RateQuestionType,
     CreateRateQuestionInputType,
+    IndexRateQuestionsPayload,
 } from './QuestionsType'
 
 export type {

--- a/services/app-api/src/postgres/questionResponse/index.ts
+++ b/services/app-api/src/postgres/questionResponse/index.ts
@@ -4,6 +4,7 @@ export {
     convertToIndexQuestionsPayload,
     questionPrismaToDomainType,
     rateQuestionPrismaToDomainType,
+    convertToIndexRateQuestionsPayload,
 } from './questionHelpers'
 export { insertQuestionResponse } from './insertQuestionResponse'
 export { insertRateQuestion } from './insertRateQuestion'

--- a/services/app-api/src/resolvers/configureResolvers.ts
+++ b/services/app-api/src/resolvers/configureResolvers.ts
@@ -185,7 +185,7 @@ export function configureResolvers(
         CMSUser: cmsUserResolver,
         CMSApproverUser: cmsApproverUserResolver,
         HealthPlanPackage: healthPlanPackageResolver(store),
-        Rate: rateResolver,
+        Rate: rateResolver(store),
         RateRevision: rateRevisionResolver(store),
         Contract: contractResolver(store),
         UnlockedContract: unlockedContractResolver(),

--- a/services/app-api/src/resolvers/contract/contractResolver.ts
+++ b/services/app-api/src/resolvers/contract/contractResolver.ts
@@ -11,7 +11,7 @@ import {
     setErrorAttributesOnActiveSpan,
     setResolverDetailsOnActiveSpan,
 } from '../attributeHelper'
-import type { IndexQuestionsPayload } from '../../domain-models/QuestionsType'
+import { convertToIndexQuestionsPayload } from '../../postgres/questionResponse'
 
 export function contractResolver(store: Store): Resolvers['Contract'] {
     return {
@@ -145,49 +145,7 @@ export function contractResolver(store: Store): Resolvers['Contract'] {
                 })
             }
 
-            const dmcoQuestions = questionsForContract
-                .filter((question) => question.division === 'DMCO')
-                .map((question) => {
-                    return {
-                        node: {
-                            ...question,
-                        },
-                    }
-                })
-            const dmcpQuestions = questionsForContract
-                .filter((question) => question.division === 'DMCP')
-                .map((question) => {
-                    return {
-                        node: {
-                            ...question,
-                        },
-                    }
-                })
-            const oactQuestions = questionsForContract
-                .filter((question) => question.division === 'OACT')
-                .map((question) => {
-                    return {
-                        node: {
-                            ...question,
-                        },
-                    }
-                })
-
-            const questionPayload: IndexQuestionsPayload = {
-                DMCOQuestions: {
-                    totalCount: dmcoQuestions.length,
-                    edges: dmcoQuestions,
-                },
-                DMCPQuestions: {
-                    totalCount: dmcpQuestions.length,
-                    edges: dmcpQuestions,
-                },
-                OACTQuestions: {
-                    totalCount: oactQuestions.length,
-                    edges: oactQuestions,
-                },
-            }
-            return questionPayload
+            return convertToIndexQuestionsPayload(questionsForContract)
         },
     }
 }

--- a/services/app-api/src/resolvers/contract/indexContracts.test.ts
+++ b/services/app-api/src/resolvers/contract/indexContracts.test.ts
@@ -1,4 +1,4 @@
-import INDEX_CONTRACTS from '../../../../app-graphql/src/queries/indexContracts.graphql'
+import INDEX_CONTRACTS from '../../../../app-graphql/src/queries/indexContractsForDashboard.graphql'
 import {
     constructTestPostgresServer,
     createTestHealthPlanPackage,

--- a/services/app-api/src/resolvers/rate/fetchRate.test.ts
+++ b/services/app-api/src/resolvers/rate/fetchRate.test.ts
@@ -559,5 +559,10 @@ describe('fetchRate', () => {
         expect(rateQuestions2.DMCOQuestions.edges[0].node.addedBy).toEqual(
             expect.objectContaining(dmco2CmsUser)
         )
+        // Expect earlier DMCO question to be at index 1
+        expect(rateQuestions2.DMCOQuestions.edges).toHaveLength(2)
+        expect(rateQuestions2.DMCOQuestions.edges[1].node.addedBy).toEqual(
+            expect.objectContaining(dmcoCmsUser)
+        )
     })
 })

--- a/services/app-api/src/resolvers/rate/rateResolver.ts
+++ b/services/app-api/src/resolvers/rate/rateResolver.ts
@@ -6,6 +6,13 @@ import type {
     RatePackageSubmissionWithCauseType,
     RateType,
 } from '../../domain-models'
+import {
+    setErrorAttributesOnActiveSpan,
+    setResolverDetailsOnActiveSpan,
+} from '../attributeHelper'
+import type { Store } from '../../postgres'
+import { NotFoundError } from '../../postgres'
+import { convertToIndexRateQuestionsPayload } from '../../postgres/questionResponse'
 
 // Return the date of the first submission for a rate
 // This method relies on revisions always being presented in most-recent-first order
@@ -14,86 +21,126 @@ function initialSubmitDate(rate: RateType): Date | undefined {
     return firstSubmittedRev?.submitInfo?.updatedAt
 }
 
-export const rateResolver: Resolvers['Rate'] = {
-    initiallySubmittedAt(parent) {
-        return initialSubmitDate(parent) || null
-    },
-    state(parent) {
-        const packageState = parent.stateCode
-        const state = statePrograms.states.find(
-            (st) => st.code === packageState
-        )
+export function rateResolver(store: Store): Resolvers['Rate'] {
+    return {
+        initiallySubmittedAt(parent) {
+            return initialSubmitDate(parent) || null
+        },
+        state(parent) {
+            const packageState = parent.stateCode
+            const state = statePrograms.states.find(
+                (st) => st.code === packageState
+            )
 
-        if (state === undefined) {
-            const errMessage = 'State not found in database: ' + packageState
-            throw new GraphQLError(errMessage, {
-                extensions: {
-                    code: 'INTERNAL_SERVER_ERROR',
-                    cause: 'DB_ERROR',
-                },
-            })
-        }
-        return state
-    },
-    packageSubmissions(parent) {
-        const gqlSubs: RatePackageSubmissionWithCauseType[] = []
-        for (let i = 0; i < parent.packageSubmissions.length; i++) {
-            const thisSub = parent.packageSubmissions[i]
-            let prevSub = undefined
-            if (i < parent.packageSubmissions.length - 1) {
-                prevSub = parent.packageSubmissions[i + 1]
+            if (state === undefined) {
+                const errMessage =
+                    'State not found in database: ' + packageState
+                throw new GraphQLError(errMessage, {
+                    extensions: {
+                        code: 'INTERNAL_SERVER_ERROR',
+                        cause: 'DB_ERROR',
+                    },
+                })
             }
+            return state
+        },
+        packageSubmissions(parent) {
+            const gqlSubs: RatePackageSubmissionWithCauseType[] = []
+            for (let i = 0; i < parent.packageSubmissions.length; i++) {
+                const thisSub = parent.packageSubmissions[i]
+                let prevSub = undefined
+                if (i < parent.packageSubmissions.length - 1) {
+                    prevSub = parent.packageSubmissions[i + 1]
+                }
 
-            // determine the cause for this submission
-            let cause: SubmissionReason = 'RATE_SUBMISSION'
+                // determine the cause for this submission
+                let cause: SubmissionReason = 'RATE_SUBMISSION'
 
-            if (
-                !thisSub.submittedRevisions.find(
-                    (r) => r.id === thisSub.rateRevision.id
-                )
-            ) {
-                // not a rate submission, this rate wasn't in the submitted bits
-                const connectedContractRevisionIDs =
-                    thisSub.contractRevisions.map((r) => r.id)
-                const submittedContract = thisSub.submittedRevisions.find((r) =>
-                    connectedContractRevisionIDs.includes(r.id)
-                )
+                if (
+                    !thisSub.submittedRevisions.find(
+                        (r) => r.id === thisSub.rateRevision.id
+                    )
+                ) {
+                    // not a rate submission, this rate wasn't in the submitted bits
+                    const connectedContractRevisionIDs =
+                        thisSub.contractRevisions.map((r) => r.id)
+                    const submittedContract = thisSub.submittedRevisions.find(
+                        (r) => connectedContractRevisionIDs.includes(r.id)
+                    )
 
-                if (!submittedContract) {
-                    cause = 'RATE_UNLINK'
-                } else {
-                    const thisSubmittedContract =
-                        submittedContract as ContractRevisionType
-                    if (!prevSub) {
-                        throw new Error(
-                            'Programming Error: a non-rate submission must have a previous rate submission'
-                        )
-                    }
-                    const previousContractRevisionIDs =
-                        prevSub.contractRevisions.map((r) => r.contract.id)
-                    if (
-                        previousContractRevisionIDs.includes(
-                            thisSubmittedContract.contract.id
-                        )
-                    ) {
-                        cause = 'CONTRACT_SUBMISSION'
+                    if (!submittedContract) {
+                        cause = 'RATE_UNLINK'
                     } else {
-                        cause = 'RATE_LINK'
+                        const thisSubmittedContract =
+                            submittedContract as ContractRevisionType
+                        if (!prevSub) {
+                            throw new Error(
+                                'Programming Error: a non-rate submission must have a previous rate submission'
+                            )
+                        }
+                        const previousContractRevisionIDs =
+                            prevSub.contractRevisions.map((r) => r.contract.id)
+                        if (
+                            previousContractRevisionIDs.includes(
+                                thisSubmittedContract.contract.id
+                            )
+                        ) {
+                            cause = 'CONTRACT_SUBMISSION'
+                        } else {
+                            cause = 'RATE_LINK'
+                        }
                     }
                 }
+
+                const gqlSub: RatePackageSubmissionWithCauseType = {
+                    cause,
+                    submitInfo: thisSub.submitInfo,
+                    submittedRevisions: thisSub.submittedRevisions,
+                    rateRevision: thisSub.rateRevision,
+                    contractRevisions: thisSub.contractRevisions,
+                }
+
+                gqlSubs.push(gqlSub)
             }
 
-            const gqlSub: RatePackageSubmissionWithCauseType = {
-                cause,
-                submitInfo: thisSub.submitInfo,
-                submittedRevisions: thisSub.submittedRevisions,
-                rateRevision: thisSub.rateRevision,
-                contractRevisions: thisSub.contractRevisions,
+            return gqlSubs
+        },
+        questions: async (parent, _args, context) => {
+            const { user, ctx, tracer } = context
+            // add a span to OTEL
+            const span = tracer?.startSpan(
+                'fetchRateWithQuestionsResolver',
+                {},
+                ctx
+            )
+            setResolverDetailsOnActiveSpan('fetchRateWithQuestions', user, span)
+
+            const questionsForRate = await store.findAllQuestionsByRate(
+                parent.id
+            )
+
+            if (questionsForRate instanceof Error) {
+                const errMessage = `Issue finding questions for rate. Message: ${questionsForRate.message}`
+                setErrorAttributesOnActiveSpan(errMessage, span)
+
+                if (questionsForRate instanceof NotFoundError) {
+                    throw new GraphQLError(errMessage, {
+                        extensions: {
+                            code: 'NOT_FOUND',
+                            cause: 'DB_ERROR',
+                        },
+                    })
+                }
+
+                throw new GraphQLError(errMessage, {
+                    extensions: {
+                        code: 'INTERNAL_SERVER_ERROR',
+                        cause: 'DB_ERROR',
+                    },
+                })
             }
 
-            gqlSubs.push(gqlSub)
-        }
-
-        return gqlSubs
-    },
+            return convertToIndexRateQuestionsPayload(questionsForRate)
+        },
+    }
 }

--- a/services/app-api/src/resolvers/user/userResolver.ts
+++ b/services/app-api/src/resolvers/user/userResolver.ts
@@ -1,11 +1,8 @@
 import type { Resolvers } from '../../gen/gqlServer'
 import statePrograms from '../../../../app-web/src/common-code/data/statePrograms.json'
-import type {
-    CMSUserType,
-    CMSApproverUserType,
-} from '../../domain-models/UserType'
+import type { CMSUsersUnionType } from '../../domain-models/UserType'
 
-function getStateAssignments(user: CMSUserType | CMSApproverUserType) {
+function getStateAssignments(user: CMSUsersUnionType) {
     const userStates = user.stateAssignments
     const statesWithPrograms = userStates.map((userState) => {
         const state = statePrograms.states.find(

--- a/services/app-graphql/src/queries/fetchRateWithQuestions.graphql
+++ b/services/app-graphql/src/queries/fetchRateWithQuestions.graphql
@@ -1,0 +1,319 @@
+query fetchRateWithQuestions($input: FetchRateInput!) {
+    fetchRate(input: $input) {
+        rate {
+            ...rateFieldsForFetchRate
+
+            draftRevision {
+                ...rateRevisionFragmentForFetchRate
+            }
+
+            revisions {
+                ...rateRevisionFragmentForFetchRate
+            }
+            questions {
+                DMCOQuestions {
+                    edges {
+                        ...rateQuestionEdgeFragment
+                    }
+                }
+                DMCPQuestions {
+                    edges {
+                        ...rateQuestionEdgeFragment
+                    }
+                }
+                OACTQuestions {
+                    edges {
+                        ...rateQuestionEdgeFragment
+                    }
+                }
+            }
+        }
+    }
+}
+
+fragment rateRevisionFragmentForFetchRate on RateRevision {
+    id
+    rateID
+    createdAt
+    updatedAt
+    unlockInfo {
+        ...updateInformationFields
+    }
+    submitInfo {
+        ...updateInformationFields
+    }
+    formData {
+        rateType
+        rateCapitationType
+        rateDocuments {
+            name
+            s3URL
+            sha256
+            dateAdded
+            downloadURL
+        }
+        supportingDocuments {
+            name
+            s3URL
+            sha256
+            dateAdded
+            downloadURL
+        }
+        rateDateStart
+        rateDateEnd
+        rateDateCertified
+        amendmentEffectiveDateStart
+        amendmentEffectiveDateEnd
+        rateProgramIDs
+        deprecatedRateProgramIDs
+        rateCertificationName
+        certifyingActuaryContacts {
+            id
+            name
+            titleRole
+            email
+            actuarialFirm
+            actuarialFirmOther
+        }
+        addtlActuaryContacts {
+            id
+            name
+            titleRole
+            email
+            actuarialFirm
+            actuarialFirmOther
+        }
+        actuaryCommunicationPreference
+        packagesWithSharedRateCerts {
+            packageName
+            packageId
+            packageStatus
+        }
+    }
+}
+
+fragment rateFieldsForFetchRate on Rate {
+    id
+    createdAt
+    updatedAt
+    stateCode
+    stateNumber
+    parentContractID
+    state {
+        code
+        name
+        programs {
+            id
+            name
+            fullName
+            isRateProgram
+        }
+    }
+    status
+    parentContractID
+    initiallySubmittedAt
+    withdrawInfo {
+        ...updateInformationFields
+    }
+    packageSubmissions {
+        ...packageSubmissionsFragmentForFetchRate
+    }
+}
+
+fragment packageSubmissionsFragmentForFetchRate on RatePackageSubmission {
+    cause
+    submitInfo {
+        ...updateInformationFields
+    }
+
+    submittedRevisions {
+        ...submittableRevisionsFieldsForFetchRate
+    }
+
+    rateRevision {
+        ...rateRevisionFragmentForFetchRate
+    }
+
+    contractRevisions {
+        ...contractRevisionFragmentForFetchRate
+    }
+}
+
+fragment contractFormDataFragmentForFetchRate on ContractFormData {
+    programIDs
+
+    populationCovered
+    submissionType
+
+    riskBasedContract
+    submissionDescription
+
+    stateContacts {
+        name
+        titleRole
+        email
+    }
+
+    supportingDocuments {
+        name
+        s3URL
+        sha256
+        dateAdded
+        downloadURL
+    }
+
+    contractType
+    contractExecutionStatus
+    contractDocuments {
+        name
+        s3URL
+        sha256
+        dateAdded
+        downloadURL
+    }
+
+    contractDateStart
+    contractDateEnd
+    managedCareEntities
+    federalAuthorities
+    inLieuServicesAndSettings
+    modifiedBenefitsProvided
+    modifiedGeoAreaServed
+    modifiedMedicaidBeneficiaries
+    modifiedRiskSharingStrategy
+    modifiedIncentiveArrangements
+    modifiedWitholdAgreements
+    modifiedStateDirectedPayments
+    modifiedPassThroughPayments
+    modifiedPaymentsForMentalDiseaseInstitutions
+    modifiedMedicaidBeneficiaries
+    modifiedMedicalLossRatioStandards
+    modifiedOtherFinancialPaymentIncentive
+    modifiedEnrollmentProcess
+    modifiedGrevienceAndAppeal
+    modifiedNetworkAdequacyStandards
+    modifiedLengthOfContract
+    modifiedNonRiskPaymentArrangements
+    statutoryRegulatoryAttestation
+    statutoryRegulatoryAttestationDescription
+}
+
+fragment contractRevisionFragmentForFetchRate on ContractRevision {
+    id
+    createdAt
+    updatedAt
+    contractID
+    contractName
+
+    submitInfo {
+        ...updateInformationFields
+    }
+
+    unlockInfo {
+        ...updateInformationFields
+    }
+
+    formData {
+        ...contractFormDataFragmentForFetchRate
+    }
+}
+
+fragment submittableRevisionsFieldsForFetchRate on SubmittableRevision {
+    ... on ContractRevision {
+        ...contractRevisionFragmentForFetchRate
+    }
+    ... on RateRevision {
+        ...rateRevisionFragmentForFetchRate
+    }
+}
+
+
+fragment updateInformationFields on UpdateInformation {
+    updatedAt
+    updatedBy {
+        email
+        role
+        familyName
+        givenName
+    }
+    updatedReason
+}
+
+fragment rateQuestionEdgeFragment on RateQuestionEdge {
+    node {
+        id
+        rateID
+        createdAt
+        addedBy {
+            ... on CMSUser {
+                id
+                email
+                role
+                familyName
+                givenName
+                stateAssignments {
+                    code
+                    name
+                    programs {
+                        id
+                        name
+                        fullName
+                        isRateProgram
+                    }
+                }
+                divisionAssignment
+            }
+            ... on CMSApproverUser {
+                id
+                email
+                role
+                familyName
+                givenName
+                stateAssignments {
+                    code
+                    name
+                    programs {
+                        id
+                        name
+                        fullName
+                        isRateProgram
+                    }
+                }
+                divisionAssignment
+            }
+        }
+        division
+        documents {
+            s3URL
+            name
+            downloadURL
+        }
+        responses {
+            id
+            questionID
+            createdAt
+            addedBy {
+                id
+                role
+                email
+                givenName
+                familyName
+                state {
+                    code
+                    name
+                    programs {
+                        id
+                        name
+                        fullName
+                        isRateProgram
+                    }
+                }
+            }
+            documents {
+                name
+                s3URL
+                downloadURL
+            }
+        }
+    }
+}

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -648,13 +648,31 @@ type IndexQuestionsPayload {
     OACTQuestions: QuestionList!
 }
 
+type IndexRateQuestionsPayload {
+    "Questions for a given rate that were asked by DMCO within CMS"
+    DMCOQuestions: RateQuestionList!
+    "Questions for a given rate that were asked by DMCP within CMS"
+    DMCPQuestions: RateQuestionList!
+    "Questions for a given rate that were asked by OACT within CMS"
+    OACTQuestions: RateQuestionList!
+}
+
 type QuestionList {
     totalCount: Int
     edges: [QuestionEdge!]!
 }
 
+type RateQuestionList {
+    totalCount: Int
+    edges: [RateQuestionEdge!]!
+}
+
 type QuestionEdge {
     node: Question!
+}
+
+type RateQuestionEdge {
+    node: RateQuestion!
 }
 
 input DocumentInput {
@@ -1642,6 +1660,12 @@ type Rate {
     was associated with.
     """
     packageSubmissions: [RatePackageSubmission!]
+    """
+    questions field is an array of questions asked about the rate by CMS. Each questions also contains responses
+    to the question submitted by the State. DRAFT rates will not have questions, only rates that have been submitted
+    , unlocked, or resubmitted. The array is in descending order by createdAt.
+    """
+    questions: IndexRateQuestionsPayload
 }
 
 """
@@ -1760,6 +1784,12 @@ type Contract {
     submission is in the first position in the array.
     """
     packageSubmissions: [ContractPackageSubmission!]!
+
+    """
+    questions field is an array of questions asked about the contract by CMS. Each questions also contains responses
+    to the question submitted by the State. DRAFT contracts will not have questions, only contracts that have been submitted
+    , unlocked, or resubmitted. The array is in descending order by createdAt.
+    """
     questions: IndexQuestionsPayload
 }
 


### PR DESCRIPTION
## Summary
[MCR-4450](https://jiraent.cms.gov/browse/MCR-4450)

- `rateResolver` returns questions similar to `contractResolver`.
- Refactored the questionHelpers to work with both types of questions
- new `fetchRateWithQuestions` that includes the `questions` field.

NOTE: As a follow on ticket I wanted to rename all the existing `question` for contract questions to `contractQuestion` to better clarify which question type belongs to a rate and a contract. Separating it from this work will make it easier to review.

#### Related issues

#### Screenshots

#### Test cases covered

`fetchRate.test.ts`
- `'returns the questions on for a rate'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
