### PR TITLE
Tweak Prisma connection pooling

### DIFF
--- a/services/app-api/src/secrets/secrets.ts
+++ b/services/app-api/src/secrets/secrets.ts
@@ -64,7 +64,7 @@ function getConnectionURL(secrets: Secret): string {
         secrets.password
     )}@${secrets.host}:${secrets.port}/${
         secrets.dbname
-    }?schema=public&connection_limit=5&connect_timeout=60&pool_timeout=70`
+    }?schema=public&connection_limit=1&pool_timeout=10&connect_timeout=10&max_connections=1`
 
     return postgresURL
 }


### PR DESCRIPTION
## Summary

The SFDC team was hitting our API and getting some internal service errors back on a few requests, which would succeed on retries. In the logs we found that the errors coming back were from throttling exceptions in Aurora. This tweaks the connection string to fail faster when a connection cannot be made, and limits the connection from a lambda to 1 (since many lambdas will be spun up for dealing with requests and Prisma manages pooling)




