### PR TITLE
MCR-4586: CMS sees an approve submission button

### DIFF
--- a/services/app-web/src/components/Modal/ModalOpenButton/ModalOpenButton.tsx
+++ b/services/app-web/src/components/Modal/ModalOpenButton/ModalOpenButton.tsx
@@ -7,7 +7,7 @@ import { useTealium } from '../../../hooks'
 import { usePage } from '../../../contexts/PageContext'
 import { extractText } from '../../TealiumLogging/tealiamLoggingHelpers'
 
-type ModalOpenButtonProps = {
+export type ModalOpenButtonProps = {
     id: string
     modalRef: React.RefObject<ModalRef>
     children: React.ReactNode

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.module.scss
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.module.scss
@@ -45,3 +45,11 @@
 .backLinkContainerNoSideBar {
     padding-bottom: uswds.units(2);
 }
+
+.approveWithdrawButtonContainer {
+    justify-content: end;
+
+    button {
+        margin-right: 0;
+    }
+}

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -10,6 +10,8 @@ import {
     mockContractPackageSubmitted,
     mockContractPackageSubmittedWithQuestions,
     iterableCmsUsersMockData,
+    mockValidCMSUser,
+    iterableNonCMSUsersMockData,
 } from '../../testHelpers/apolloMocks'
 import { renderWithProviders } from '../../testHelpers/jestHelpers'
 import { SubmissionSummary } from './SubmissionSummary'
@@ -1019,5 +1021,184 @@ describe('SubmissionSummary', () => {
                 await screen.findByTestId('submission-side-nav')
             ).toBeInTheDocument()
         })
+    })
+
+    describe('Submission approval tests', () => {
+        it.each(iterableCmsUsersMockData)(
+            'renders approve submission button for $userRole',
+            async ({ mockUser }) => {
+                const contract =
+                    mockContractPackageSubmittedWithQuestions('test-abc-123')
+                renderWithProviders(
+                    <Routes>
+                        <Route element={<SubmissionSideNav />}>
+                            <Route
+                                path={RoutesRecord.SUBMISSIONS_SUMMARY}
+                                element={<SubmissionSummary />}
+                            />
+                        </Route>
+                    </Routes>,
+                    {
+                        apolloProvider: {
+                            mocks: [
+                                fetchCurrentUserMock({
+                                    user: mockUser(),
+                                    statusCode: 200,
+                                }),
+                                fetchContractWithQuestionsMockSuccess({
+                                    contract,
+                                }),
+                                fetchContractMockSuccess({
+                                    contract,
+                                }),
+                            ],
+                        },
+                        routerProvider: {
+                            route: '/submissions/test-abc-123',
+                        },
+                        featureFlags: {
+                            'submission-approvals': true,
+                        },
+                    }
+                )
+
+                await waitFor(() => {
+                    expect(
+                        screen.getByTestId('submission-side-nav')
+                    ).toBeInTheDocument()
+                    expect(
+                        screen.getByText('MCR-MN-0005-SNBC')
+                    ).toBeInTheDocument()
+                })
+
+                // expect submission approval button to be on the screen
+                expect(
+                    screen.getByRole('button', { name: 'Approve submission' })
+                ).toBeInTheDocument()
+
+                // expect submission approval button to not be disabled
+                expect(
+                    screen.getByRole('button', { name: 'Approve submission' })
+                ).not.toBeDisabled()
+
+                // expect unlock button to have outline style
+                expect(
+                    screen.getByRole('button', { name: 'Unlock submission' })
+                ).toHaveClass('usa-button--outline')
+            }
+        )
+        it('renders disabled approve submission button on unlocked submission', async () => {
+            const unlockedContract =
+                mockContractPackageUnlockedWithUnlockedType({
+                    id: 'test-abc-123',
+                })
+            renderWithProviders(
+                <Routes>
+                    <Route element={<SubmissionSideNav />}>
+                        <Route
+                            path={RoutesRecord.SUBMISSIONS_SUMMARY}
+                            element={<SubmissionSummary />}
+                        />
+                    </Route>
+                </Routes>,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                user: mockValidCMSUser(),
+                                statusCode: 200,
+                            }),
+                            fetchContractWithQuestionsMockSuccess({
+                                contract: unlockedContract,
+                            }),
+                            fetchContractMockSuccess({
+                                contract: unlockedContract,
+                            }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: '/submissions/test-abc-123',
+                    },
+                    featureFlags: {
+                        'submission-approvals': true,
+                    },
+                }
+            )
+            await waitFor(() => {
+                expect(
+                    screen.getByTestId('submission-side-nav')
+                ).toBeInTheDocument()
+                expect(screen.getByText('MCR-MN-0005-SNBC')).toBeInTheDocument()
+            })
+
+            // expect submission approval button to be on the screen
+            expect(
+                screen.getByRole('button', { name: 'Approve submission' })
+            ).toBeInTheDocument()
+
+            // expect submission approval button to be disabled
+            expect(
+                screen.getByRole('button', { name: 'Approve submission' })
+            ).toBeDisabled()
+
+            // expect unlock button to be disabled
+            expect(
+                screen.getByRole('button', { name: 'Unlock submission' })
+            ).toBeDisabled()
+        })
+
+        it.each(iterableNonCMSUsersMockData)(
+            'does not render approve submission button for $userRole',
+            async ({ mockUser }) => {
+                const contract =
+                    mockContractPackageSubmittedWithQuestions('test-abc-123')
+                renderWithProviders(
+                    <Routes>
+                        <Route element={<SubmissionSideNav />}>
+                            <Route
+                                path={RoutesRecord.SUBMISSIONS_SUMMARY}
+                                element={<SubmissionSummary />}
+                            />
+                        </Route>
+                    </Routes>,
+                    {
+                        apolloProvider: {
+                            mocks: [
+                                fetchCurrentUserMock({
+                                    user: mockUser(),
+                                    statusCode: 200,
+                                }),
+                                fetchContractWithQuestionsMockSuccess({
+                                    contract,
+                                }),
+                                fetchContractMockSuccess({
+                                    contract,
+                                }),
+                            ],
+                        },
+                        routerProvider: {
+                            route: '/submissions/test-abc-123',
+                        },
+                        featureFlags: {
+                            'submission-approvals': true,
+                        },
+                    }
+                )
+
+                await waitFor(() => {
+                    expect(
+                        screen.getByTestId('submission-side-nav')
+                    ).toBeInTheDocument()
+                    expect(
+                        screen.getByText('MCR-MN-0005-SNBC')
+                    ).toBeInTheDocument()
+                })
+
+                // expect submission approval button to be on the screen
+                expect(
+                    screen.queryByRole('button', { name: 'Approve submission' })
+                ).toBeNull()
+            }
+        )
     })
 })

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -1,4 +1,4 @@
-import { GridContainer, Link, ModalRef } from '@trussworks/react-uswds'
+import { Grid, GridContainer, Link, ModalRef } from '@trussworks/react-uswds'
 import React, { useEffect, useRef, useState } from 'react'
 import { useAuth } from '../../contexts/AuthContext'
 import { ContractDetailsSummarySection } from '../StateSubmission/ReviewSubmit/ContractDetailsSummarySection'
