### PR TITLE
Change handleDeleteFile in app-web

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -571,7 +571,7 @@ importers:
         version: 10.4.0
       '@testing-library/jest-dom':
         specifier: ^6.1.3
-        version: 6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.12))(vitest@1.6.0(@types/node@20.14.12)(@vitest/ui@1.6.0)(jsdom@24.1.1)(sass@1.77.2)(terser@5.34.1))
+        version: 6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0))(vitest@1.6.0(@types/node@20.14.12)(@vitest/ui@1.6.0)(jsdom@24.1.1)(sass@1.77.2)(terser@5.34.1))
       '@testing-library/react':
         specifier: ^16.0.1
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -634,7 +634,7 @@ importers:
         version: 9.1.0(eslint@8.57.0)
       eslint-plugin-jest:
         specifier: ^27.0.1
-        version: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(jest@29.7.0(@types/node@20.14.12))(typescript@4.9.5)
+        version: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0))(typescript@4.9.5)
       eslint-plugin-jsx-a11y:
         specifier: ^6.5.1
         version: 6.8.0(eslint@8.57.0)
@@ -14122,7 +14122,7 @@ snapshots:
       '@aws-sdk/client-sso-oidc': 3.609.0(@aws-sdk/client-sts@3.609.0)
       '@aws-sdk/client-sts': 3.609.0
       '@aws-sdk/core': 3.609.0
-      '@aws-sdk/credential-provider-node': 3.609.0(@aws-sdk/client-sso-oidc@3.609.0(@aws-sdk/client-sts@3.609.0))(@aws-sdk/client-sts@3.609.0)
+      '@aws-sdk/credential-provider-node': 3.609.0(@aws-sdk/client-sso-oidc@3.609.0(@aws-sdk/client-sts@3.609.0))(@aws-sdk/client-sts@3.666.0)
       '@aws-sdk/middleware-host-header': 3.609.0
       '@aws-sdk/middleware-logger': 3.609.0
       '@aws-sdk/middleware-recursion-detection': 3.609.0
@@ -14432,10 +14432,10 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.609.0(@aws-sdk/client-sts@3.609.0)
+      '@aws-sdk/client-sso-oidc': 3.609.0(@aws-sdk/client-sts@3.666.0)
       '@aws-sdk/client-sts': 3.609.0
       '@aws-sdk/core': 3.609.0
-      '@aws-sdk/credential-provider-node': 3.609.0(@aws-sdk/client-sso-oidc@3.609.0(@aws-sdk/client-sts@3.609.0))(@aws-sdk/client-sts@3.609.0)
+      '@aws-sdk/credential-provider-node': 3.609.0(@aws-sdk/client-sso-oidc@3.609.0(@aws-sdk/client-sts@3.609.0))(@aws-sdk/client-sts@3.666.0)
       '@aws-sdk/middleware-host-header': 3.609.0
       '@aws-sdk/middleware-logger': 3.609.0
       '@aws-sdk/middleware-recursion-detection': 3.609.0
@@ -14514,10 +14514,10 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.609.0(@aws-sdk/client-sts@3.666.0)
+      '@aws-sdk/client-sso-oidc': 3.609.0(@aws-sdk/client-sts@3.609.0)
       '@aws-sdk/client-sts': 3.609.0
       '@aws-sdk/core': 3.609.0
-      '@aws-sdk/credential-provider-node': 3.609.0(@aws-sdk/client-sso-oidc@3.609.0(@aws-sdk/client-sts@3.609.0))(@aws-sdk/client-sts@3.609.0)
+      '@aws-sdk/credential-provider-node': 3.609.0(@aws-sdk/client-sso-oidc@3.609.0(@aws-sdk/client-sts@3.609.0))(@aws-sdk/client-sts@3.666.0)
       '@aws-sdk/middleware-host-header': 3.609.0
       '@aws-sdk/middleware-logger': 3.609.0
       '@aws-sdk/middleware-recursion-detection': 3.609.0
@@ -15138,7 +15138,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/client-sts': 3.609.0
       '@aws-sdk/core': 3.609.0
-      '@aws-sdk/credential-provider-node': 3.609.0(@aws-sdk/client-sso-oidc@3.609.0(@aws-sdk/client-sts@3.609.0))(@aws-sdk/client-sts@3.609.0)
+      '@aws-sdk/credential-provider-node': 3.609.0(@aws-sdk/client-sso-oidc@3.609.0(@aws-sdk/client-sts@3.609.0))(@aws-sdk/client-sts@3.666.0)
       '@aws-sdk/middleware-host-header': 3.609.0
       '@aws-sdk/middleware-logger': 3.609.0
       '@aws-sdk/middleware-recursion-detection': 3.609.0
