### PR TITLE
Refactor initializeTealium to append async script via createScript

### DIFF
--- a/services/app-web/src/hooks/useScript.ts
+++ b/services/app-web/src/hooks/useScript.ts
@@ -12,6 +12,7 @@ type CustomScriptParams = {
 const createScript = ({
     id,
     type = 'text/javascript',
+    async = false,
     src = '',
     inlineScriptAsString,
 }: CustomScriptParams): HTMLScriptElement => {
@@ -19,6 +20,7 @@ const createScript = ({
     const script = document.createElement('script')
     script.type = type
     script.id = id
+    script.async = async
     if (inlineScriptAsString) script.textContent = inlineScriptAsString
     if (inlineScriptAsString && src !== '') {
         console.error('programming error: inlineScriptAsString is true but src is still passed in as if this is a third party script. Please correct src (should be empty string)')

--- a/services/app-web/src/tealium/tealium.ts
+++ b/services/app-web/src/tealium/tealium.ts
@@ -32,25 +32,12 @@ const tealiumClient = (tealiumEnv: Omit<TealiumEnv, 'dev'>): TealiumClientType =
             }
 
             // Load utag.js - Add to body element- ASYNC load inline script
-            const inlineScript = `(function (t, e, a, l, i, u, m) {
-                t = '${tealiumProfile}'
-                e = '${tealiumEnv}'
-                a = '/' + t + '/' + e + '/utag.js'
-                l = ${`//${tealiumHostname}`} + a
-                i = document
-                u = 'script'
-                m = i.createElement(u)
-                m.src = l
-                m.type = 'text/java' + u
-                m.async = true
-                l = i.getElementsByTagName(u)[0]
-                l.parentNode.insertBefore(m, l)
-            })()`
+            const asyncSrc = `//${tealiumHostname}/${tealiumProfile}/${tealiumEnv}/utag.js`
 
             const loadTagsSnippet = createScript({
-                src: '',
-                inlineScriptAsString: inlineScript,
+                src: asyncSrc,
                 id: 'tealium-load-tags-async',
+                async: true
             })
             if (document.getElementById(loadTagsSnippet.id) === null) {
                 document.body.appendChild(loadTagsSnippet)


### PR DESCRIPTION
## Summary
This is to address an error showing up in the console in higher environments.  Found a way to resolve that also rips out the odd boilerplate code we had in there for loading the async analytics tag (with adds `utag.js`).

#### Related issues
https://jira.cms.gov/browse/BLSTANALYT-9419
https://jira.cms.gov/browse/BLSTANALYT-9293

#### Screenshots

#### Test cases covered
We can only test on VAL or prod, no tealium in lower env. 

## QA guidance
look over code, if tests pass, lets merge and check again
