### PR TITLE
Fix cms rate q&a questions table UI

### DIFF
--- a/services/app-web/src/pages/QuestionResponse/QATable/CMSQuestionResponseTable.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/CMSQuestionResponseTable.tsx
@@ -111,7 +111,7 @@ export const CMSQuestionResponseTable = ({
                 className={styles.questionSection}
                 data-testid={'otherDivisionQuestions'}
             >
-                <SectionHeader header="Other division's questions" />
+                <SectionHeader header="Other divisions' questions" />
                 {otherDivisionRounds().length ? (
                     otherDivisionRounds().map((questionRound, index) =>
                         questionRound.map(({ roundTitle, questionData }) => (

--- a/services/app-web/src/pages/QuestionResponse/QATable/QuestionResponseRound.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/QuestionResponseRound.tsx
@@ -23,6 +23,8 @@ export const QuestionResponseRound = ({
     roundTitle: string
     currentUser?: User
 }) => {
+    const isStateUser = currentUser?.__typename === 'StateUser'
+
     // Combines question and response documents and sorts them in desc order.
     const documents = [
         ...question.documents.map((doc) => ({
@@ -51,7 +53,7 @@ export const QuestionResponseRound = ({
             addedBy.__typename === 'CMSUser' ||
             addedBy.__typename === 'CMSApproverUser'
         ) {
-            return `${addedBy.givenName} (CMS)`
+            return `${addedBy.givenName} ${isStateUser ? '(CMS)' : ''}`
         }
         if (addedBy.__typename === 'StateUser') {
             return `${addedBy.givenName} (${addedBy.state.code})`


### PR DESCRIPTION
## Summary

- Other divisions' questions section header typo
- Remove `(CMS)` tag on rate Q&A document table for CMS users.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
