### PR TITLE
S3 document audit enhancements

### DIFF
--- a/services/app-api/src/handlers/audit_s3.ts
+++ b/services/app-api/src/handlers/audit_s3.ts
@@ -70,11 +70,14 @@ const main: Handler = async (): Promise<APIGatewayProxyResultV2> => {
             missingOrErrorDocuments.push(processResult)
         }
     }
+
+    const uniqueDocuments = deduplicateDocuments(missingOrErrorDocuments)
     console.info(
-        `Missing ${missingOrErrorDocuments.length} of ${docResult.length} documents`
+        `Missing ${uniqueDocuments.length} of ${docResult.length} documents`
     )
+
     console.info(
-        `These documents could not be retreived from s3: ${JSON.stringify(missingOrErrorDocuments)}`
+        `These documents could not be retreived from s3: ${JSON.stringify(uniqueDocuments)}`
     )
 
     const success: APIGatewayProxyResultV2 = {
@@ -163,6 +166,18 @@ async function processDocument(
         )
         return doc
     }
+}
+
+function deduplicateDocuments(documents: AuditDocument[]): AuditDocument[] {
+    const uniqueDocuments = new Map<string, AuditDocument>()
+
+    for (const doc of documents) {
+        if (!uniqueDocuments.has(doc.s3URL)) {
+            uniqueDocuments.set(doc.s3URL, doc)
+        }
+    }
+
+    return Array.from(uniqueDocuments.values())
 }
 
 module.exports = { main }


### PR DESCRIPTION
## Summary

This adds some enhancements to the last PR to add the audit lambda in #2844.

We now dedup the documents coming back as well as go back in and fetch the parent contract or rate associated with the missing file.

#### Related issues
https://github.com/Enterprise-CMCS/managed-care-review/pull/2844
