### PR TITLE
Skip delete from app-web

### DIFF
--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -77,24 +77,7 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
             filename: string,
             bucket: BucketShortName
         ): Promise<void | S3Error> => {
-            try {
-                await Storage.remove(filename, {
-                    bucket: bucketConfig[bucket],
-                })
-                return
-            } catch (err) {
-                assertIsS3PutError(err)
-                recordJSException(err)
-                if (err.name === 'Error' && err.message === 'Network Error') {
-                    console.info('Error deleting file', err)
-                    return {
-                        code: 'NETWORK_ERROR',
-                        message: 'Error deleting file from the cloud.',
-                    }
-                }
-                console.info('Unexpected Error deleting file from S3', err)
-                throw err
-            }
+            console.info(`deleteFile requested for ${filename} in ${bucket}`)
         },
         /*  
             Poll for scanning completion


### PR DESCRIPTION
## Summary

We have an ongoing issue where sometimes some files are being removed from s3 by `app-web`. While we work through this, we want to skip actually deleting files in the interim.

#### Related Issues:
https://jiraent.cms.gov/browse/MCR-4491
https://jiraent.cms.gov/browse/MCR-4531
