### PR TITLE
Use ipv4 address in jumpbox clone

### DIFF
--- a/dev_tool/src/jumpbox.ts
+++ b/dev_tool/src/jumpbox.ts
@@ -140,7 +140,7 @@ async function ensureAllowlistIP(
     instance: Instance
 ): Promise<undefined | Error> {
     // get my IP address
-    const myIPAddress = await httpRequest('http://ifconfig.me/ip')
+    const myIPAddress = await httpRequest('https://api4.ipify.org')
     if (myIPAddress instanceof Error) {
         return myIPAddress
     }


### PR DESCRIPTION
## Summary
Meghan had an issue running the jumpbox clone command to get some prod data. Turns out her home network has both ipv6 and ipv4 external addresses, and the command to get her external address was returning the ipv6 address, but ssh/scp defaults to ipv4.

Here we just add the ipv4 address explicitly to the allowlist.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4501