### PR TITLE
MCR-4623: Fix cc address to be on only state email for new rate questions

### DIFF
--- a/services/app-api/src/emailer/emails/sendRateQuestionCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/sendRateQuestionCMSEmail.test.ts
@@ -43,24 +43,22 @@ describe('sendRateQuestionCMSEmail', () => {
             throw template
         }
 
-        expect(template).toEqual(
-            expect.not.objectContaining({
-                toAddresses: expect.arrayContaining([
-                    ...testEmailConfig().oactEmails,
-                    ...testEmailConfig().dmcpReviewEmails,
-                ]),
-            })
-        )
-
-        // expect consistent email addresses to be in toAddresses and ccAddresses
+        // expected to include address
         expect(template).toEqual(
             expect.objectContaining({
                 toAddresses: expect.arrayContaining([
                     ...stateAnalysts,
                     ...testEmailConfig().devReviewTeamEmails,
                 ]),
-                ccAddresses: expect.arrayContaining([
-                    ...testEmailConfig().dmcpSubmissionEmails,
+            })
+        )
+
+        // expected to not include addresses
+        expect(template).toEqual(
+            expect.not.objectContaining({
+                toAddresses: expect.arrayContaining([
+                    ...testEmailConfig().oactEmails,
+                    ...testEmailConfig().dmcpReviewEmails,
                 ]),
             })
         )
@@ -86,9 +84,6 @@ describe('sendRateQuestionCMSEmail', () => {
                     ...testEmailConfig().devReviewTeamEmails,
                     ...testEmailConfig().oactEmails,
                 ]),
-                ccAddresses: expect.arrayContaining([
-                    ...testEmailConfig().dmcpSubmissionEmails,
-                ]),
             })
         )
     })
@@ -112,9 +107,6 @@ describe('sendRateQuestionCMSEmail', () => {
                     ...stateAnalysts,
                     ...testEmailConfig().devReviewTeamEmails,
                     ...testEmailConfig().dmcpReviewEmails,
-                ]),
-                ccAddresses: expect.arrayContaining([
-                    ...testEmailConfig().dmcpSubmissionEmails,
                 ]),
             })
         )