@@ -15436,7 +15436,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/client-sso-oidc': 3.609.0(@aws-sdk/client-sts@3.609.0)
       '@aws-sdk/core': 3.609.0
-      '@aws-sdk/credential-provider-node': 3.609.0(@aws-sdk/client-sso-oidc@3.609.0(@aws-sdk/client-sts@3.609.0))(@aws-sdk/client-sts@3.609.0)
+      '@aws-sdk/credential-provider-node': 3.609.0(@aws-sdk/client-sso-oidc@3.609.0(@aws-sdk/client-sts@3.609.0))(@aws-sdk/client-sts@3.666.0)
       '@aws-sdk/middleware-host-header': 3.609.0
       '@aws-sdk/middleware-logger': 3.609.0
       '@aws-sdk/middleware-recursion-detection': 3.609.0
@@ -15715,24 +15715,6 @@ snapshots:
       '@aws-sdk/types': 3.6.1
       tslib: 1.14.1
 
-  '@aws-sdk/credential-provider-ini@3.609.0(@aws-sdk/client-sso-oidc@3.609.0(@aws-sdk/client-sts@3.609.0))(@aws-sdk/client-sts@3.609.0)':
-    dependencies:
-      '@aws-sdk/client-sts': 3.609.0
-      '@aws-sdk/credential-provider-env': 3.609.0
-      '@aws-sdk/credential-provider-http': 3.609.0
-      '@aws-sdk/credential-provider-process': 3.609.0
-      '@aws-sdk/credential-provider-sso': 3.609.0(@aws-sdk/client-sso-oidc@3.609.0(@aws-sdk/client-sts@3.609.0))
-      '@aws-sdk/credential-provider-web-identity': 3.609.0(@aws-sdk/client-sts@3.609.0)
-      '@aws-sdk/types': 3.609.0
-      '@smithy/credential-provider-imds': 3.2.4
-      '@smithy/property-provider': 3.1.7
-      '@smithy/shared-ini-file-loader': 3.1.8
-      '@smithy/types': 3.5.0
-      tslib: 2.7.0
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
-      - aws-crt
-
   '@aws-sdk/credential-provider-ini@3.609.0(@aws-sdk/client-sso-oidc@3.609.0(@aws-sdk/client-sts@3.609.0))(@aws-sdk/client-sts@3.666.0)':
     dependencies:
       '@aws-sdk/client-sts': 3.666.0
@@ -15794,25 +15776,6 @@ snapshots:
       '@aws-sdk/shared-ini-file-loader': 3.6.1
       '@aws-sdk/types': 3.6.1
       tslib: 1.14.1
-
-  '@aws-sdk/credential-provider-node@3.609.0(@aws-sdk/client-sso-oidc@3.609.0(@aws-sdk/client-sts@3.609.0))(@aws-sdk/client-sts@3.609.0)':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.609.0
-      '@aws-sdk/credential-provider-http': 3.609.0
-      '@aws-sdk/credential-provider-ini': 3.609.0(@aws-sdk/client-sso-oidc@3.609.0(@aws-sdk/client-sts@3.609.0))(@aws-sdk/client-sts@3.609.0)
-      '@aws-sdk/credential-provider-process': 3.609.0
-      '@aws-sdk/credential-provider-sso': 3.609.0(@aws-sdk/client-sso-oidc@3.609.0(@aws-sdk/client-sts@3.609.0))
-      '@aws-sdk/credential-provider-web-identity': 3.609.0(@aws-sdk/client-sts@3.609.0)
-      '@aws-sdk/types': 3.609.0
-      '@smithy/credential-provider-imds': 3.2.4
-      '@smithy/property-provider': 3.1.7
-      '@smithy/shared-ini-file-loader': 3.1.8
-      '@smithy/types': 3.5.0
-      tslib: 2.7.0
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
-      - '@aws-sdk/client-sts'
-      - aws-crt
 
   '@aws-sdk/credential-provider-node@3.609.0(@aws-sdk/client-sso-oidc@3.609.0(@aws-sdk/client-sts@3.609.0))(@aws-sdk/client-sts@3.666.0)':
     dependencies:
@@ -15923,14 +15886,6 @@ snapshots:
     dependencies:
       '@aws-sdk/property-provider': 3.186.0
       '@aws-sdk/types': 3.186.0
