### PR TITLE
MCR-4623: add mmcratesetting mailbox as cc on state rate question emails

### DIFF
--- a/services/app-api/src/emailer/emails/sendRateQuestionCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/sendRateQuestionCMSEmail.test.ts
@@ -52,9 +52,16 @@ describe('sendRateQuestionCMSEmail', () => {
             })
         )
 
+        // expect consistent email addresses to be in toAddresses and ccAddresses
         expect(template).toEqual(
             expect.objectContaining({
-                toAddresses: expect.arrayContaining([...stateAnalysts]),
+                toAddresses: expect.arrayContaining([
+                    ...stateAnalysts,
+                    ...testEmailConfig().devReviewTeamEmails,
+                ]),
+                ccAddresses: expect.arrayContaining([
+                    ...testEmailConfig().dmcpSubmissionEmails,
+                ]),
             })
         )
     })
@@ -76,7 +83,11 @@ describe('sendRateQuestionCMSEmail', () => {
             expect.objectContaining({
                 toAddresses: expect.arrayContaining([
                     ...stateAnalysts,
+                    ...testEmailConfig().devReviewTeamEmails,
                     ...testEmailConfig().oactEmails,
+                ]),
+                ccAddresses: expect.arrayContaining([
+                    ...testEmailConfig().dmcpSubmissionEmails,
                 ]),
             })
         )
@@ -99,7 +110,11 @@ describe('sendRateQuestionCMSEmail', () => {
             expect.objectContaining({
                 toAddresses: expect.arrayContaining([
                     ...stateAnalysts,
+                    ...testEmailConfig().devReviewTeamEmails,
                     ...testEmailConfig().dmcpReviewEmails,
+                ]),
+                ccAddresses: expect.arrayContaining([
+                    ...testEmailConfig().dmcpSubmissionEmails,
                 ]),
             })
         )

--- a/services/app-api/src/emailer/emails/sendRateQuestionCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/sendRateQuestionCMSEmail.ts
@@ -25,11 +25,9 @@ export const sendRateQuestionCMSEmail = async (
         )
     }
 
-    let receiverEmails = [
-        ...stateAnalystsEmails,
-        ...config.devReviewTeamEmails,
-        ...config.dmcpSubmissionEmails,
-    ]
+    let receiverEmails = [...stateAnalystsEmails, ...config.devReviewTeamEmails]
+
+    const ccAddresses = [...config.dmcpSubmissionEmails]
 
     if (currentQuestion.division === 'DMCP') {
         receiverEmails.push(...config.dmcpReviewEmails)
@@ -73,6 +71,7 @@ export const sendRateQuestionCMSEmail = async (
     } else {
         return {
             toAddresses: receiverEmails,
+            ccAddresses,
             replyToAddresses: [],
             sourceEmail: config.emailSource,
             subject: `${

--- a/services/app-api/src/emailer/emails/sendRateQuestionCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/sendRateQuestionCMSEmail.ts
@@ -25,7 +25,11 @@ export const sendRateQuestionCMSEmail = async (
         )
     }
 
-    let receiverEmails = [...stateAnalystsEmails, ...config.devReviewTeamEmails]
+    let receiverEmails = [
+        ...stateAnalystsEmails,
+        ...config.devReviewTeamEmails,
+        ...config.dmcpSubmissionEmails,
+    ]
 
     if (currentQuestion.division === 'DMCP') {
         receiverEmails.push(...config.dmcpReviewEmails)

--- a/services/app-api/src/emailer/emails/sendRateQuestionResponseCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/sendRateQuestionResponseCMSEmail.test.ts
@@ -54,7 +54,13 @@ describe('sendRateQuestionResponseCMSEmail', () => {
 
         expect(template).toEqual(
             expect.objectContaining({
-                toAddresses: expect.arrayContaining([...stateAnalysts]),
+                toAddresses: expect.arrayContaining([
+                    ...stateAnalysts,
+                    ...testEmailConfig().devReviewTeamEmails,
+                ]),
+                ccAddresses: expect.arrayContaining([
+                    ...testEmailConfig().dmcpSubmissionEmails,
+                ]),
             })
         )
     })
@@ -76,7 +82,11 @@ describe('sendRateQuestionResponseCMSEmail', () => {
             expect.objectContaining({
                 toAddresses: expect.arrayContaining([
                     ...stateAnalysts,
+                    ...testEmailConfig().devReviewTeamEmails,
                     ...testEmailConfig().oactEmails,
+                ]),
+                ccAddresses: expect.arrayContaining([
+                    ...testEmailConfig().dmcpSubmissionEmails,
                 ]),
             })
         )
@@ -99,7 +109,11 @@ describe('sendRateQuestionResponseCMSEmail', () => {
             expect.objectContaining({
                 toAddresses: expect.arrayContaining([
                     ...stateAnalysts,
+                    ...testEmailConfig().devReviewTeamEmails,
                     ...testEmailConfig().dmcpReviewEmails,
+                ]),
+                ccAddresses: expect.arrayContaining([
+                    ...testEmailConfig().dmcpSubmissionEmails,
                 ]),
             })
         )

--- a/services/app-api/src/emailer/emails/sendRateQuestionResponseCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/sendRateQuestionResponseCMSEmail.ts
@@ -35,16 +35,16 @@ export const sendRateQuestionResponseCMSEmail = async (
         return questionRound
     }
 
-    let receiverEmails = [
-        ...stateAnalystsEmails,
-        ...config.devReviewTeamEmails,
-        ...config.dmcpSubmissionEmails,
-    ]
+    let receiverEmails = [...stateAnalystsEmails, ...config.devReviewTeamEmails]
+
+    const ccAddresses = [...config.dmcpSubmissionEmails]
+
     if (division === 'DMCP') {
         receiverEmails.push(...config.dmcpReviewEmails)
     } else if (division === 'OACT') {
         receiverEmails.push(...config.oactEmails)
     }
+
     receiverEmails = pruneDuplicateEmails(receiverEmails)
 
     const questionResponseURL = rateSummaryQuestionResponseURL(
@@ -75,6 +75,7 @@ export const sendRateQuestionResponseCMSEmail = async (
     } else {
         return {
             toAddresses: receiverEmails,
+            ccAddresses,
             replyToAddresses: [],
             sourceEmail: config.emailSource,
             subject: `${

--- a/services/app-api/src/emailer/emails/sendRateQuestionResponseCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/sendRateQuestionResponseCMSEmail.ts
@@ -35,7 +35,11 @@ export const sendRateQuestionResponseCMSEmail = async (
         return questionRound
     }
 
-    let receiverEmails = [...stateAnalystsEmails, ...config.devReviewTeamEmails]
+    let receiverEmails = [
+        ...stateAnalystsEmails,
+        ...config.devReviewTeamEmails,
+        ...config.dmcpSubmissionEmails,
+    ]
     if (division === 'DMCP') {
         receiverEmails.push(...config.dmcpReviewEmails)
     } else if (division === 'OACT') {


### PR DESCRIPTION
## Summary
[MCR-4623](https://jiraent.cms.gov/browse/MCR-4623)

Adding the mmcratesetting mailbox to the `ccAddresses` field for new rate question and response CMS emails.

On dev, the parameter store for `dmcpSubmissionEmails` includes the following emails

`DMCP Submission Dev1 <mc-review-qa+DMCPsubmissiondev1@truss.works>`
`DMCP Submission Dev2 <mc-review-qa+DMCPsubmissiondev2@truss.works>`

#### Related issues

#### Screensho
<img src="https://github.com/user-attachments/assets/9437b1da-57c3-44cf-989d-747e0ffb2e6f" width=650 />


<img src="https://github.com/user-attachments/assets/2160e6c2-d426-42e4-9f9a-ae7fee95d0b3" width=650 />



#### Test cases covered
- Updated test to also look for the expected `ccAddresses`.

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
