### PR TITLE
Add Salesforce model docs

### DIFF
--- a/docs/contract-rate-non-revision-design.md
+++ b/docs/contract-rate-non-revision-design.md
@@ -6,7 +6,7 @@ This is an ER diagram of the data that is planned to be sent to Salesforce on su
 erDiagram
 
 Contract {
-    String id
+    String externalID
     String externalURL
     DateTime initiallySubmittedAt
     DateTime updatedAt
@@ -54,7 +54,7 @@ Contract {
 }
 
 Rate {
-    String id
+    String externalID
     String externalURL
     DateTime initiallySubmittedAt
     DateTime updatedAt

--- a/docs/contract-rate-non-revision-design.md
+++ b/docs/contract-rate-non-revision-design.md
@@ -14,16 +14,17 @@ Contract {
     String name
     String mccrsID
     String submissionReason
+    Rate[] relatedRates
 
     String[] programNicknames
-    PopulationCoveredEnum populationCovered "MEDICAID, CHIP, MEDICAID_AND_CHIP" 
-    SubmissionTypeEnum submissionType "CONTRACT_ONLY, CONTRACT_AND_RATES"
+    Enum populationCovered "MEDICAID, CHIP, MEDICAID_AND_CHIP" 
+    Enum submissionType "CONTRACT_ONLY, CONTRACT_AND_RATES"
     Boolean riskBasedContract
     String submissionDescription
     Document[] contractDocuments
     Document[] supportingDocuments
-    ContractTypeEnum contractType "BASE, AMENDMENT"
-    ContractExecutionStatusEnum contractExecutionStatus "EXECUTED, UNEXECUTED"
+    Enum contractType "BASE, AMENDMENT"
+    Enum contractExecutionStatus "EXECUTED, UNEXECUTED"
     CalendarDate contractDateStart
     CalendarDate contractDateEnd
     String[] managedCareEntities
@@ -51,6 +52,7 @@ Contract {
     Boolean statutoryRegulatoryAttestation
     Boolean statutoryRegulatoryAttestationDescription
     
+    Contact[] stateContacts
 }
 
 Rate {
@@ -61,9 +63,10 @@ Rate {
     StateCode stateCode
     String name
     String submissionReason
+    Contract[] relatedContracts
     
-    RateTypeEnum rateType "NEW, AMENDMENT"
-    RateCapitationTypeEnum rateCapitationType "RATE_CELL, RATE_RANGE"
+    Enum rateType "NEW, AMENDMENT"
+    Enum rateCapitationType "RATE_CELL, RATE_RANGE"
 
     String[] programNicknames
     Document[] rateDocuments
@@ -76,6 +79,9 @@ Rate {
     CalendarDate amendmentEffectiveDateEnd
 
     Enum actuaryCommunicationPreference "OACT_TO_ACTUARY, OACT_TO_STATE"
+
+    Contact[] certifyingActuaries
+    Contact[] additionalActuaries
 }
 
 Document {

--- a/docs/contract-rate-non-revision-design.md
+++ b/docs/contract-rate-non-revision-design.md
@@ -1,0 +1,77 @@
+# Contract and Rate Without Revisions Design
+
+This is an ER diagram of the data that is planned to be sent to Salesforce on submission. It relies on Salesforce's native diff tracking so elides the concept of Revisions. 
+
+```mermaid
+erDiagram
+
+Contract {
+    String id
+    DateTime initiallySubmittedAt
+    DateTime updatedAt
+    StateCode stateCode
+    String name
+    String mccrsID
+
+    String[] programNicknames
+    PopulationCoveredEnum populationCovered "MEDICAID, CHIP, MEDICAID_AND_CHIP" 
+    SubmissionTypeEnum submissionType "CONTRACT_ONLY, CONTRACT_AND_RATES"
+    Boolean riskBasedContract
+    String submissionDescription
+    Document[] contractDocuments
+    Document[] supportingDocuments
+    ContractTypeEnum contractType "BASE, AMENDMENT"
+    ContractExecutionStatusEnum contractExecutionStatus "EXECUTED, UNEXECUTED"
+    CalendarDate contractDateStart
+    CalendarDate contractDateEnd
+    String[] managedCareEntities
+    String[] federalAuthorities
+    Boolean statutoryRegulatoryAttestation
+    String statutoryRegulatoryAttestationDescription
+
+    Boolean inLieuServicesAndSettings
+    Boolean modifiedBenefitsProvided
+    Boolean modifiedGeoAreaServed
+    Boolean modifiedMedicaidBeneficiaries
+    Boolean modifiedRiskSharingStrategy
+    Boolean modifiedIncentiveArrangements
+    Boolean modifiedWitholdAgreements
+    Boolean modifiedStateDirectedPayments
+    Boolean modifiedPassThroughPayments
+    Boolean modifiedPaymentsForMentalDiseaseInstitutions
+    Boolean modifiedMedicalLossRatioStandards
+    Boolean modifiedOtherFinancialPaymentIncentive
+    Boolean modifiedEnrollmentProcess
+    Boolean modifiedGrevienceAndAppeal
+    Boolean modifiedNetworkAdequacyStandards
+    Boolean modifiedLengthOfContract
+    Boolean modifiedNonRiskPaymentArrangements
+    Boolean statutoryRegulatoryAttestation
+    Boolean statutoryRegulatoryAttestationDescription
+    
+}
+
+Rate {
+    String id
+    DateTime initiallySubmittedAt
+    DateTime updatedAt
+    StateCode stateCode
+    String name
+    
+    RateTypeEnum rateType "NEW, AMENDMENT"
+    RateCapitationTypeEnum rateCapitationType "RATE_CELL, RATE_RANGE"
+
+    String[] programNicknames
+    Document[] rateDocuments
+    Document[] supportingDocuments
+
+    CalendarDate rateDateStart
+    CalendarDate rateDateEnd
+    CalendarDate rateDateCertified
+    CalendarDate amendmentEffectiveDateStart
+    CalendarDate amendmentEffectiveDateEnd
+}
+
+
+Contract }|--|{ Rate : "many to many"
+```

--- a/docs/contract-rate-non-revision-design.md
+++ b/docs/contract-rate-non-revision-design.md
@@ -7,11 +7,13 @@ erDiagram
 
 Contract {
     String id
+    String externalURL
     DateTime initiallySubmittedAt
     DateTime updatedAt
     StateCode stateCode
     String name
     String mccrsID
+    String submissionReason
 
     String[] programNicknames
     PopulationCoveredEnum populationCovered "MEDICAID, CHIP, MEDICAID_AND_CHIP" 
@@ -53,10 +55,12 @@ Contract {
 
 Rate {
     String id
+    String externalURL
     DateTime initiallySubmittedAt
     DateTime updatedAt
     StateCode stateCode
     String name
+    String submissionReason
     
     RateTypeEnum rateType "NEW, AMENDMENT"
     RateCapitationTypeEnum rateCapitationType "RATE_CELL, RATE_RANGE"
@@ -70,6 +74,8 @@ Rate {
     CalendarDate rateDateCertified
     CalendarDate amendmentEffectiveDateStart
     CalendarDate amendmentEffectiveDateEnd
+
+    Enum actuaryCommunicationPreference "OACT_TO_ACTUARY, OACT_TO_STATE"
 }
 
 Document {
@@ -77,8 +83,18 @@ Document {
     string fileName
 }
 
+Contact {
+    string email
+    string givenName
+    string familyName
+    string title
+    string ActuarialFirm
+}
 
 Contract }|--|{ Rate : "many to many"
 Contract ||--|{ Document : "one to many"
 Rate ||--|{ Document : "one to many"
+Rate }|--|{ Contact : "certifying actuaries"
+Rate }|--|{ Contact : "additional actuaries"
+Contract }|--|{ Contact : "state contacts"
 ```

--- a/docs/contract-rate-non-revision-design.md
+++ b/docs/contract-rate-non-revision-design.md
@@ -72,6 +72,13 @@ Rate {
     CalendarDate amendmentEffectiveDateEnd
 }
 
+Document {
+    FileData fileData
+    string fileName
+}
+
 
 Contract }|--|{ Rate : "many to many"
+Contract ||--|{ Document : "one to many"
+Rate ||--|{ Document : "one to many"
 ```

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -1725,7 +1725,7 @@ type RatePackageSubmission {
 }
 
 """
-Contact is a single contract submission, holding all the form data for a single contract
+Contract is a single contract submission, holding all the form data for a single contract
 and associated with zero or more Rates
 """
 type Contract {
@@ -1777,7 +1777,7 @@ type Contract {
 }
 
 """
-UnlockedContact is a single unlocked contract, holding all the draft form data for a single contract
+UnlockedContract is a single unlocked contract, holding all the draft form data for a single contract
 and associated with zero or more Rates
 """
 type UnlockedContract {


### PR DESCRIPTION
## Summary

Added docs with all the fields I think we need to send to salesforce for the POC. 

Notably not sending any "revision" info, just straight contract and rate b/c Salesforce does auto-history-tracking

Also left out contacts for now, we use those for emailing which Salesforce doesn't need to do for us now so it reduces the complexity. 

#### Related issues

https://jiraent.cms.gov/browse/MCR-4493