### PR TITLE
Fix rate summary sidenav layout route not showing.

### DIFF
--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -135,7 +135,9 @@ const StateUserRoutes = ({
                 )}
                 <Route element={<SubmissionSideNav />}>
                     <Route
-                        path={RoutesRecord.SUBMISSIONS_CONTRACT_QUESTIONS_AND_ANSWERS}
+                        path={
+                            RoutesRecord.SUBMISSIONS_CONTRACT_QUESTIONS_AND_ANSWERS
+                        }
                         element={<QuestionResponse />}
                     />
                     <Route
@@ -218,7 +220,9 @@ const CMSUserRoutes = ({
 
                 <Route element={<SubmissionSideNav />}>
                     <Route
-                        path={RoutesRecord.SUBMISSIONS_CONTRACT_QUESTIONS_AND_ANSWERS}
+                        path={
+                            RoutesRecord.SUBMISSIONS_CONTRACT_QUESTIONS_AND_ANSWERS
+                        }
                         element={<QuestionResponse />}
                     />
                     <Route
@@ -231,10 +235,6 @@ const CMSUserRoutes = ({
                     />
                 </Route>
 
-                <Route
-                    path={RoutesRecord.RATES_SUMMARY}
-                    element={<RateSummary />}
-                />
                 {showQAbyRates ? (
                     <>
                         <Route element={<RateSummarySideNav />}>
@@ -249,9 +249,9 @@ const CMSUserRoutes = ({
                                 element={<RateQuestionResponse />}
                             />
                             <Route
-                                path={RoutesRecord.RATES_UPLOAD_QUESTION }
-                                element={<UploadRateQuestions/>}
-                                />
+                                path={RoutesRecord.RATES_UPLOAD_QUESTION}
+                                element={<UploadRateQuestions />}
+                            />
                             {/*This route will cause the RateSummarySideNav to redirect to rate summary Q&A page*/}
                             <Route
                                 path={


### PR DESCRIPTION
## Summary

There was an extra `RATES_SUMMARY` route that prevented the layout route from being hit.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