-      tslib: 2.7.0
-
-  '@aws-sdk/credential-provider-web-identity@3.609.0(@aws-sdk/client-sts@3.609.0)':
-    dependencies:
-      '@aws-sdk/client-sts': 3.609.0
-      '@aws-sdk/types': 3.609.0
-      '@smithy/property-provider': 3.1.7
-      '@smithy/types': 3.5.0
       tslib: 2.7.0
 
   '@aws-sdk/credential-provider-web-identity@3.609.0(@aws-sdk/client-sts@3.666.0)':
@@ -16536,7 +16491,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.609.0(@aws-sdk/client-sso-oidc@3.609.0(@aws-sdk/client-sts@3.609.0))':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.609.0(@aws-sdk/client-sts@3.609.0)
+      '@aws-sdk/client-sso-oidc': 3.609.0(@aws-sdk/client-sts@3.666.0)
       '@aws-sdk/types': 3.609.0
       '@smithy/property-provider': 3.1.7
       '@smithy/shared-ini-file-loader': 3.1.8
@@ -19405,42 +19360,6 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.16.5
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.16.5)
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.7
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    optional: true
-
   '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.16.5)(typescript@4.9.5))':
     dependencies:
       '@jest/console': 29.7.0
@@ -21853,7 +21772,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.12))(vitest@1.6.0(@types/node@20.14.12)(@vitest/ui@1.6.0)(jsdom@24.1.1)(sass@1.77.2)(terser@5.34.1))':
+  '@testing-library/jest-dom@6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0))(vitest@1.6.0(@types/node@20.14.12)(@vitest/ui@1.6.0)(jsdom@24.1.1)(sass@1.77.2)(terser@5.34.1))':
     dependencies:
       '@adobe/css-tools': 4.3.3
       '@babel/runtime': 7.25.0
@@ -21866,7 +21785,7 @@ snapshots:
     optionalDependencies:
       '@jest/globals': 29.7.0
       '@types/jest': 29.5.12
-      jest: 29.7.0(@types/node@20.14.12)
+      jest: 29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)
       vitest: 1.6.0(@types/node@20.14.12)(@vitest/ui@1.6.0)(jsdom@24.1.1)(sass@1.77.2)(terser@5.34.1)
 
   '@testing-library/react@16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -24154,13 +24073,13 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.11
 
-  create-jest@29.7.0(@types/node@20.14.12):
+  create-jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.14.12)
+      jest-config: 29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -24967,13 +24886,13 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(jest@29.7.0(@types/node@20.14.12))(typescript@4.9.5):
+  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0))(typescript@4.9.5):
     dependencies:
       '@typescript-eslint/utils': 5.57.0(eslint@8.57.0)(typescript@4.9.5)
       eslint: 8.57.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5)
-      jest: 29.7.0(@types/node@20.14.12)
+      jest: 29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -26606,16 +26525,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.14.12):
+  jest-cli@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.16.5)(typescript@4.9.5))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.14.12)
+      create-jest: 29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.14.12)
+      jest-config: 29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -26645,7 +26564,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.14.12):
+  jest-config@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0):
     dependencies:
       '@babel/core': 7.24.7
       '@jest/test-sequencer': 29.7.0
