### PR TITLE
Ungroup "npm_and_yarn" dependabot 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,15 @@ updates:
         applies-to: version-updates
         patterns:
           - '@storybook/*'
+    npm-minor-patch:
+      patterns:
+        - '*'
+      exclude-patterns:
+        - '@aws-sdk/*'
+        - '@prisma/client'
+        - 'prisma'
+        - '@opentelemetry/*'
+        - '@storybook/*'
+      update-types:
+        - 'minor'
+        - 'patch'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,7 +40,3 @@ updates:
         applies-to: version-updates
         patterns:
           - '@storybook/*'
-      typescript-eslint:
-        applies-to: version-updates
-        patterns:
-          - '@typescript-eslint/*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,15 +40,15 @@ updates:
         applies-to: version-updates
         patterns:
           - '@storybook/*'
-    npm-minor-patch:
-      patterns:
-        - '*'
-      exclude-patterns:
-        - '@aws-sdk/*'
-        - '@prisma/client'
-        - 'prisma'
-        - '@opentelemetry/*'
-        - '@storybook/*'
-      update-types:
-        - 'minor'
-        - 'patch'
+      npm-minor-patch:
+        patterns:
+          - '*'
+        exclude-patterns:
+          - '@aws-sdk/*'
+          - '@prisma/client'
+          - 'prisma'
+          - '@opentelemetry/*'
+          - '@storybook/*'
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
## Summary

We started getting dependabot updates that were grouping minor updates of totally unrelated packages. This is not what we want, so I've set it in the config to deal with everything outside of our explicit groupings.

This also ungroups the `tsconfig-eslint` group, as it's impossible to ignore major versions when grouped and dependabot keeps opening PRs for it (we are a couple versions behind and have a ticket for the upgrade).
