### PR TITLE
MCR-4633: CMS can filter  on submission status

### DIFF
--- a/services/app-web/src/components/ContractTable/ContractTable.tsx
+++ b/services/app-web/src/components/ContractTable/ContractTable.tsx
@@ -513,6 +513,10 @@ export const ContractTable = ({
                                             value: 'UNLOCKED',
                                         },
                                         {
+                                            label: 'WITHDRAWN',
+                                            value: 'WITHDRAWN',
+                                        },
+                                        {
                                             label: 'APPROVED',
                                             value: 'APPROVED',
                                         },

--- a/services/app-web/src/components/ContractTable/ContractTable.tsx
+++ b/services/app-web/src/components/ContractTable/ContractTable.tsx
@@ -302,6 +302,7 @@ export const ContractTable = ({
                 },
             }),
             columnHelper.accessor('status', {
+                id: 'status',
                 header: 'Status',
                 cell: (info) => (
                     <StatusTag
@@ -312,6 +313,7 @@ export const ContractTable = ({
                 meta: {
                     dataTestID: `${tableConfig.rowIDName}-status`,
                 },
+                filterFn: `arrIncludesSome`,
             }),
         ],
         [isNotStateUser, tableConfig.rowIDName]
@@ -348,6 +350,9 @@ export const ContractTable = ({
     ) as Column<ContractInDashboardType>
     const submissionTypeColumn = reactTable.getColumn(
         'submissionType'
+    ) as Column<ContractInDashboardType>
+    const statusColumn = reactTable.getColumn(
+        'status'
     ) as Column<ContractInDashboardType>
 
     // Filter options based on table data instead of static list of options.
@@ -388,7 +393,6 @@ export const ContractTable = ({
     const clearFilters = () => {
         lastClickedElement.current = 'clearFiltersButton'
         setTableCaption(null)
-
         setColumnFilters([])
     }
 
@@ -489,6 +493,35 @@ export const ContractTable = ({
                                             submissionTypeColumn,
                                             selectedOptions,
                                             'submissionType'
+                                        )
+                                    }
+                                />
+                                <FilterSelect
+                                    value={getSelectedFiltersFromUrl(
+                                        columnFilters,
+                                        'status'
+                                    )}
+                                    name="status"
+                                    label="Status"
+                                    filterOptions={[
+                                        {
+                                            label: 'SUBMITTED',
+                                            value: 'SUBMITTED',
+                                        },
+                                        {
+                                            label: 'UNLOCKED',
+                                            value: 'UNLOCKED',
+                                        },
+                                        {
+                                            label: 'APPROVED',
+                                            value: 'APPROVED',
+                                        },
+                                    ]}
+                                    onChange={(selectedOptions) =>
+                                        updateFilters(
+                                            statusColumn,
+                                            selectedOptions,
+                                            'status'
                                         )
                                     }
                                 />

--- a/services/app-web/src/components/FilterAccordion/FilterAccordion.module.scss
+++ b/services/app-web/src/components/FilterAccordion/FilterAccordion.module.scss
@@ -17,4 +17,9 @@
         background: custom.$mcr-gray-lightest;
         overflow: visible;
     }
+
+    [class*='grid-row'] {
+        margin-top: 0.75rem;
+        margin-bottom: 0.75rem;
+    }
 }


### PR DESCRIPTION
## Summary
[MCR-4633](https://jiraent.cms.gov/browse/MCR-4633)

- CMS sees a `Status` filter
- `Status` filter has four options `SUBMITTED`, `UNLOCKED`, `WITHDRAWN`, `APPROVED`
   - `WITHDRAWN` submissions has not been implemented yet, the filter works but you wont get any data to work with.
   - The AC on the ticket has the words title cased, but it seems like the new design for the status tags are all caps so the filter options are all caps to match.
- Filter is multi-select

#### Related issues

#### Screenshots

#### Test cases covered

`ContractTable.test.tsx`
- `'can filter table by submission status'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
