### PR TITLE
Fixes for file upload when virus is present

### DIFF
--- a/services/app-web/src/contexts/AuthContext.tsx
+++ b/services/app-web/src/contexts/AuthContext.tsx
@@ -170,7 +170,7 @@ function AuthProvider({
     const checkAuth: AuthContextType['checkAuth'] = async () => {
         try {
             const refetchRes = await refetch()
-            console.info(`refetch result: ${refetchRes}`)
+            console.info(`refetch result: ${JSON.stringify(refetchRes)}`)
             return refetchRes
         } catch (e) {
             // if we fail auth at a time we expected logged in user, the session may have timed out. Logout fully to reflect that and force React state update

--- a/services/app-web/src/contexts/AuthContext.tsx
+++ b/services/app-web/src/contexts/AuthContext.tsx
@@ -169,9 +169,7 @@ function AuthProvider({
     */
     const checkAuth: AuthContextType['checkAuth'] = async () => {
         try {
-            const refetchRes = await refetch()
-            console.info(`refetch result: ${JSON.stringify(refetchRes)}`)
-            return refetchRes
+            return await refetch()
         } catch (e) {
             // if we fail auth at a time we expected logged in user, the session may have timed out. Logout fully to reflect that and force React state update
             if (loggedInUser) {

--- a/services/app-web/src/contexts/AuthContext.tsx
+++ b/services/app-web/src/contexts/AuthContext.tsx
@@ -169,7 +169,9 @@ function AuthProvider({
     */
     const checkAuth: AuthContextType['checkAuth'] = async () => {
         try {
-            return await refetch()
+            const refetchRes = await refetch()
+            console.info(`refetch result: ${refetchRes}`)
+            return refetchRes
         } catch (e) {
             // if we fail auth at a time we expected logged in user, the session may have timed out. Logout fully to reflect that and force React state update
             if (loggedInUser) {
@@ -191,9 +193,9 @@ function AuthProvider({
     const refreshAuth = async () => {
         if (authMode !== 'LOCAL') {
             const result = await extendSession()
-            if (result instanceof Error){
+            if (result instanceof Error) {
                 await logout({
-                    type: 'TIMEOUT'
+                    type: 'TIMEOUT',
                 })
             }
         }

--- a/services/app-web/src/contexts/S3Context.tsx
+++ b/services/app-web/src/contexts/S3Context.tsx
@@ -65,7 +65,7 @@ const useS3 = (): S3ContextT => {
             const s3URL = await getS3URL(s3Key, file.name, bucket)
             return { key: s3Key, s3URL: s3URL }
         } catch (err) {
-            console.error(err)
+            console.error(`uploadFile error ${err}`)
             throw err
         }
     }

--- a/services/app-web/src/contexts/S3Context.tsx
+++ b/services/app-web/src/contexts/S3Context.tsx
@@ -91,7 +91,7 @@ const useS3 = (): S3ContextT => {
         } catch (e) {
             const error = new Error(`handleScanFile error: ${e}`)
             console.error(error)
-            return error
+            throw error
         }
     }
     // We often don't want to actually delete a resource from s3 and that's what permanentFileKeys is for

--- a/services/app-web/src/contexts/S3Context.tsx
+++ b/services/app-web/src/contexts/S3Context.tsx
@@ -4,7 +4,7 @@ import { S3FileData } from '../components'
 import type { S3ClientT } from '../s3'
 import { BucketShortName } from '../s3/s3Amplify'
 import { recordJSException } from '../otelHelpers'
-import { useAuth } from './AuthContext'
+//import { useAuth } from './AuthContext'
 
 type S3ContextT = {
     handleUploadFile: (
@@ -42,7 +42,7 @@ const useS3 = (): S3ContextT => {
     }
 
     const { deleteFile, uploadFile, scanFile, getS3URL } = context
-    const { checkAuth, logout } = useAuth()
+    //const { checkAuth, logout } = useAuth()
 
     const handleUploadFile = async (
         file: File,
@@ -53,12 +53,14 @@ const useS3 = (): S3ContextT => {
         if (isS3Error(s3Key)) {
             const error = new Error(`Error in S3: ${file.name}`)
             recordJSException(error)
+            /*
             // s3 file upload failing could be due to IDM session timeout
             // double check the user still has their session, if not, logout to update the React state with their login status
             const responseCheckAuth = await checkAuth()
             if (responseCheckAuth instanceof Error) {
                 await logout({ type: 'TIMEOUT' })
             }
+                */
             throw error
         }
         const s3URL = await getS3URL(s3Key, file.name, bucket)
@@ -79,10 +81,12 @@ const useS3 = (): S3ContextT => {
             }
             // s3 file upload failing could be due to IDM session timeout
             // double check the user still has their session, if not, logout to update the React state with their login status
+            /* test disable
             const responseCheckAuth = await checkAuth()
             if (responseCheckAuth instanceof Error) {
                 await logout({ type: 'TIMEOUT' })
             }
+                */
             const error = new Error('Scanning error: Scanning retry timed out')
             recordJSException(error)
             throw error

--- a/services/app-web/src/contexts/S3Context.tsx
+++ b/services/app-web/src/contexts/S3Context.tsx
@@ -84,12 +84,10 @@ const useS3 = (): S3ContextT => {
             }
             // s3 file upload failing could be due to IDM session timeout
             // double check the user still has their session, if not, logout to update the React state with their login status
-            /* test disable
             const responseCheckAuth = await checkAuth()
             if (responseCheckAuth instanceof Error) {
                 await logout({ type: 'TIMEOUT' })
             }
-                */
             const error = new Error('Scanning error: Scanning retry timed out')
             recordJSException(error)
             throw error

--- a/services/app-web/src/s3/s3Error.ts
+++ b/services/app-web/src/s3/s3Error.ts
@@ -1,5 +1,5 @@
 export const S3ErrorCodes = ['NETWORK_ERROR'] as const
-type S3ErrorCode = typeof S3ErrorCodes[number] // iterable union type
+type S3ErrorCode = (typeof S3ErrorCodes)[number] // iterable union type
 
 export type S3Error = {
     code: S3ErrorCode

--- a/services/cypress/integration/cmsWorkflow/rateReview.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/rateReview.spec.ts
@@ -1,4 +1,4 @@
-import { cmsUser, stateUser } from "../../utils/apollo-test-utils"
+import { cmsUser, stateUser } from '../../utils/apollo-test-utils'
 
 describe('CMS user can view rate reviews', () => {
     beforeEach(() => {
@@ -8,8 +8,7 @@ describe('CMS user can view rate reviews', () => {
 
     // NEEDS TO BE REWRITTEN AS API TEST WE FINISH CONTRACT API EPIC
     it.skip('and navigate to a specific rate from the rates dashboard', () => {
-          cy.apiAssignDivisionToCMSUser(cmsUser(), 'DMCO').then(() => {
-
+        cy.apiAssignDivisionToCMSUser(cmsUser(), 'DMCO').then(() => {
             // Create a new contract and rates submission with two attached rates
             cy.apiCreateAndSubmitContractWithRates(stateUser()).then(
                 (contract) => {
@@ -24,22 +23,46 @@ describe('CMS user can view rate reviews', () => {
                     })
 
                     cy.get('table')
-                        .findByTestId(`rate-link-${rate1.rateID}`).should('exist')
+                        .findByTestId(`rate-link-${rate1.rateID}`)
+                        .should('exist')
                     cy.get('table')
-                        .findByTestId(`rate-link-${rate2.rateID}`).should('exist')
+                        .findByTestId(`rate-link-${rate2.rateID}`)
+                        .should('exist')
 
                     // click the first rate to navigate to rate summary page
                     cy.get('table')
-                        .findByTestId(`rate-link-${rate1.rateID}`).click()
-                    cy.url({ timeout: 10_000 }).should('contain',rate1.rateID)
+                        .findByTestId(`rate-link-${rate1.rateID}`)
+                        .click()
+                    cy.url({ timeout: 10_000 }).should('contain', rate1.rateID)
                     cy.findByRole('heading', {
                         name: `${rate1.formData.rateCertificationName}`,
                     }).should('exist')
-                    cy.findByText('Rate certification type').should('exist').siblings('dd').should('have.text', 'New rate certification')
-                    cy.findByText('Rating period').should('exist').siblings('dd').should('have.text', '06/01/2025 to 05/30/2026')
-                    cy.findByText('Date certified').should('exist').siblings('dd').should('have.text', '04/15/2025')
-                    cy.findByText('Submission this rate was submitted with').should('exist').siblings('dd').should('have.text', latestSubmission.contractRevision.contractName)
-                    cy.findByText('Certifying actuary').should('exist').siblings('dd').should('have.text', 'actuary1test titleemail@example.comMercer')
+                    cy.findByText('Rate certification type')
+                        .should('exist')
+                        .siblings('dd')
+                        .should('have.text', 'New rate certification')
+                    cy.findByText('Rating period')
+                        .should('exist')
+                        .siblings('dd')
+                        .should('have.text', '06/01/2025 to 05/30/2026')
+                    cy.findByText('Date certified')
+                        .should('exist')
+                        .siblings('dd')
+                        .should('have.text', '04/15/2025')
+                    cy.findByText('Submission this rate was submitted with')
+                        .should('exist')
+                        .siblings('dd')
+                        .should(
+                            'have.text',
+                            latestSubmission.contractRevision.contractName
+                        )
+                    cy.findByText('Certifying actuary')
+                        .should('exist')
+                        .siblings('dd')
+                        .should(
+                            'have.text',
+                            'actuary1test titleemail@example.comMercer'
+                        )
                     // cy.findByText('Download all rate documents').should('exist')
                     cy.findByRole('table', {
                         name: 'Rate certification',
@@ -48,18 +71,48 @@ describe('CMS user can view rate reviews', () => {
                     cy.findByRole('table', {
                         name: 'Rate supporting documents',
                     }).should('exist')
-                })
-                cy.findByText('rate1SupportingDocument1.pdf').should('exist')
+                    cy.findByText('rate1SupportingDocument1.pdf').should(
+                        'exist'
+                    )
 
-                // No document dates or other fields are undefined
-                cy.findByText('N/A').should('not.exist')
+                    // No document dates or other fields are undefined
+                    cy.findByText('N/A').should('not.exist')
 
-                // Go back to dashboard and check both rates in the table
-                // check the dashboard has the columns we expect
-                cy.findByText('Back to dashboard').should('exist').click()
-                cy.url({ timeout: 10_000 }).should('contain', 'rate-reviews')
-                cy.findByText('Rate reviews').should('exist')
-                cy.get('thead').should('have.attr', 'data-testid', 'rate-reviews-table').should('be.visible') // can't put id on table itself because data attributes not passing through in react-uswds component
+                    // Download rate zip file
+                    cy.findByText('Download all rate documents')
+                        .should('exist')
+                        .click()
+
+                    // Wait for download and verify
+                    cy.readFile(
+                        `cypress/downloads/${rate1.rateID}-rate-details.zip`,
+                        { timeout: 15000 }
+                    ).should('exist')
+
+                    // Optional: Verify file size is greater than 0 bytes
+                    cy.readFile(
+                        `cypress/downloads/${rate1.rateID}-rate-details.zip`
+                    ).then((contents) => {
+                        expect(contents.length).to.be.greaterThan(0)
+                    })
+
+                    // Go back to dashboard and check both rates in the table
+                    // check the dashboard has the columns we expect
+                    cy.findByText('Back to dashboard').should('exist').click()
+                    cy.url({ timeout: 10_000 }).should(
+                        'contain',
+                        'rate-reviews'
+                    )
+                    cy.findByText('Rate reviews').should('exist')
+                    cy.get('thead')
+                        .should(
+                            'have.attr',
+                            'data-testid',
+                            'rate-reviews-table'
+                        )
+                        .should('be.visible') // can't put id on table itself because data attributes not passing through in react-uswds component
+                }
+            )
         })
     })
 })

--- a/services/cypress/integration/cmsWorkflow/rateReview.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/rateReview.spec.ts
@@ -71,48 +71,21 @@ describe('CMS user can view rate reviews', () => {
                     cy.findByRole('table', {
                         name: 'Rate supporting documents',
                     }).should('exist')
-                    cy.findByText('rate1SupportingDocument1.pdf').should(
-                        'exist'
-                    )
-
-                    // No document dates or other fields are undefined
-                    cy.findByText('N/A').should('not.exist')
-
-                    // Download rate zip file
-                    cy.findByText('Download all rate documents')
-                        .should('exist')
-                        .click()
-
-                    // Wait for download and verify
-                    cy.readFile(
-                        `cypress/downloads/${rate1.rateID}-rate-details.zip`,
-                        { timeout: 15000 }
-                    ).should('exist')
-
-                    // Optional: Verify file size is greater than 0 bytes
-                    cy.readFile(
-                        `cypress/downloads/${rate1.rateID}-rate-details.zip`
-                    ).then((contents) => {
-                        expect(contents.length).to.be.greaterThan(0)
-                    })
-
-                    // Go back to dashboard and check both rates in the table
-                    // check the dashboard has the columns we expect
-                    cy.findByText('Back to dashboard').should('exist').click()
-                    cy.url({ timeout: 10_000 }).should(
-                        'contain',
-                        'rate-reviews'
-                    )
-                    cy.findByText('Rate reviews').should('exist')
-                    cy.get('thead')
-                        .should(
-                            'have.attr',
-                            'data-testid',
-                            'rate-reviews-table'
-                        )
-                        .should('be.visible') // can't put id on table itself because data attributes not passing through in react-uswds component
                 }
             )
+            cy.findByText('rate1SupportingDocument1.pdf').should('exist')
+
+            // No document dates or other fields are undefined
+            cy.findByText('N/A').should('not.exist')
+
+            // Go back to dashboard and check both rates in the table
+            // check the dashboard has the columns we expect
+            cy.findByText('Back to dashboard').should('exist').click()
+            cy.url({ timeout: 10_000 }).should('contain', 'rate-reviews')
+            cy.findByText('Rate reviews').should('exist')
+            cy.get('thead')
+                .should('have.attr', 'data-testid', 'rate-reviews-table')
+                .should('be.visible') // can't put id on table itself because data attributes not passing through in react-uswds component
         })
     })
 })

--- a/services/cypress/integration/stateWorkflow/virusScan/virusScan.spec.ts
+++ b/services/cypress/integration/stateWorkflow/virusScan/virusScan.spec.ts
@@ -30,7 +30,7 @@ describe.only('documents', () => {
                 cy.findByText(/0 complete, 0 errors, 2 pending/)
                 cy.waitForDocumentsToLoad()
 
-                cy.findByText(/2 complete, 1 error, 0 pending/).should('exist')
+                cy.findByText(/1 complete, 1 error, 0 pending/).should('exist')
 
                 cy.findByText('Failed security scan, please remove', {
                     timeout: 200_000,

--- a/services/cypress/integration/stateWorkflow/virusScan/virusScan.spec.ts
+++ b/services/cypress/integration/stateWorkflow/virusScan/virusScan.spec.ts
@@ -35,6 +35,24 @@ describe.only('documents', () => {
                 cy.findByText('Failed security scan, please remove', {
                     timeout: 200_000,
                 }).should('exist')
+
+                // Remove the virus-infected file
+                cy.findByText('Failed security scan, please remove')
+                    .parent()
+                    .find('button[aria-label="Remove badDummy.pdf document"]')
+                    .click()
+
+                // Verify the file has been removed
+                cy.findByText(/1 complete, 0 errors, 0 pending/).should('exist')
+                cy.findByText('Failed security scan, please remove').should(
+                    'not.exist'
+                )
+
+                // Upload a clean file
+                fileInput.attachFile(['documents/how-to-open-source.pdf'])
+                cy.findByText(/1 complete, 0 errors, 1 pending/)
+                cy.waitForDocumentsToLoad()
+                cy.findByText(/2 complete, 0 errors, 0 pending/).should('exist')
             })
         })
     }

--- a/services/cypress/integration/stateWorkflow/virusScan/virusScan.spec.ts
+++ b/services/cypress/integration/stateWorkflow/virusScan/virusScan.spec.ts
@@ -37,10 +37,13 @@ describe.only('documents', () => {
                 }).should('exist')
 
                 // Remove the virus-infected file
-                cy.findByText('Failed security scan, please remove')
-                    .parent()
-                    .find('button[aria-label="Remove eicar_com.pdf document"]')
-                    .click()
+                cy.contains('Failed security scan, please remove')
+                    .closest('li')
+                    .within(() => {
+                        cy.findByRole('button', {
+                            name: /Remove eicar_com.pdf document/,
+                        }).click()
+                    })
 
                 // Verify the file has been removed
                 cy.findByText(/1 complete, 0 errors, 0 pending/).should('exist')

--- a/services/cypress/integration/stateWorkflow/virusScan/virusScan.spec.ts
+++ b/services/cypress/integration/stateWorkflow/virusScan/virusScan.spec.ts
@@ -12,18 +12,29 @@ describe.only('documents', () => {
             cy.location().then((fullUrl) => {
                 const { pathname } = fullUrl
                 const draftSubmissionID = pathname.split('/')[2]
+
                 cy.navigateFormByDirectLink(
-                    `/submissions/${draftSubmissionID}/edit/documents`
+                    `/submissions/${draftSubmissionID}/edit/type`
                 )
-                cy.findByTestId('file-input-input').attachFile({
+                cy.navigateContractForm('CONTINUE')
+
+                // Upload a good file and a bad file
+                const fileInput = cy.findAllByTestId('file-input-input')
+                fileInput.attachFile(['documents/trussel-guide.pdf'])
+                cy.findByText(/0 complete, 0 errors, 1 pending/)
+
+                fileInput.attachFile({
                     filePath: 'documents/eicar_com.pdf',
                     encoding: 'binary',
                 })
+                cy.findByText(/0 complete, 0 errors, 2 pending/)
+                cy.waitForDocumentsToLoad()
+
+                cy.findByText(/2 complete, 1 error, 0 pending/).should('exist')
+
                 cy.findByText('Failed security scan, please remove', {
                     timeout: 200_000,
-                }).should(
-                    'exist'
-                )
+                }).should('exist')
             })
         })
     }

--- a/services/cypress/integration/stateWorkflow/virusScan/virusScan.spec.ts
+++ b/services/cypress/integration/stateWorkflow/virusScan/virusScan.spec.ts
@@ -39,7 +39,7 @@ describe.only('documents', () => {
                 // Remove the virus-infected file
                 cy.findByText('Failed security scan, please remove')
                     .parent()
-                    .find('button[aria-label="Remove badDummy.pdf document"]')
+                    .find('button[aria-label="Remove eicar_com.pdf document"]')
                     .click()
 
                 // Verify the file has been removed


### PR DESCRIPTION
## Summary

This fixes up the test for av scanning to trigger the case I had seen when a good file and a bad file are added to the file upload dialogue causing the application to reload and clearing out even the good file. This cypress test successfully triggered that behavior, and I elaborated on the test by then removing the bad file and re-uploading a known good file.

Some cleanup around the s3 funcs fixed up this behavior.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4500