@@ -10,6 +10,7 @@ import {
     SubmissionUpdatedBanner,
     DocumentWarningBanner,
     LinkWithLogging,
+    ButtonWithLogging,
 } from '../../components'
 import { Loading } from '../../components'
 import { usePage } from '../../contexts/PageContext'
@@ -25,25 +26,8 @@ import { useRouteParams } from '../../hooks'
 import { getVisibleLatestContractFormData } from '../../gqlHelpers/contractsAndRates'
 import { generatePath, Navigate } from 'react-router-dom'
 import { hasCMSUserPermissions } from '../../gqlHelpers'
-
-function UnlockModalButton({
-    disabled,
-    modalRef,
-}: {
-    disabled: boolean
-    modalRef: React.RefObject<ModalRef>
-}) {
-    return (
-        <ModalOpenButton
-            modalRef={modalRef}
-            className={styles.submitButton}
-            id="form-submit"
-            disabled={disabled}
-        >
-            Unlock submission
-        </ModalOpenButton>
-    )
-}
+import { useLDClient } from 'launchdarkly-react-client-sdk'
+import { featureFlags } from '../../common-code/featureFlags'
 
 export const SubmissionSummary = (): React.ReactElement => {
     // Page level state
@@ -56,6 +40,13 @@ export const SubmissionSummary = (): React.ReactElement => {
     const hasCMSPermissions = hasCMSUserPermissions(loggedInUser)
     const isStateUser = loggedInUser?.role === 'STATE_USER'
     const isHelpDeskUser = loggedInUser?.role === 'HELPDESK_USER'
+
+    const ldClient = useLDClient()
+
+    const submissionApprovalFlag = ldClient?.variation(
+        featureFlags.SUBMISSION_APPROVALS.flag,
+        featureFlags.SUBMISSION_APPROVALS.defaultValue
+    )
 
     // API requests
     const {
@@ -168,6 +159,9 @@ export const SubmissionSummary = (): React.ReactElement => {
         : 'Add MC-CRS record number'
     const explainMissingData = (isHelpDeskUser || isStateUser) && !isSubmitted
 
+    // Only show for CMS_USER or CMS_APPROVER_USER users
+    const showSubmissionApproval = submissionApprovalFlag && hasCMSPermissions
+
     return (
         <div className={styles.background}>
             <GridContainer
@@ -191,6 +185,17 @@ export const SubmissionSummary = (): React.ReactElement => {
 
                 {documentError && (
                     <DocumentWarningBanner className={styles.banner} />
+                )}
+
+                {showSubmissionApproval && (
+                    <Grid className={styles.approveWithdrawButtonContainer} row>
+                        <ButtonWithLogging
+                            type={'button'}
+                            disabled={!isSubmitted}
+                        >
+                            Approve submission
+                        </ButtonWithLogging>
+                    </Grid>
                 )}
 
                 <SubmissionTypeSummarySection
@@ -224,12 +229,17 @@ export const SubmissionSummary = (): React.ReactElement => {
                     submissionName={name}
                     headerChildComponent={
                         hasCMSPermissions ? (
-                            <UnlockModalButton
+                            <ModalOpenButton
                                 modalRef={modalRef}
                                 disabled={['DRAFT', 'UNLOCKED'].includes(
                                     contract.status
                                 )}
-                            />
+                                className={styles.submitButton}
+                                id="form-submit"
+                                outline={showSubmissionApproval}
+                            >
+                                Unlock submission
+                            </ModalOpenButton>
                         ) : undefined
                     }
                     statePrograms={statePrograms}

--- a/services/app-web/src/testHelpers/apolloMocks/index.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/index.ts
@@ -45,7 +45,8 @@ export {
     mockValidCMSApproverUser,
     iterableCmsUsersMockData,
     iterableAdminUsersMockData,
-    mockValidBusinessOwnerUser
+    mockValidBusinessOwnerUser,
+    iterableNonCMSUsersMockData
 } from './userGQLMock'
 
 export {

--- a/services/app-web/src/testHelpers/apolloMocks/userGQLMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/userGQLMock.ts
@@ -296,6 +296,28 @@ const iterableAdminUsersMockData: {
     }
 ]
 
+const iterableNonCMSUsersMockData: {
+    userRole: 'HELPDESK_USER' | 'BUSINESSOWNER_USER' | 'ADMIN_USER' | 'STATE_USER'
+    mockUser: <T>(userData?: Partial<T>) => AdminUser | BusinessOwnerUser | HelpdeskUser | StateUser
+}[] = [
+    {
+        userRole: 'ADMIN_USER',
+        mockUser: mockValidAdminUser,
+    },
+    {
+        userRole: 'BUSINESSOWNER_USER',
+        mockUser: mockValidBusinessOwnerUser,
+    },
+    {
+        userRole: 'HELPDESK_USER',
+        mockUser: mockValidHelpDeskUser
+    },
+    {
+        userRole: 'STATE_USER',
+        mockUser: mockValidStateUser
+    }
+]
+
 export {
     fetchCurrentUserMock,
     mockValidStateUser,
@@ -311,4 +333,5 @@ export {
     indexUsersQueryFailMock,
     updateStateAssignmentsMutationMockSuccess,
     updateStateAssignmentsMutationMockFailure,
+    iterableNonCMSUsersMockData
 }


### PR DESCRIPTION
## Summary
[MCR-4586](https://jiraent.cms.gov/browse/MCR-4586)
[Figma](https://www.figma.com/design/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?node-id=14836-39365&node-type=canvas)

- Add `Approve submission` button behind feature flag.
   - Only `CMS_USER` and `CMS_APPROVER_USER` can see the approve button.
   - Unlock button style appears as a secondary button (`outline`) when `submission-approvals` flag is toggled on
   - If a submission is unlocked the `Approve submission` button is disabled
- Feature flag Unlock button style change

#### Related issues

#### Screenshots

<img src="https://github.com/user-attachments/assets/b69757a7-7cb3-4fbc-95f3-d0fda5462bd7" width="450"/>

<img src="https://github.com/user-attachments/assets/77cd2b3d-adcc-4c0d-a0df-d0da55954657" width="450"/>

#### Test cases covered

`SubmissionSummary.test.tsx`
- `'Submission approval tests'`
   - `'renders approve submission button for $userRole'`
      - `userRoles: 'CMS_USER', 'CMS_APPROVER_USER'`
   - `'renders disabled approve submission button on unlocked submission'`
   - `'does not render approve submission button for $userRole'`
      - `userRoles: 'HELPDESK_USER', 'BUSINESSOWNER_USER', 'ADMIN_USER', 'STATE_USER'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
