### PR TITLE
MCR-4480 FIX: Add sorting after organizing questions.

### DIFF
--- a/services/app-web/src/pages/QuestionResponse/QATable/CMSQuestionResponseTable.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/CMSQuestionResponseTable.tsx
@@ -50,7 +50,8 @@ export const CMSQuestionResponseTable = ({
                 const questionsList: RateQuestionList | ContractQuestionList =
                     value
 
-                //reverse questions to the earliest question first as rounds would be mismatched when looping through two arrays of different lengths
+                // Reverse each division question so that we start at round 1 for each question, otherwise we get
+                // mismatching rounds.
                 Array.from([...questionsList.edges])
                     .reverse()
                     .forEach(({ node }, index) => {
@@ -66,8 +67,16 @@ export const CMSQuestionResponseTable = ({
             }
         })
 
-        // return the rounds to latest questions first
-        return rounds.reverse()
+        // return the round questions sorted to latest questions first and reverse rounds to latest round first
+        return rounds
+            .map((round) =>
+                round.sort(
+                    (a, b) =>
+                        new Date(b.questionData.createdAt).getTime() -
+                        new Date(a.questionData.createdAt).getTime()
+                )
+            )
+            .reverse()
     }
 
     return (

--- a/services/app-web/src/pages/QuestionResponse/RateQuestionResponse.test.tsx
+++ b/services/app-web/src/pages/QuestionResponse/RateQuestionResponse.test.tsx
@@ -198,23 +198,23 @@ describe('RateQuestionResponse', () => {
             )
 
             expect(answeredRounds[2]).toHaveTextContent(
-                'Asked by: Division of Managed Care Policy (DMCP)'
+                'Asked by: Office of the Actuary (OACT)'
             )
             expect(answeredRounds[2]).toHaveTextContent(
-                'dmcp-question-1-document-1'
+                'oact-question-1-document-1'
             )
             expect(answeredRounds[2]).toHaveTextContent(
-                'response-to-dmcp-1-document-1'
+                'response-to-oact-1-document-1'
             )
 
             expect(answeredRounds[3]).toHaveTextContent(
-                'Asked by: Office of the Actuary (OACT)'
+                'Asked by: Division of Managed Care Policy (DMCP)'
             )
             expect(answeredRounds[3]).toHaveTextContent(
-                'oact-question-1-document-1'
+                'dmcp-question-1-document-1'
             )
             expect(answeredRounds[3]).toHaveTextContent(
-                'response-to-oact-1-document-1'
+                'response-to-dmcp-1-document-1'
             )
         })
 
@@ -431,22 +431,22 @@ describe('RateQuestionResponse', () => {
                 'response-to-oact-2-document-1'
             )
 
-            // expect next round to be round 1 with DMCP question
+            // expect round 1 with OACT question 1
             expect(otherDivisionRounds[1]).toHaveTextContent('Round 1')
             expect(otherDivisionRounds[1]).toHaveTextContent(
-                'dmcp-question-1-document-1'
-            )
-            expect(otherDivisionRounds[1]).toHaveTextContent(
-                'response-to-dmcp-1-document-1'
-            )
-
-            // expect next round (last round) to also be round 1 with OACT question 1
-            expect(otherDivisionRounds[2]).toHaveTextContent('Round 1')
-            expect(otherDivisionRounds[2]).toHaveTextContent(
                 'oact-question-1-document-1'
             )
-            expect(otherDivisionRounds[2]).toHaveTextContent(
+            expect(otherDivisionRounds[1]).toHaveTextContent(
                 'response-to-oact-1-document-1'
+            )
+
+            // expect last question in round 1 to be DMCP question
+            expect(otherDivisionRounds[2]).toHaveTextContent('Round 1')
+            expect(otherDivisionRounds[2]).toHaveTextContent(
+                'dmcp-question-1-document-1'
+            )
+            expect(otherDivisionRounds[2]).toHaveTextContent(
+                'response-to-dmcp-1-document-1'
             )
         })
         it('renders with question submit banner after question submitted', async () => {

--- a/services/app-web/src/testHelpers/apolloMocks/rateDataMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/rateDataMock.ts
@@ -581,7 +581,7 @@ function mockRateSubmittedWithQuestions(
                             id: 'dmco-question-1-id',
                             rateID,
                             createdAt: new Date('2022-12-15'),
-                            addedBy: mockValidCMSUser(),
+                            addedBy: mockValidCMSUser() as CmsUser,
                             documents: [
                                 {
                                     s3URL: 's3://bucketname/key/dmco-question-1-document-1',
@@ -647,7 +647,7 @@ function mockRateSubmittedWithQuestions(
                             __typename: 'RateQuestion' as const,
                             id: 'oact-question-2-id',
                             rateID,
-                            createdAt: new Date('2022-12-16'),
+                            createdAt: new Date('2022-12-17'),
                             addedBy: mockValidCMSUser({
                                 divisionAssignment: 'OACT',
                             }) as CmsUser,
@@ -683,7 +683,7 @@ function mockRateSubmittedWithQuestions(
                             __typename: 'RateQuestion' as const,
                             id: 'oact-question-1-id',
                             rateID,
-                            createdAt: new Date('2022-12-15'),
+                            createdAt: new Date('2022-12-16'),
                             addedBy: mockValidCMSUser({
                                 divisionAssignment: 'OACT',
                             }) as CmsUser,


### PR DESCRIPTION
## Summary
[MCR-4480](https://jiraent.cms.gov/browse/MCR-4480)

- CMS Rate Q&A table
   - Fix questions in rounds not being sorted by `createdAt` in descending order
   - Fix test data to better test for question order

- State Rate Q&A table
   - Reduce complexity of `answeredQuestions` and `unasnweredQuestions` array from `RoundData[][]` to `RoundData[]`. Essentially instead of an array of array of questions, it will now just be an array of questions.
   - Sort `answeredQuestions` and `unasnweredQuestions` by `createdAt` in descending order
   - Fix test data to better test for question order

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
- See Kelsey's [comment](https://jiraent.cms.gov/browse/MCR-4480?focusedId=3145878&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-3145878) for reproduction steps of the issue.

<!---These are developer instructions on how to test or validate the work -->
