### PR TITLE
Add codegen and package build to Cypress in Promote

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -299,7 +299,7 @@ jobs:
       needs.api-unit-tests.result == 'success' &&
       needs.build-prisma-client-lambda-layer.result == 'success' &&
       needs.begin-deployment.result == 'success'
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@mt-common-code
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -268,10 +268,12 @@ jobs:
           name: cypress-gen deploy prod
           path: ./services/cypress/gen
 
-      - name: Cypress chrome fix
-        run: |
-          export DISPLAY=:1
-          Xvfb :1 -screen 0 1024x768x16 2>/dev/null &
+      - name: Generate Code
+        run: pnpm -r generate
+
+      - name: Build packages
+        shell: bash
+        run: pnpm build:packages
 
       - name: Cypress on Prod -- Chrome
         id: cypress


### PR DESCRIPTION
## Summary

Looks like the new common-code packages build is missing from the Cypress step in promote. This adds it.


