### PR TITLE
Fix test url from merges

### DIFF
--- a/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.test.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.test.tsx
@@ -231,7 +231,7 @@ describe('SubmissionSideNav', () => {
         // Expect second rate link using depreciated rates to have correct href url
         expect(rate3Link).toHaveAttribute(
             'href',
-            '/submissions/15/rate/third-rate/question-and-answers'
+            '/submissions/15/rates/third-rate/question-and-answers'
         )
 
         const rate4Link = withinSideNav.getByRole('link', {
@@ -244,7 +244,7 @@ describe('SubmissionSideNav', () => {
         // Expect fourth rate link falling back to UnknownProgram to have correct href url
         expect(rate4Link).toHaveAttribute(
             'href',
-            '/submissions/15/rate/fourth-rate/question-and-answers'
+            '/submissions/15/rates/fourth-rate/question-and-answers'
         )
     })
 


### PR DESCRIPTION
## Summary

`SubmissionSideNav` test failing, due to updates in route paths.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