--- a/services/app-api/src/emailer/emails/sendRateQuestionCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/sendRateQuestionCMSEmail.ts
@@ -27,8 +27,6 @@ export const sendRateQuestionCMSEmail = async (
 
     let receiverEmails = [...stateAnalystsEmails, ...config.devReviewTeamEmails]
 
-    const ccAddresses = [...config.dmcpSubmissionEmails]
-
     if (currentQuestion.division === 'DMCP') {
         receiverEmails.push(...config.dmcpReviewEmails)
     } else if (currentQuestion.division === 'OACT') {
@@ -71,7 +69,6 @@ export const sendRateQuestionCMSEmail = async (
     } else {
         return {
             toAddresses: receiverEmails,
-            ccAddresses,
             replyToAddresses: [],
             sourceEmail: config.emailSource,
             subject: `${

--- a/services/app-api/src/emailer/emails/sendRateQuestionResponseCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/sendRateQuestionResponseCMSEmail.test.ts
@@ -44,22 +44,19 @@ describe('sendRateQuestionResponseCMSEmail', () => {
         }
 
         expect(template).toEqual(
-            expect.not.objectContaining({
-                toAddresses: expect.arrayContaining([
-                    ...testEmailConfig().oactEmails,
-                    ...testEmailConfig().dmcpReviewEmails,
-                ]),
-            })
-        )
-
-        expect(template).toEqual(
             expect.objectContaining({
                 toAddresses: expect.arrayContaining([
                     ...stateAnalysts,
                     ...testEmailConfig().devReviewTeamEmails,
                 ]),
-                ccAddresses: expect.arrayContaining([
-                    ...testEmailConfig().dmcpSubmissionEmails,
+            })
+        )
+
+        expect(template).toEqual(
+            expect.not.objectContaining({
+                toAddresses: expect.arrayContaining([
+                    ...testEmailConfig().oactEmails,
+                    ...testEmailConfig().dmcpReviewEmails,
                 ]),
             })
         )
@@ -85,9 +82,6 @@ describe('sendRateQuestionResponseCMSEmail', () => {
                     ...testEmailConfig().devReviewTeamEmails,
                     ...testEmailConfig().oactEmails,
                 ]),
-                ccAddresses: expect.arrayContaining([
-                    ...testEmailConfig().dmcpSubmissionEmails,
-                ]),
             })
         )
     })
@@ -111,9 +105,6 @@ describe('sendRateQuestionResponseCMSEmail', () => {
                     ...stateAnalysts,
                     ...testEmailConfig().devReviewTeamEmails,
                     ...testEmailConfig().dmcpReviewEmails,
-                ]),
-                ccAddresses: expect.arrayContaining([
-                    ...testEmailConfig().dmcpSubmissionEmails,
                 ]),
             })
         )

--- a/services/app-api/src/emailer/emails/sendRateQuestionResponseCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/sendRateQuestionResponseCMSEmail.ts
@@ -37,8 +37,6 @@ export const sendRateQuestionResponseCMSEmail = async (
 
     let receiverEmails = [...stateAnalystsEmails, ...config.devReviewTeamEmails]
 
-    const ccAddresses = [...config.dmcpSubmissionEmails]
-
     if (division === 'DMCP') {
         receiverEmails.push(...config.dmcpReviewEmails)
     } else if (division === 'OACT') {
@@ -75,7 +73,6 @@ export const sendRateQuestionResponseCMSEmail = async (
     } else {
         return {
             toAddresses: receiverEmails,
-            ccAddresses,
             replyToAddresses: [],
             sourceEmail: config.emailSource,
             subject: `${

--- a/services/app-api/src/emailer/emails/sendRateQuestionStateEmail.test.ts
+++ b/services/app-api/src/emailer/emails/sendRateQuestionStateEmail.test.ts
@@ -214,6 +214,25 @@ describe('sendRateQuestionStateEmail', () => {
             })
         )
     })
+    it('includes mmcratesetting in the ccAddress', async () => {
+        const template = await sendRateQuestionStateEmail(
+            testRate,
+            testEmailConfig(),
+            currentQuestion()
+        )
+
+        if (template instanceof Error) {
+            throw template
+        }
+
+        expect(template).toEqual(
+            expect.objectContaining({
+                ccAddresses: expect.arrayContaining([
+                    ...testEmailConfig().dmcpSubmissionEmails,
+                ]),
+            })
+        )
+    })
     it('to addresses list includes all state contacts on all contracts submitted with rate', async () => {
         const template = await sendRateQuestionStateEmail(
             testRate,

--- a/services/app-api/src/emailer/emails/sendRateQuestionStateEmail.ts
+++ b/services/app-api/src/emailer/emails/sendRateQuestionStateEmail.ts
@@ -65,6 +65,7 @@ export const sendRateQuestionStateEmail = async (
     } else {
         return {
             toAddresses: toAddresses,
+            ccAddresses: [...config.dmcpSubmissionEmails],
             replyToAddresses: [],
             sourceEmail: config.emailSource,
             subject: `${

--- a/services/app-api/src/testHelpers/emailerHelpers.ts
+++ b/services/app-api/src/testHelpers/emailerHelpers.ts
@@ -355,6 +355,7 @@ const mockUnlockedContract = (
         status: 'UNLOCKED',
         stateCode: 'MN',
         stateNumber: 4,
+        reviewStatus: 'UNDER_REVIEW',
 
         draftRevision: mockContractRev(),
         draftRates,


### PR DESCRIPTION
## Summary
[MCR-4623](https://jiraent.cms.gov/browse/MCR-4623)

Fixed the CC of `mmcratesetting` ( `config.dmcpSubmissionEmails` in code ) to be only on new rate question for STATE email only.

Removed the CC from CMS emails for new rate question and responses.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
