### PR TITLE
MCR-4624: update copy on rate Q&A

### DIFF
--- a/services/app-api/src/emailer/emails/__snapshots__/sendQuestionStateEmail.test.ts.snap
+++ b/services/app-api/src/emailer/emails/__snapshots__/sendQuestionStateEmail.test.ts.snap
@@ -6,7 +6,7 @@ exports[`renders overall email for a new question as expected 1`] = `
 <br />
 <b>Date:</b> 01/01/2024<br />
 <br />
-You must respond to the questions before CMS can continue their review.<br />
+You must respond to the questions before CMS can continue their review. Responses should be submitted in DOC or DOCX format.<br />
 <br />
 <a href="http://localhost/submissions/12345/question-and-answers">Open the submission in MC-Review to answer questions</a>
 

--- a/services/app-api/src/emailer/emails/__snapshots__/sendRateQuestionStateEmail.test.ts.snap
+++ b/services/app-api/src/emailer/emails/__snapshots__/sendRateQuestionStateEmail.test.ts.snap
@@ -6,7 +6,7 @@ exports[`sendRateQuestionStateEmail renders overall email for a new rate questio
 <br />
 <b>Date:</b> 04/22/2024<br />
 <br />
-You must respond to the questions before CMS can continue their review.<br />
+You must respond to the questions before CMS can continue their review. Responses should be submitted in DOC or DOCX format.<br />
 <br />
 <a href="http://localhost/submissions/parent-contract/rates/test-rate/question-and-answers">Open the submission in MC-Review to answer questions</a>
 

--- a/services/app-api/src/emailer/etaTemplates/sendQuestionStateEmail.eta
+++ b/services/app-api/src/emailer/etaTemplates/sendQuestionStateEmail.eta
@@ -3,7 +3,7 @@ CMS asked questions about <%= it.packageName %><br />
 <br />
 <b>Date:</b> <%= it.dateAsked %><br />
 <br />
-You must respond to the questions before CMS can continue their review.<br />
+You must respond to the questions before CMS can continue their review. Responses should be submitted in DOC or DOCX format.<br />
 <br />
 <a href="<%= it.questionResponseURL %>">Open the submission in MC-Review to answer questions</a>
 

--- a/services/app-api/src/postgres/contractAndRates/approveContract.test.ts
+++ b/services/app-api/src/postgres/contractAndRates/approveContract.test.ts
@@ -52,6 +52,7 @@ describe('approveContract', () => {
             await approveContract(client, {
                 contractID: submittedContract.id,
                 updatedByID: cmsUser.id,
+                updatedReason: undefined,
             })
         )
 

--- a/services/app-web/src/pages/QuestionResponse/UploadResponse/UploadResponseForm.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadResponse/UploadResponseForm.tsx
@@ -129,8 +129,11 @@ const UploadResponseForm = ({
                         error={showFileUploadError ? fileUploadError : ''}
                         hint={
                             <span>
-                                This input only accepts PDF, CSV, DOC, DOCX,
-                                XLS, XLSX, XLSM files.
+                                You must submit the response in a DOC or DOCX
+                                format.
+                                <br />
+                                Appendices to the responses can be in PDF, CSV,
+                                DOC, DOCX, XLS, XLSX files.
                             </span>
                         }
                         accept={ACCEPTED_SUBMISSION_FILE_TYPES}

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -396,7 +396,7 @@ describe('RateDetails', () => {
                 const rateCertsAfterAddAnother = rateCertifications(screen)
                 expect(rateCertsAfterAddAnother).toHaveLength(2)
             })
-        })
+        }, 10000)
 
         it('display rest of the form when linked rates question is answered with NO', async () => {
             const { user } = renderWithProviders(


### PR DESCRIPTION
## Summary
[MCR-4624](https://jiraent.cms.gov/browse/MCR-4624)

- Add the following copy to the "Add responses" page for rate questions: 
   - `"You must submit the response in a DOC or DOCX format. Appendices to the responses can be in PDF, CSV, DOC, DOCX, XLS, XLSX files."`
   - See [Figma link ](https://www.figma.com/design/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?node-id=14541-53262&t=QZEn0JiVxA9oPXjV-1)for details. 

- Add the following copy to the State Rate Question Notification emails: 
   - `"You must respond to the questions before CMS can continue their review. Responses should be submitted in DOC or DOCX format."`
   - See [Figma link ](https://www.figma.com/design/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?node-id=14778-34327&t=WbyjwzwEiNL8FSmn-1) for details.

- Fix input error in 1 API unit test.
- Fix flakey web unit test

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
