### PR TITLE
Change Back to dashboard to Go to dashboard

### DIFF
--- a/services/app-web/src/pages/QuestionResponse/RateQuestionResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/RateQuestionResponse.tsx
@@ -18,11 +18,15 @@ import { handleApolloError } from '../../gqlHelpers/apolloErrors'
 import { Error404 } from '../Errors/Error404Page'
 import { recordJSException } from '../../otelHelpers'
 import { RoutesRecord } from '../../constants'
+import { usePage } from '../../contexts/PageContext'
+import { useEffect, useState } from 'react'
 
 export const RateQuestionResponse = () => {
     const { id } = useParams() as { id: string }
     const { loggedInUser } = useAuth()
     const { pathname } = useLocation()
+    const { updateHeading } = usePage()
+    const [rateName, setRateName] = useState<string | undefined>(undefined)
     const hasCMSPermissions = hasCMSUserPermissions(loggedInUser)
     let division: Division | undefined = undefined
 
@@ -39,6 +43,10 @@ export const RateQuestionResponse = () => {
         },
         fetchPolicy: 'network-only',
     })
+
+    useEffect(() => {
+        updateHeading({ customHeading: rateName })
+    }, [rateName, updateHeading])
 
     if (loading) {
         return (
@@ -68,6 +76,13 @@ export const RateQuestionResponse = () => {
 
     if (rate?.status === 'DRAFT' || !loggedInUser || !rateRev) {
         return <GenericErrorPage />
+    }
+
+    if (
+        rateName !== rateRev.formData.rateCertificationName &&
+        rateRev.formData.rateCertificationName
+    ) {
+        setRateName(rateRev.formData.rateCertificationName)
     }
 
     if (hasCMSPermissions) {

--- a/services/app-web/src/pages/SubmissionSideNav/RateSummarySideNav.test.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/RateSummarySideNav.test.tsx
@@ -56,7 +56,7 @@ describe('RateSummarySideNav', () => {
 
         // Expect to only have one back to dashboard link.
         expect(
-            await screen.findAllByRole('link', { name: /Back to dashboard/ })
+            await screen.findAllByRole('link', { name: /Go to dashboard/ })
         ).toHaveLength(1)
 
         const summaryLink = withinSideNav.getByRole('link', {
@@ -154,7 +154,7 @@ describe('RateSummarySideNav', () => {
 
         // Expect to only have one back to dashboard link.
         expect(
-            await screen.findAllByRole('link', { name: /Back to dashboard/ })
+            await screen.findAllByRole('link', { name: /Go to dashboard/ })
         ).toHaveLength(1)
 
         const summaryLink = withinSideNav.getByRole('link', {

--- a/services/app-web/src/pages/SubmissionSideNav/RateSummarySideNav.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/RateSummarySideNav.tsx
@@ -102,7 +102,7 @@ export const RateSummarySideNav = () => {
                             event_name="back_button"
                         >
                             <Icon.ArrowBack />
-                            <span>{` Back to dashboard`}</span>
+                            <span>{` Go to dashboard`}</span>
                         </NavLinkWithLogging>
                     </div>
                     <SideNav

--- a/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.test.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.test.tsx
@@ -62,14 +62,14 @@ describe('SubmissionSideNav', () => {
         })
 
         // Wait for sidebar nav and sections to exist. Addresses test flakes to wait for these up front.
-           await screen.findByTestId('sidenav')
-           await screen.findByText(/Contract questions/)
+        await screen.findByTestId('sidenav')
+        await screen.findByText(/Contract questions/)
 
         const withinSideNav = within(screen.getByTestId('sidenav'))
 
         // Expect to only have one back to dashboard link.
         expect(
-            await screen.findAllByRole('link', { name: /Back to dashboard/ })
+            await screen.findAllByRole('link', { name: /Go to dashboard/ })
         ).toHaveLength(1)
 
         const summaryLink = withinSideNav.getByRole('link', {
@@ -140,10 +140,10 @@ describe('SubmissionSideNav', () => {
             },
         })
 
-         // Wait for sidebar nav and sections to exist. Addresses test flakes to wait for these up front.
-         await screen.findByTestId('sidenav')
-         await screen.findByText(/Contract questions/)
-         await screen.findAllByText(/Rate questions/)
+        // Wait for sidebar nav and sections to exist. Addresses test flakes to wait for these up front.
+        await screen.findByTestId('sidenav')
+        await screen.findByText(/Contract questions/)
+        await screen.findAllByText(/Rate questions/)
 
         const withinSideNav = within(screen.getByTestId('sidenav'))
 
@@ -311,7 +311,7 @@ describe('SubmissionSideNav', () => {
 
         // Navigate to dashboard using back to dashboard link
         await userEvent.click(
-            screen.getByRole('link', { name: /Back to dashboard/ })
+            screen.getByRole('link', { name: /Go to dashboard/ })
         )
         await waitFor(() => {
             expect(testLocation.pathname).toBe(`/dashboard/submissions`)
@@ -339,7 +339,7 @@ describe('SubmissionSideNav', () => {
             },
         })
         expect(
-            await screen.findByRole('link', { name: /Back to state dashboard/ })
+            await screen.findByRole('link', { name: /Go to state dashboard/ })
         ).toBeInTheDocument()
     })
 
@@ -367,7 +367,7 @@ describe('SubmissionSideNav', () => {
 
         expect(
             await screen.findByRole('link', {
-                name: /Back to dashboard/,
+                name: /Go to dashboard/,
             })
         ).toBeInTheDocument()
     })

--- a/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
@@ -203,9 +203,9 @@ export const SubmissionSideNav = () => {
                             >
                                 <Icon.ArrowBack />
                                 {loggedInUser?.__typename === 'StateUser' ? (
-                                    <span>&nbsp;Back to state dashboard</span>
+                                    <span>&nbsp;Go to state dashboard</span>
                                 ) : (
-                                    <span>&nbsp;Back to dashboard</span>
+                                    <span>&nbsp;Go to dashboard</span>
                                 )}
                             </NavLinkWithLogging>
                         </div>

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -395,7 +395,7 @@ describe('SubmissionSummary', () => {
 
                 expect(
                     await screen.findByRole('link', {
-                        name: /Back to dashboard/,
+                        name: /Go to dashboard/,
                     })
                 ).toBeInTheDocument()
             })
@@ -970,7 +970,7 @@ describe('SubmissionSummary', () => {
             ).toBeInTheDocument()
             expect(
                 await screen.findByRole('link', {
-                    name: /Back to state dashboard/,
+                    name: /Go to state dashboard/,
                 })
             ).toBeInTheDocument()
         })

--- a/services/cypress/integration/cmsWorkflow/rateReview.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/rateReview.spec.ts
@@ -80,7 +80,7 @@ describe('CMS user can view rate reviews', () => {
 
             // Go back to dashboard and check both rates in the table
             // check the dashboard has the columns we expect
-            cy.findByText('Back to dashboard').should('exist').click()
+            cy.findByText('Go to dashboard').should('exist').click()
             cy.url({ timeout: 10_000 }).should('contain', 'rate-reviews')
             cy.findByText('Rate reviews').should('exist')
             cy.get('thead')

--- a/services/cypress/integration/stateWorkflow/submissionSummary.spec.ts
+++ b/services/cypress/integration/stateWorkflow/submissionSummary.spec.ts
@@ -93,7 +93,7 @@ describe('State user can view submissions', () => {
            cy.findByText(/You must provide this information/).should('not.exist')
 
             // Link back to dashboard, submission visible in default program
-            cy.findByText('Back to state dashboard').should('exist').click()
+            cy.findByText('Go to state dashboard').should('exist').click()
             cy.findByText('Submissions dashboard').should('exist')
             // check the table of submissions--find a draft row, then the link in the ID column
             cy.get('table')


### PR DESCRIPTION
## Summary
[MCR-2553](https://jiraent.cms.gov/browse/MCR-2553)

Fix back link text. `Back to dashboard` -> `Go to dashboard`

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