@@ -26671,37 +26590,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.12
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-    optional: true
-
-  jest-config@29.7.0(@types/node@20.16.5):
-    dependencies:
-      '@babel/core': 7.24.7
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.24.7)
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.7
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.16.5
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -26967,12 +26855,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.14.12):
+  jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.16.5)(typescript@4.9.5))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.14.12)
+      jest-cli: 29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -105,8 +105,8 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
                 console.info('Copying file to update metadata')
                 try {
                     await Storage.copy(
-                        { key: fullKey },
-                        { key: fullKey },
+                        { key: filename },
+                        { key: filename },
                         { metadata: updatedMetadata }
                     )
                     console.info('Successfully updated file metadata')

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -78,7 +78,7 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
             bucket: BucketShortName
         ): Promise<void | S3Error> => {
             // Construct the full key including the bucket prefix
-            const fullKey = `${bucketConfig[bucket]}/${filename}`
+            const fullKey = `${bucketConfig[bucket]}/allusers/${filename}`
             console.info(`Attempting to tag file as deleted: ${fullKey}`)
             let metadata
 

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -92,8 +92,8 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
                 // Add or update the 'deleted' tag
                 const updatedMetadata = {
                     ...metadata,
-                    'x-amz-meta-deleted': 'true',
-                    'x-amz-meta-deletedat': new Date().toISOString(),
+                    deleted: 'true',
+                    deletedAt: new Date().toISOString(),
                 }
                 console.info(
                     `updatedMetadata: ${JSON.stringify(updatedMetadata)}`
@@ -103,16 +103,24 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
                 try {
                     const copyResult = await Storage.copy(
                         { key: filename },
-                        { key: filename },
+                        { key: 'deleted/' + filename },
                         { metadata: updatedMetadata }
                     )
                     console.info(`File tagged: ${JSON.stringify(copyResult)}`)
-
-                    return
                 } catch (copyError) {
                     console.error('Error in Storage.copy:', copyError)
                     throw copyError
                 }
+
+                try {
+                    console.info(`deleting file from allusers/: ${filename}`)
+                    const delResult = await Storage.remove(filename)
+                    console.info(`delete result: ${delResult}`)
+                } catch (err) {
+                    console.error('Error in Storage.delete: ${err}')
+                    throw err
+                }
+                return
             } catch (err) {
                 console.error(
                     `Error in tagFileAsDeleted for ${filename}: ${err}`

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -95,22 +95,21 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
                     deleted: 'true',
                     deletedAt: new Date().toISOString(),
                 }
+                console.info(`updatedMetadata: ${updatedMetadata}`)
 
                 // Update the file's metadata
                 try {
-                    await Storage.copy(
+                    const res = await Storage.copy(
                         { key: filename },
                         { key: filename },
                         { metadata: updatedMetadata }
                     )
+                    console.info(`result: ${res}`)
                 } catch (copyError) {
                     console.error('Error in Storage.copy:', copyError)
                     throw copyError
                 }
 
-                console.info(
-                    `File ${filename} tagged as deleted in bucket ${bucket}`
-                )
                 return
             } catch (err) {
                 console.error(

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -95,7 +95,9 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
                     deleted: 'true',
                     deletedAt: new Date().toISOString(),
                 }
-                console.info(`updatedMetadata: ${updatedMetadata}`)
+                console.info(
+                    `updatedMetadata: ${JSON.stringify(updatedMetadata)}`
+                )
 
                 // Update the file's metadata
                 try {
@@ -104,7 +106,7 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
                         { key: filename },
                         { metadata: updatedMetadata }
                     )
-                    console.info(`result: ${res}`)
+                    console.info(`result: ${JSON.stringify(res)}`)
                 } catch (copyError) {
                     console.error('Error in Storage.copy:', copyError)
                     throw copyError

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -78,7 +78,9 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
             bucket: BucketShortName
         ): Promise<void | S3Error> => {
             // Construct the full key including the bucket prefix
-            const fullKey = `allusers/${filename}`
+            const fullKey = filename.startsWith('allusers/')
+                ? filename
+                : `allusers/${filename}`
             console.info(`Attempting to tag file as deleted: ${fullKey}`)
             let metadata
 
@@ -105,8 +107,8 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
                 console.info('Copying file to update metadata')
                 try {
                     await Storage.copy(
-                        { key: fullKey },
-                        { key: fullKey },
+                        { key: filename },
+                        { key: filename },
                         { metadata: updatedMetadata }
                     )
                     console.info('Successfully updated file metadata')

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -92,30 +92,21 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
                 // Add or update the 'deleted' tag
                 const updatedMetadata = {
                     ...metadata,
-                    deleted: 'true',
-                    deletedAt: new Date().toISOString(),
+                    'x-amz-meta-deleted': 'true',
+                    'x-amz-meta-deletedat': new Date().toISOString(),
                 }
                 console.info(
                     `updatedMetadata: ${JSON.stringify(updatedMetadata)}`
                 )
 
                 // Update the file's metadata
-                const newKey = `deleted/${filename}`
                 try {
                     const copyResult = await Storage.copy(
                         { key: filename },
-                        { key: newKey },
+                        { key: filename },
                         { metadata: updatedMetadata }
                     )
-                    console.info(
-                        `File moved and tagged: ${JSON.stringify(copyResult)}`
-                    )
-
-                    const delResult = await Storage.remove(filename, {
-                        level: 'private',
-                    })
-                    console.info(`Original file removed: ${filename}`)
-                    console.info(`delResult: ${JSON.stringify(delResult)}`)
+                    console.info(`File tagged: ${JSON.stringify(copyResult)}`)
 
                     return
                 } catch (copyError) {

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -83,7 +83,8 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
             let metadata
 
             try {
-                const result = await Storage.getProperties(fullKey)
+                console.info(`filename: ${filename}`)
+                const result = await Storage.getProperties(filename)
                 metadata = result.metadata
                 console.info('Successfully got file properties', metadata)
             } catch (getPropertiesError) {

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -100,19 +100,25 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
                 )
 
                 // Update the file's metadata
+                const newKey = `deleted/${filename}`
                 try {
-                    const res = await Storage.copy(
+                    const copyResult = await Storage.copy(
                         { key: filename },
-                        { key: filename },
+                        { key: newKey },
                         { metadata: updatedMetadata }
                     )
-                    console.info(`result: ${JSON.stringify(res)}`)
+                    console.info(
+                        `File moved and tagged: ${JSON.stringify(copyResult)}`
+                    )
+
+                    await Storage.remove(filename, { level: 'private' })
+                    console.info(`Original file removed: ${filename}`)
+
+                    return
                 } catch (copyError) {
                     console.error('Error in Storage.copy:', copyError)
                     throw copyError
                 }
-
-                return
             } catch (err) {
                 console.error(
                     `Error in tagFileAsDeleted for ${filename}: ${err}`

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -111,8 +111,11 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
                         `File moved and tagged: ${JSON.stringify(copyResult)}`
                     )
 
-                    await Storage.remove(filename, { level: 'private' })
+                    const delResult = await Storage.remove(filename, {
+                        level: 'private',
+                    })
                     console.info(`Original file removed: ${filename}`)
+                    console.info(`delResult: ${JSON.stringify(delResult)}`)
 
                     return
                 } catch (copyError) {

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -92,8 +92,8 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
                 // Add or update the 'deleted' tag
                 const updatedMetadata = {
                     ...metadata,
-                    deleted: 'true',
-                    deletedAt: new Date().toISOString(),
+                    'x-amz-meta-deleted': 'true',
+                    'x-amz-meta-deletedAt': new Date().toISOString(),
                 }
                 console.info(
                     `updatedMetadata: ${JSON.stringify(updatedMetadata)}`

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -78,7 +78,7 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
             bucket: BucketShortName
         ): Promise<void | S3Error> => {
             // Construct the full key including the bucket prefix
-            const fullKey = `${bucketConfig[bucket]}/allusers/${filename}`
+            const fullKey = `allusers/${filename}`
             console.info(`Attempting to tag file as deleted: ${fullKey}`)
             let metadata
 
@@ -105,8 +105,8 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
                 console.info('Copying file to update metadata')
                 try {
                     await Storage.copy(
-                        { key: filename },
-                        { key: filename },
+                        { key: fullKey },
+                        { key: fullKey },
                         { metadata: updatedMetadata }
                     )
                     console.info('Successfully updated file metadata')

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -211,9 +211,11 @@ resources:
                   Action:
                     - 's3:*'
                   Resource:
+                    - ${self:custom.document_uploads_bucket_arn}
+                    - ${self:custom.document_uploads_bucket_arn}/*
+                    - ${self:custom.qa_uploads_bucket_arn}
+                    - ${self:custom.qa_uploads_bucket_arn}/*
                     # Must use Join here.  See: https://github.com/serverless/serverless/issues/3565
-                    - ${self:custom.document_uploads_bucket_arn}/allusers/*
-                    - ${self:custom.qa_uploads_bucket_arn}/allusers/*
                     # This private bucket is used by any files stored "private" by Amplify
                     # https://docs.amplify.aws/lib/storage/configureaccess/q/platform/js/
                     - Fn::Join:

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -40,6 +40,14 @@ provider:
             - !Sub arn:aws:s3:::${self:service}-${sls:stage}-qa-${AWS::AccountId}/*
         - Effect: 'Allow'
           Action:
+            - s3:GetObject
+            - s3:GetObjectAttributes
+            - s3:GetObjectTagging
+            - s3:PutObject
+            - s3:PutObjectAcl
+            - s3:PutObjectTagging
+            - s3:PutObjectVersionTagging
+            - s3:DeleteObject
             - s3:ListBucket
           Resource:
             - !Sub arn:aws:s3:::${self:service}-${sls:stage}-uploads-${AWS::AccountId}

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -26,6 +26,7 @@ provider:
         - Effect: 'Allow'
           Action:
             - s3:GetObject
+            - s3:GetObjectAttributes
             - s3:GetObjectTagging
             - s3:PutObject
             - s3:PutObjectAcl


### PR DESCRIPTION
## Summary

We ran into an issue where a state submitted, but the contract document that was uploaded was missing from the package. We decided we don't really have a need for doing an actual delete from `app-web`, so this changes the `handleDeleteFile` func to not actually delete files, but tag the metadata instead when a delete operation occurs.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4491


