### PR TITLE
Remove the npm minor patch group from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,15 +40,3 @@ updates:
         applies-to: version-updates
         patterns:
           - '@storybook/*'
-      npm-minor-patch:
-        patterns:
-          - '*'
-        exclude-patterns:
-          - '@aws-sdk/*'
-          - '@prisma/client'
-          - 'prisma'
-          - '@opentelemetry/*'
-          - '@storybook/*'
-        update-types:
-          - 'minor'
-          - 'patch'


### PR DESCRIPTION
## Summary

Removing this patch group from dependabot config as we've been getting groupings too aggressively lately. 
