### PR TITLE
MCR-4480: states see distinct table for rate questions

### DIFF
--- a/services/app-web/src/pages/QuestionResponse/QATable/CMSQuestionResponseTable.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/CMSQuestionResponseTable.tsx
@@ -1,8 +1,6 @@
 import {
     ContractQuestionList,
     Division,
-    IndexContractQuestionsPayload,
-    IndexRateQuestionsPayload,
     RateQuestionList,
 } from '../../../gen/gqlClient'
 import type { QuestionRounds } from './QuestionResponseRound'
@@ -10,10 +8,7 @@ import { QuestionResponseRound } from './QuestionResponseRound'
 import { NavLinkWithLogging, SectionHeader } from '../../../components'
 import styles from '../QuestionResponse.module.scss'
 import { useAuth } from '../../../contexts/AuthContext'
-
-type IndexQuestionType =
-    | IndexContractQuestionsPayload
-    | IndexRateQuestionsPayload
+import { IndexQuestionType } from '../QuestionResponseHelpers'
 
 type CMSQuestionResponseTableProps = {
     indexQuestions: IndexQuestionType

--- a/services/app-web/src/pages/QuestionResponse/QATable/QuestionResponseRound.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/QuestionResponseRound.tsx
@@ -1,7 +1,8 @@
 import { RateQuestion, ContractQuestion, User } from '../../../gen/gqlClient'
 import styles from './QATable.module.scss'
-import { LinkWithLogging } from '../../../components'
+import { LinkWithLogging, NavLinkWithLogging } from '../../../components'
 import { formatCalendarDate } from '../../../common-code/dateHelpers'
+import classNames from 'classnames'
 
 type QuestionType =
     | Omit<RateQuestion, 'rateID'>
@@ -23,6 +24,8 @@ export const QuestionResponseRound = ({
     roundTitle: string
     currentUser?: User
 }) => {
+    const isStateUser = currentUser?.__typename === 'StateUser'
+
     // Combines question and response documents and sorts them in desc order.
     const documents = [
         ...question.documents.map((doc) => ({
@@ -59,10 +62,23 @@ export const QuestionResponseRound = ({
         return `${addedBy.givenName}`
     }
 
+    const classes = classNames('usa-button', {
+        'usa-button--outline': question.responses.length > 0,
+    })
+
     return (
-        <div>
+        <div data-testid="questionResponseRound">
             <div className={styles.tableHeader}>
                 <h4>{roundTitle}</h4>
+                {isStateUser && (
+                    <NavLinkWithLogging
+                        className={classes}
+                        variant="unstyled"
+                        to={`./${question.division.toLowerCase()}/${question.id}/upload-response`}
+                    >
+                        Upload response
+                    </NavLinkWithLogging>
+                )}
             </div>
             <table
                 className={`borderTopLinearGradient ${styles.qaDocumentTable}`}

--- a/services/app-web/src/pages/QuestionResponse/QATable/StateQuestionResponseTable.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/StateQuestionResponseTable.tsx
@@ -1,71 +1,99 @@
-import {
-    IndexContractQuestionsPayload,
-    IndexRateQuestionsPayload,
-} from '../../../gen/gqlClient'
+import { ContractQuestionList, RateQuestionList } from '../../../gen/gqlClient'
 import { SectionHeader } from '../../../components'
 import styles from '../QuestionResponse.module.scss'
 import { useAuth } from '../../../contexts/AuthContext'
-import { extractQuestions, QuestionData } from '../QuestionResponseHelpers'
-import { QATable } from './QATable'
-
-type Division = 'DMCO' |  'DMCP' | 'OACT'
-type IndexQuestionType =
-    | IndexContractQuestionsPayload
-    | IndexRateQuestionsPayload
+import { divisionFullNames } from '../QuestionResponseHelpers'
+import type { IndexQuestionType } from '../QuestionResponseHelpers'
+import { QuestionResponseRound, QuestionRounds } from './QuestionResponseRound'
 
 type StateQuestionResponseTableProps = {
     indexQuestions: IndexQuestionType
 }
-type QuestionTableDataType = {
-    division: Division // eventually rip out division logic, replace with answered/unanswered
-    questions: QuestionData[]
-}
+
 export const StateQuestionResponseTable = ({
     indexQuestions,
 }: StateQuestionResponseTableProps) => {
     const { loggedInUser } = useAuth()
-    const questions: QuestionTableDataType[] = []
-    const divisions: Division[] =   ['DMCO', 'DMCP', 'OACT']
-    divisions.forEach(
-        (division) =>
-            indexQuestions[`${division}Questions`].totalCount &&
-            questions.push({
-                division: division,
-                questions: extractQuestions(
-                    indexQuestions[`${division}Questions`].edges
-                ),
+    const answeredQuestions: QuestionRounds = []
+    const unansweredQuestions: QuestionRounds = []
+
+    // Bucket questions
+    Object.entries(indexQuestions).forEach(([key, value]) => {
+        if (key === '__typename') {
+            return
+        }
+        const questionsList: RateQuestionList | ContractQuestionList = value
+
+        // reverse questions to the earliest question first as rounds would be mismatched when looping through two arrays of different lengths
+        Array.from([...questionsList.edges])
+            .reverse()
+            .forEach(({ node }, index) => {
+                if (node.responses.length > 0) {
+                    if (!answeredQuestions[index]) {
+                        answeredQuestions[index] = []
+                    }
+                    answeredQuestions[index].push({
+                        roundTitle: `Asked by: ${divisionFullNames[node.division]}`,
+                        questionData: node,
+                    })
+                } else {
+                    if (!unansweredQuestions[index]) {
+                        unansweredQuestions[index] = []
+                    }
+                    unansweredQuestions[index].push({
+                        roundTitle: `Asked by: ${divisionFullNames[node.division]}`,
+                        questionData: node,
+                    })
+                }
             })
-    )
-const mapQASections = () =>
-    questions.map((divisionQuestions) => (
-        <section
-            key={divisionQuestions.division}
-            className={styles.questionSection}
-            data-testid={`${divisionQuestions.division.toLowerCase()}-qa-section`}
-        >
-            <h4>{`Asked by ${divisionQuestions.division}`}</h4>
-            {divisionQuestions.questions.map((question, index) => (
-                <QATable
-                    key={question.id}
-                    question={question}
-                    division={divisionQuestions.division}
-                    round={divisionQuestions.questions.length - index}
-                    user={loggedInUser!}
-                />
-            ))}
-        </section>
-    ))
+    })
 
     return (
         <>
-
             <section
                 className={styles.questionSection}
-                data-testid={'questions'}
+                data-testid={'outstandingQuestions'}
             >
-                <SectionHeader header="All questions" />
-                {questions.length ? (
-                  mapQASections()
+                <SectionHeader header="Outstanding questions" />
+                {unansweredQuestions.length ? (
+                    unansweredQuestions
+                        .reverse()
+                        .map((questionRound) =>
+                            questionRound.map(
+                                ({ roundTitle, questionData }) => (
+                                    <QuestionResponseRound
+                                        key={questionData.id}
+                                        question={questionData}
+                                        roundTitle={roundTitle}
+                                        currentUser={loggedInUser}
+                                    />
+                                )
+                            )
+                        )
+                ) : (
+                    <p>No questions have been submitted yet.</p>
+                )}
+            </section>
+            <section
+                className={styles.questionSection}
+                data-testid={'answeredQuestions'}
+            >
+                <SectionHeader header="Answered questions" />
+                {answeredQuestions.length ? (
+                    answeredQuestions
+                        .reverse()
+                        .map((questionRound) =>
+                            questionRound.map(
+                                ({ roundTitle, questionData }) => (
+                                    <QuestionResponseRound
+                                        key={questionData.id}
+                                        question={questionData}
+                                        roundTitle={roundTitle}
+                                        currentUser={loggedInUser}
+                                    />
+                                )
+                            )
+                        )
                 ) : (
                     <p>No questions have been submitted yet.</p>
                 )}

--- a/services/app-web/src/pages/QuestionResponse/QATable/StateQuestionResponseTable.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/StateQuestionResponseTable.tsx
@@ -8,10 +8,12 @@ import { QuestionResponseRound, QuestionRounds } from './QuestionResponseRound'
 
 type StateQuestionResponseTableProps = {
     indexQuestions: IndexQuestionType
+    rateCertName?: string
 }
 
 export const StateQuestionResponseTable = ({
     indexQuestions,
+    rateCertName,
 }: StateQuestionResponseTableProps) => {
     const { loggedInUser } = useAuth()
     const answeredQuestions: QuestionRounds = []
@@ -50,6 +52,12 @@ export const StateQuestionResponseTable = ({
 
     return (
         <>
+            <div className={styles.tableHeader}>
+                <SectionHeader
+                    header={`Rate questions: ${rateCertName}`}
+                    hideBorder
+                />
+            </div>
             <section
                 className={styles.questionSection}
                 data-testid={'outstandingQuestions'}

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponse.module.scss
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponse.module.scss
@@ -11,6 +11,12 @@
     padding: 2rem 0;
 }
 
+.tableHeader {
+    h2 {
+        margin-bottom: 0;
+    }
+}
+
 %questionSection {
     margin: uswds.units(2) auto;
     background: custom.$mcr-foundation-white;
@@ -21,6 +27,7 @@
     @include uswds.u-radius('md');
 
     h2 {
+        margin: 0;
         font-weight: normal;
     }
 

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponseHelpers/index.ts
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponseHelpers/index.ts
@@ -1,2 +1,2 @@
-export { extractQuestions, getDivisionOrder, getUserDivision } from './questionResponseHelpers'
-export type { QuestionData, QuestionDocumentWithLink, DivisionQuestionDataType } from './questionResponseHelpers'
+export { extractQuestions, getDivisionOrder, getUserDivision, divisionFullNames } from './questionResponseHelpers'
+export type { QuestionData, QuestionDocumentWithLink, DivisionQuestionDataType, IndexQuestionType } from './questionResponseHelpers'

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponseHelpers/questionResponseHelpers.ts
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponseHelpers/questionResponseHelpers.ts
@@ -27,6 +27,16 @@ type QuestionDocumentWithLink = {
     url?: string | null
 }
 
+type IndexQuestionType =
+    | IndexContractQuestionsPayload
+    | IndexRateQuestionsPayload
+
+const divisionFullNames = {
+    DMCO: 'Division of Managed Care Operations (DMCO)',
+    DMCP: 'Division of Managed Care Policy (DMCP)',
+    OACT: 'Office of the Actuary (OACT)'
+}
+
 const extractQuestions = (edges?: (ContractQuestionEdge | RateQuestionEdge)[]): QuestionData[] => {
     if (!edges) {
         return []
@@ -63,10 +73,12 @@ export {
     extractQuestions,
     getUserDivision,
     getDivisionOrder,
+    divisionFullNames
 }
 
 export type {
     QuestionData,
     QuestionDocumentWithLink,
-    DivisionQuestionDataType
+    DivisionQuestionDataType,
+    IndexQuestionType
 }

--- a/services/app-web/src/pages/QuestionResponse/RateQuestionResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/RateQuestionResponse.tsx
@@ -7,10 +7,7 @@ import {
 } from '../../gen/gqlClient'
 import { useParams, matchPath, useLocation } from 'react-router-dom'
 import { GridContainer } from '@trussworks/react-uswds'
-import {
-    QuestionResponseSubmitBanner,
-    SectionHeader,
-} from '../../components'
+import { QuestionResponseSubmitBanner } from '../../components'
 import { GenericErrorPage } from '../Errors/GenericErrorPage'
 import { hasCMSUserPermissions } from '../../gqlHelpers'
 import { getUserDivision } from './QuestionResponseHelpers'
@@ -18,7 +15,10 @@ import { UserAccountWarningBanner } from '../../components/Banner'
 import { ContactSupportLink } from '../../components/ErrorAlert/ContactSupportLink'
 import { useAuth } from '../../contexts/AuthContext'
 import { RoutesRecord } from '../../constants'
-import { ErrorOrLoadingPage, handleAndReturnErrorState } from '../StateSubmission/ErrorOrLoadingPage'
+import {
+    ErrorOrLoadingPage,
+    handleAndReturnErrorState,
+} from '../StateSubmission/ErrorOrLoadingPage'
 import { usePage } from '../../contexts/PageContext'
 import { CMSQuestionResponseTable } from './QATable/CMSQuestionResponseTable'
 import { StateQuestionResponseTable } from './QATable/StateQuestionResponseTable'
@@ -57,14 +57,12 @@ export const RateQuestionResponse = () => {
     }
 
     if (error) {
-        return (
-            <ErrorOrLoadingPage
-                state={handleAndReturnErrorState(error)}
-            />
-        )
+        return <ErrorOrLoadingPage state={handleAndReturnErrorState(error)} />
     }
     const rate = data?.fetchRate.rate
     const rateRev = rate?.packageSubmissions?.[0]?.rateRevision
+    const rateCertificationName =
+        rateRev?.formData.rateCertificationName ?? undefined
 
     if (
         rate?.status === 'DRAFT' ||
@@ -75,11 +73,8 @@ export const RateQuestionResponse = () => {
         return <GenericErrorPage />
     }
 
-    if (
-        rateName !== rateRev.formData.rateCertificationName &&
-        rateRev.formData.rateCertificationName
-    ) {
-        setRateName(rateRev.formData.rateCertificationName)
+    if (rateCertificationName && rateName !== rateCertificationName) {
+        setRateName(rateCertificationName)
     }
 
     if (hasCMSPermissions) {
@@ -102,24 +97,21 @@ export const RateQuestionResponse = () => {
                         }
                     />
                 )}
+
                 {submitType && (
                     <QuestionResponseSubmitBanner submitType={submitType} />
                 )}
+
                 {hasCMSPermissions ? (
                     <CMSQuestionResponseTable
                         indexQuestions={rate.questions}
                         userDivision={division}
                     />
                 ) : (
-                    <>
-                        <SectionHeader
-                            header={`Rate questions: ${rateRev.formData.rateCertificationName}`}
-                            hideBorder
-                        />
-                        <StateQuestionResponseTable
-                         indexQuestions={rate.questions}
-                        />
-                    </>
+                    <StateQuestionResponseTable
+                        indexQuestions={rate.questions}
+                        rateCertName={rateCertificationName}
+                    />
                 )}
             </GridContainer>
         </div>

--- a/services/app-web/src/testHelpers/apolloMocks/rateDataMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/rateDataMock.ts
@@ -539,25 +539,6 @@ function mockRateSubmittedWithQuestions(
                         __typename: 'RateQuestionEdge' as const,
                         node: {
                             __typename: 'RateQuestion' as const,
-                            id: 'dmco-question-1-id',
-                            rateID,
-                            createdAt: new Date('2022-12-15'),
-                            addedBy: mockValidCMSUser(),
-                            documents: [
-                                {
-                                    s3URL: 's3://bucketname/key/dmco-question-1-document-1',
-                                    name: 'dmco-question-1-document-1',
-                                    downloadURL: expect.any(String),
-                                },
-                            ],
-                            division: 'DMCO',
-                            responses:[],
-                        },
-                    },
-                    {
-                        __typename: 'RateQuestionEdge' as const,
-                        node: {
-                            __typename: 'RateQuestion' as const,
                             id: 'dmco-question-2-id',
                             rateID,
                             createdAt: new Date('2022-12-18'),
@@ -591,6 +572,25 @@ function mockRateSubmittedWithQuestions(
                                     ],
                                 },
                             ],
+                        },
+                    },
+                    {
+                        __typename: 'RateQuestionEdge' as const,
+                        node: {
+                            __typename: 'RateQuestion' as const,
+                            id: 'dmco-question-1-id',
+                            rateID,
+                            createdAt: new Date('2022-12-15'),
+                            addedBy: mockValidCMSUser(),
+                            documents: [
+                                {
+                                    s3URL: 's3://bucketname/key/dmco-question-1-document-1',
+                                    name: 'dmco-question-1-document-1',
+                                    downloadURL: expect.any(String),
+                                },
+                            ],
+                            division: 'DMCO',
+                            responses:[],
                         },
                     },
                 ],
@@ -645,6 +645,42 @@ function mockRateSubmittedWithQuestions(
                         __typename: 'RateQuestionEdge' as const,
                         node: {
                             __typename: 'RateQuestion' as const,
+                            id: 'oact-question-2-id',
+                            rateID,
+                            createdAt: new Date('2022-12-16'),
+                            addedBy: mockValidCMSUser({
+                                divisionAssignment: 'OACT',
+                            }) as CmsUser,
+                            documents: [
+                                {
+                                    s3URL: 's3://bucketname/key/oact-question-1-document-1',
+                                    name: 'oact-question-2-document-1',
+                                    downloadURL: expect.any(String),
+                                },
+                            ],
+                            division: 'OACT',
+                            responses: [
+                                {
+                                    __typename: 'QuestionResponse' as const,
+                                    id: 'response-to-oact-2-id',
+                                    questionID: 'oact-question-2-id',
+                                    addedBy: mockValidUser() as StateUser,
+                                    createdAt: new Date('2022-12-16'),
+                                    documents: [
+                                        {
+                                            s3URL: 's3://bucketname/key/response-to-oact-1-document-1',
+                                            name: 'response-to-oact-2-document-1',
+                                            downloadURL: expect.any(String),
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    },
+                    {
+                        __typename: 'RateQuestionEdge' as const,
+                        node: {
+                            __typename: 'RateQuestion' as const,
                             id: 'oact-question-1-id',
                             rateID,
                             createdAt: new Date('2022-12-15'),
@@ -670,42 +706,6 @@ function mockRateSubmittedWithQuestions(
                                         {
                                             s3URL: 's3://bucketname/key/response-to-oact-1-document-1',
                                             name: 'response-to-oact-1-document-1',
-                                            downloadURL: expect.any(String),
-                                        },
-                                    ],
-                                },
-                            ],
-                        },
-                    },
-                    {
-                        __typename: 'RateQuestionEdge' as const,
-                        node: {
-                            __typename: 'RateQuestion' as const,
-                            id: 'oact-question-2-id',
-                            rateID,
-                            createdAt: new Date('2022-12-15'),
-                            addedBy: mockValidCMSUser({
-                                divisionAssignment: 'OACT',
-                            }) as CmsUser,
-                            documents: [
-                                {
-                                    s3URL: 's3://bucketname/key/oact-question-1-document-1',
-                                    name: 'oact-question-2-document-1',
-                                    downloadURL: expect.any(String),
-                                },
-                            ],
-                            division: 'OACT',
-                            responses: [
-                                {
-                                    __typename: 'QuestionResponse' as const,
-                                    id: 'response-to-oact-2-id',
-                                    questionID: 'oact-question-2-id',
-                                    addedBy: mockValidUser() as StateUser,
-                                    createdAt: new Date('2022-12-16'),
-                                    documents: [
-                                        {
-                                            s3URL: 's3://bucketname/key/response-to-oact-1-document-1',
-                                            name: 'response-to-oact-2-document-1',
                                             downloadURL: expect.any(String),
                                         },
                                     ],


### PR DESCRIPTION
## Summary
[MCR-4480](https://jiraent.cms.gov/browse/MCR-4480)

- Questions and responses are organized in two sections (see [designs](https://www.figma.com/design/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?node-id=14541-53434&node-type=frame&t=kL6zigeMblAJ7NiD-0)):
   - Outstanding questions: Questions without responses.
   - Answered questions: Questions with responses.
- Each question has dynamic headings based on which CMS division the question was asked by.
- Each question has a Upload response button.
- Upload response button on outstanding questions is the primary button style.
- Upload response button on answered questions is the outlined button style.
- Clicking on the Upload response takes the user to the upload response page.
- Questions would be ordered by the most recent asked date on top in each section.

#### Related issues

#### Screenshots

#### Test cases covered

`RateQuestionsResponse.test.tsx`
- `'State user tests'` - ``'renders questions in correct sections'`
-  `'CMS user tests'` - `'renders questions in correct sections'`
   - Updated to test questions are in correct order.

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
