### PR TITLE
MCR-4522: Correction to the copy fix for State assignment page.

### DIFF
--- a/services/app-web/src/pages/Settings/SettingsTables/StateAssignmentTable.tsx
+++ b/services/app-web/src/pages/Settings/SettingsTables/StateAssignmentTable.tsx
@@ -279,8 +279,8 @@ const StateAssignmentTable = () => {
         <>
             <h2>State assignments</h2>
             <p>
-                Below is a list of the DMCO analysts assigned to states. To edit
-                the analysts click on the edit link below.
+                Below is a list of the DMCO staff assigned to states. To edit
+                the assigned staff click on the edit link below.
             </p>
             <FilterAccordion
                 onClearFilters={clearFilters}


### PR DESCRIPTION
## Summary
[MCR-4522](https://jiraent.cms.gov/browse/MCR-4522)

The text is corrected to be `Below is a list of the DMCO staff assigned to states. To edit the assigned staff click on the edit link below.`.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
