### PR TITLE
Fix flakey web-unit test and API testS3Client imports

### DIFF
--- a/services/app-api/src/resolvers/contract/indexContracts.test.ts
+++ b/services/app-api/src/resolvers/contract/indexContracts.test.ts
@@ -16,7 +16,7 @@ import {
     submitTestContract,
     unlockTestContract,
 } from '../../testHelpers/gqlContractHelpers'
-import { testS3Client } from '../../../../app-web/src/testHelpers/s3Helpers'
+import { testS3Client } from '../../../../app-api/src/testHelpers/s3Helpers'
 
 describe(`indexContracts`, () => {
     describe('isStateUser', () => {

--- a/services/app-api/src/resolvers/contract/submitContract.test.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.test.ts
@@ -9,7 +9,7 @@ import {
     UpdateDraftContractRatesDocument,
     SubmitContractDocument,
 } from '../../gen/gqlClient'
-import { testS3Client } from '../../../../app-web/src/testHelpers/s3Helpers'
+import { testS3Client } from '../../../../app-api/src/testHelpers/s3Helpers'
 
 import { testCMSUser } from '../../testHelpers/userHelpers'
 import type {

--- a/services/app-api/src/resolvers/contract/unlockContract.test.ts
+++ b/services/app-api/src/resolvers/contract/unlockContract.test.ts
@@ -5,7 +5,7 @@ import {
     updateTestStateAssignments,
 } from '../../testHelpers/gqlHelpers'
 import { UnlockContractDocument } from '../../gen/gqlClient'
-import { testS3Client } from '../../../../app-web/src/testHelpers/s3Helpers'
+import { testS3Client } from '../../../../app-api/src/testHelpers/s3Helpers'
 import { expectToBeDefined } from '../../testHelpers/assertionHelpers'
 
 import {

--- a/services/app-api/src/resolvers/contract/updateDraftContractRates.test.ts
+++ b/services/app-api/src/resolvers/contract/updateDraftContractRates.test.ts
@@ -16,7 +16,7 @@ import {
 } from '../../testHelpers/gqlRateHelpers'
 import { latestFormData } from '../../testHelpers/healthPlanPackageHelpers'
 import { testCMSUser, testStateUser } from '../../testHelpers/userHelpers'
-import { testS3Client } from '../../../../app-web/src/testHelpers/s3Helpers'
+import { testS3Client } from '../../../../app-api/src/testHelpers/s3Helpers'
 
 describe('updateDraftContractRates', () => {
     const mockS3 = testS3Client()

--- a/services/app-api/src/resolvers/contract/withdrawAndReplaceRedundantRate.test.ts
+++ b/services/app-api/src/resolvers/contract/withdrawAndReplaceRedundantRate.test.ts
@@ -1,5 +1,5 @@
 import { constructTestPostgresServer } from '../../testHelpers/gqlHelpers'
-import { testS3Client } from '../../../../app-web/src/testHelpers/s3Helpers'
+import { testS3Client } from '../../../../app-api/src/testHelpers/s3Helpers'
 import { WithdrawAndReplaceRedundantRateDocument } from '../../gen/gqlClient'
 import { testAdminUser, testCMSUser } from '../../testHelpers/userHelpers'
 import {

--- a/services/app-api/src/resolvers/rate/fetchRate.test.ts
+++ b/services/app-api/src/resolvers/rate/fetchRate.test.ts
@@ -32,7 +32,7 @@ import {
     submitTestContract,
 } from '../../testHelpers/gqlContractHelpers'
 import { latestFormData } from '../../testHelpers/healthPlanPackageHelpers'
-import { testS3Client } from '../../../../app-web/src/testHelpers/s3Helpers'
+import { testS3Client } from '../../../../app-api/src/testHelpers/s3Helpers'
 import dayjs from 'dayjs'
 
 describe('fetchRate', () => {

--- a/services/app-api/src/resolvers/rate/indexRates.test.ts
+++ b/services/app-api/src/resolvers/rate/indexRates.test.ts
@@ -14,7 +14,7 @@ import {
     submitTestContract,
     createAndUpdateTestContractWithRate,
 } from '../../testHelpers/gqlContractHelpers'
-import { testS3Client } from '../../../../app-web/src/testHelpers/s3Helpers'
+import { testS3Client } from '../../../../app-api/src/testHelpers/s3Helpers'
 
 describe('indexRates', () => {
     describe.each(iterableCmsUsersMockData)(

--- a/services/app-api/src/resolvers/rate/submitRate.test.ts
+++ b/services/app-api/src/resolvers/rate/submitRate.test.ts
@@ -31,7 +31,7 @@ import {
     fetchTestContract,
     submitTestContract,
 } from '../../testHelpers/gqlContractHelpers'
-import { testS3Client } from '../../../../app-web/src/testHelpers/s3Helpers'
+import { testS3Client } from '../../../../app-api/src/testHelpers/s3Helpers'
 import { submitRate } from '../../postgres/contractAndRates'
 import { sharedTestPrismaClient } from '../../testHelpers/storeHelpers'
 

--- a/services/app-api/src/resolvers/rate/unlockRate.test.ts
+++ b/services/app-api/src/resolvers/rate/unlockRate.test.ts
@@ -5,7 +5,7 @@ import { expectToBeDefined } from '../../testHelpers/assertionHelpers'
 import { testLDService } from '../../testHelpers/launchDarklyHelpers'
 import { createSubmitAndUnlockTestRate } from '../../testHelpers/gqlRateHelpers'
 import { createAndSubmitTestContractWithRate } from '../../testHelpers/gqlContractHelpers'
-import { testS3Client } from '../../../../app-web/src/testHelpers/s3Helpers'
+import { testS3Client } from '../../../../app-api/src/testHelpers/s3Helpers'
 
 describe(`unlockRate`, () => {
     describe.each(iterableCmsUsersMockData)(

--- a/services/app-web/src/components/FileUpload/FileUpload.test.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.test.tsx
@@ -22,10 +22,14 @@ describe('FileUpload component', () => {
         name: 'Default Input',
         label: 'File input label',
         uploadFile: (_file: File) =>
-            fakeRequest<S3FileData>(true, {
-                key: 'testtest',
-                s3URL: 's3://bucketname/key/fakeS3url',
-            }),
+            fakeRequest<S3FileData>(
+                true,
+                {
+                    key: 'testtest',
+                    s3URL: 's3://bucketname/key/fakeS3url',
+                },
+                50
+            ), // timeout to give vitest time to look for loading text
         scanFile: async (_key: string) => {
             await fakeRequest<S3FileData>(true, {
                 key: 'testtest',


### PR DESCRIPTION
## Summary

- Fixes issue with `FileUpload` tests not finding the text `Uploading`.
   - Added a `50`ms timeout to `fakeRequest` to give vitest time to find the text.
- Fix API test imports of `testS3Client` from web common code to api common code
   - We had removed `deleteFile` function from web `testS3Client`. 

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
