### PR TITLE
Fix rate Q&A links not showing depreciated rate names.

### DIFF
--- a/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.test.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.test.tsx
@@ -115,7 +115,31 @@ describe('SubmissionSideNav', () => {
                 rateProgramIDs: ['ea16a6c0-5fc6-4df8-adac-c627e76660ab'],
             },
         }
+        const thirdRate: RateRevision = {
+            ...rateRevision,
+            id: 'third-rate-revision',
+            rateID: 'third-rate',
+            formData: {
+                ...rateRevision.formData,
+                rateProgramIDs: [],
+                deprecatedRateProgramIDs: [
+                    '3fd36500-bf2c-47bc-80e8-e7aa417184c5',
+                ],
+            },
+        }
+        const fourthRate: RateRevision = {
+            ...rateRevision,
+            id: 'fourth-rate-revision',
+            rateID: 'fourth-rate',
+            formData: {
+                ...rateRevision.formData,
+                rateProgramIDs: [],
+                deprecatedRateProgramIDs: [],
+            },
+        }
         contract.packageSubmissions[0].rateRevisions.push(secondRate)
+        contract.packageSubmissions[0].rateRevisions.push(thirdRate)
+        contract.packageSubmissions[0].rateRevisions.push(fourthRate)
 
         renderWithProviders(<CommonRoutes />, {
             apolloProvider: {
@@ -195,6 +219,32 @@ describe('SubmissionSideNav', () => {
         expect(rate2Link).toHaveAttribute(
             'href',
             '/submissions/15/rate/second-rate/question-and-answers'
+        )
+
+        const rate3Link = withinSideNav.getByRole('link', {
+            name: /Rate questions: MSHO/,
+        })
+        // Expect third rate link using depreciated rates to exist within sidebar nav.
+        expect(rate3Link).toBeInTheDocument()
+        // Expect second rate link using depreciated rates to not be currently selected
+        expect(rate3Link).not.toHaveClass('usa-current')
+        // Expect second rate link using depreciated rates to have correct href url
+        expect(rate3Link).toHaveAttribute(
+            'href',
+            '/submissions/15/rate/third-rate/question-and-answers'
+        )
+
+        const rate4Link = withinSideNav.getByRole('link', {
+            name: 'Rate questions: Unknown Program(s)',
+        })
+        // Expect fourth rate link falling back to UnknownProgram to exist within sidebar nav.
+        expect(rate4Link).toBeInTheDocument()
+        // Expect fourth rate link falling back to UnknownProgram to not be currently selected
+        expect(rate4Link).not.toHaveClass('usa-current')
+        // Expect fourth rate link falling back to UnknownProgram to have correct href url
+        expect(rate4Link).toHaveAttribute(
+            'href',
+            '/submissions/15/rate/fourth-rate/question-and-answers'
         )
     })
 

--- a/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
@@ -155,7 +155,13 @@ export const SubmissionSideNav = () => {
         }
 
         return rateRevision.map((rev) => {
-            const ratePrograms = rev.formData.rateProgramIDs
+            const useDeprecatedRateProgramIDs =
+                rev.formData.deprecatedRateProgramIDs.length > 0 &&
+                rev.formData.rateProgramIDs.length === 0
+            const ratePrograms = useDeprecatedRateProgramIDs
+                ? rev.formData.deprecatedRateProgramIDs
+                : rev.formData.rateProgramIDs
+            const rateProgramNames = ratePrograms
                 .map(
                     (id) =>
                         programs.find((program) => program.id === id)?.name ||
@@ -169,7 +175,7 @@ export const SubmissionSideNav = () => {
                     event_name="navigation_clicked"
                 >
                     Rate questions: <br />
-                    {ratePrograms}
+                    {rateProgramNames || 'Unknown Program(s)'}
                 </NavLinkWithLogging>
             )
         })


### PR DESCRIPTION
## Summary

If you go on VAL or DEV, earlier submissions with `deprecatedRateProgramIDs` and no `rateProgramIDs` would show empty rate Q&A links.

This fix adds code to switch to `deprecatedRateProgramIDs` if:
- `deprecatedRateProgramIDs` has programs
- `rateProgramIDs` has no programs

If both conditions are not met, the link will fallback to the text `Rate questions: Unknown Program(s)`

#### Related issues

#### Screenshots

#### Test cases covered

`SubmissionSideNav.test.tsx`
- `'loads sidebar nav with expected links for state user'`
   - I updated this test to Include rates for both no programs and only `deprecatedRateProgramIDs`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

- You wont be able to test this on the review app, since we do not have submissions from a time where `deprecatedRateProgramIDs` would exist.

<!---These are developer instructions on how to test or validate the work -->
