### PR TITLE
MCR-4847: Refactor withdraw rate api to move contract to rate relationship

### DIFF
--- a/dev_tool/src/local/graphql.ts
+++ b/dev_tool/src/local/graphql.ts
@@ -17,7 +17,7 @@ export const compileGraphQLTypesWatchOnce = once(compileGraphQLTypesWatch)
 async function compileGraphQLTypes(runner: LabeledProcessRunner) {
     await runner.runCommandAndOutput(
         'gql deps',
-        ['pnpm', 'install', '--prefer--offline'],
+        ['pnpm', 'install', '--prefer-offline'],
         ''
     )
 

--- a/packages/mocks/src/apollo/contractPackageDataMock.ts
+++ b/packages/mocks/src/apollo/contractPackageDataMock.ts
@@ -309,6 +309,7 @@ function mockContractPackageDraft(partial?: Partial<Contract>): Contract {
                 },
             },
         ],
+        withdrawnRates: [],
         packageSubmissions: [],
         ...partial,
     }
@@ -336,6 +337,7 @@ function mockContractPackageSubmittedWithQuestions(
         mccrsID: null,
         draftRates: [],
         draftRevision: null,
+        withdrawnRates: [],
         packageSubmissions: [
             {
                 cause: 'CONTRACT_SUBMISSION',
@@ -909,6 +911,7 @@ function mockContractWithLinkedRateDraft(
                 ],
             },
         ],
+        withdrawnRates: [],
         packageSubmissions: [],
         ...partial,
     }
@@ -932,6 +935,7 @@ function mockContractWithLinkedRateSubmitted(
         state: mockMNState(),
         stateNumber: 5,
         mccrsID: null,
+        withdrawnRates: [],
         packageSubmissions: [
             {
                 cause: 'CONTRACT_SUBMISSION',
@@ -1096,6 +1100,7 @@ function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
         mccrsID: null,
         draftRevision: null,
         draftRates: [],
+        withdrawnRates: [],
         packageSubmissions: [
             {
                 cause: 'CONTRACT_SUBMISSION',
@@ -1307,6 +1312,7 @@ function mockContractPackageApproved(
         mccrsID: null,
         draftRevision: null,
         draftRates: [],
+        withdrawnRates: [],
         packageSubmissions: [
             {
                 cause: 'CONTRACT_SUBMISSION',
@@ -1697,6 +1703,7 @@ function mockContractPackageSubmittedWithRevisions(
         stateNumber: 5,
         draftRevision: null,
         draftRates: null,
+        withdrawnRates: [],
         packageSubmissions: [
             {
                 __typename: 'ContractPackageSubmission',
@@ -1841,6 +1848,7 @@ function mockContractPackageWithDifferentProgramsInRevisions(): Contract {
         __typename: 'Contract',
         draftRevision: null,
         draftRates: null,
+        withdrawnRates: [],
         packageSubmissions: [
             {
                 cause: 'CONTRACT_SUBMISSION',
@@ -2371,6 +2379,7 @@ function mockContractPackageUnlockedWithUnlockedType(
                 },
             },
         ],
+        withdrawnRates: [],
         packageSubmissions: [
             {
                 __typename: 'ContractPackageSubmission',
@@ -2821,6 +2830,7 @@ const mockEmptyDraftContractAndRate = (): Contract =>
                 },
             },
         ],
+        withdrawnRates: [],
     })
 
 export {

--- a/packages/mocks/src/apollo/rateDataMock.ts
+++ b/packages/mocks/src/apollo/rateDataMock.ts
@@ -136,6 +136,7 @@ const draftRateDataMock = (
             ...rateRevisionDataMock({ submitInfo: null, ...draftRevision }),
         },
         revisions: [],
+        withdrawnFromContracts: [],
         ...rate,
         id: rateID,
     }
@@ -202,6 +203,7 @@ const rateDataMock = (
         draftRevision: null,
         parentContractID: 'foo-bar',
         id: rateID,
+        withdrawnFromContracts: [],
         ...rate,
     }
 
@@ -325,6 +327,7 @@ function submittedLinkedRatesScenarioMock(): {
         id: 'r-01',
         withdrawInfo: null,
         revisions: [r1r2, r1r01],
+        withdrawnFromContracts: [],
         packageSubmissions: [r1r2c1c2pkg, r1r1c2pkg, r1r1pkg],
     }
 
@@ -446,6 +449,7 @@ function mockRateSubmittedWithQuestions(
         revisions: [rateRev()],
         draftRevision: null,
         withdrawInfo: null,
+        withdrawnFromContracts: [],
         packageSubmissions: [
             {
                 cause: 'RATE_SUBMISSION',

--- a/services/app-api/prisma/migrations/20241220161611_add_withdrawn_rate_join_table/migration.sql
+++ b/services/app-api/prisma/migrations/20241220161611_add_withdrawn_rate_join_table/migration.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+-- CreateTable
+CREATE TABLE "WithdrawnRatesJoinTable" (
+    "contractID" TEXT NOT NULL,
+    "rateID" TEXT NOT NULL,
+
+    CONSTRAINT "WithdrawnRatesJoinTable_pkey" PRIMARY KEY ("contractID","rateID")
+);
+
+-- AddForeignKey
+ALTER TABLE "WithdrawnRatesJoinTable" ADD CONSTRAINT "WithdrawnRatesJoinTable_contractID_fkey" FOREIGN KEY ("contractID") REFERENCES "ContractTable"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WithdrawnRatesJoinTable" ADD CONSTRAINT "WithdrawnRatesJoinTable_rateID_fkey" FOREIGN KEY ("rateID") REFERENCES "RateTable"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+COMMIT;

--- a/services/app-api/prisma/schema.prisma
+++ b/services/app-api/prisma/schema.prisma
@@ -46,6 +46,7 @@ model ContractTable {
   questions           ContractQuestion[]
   reviewStatusActions ContractActionTable[]
   draftRates          DraftRateJoinTable[]
+  withdrawnRates      WithdrawnRatesJoinTable[]
 
   revisions           ContractRevisionTable[]
   sharedRateRevisions RateRevisionTable[]     @relation(name: "SharedRateRevisions")
@@ -60,8 +61,9 @@ model RateTable {
   state       State  @relation(fields: [stateCode], references: [stateCode])
   stateNumber Int
 
-  withdrawInfoID String?
-  withdrawInfo   UpdateInfoTable? @relation("withdrawRateInfo", fields: [withdrawInfoID], references: [id])
+  withdrawInfoID         String?
+  withdrawInfo           UpdateInfoTable?          @relation("withdrawRateInfo", fields: [withdrawInfoID], references: [id])
+  withdrawnFromContracts WithdrawnRatesJoinTable[]
 
   questions           RateQuestion[]
   reviewStatusActions RateActionTable[]
@@ -77,6 +79,16 @@ model DraftRateJoinTable {
   rateID       String
   rate         RateTable     @relation(fields: [rateID], references: [id], onDelete: Cascade)
   ratePosition Int
+
+  @@id([contractID, rateID])
+}
+
+// Relationship for withdrawn rates and contracts
+model WithdrawnRatesJoinTable {
+  contractID String
+  contract   ContractTable @relation(fields: [contractID], references: [id])
+  rateID     String
+  rate       RateTable     @relation(fields: [rateID], references: [id], onDelete: Cascade)
 
   @@id([contractID, rateID])
 }
@@ -166,15 +178,15 @@ model RateRevisionTable {
 }
 
 model ContractActionTable {
-  id                           String             @id @default(uuid())
-  updatedAt                    DateTime           @default(now()) @updatedAt
-  updatedByID                  String
-  updatedBy                    User               @relation(fields: [updatedByID], references: [id])
-  updatedReason                String?
-  actionType                   ContractActionType
-  dateApprovalReleasedToState  DateTime?          @db.Date 
-  contractID                   String  
-  contract                     ContractTable      @relation(fields: [contractID], references: [id])
+  id                          String             @id @default(uuid())
+  updatedAt                   DateTime           @default(now()) @updatedAt
+  updatedByID                 String
+  updatedBy                   User               @relation(fields: [updatedByID], references: [id])
+  updatedReason               String?
+  actionType                  ContractActionType
+  dateApprovalReleasedToState DateTime?          @db.Date
+  contractID                  String
+  contract                    ContractTable      @relation(fields: [contractID], references: [id])
 }
 
 model RateActionTable {

--- a/services/app-api/src/domain-models/contractAndRates/contractTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/contractTypes.ts
@@ -12,6 +12,7 @@ import {
 } from './formDataTypes'
 
 const contractSchema = contractWithoutDraftRatesSchema.extend({
+    withdrawnRates: z.array(rateWithoutDraftContractsSchema).optional(),
     draftRates: z.array(rateWithoutDraftContractsSchema).optional(),
 })
 

--- a/services/app-api/src/domain-models/contractAndRates/rateTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/rateTypes.ts
@@ -7,6 +7,7 @@ import { rateRevisionSchema } from './revisionTypes'
 import { pruneDuplicateEmails } from '../../emailer/formatters'
 
 const rateSchema = rateWithoutDraftContractsSchema.extend({
+    withdrawnFromContracts: z.array(contractWithoutDraftRatesSchema).optional(),
     draftContracts: z.array(contractWithoutDraftRatesSchema).optional(),
 })
 

--- a/services/app-api/src/postgres/contractAndRates/parseContractWithHistory.ts
+++ b/services/app-api/src/postgres/contractAndRates/parseContractWithHistory.ts
@@ -241,11 +241,23 @@ function contractWithHistoryToDomainModel(
         return contractWithoutRates
     }
 
+    const withdrawnRatesOrErrors = contract.withdrawnRates.map((wr) =>
+        rateWithoutDraftContractsToDomainModel(wr.rate)
+    )
+
+    const withdrawnRatesOrError = arrayOrFirstError(withdrawnRatesOrErrors)
+    if (withdrawnRatesOrError instanceof Error) {
+        return withdrawnRatesOrError
+    }
+
     if (
         contractWithoutRates.status === 'SUBMITTED' ||
         contractWithoutRates.status === 'RESUBMITTED'
     ) {
-        return contractWithoutRates
+        return {
+            ...contractWithoutRates,
+            withdrawnRates: withdrawnRatesOrError,
+        }
     }
 
     // since we have a draft revision, we should also hold onto any set draftRates for later
@@ -270,6 +282,7 @@ function contractWithHistoryToDomainModel(
 
     return {
         ...contractWithoutRates,
+        withdrawnRates: withdrawnRatesOrError,
         draftRates: draftRatesOrError,
     }
 }

--- a/services/app-api/src/postgres/contractAndRates/parseRateWithHistory.ts
+++ b/services/app-api/src/postgres/contractAndRates/parseRateWithHistory.ts
@@ -240,11 +240,26 @@ function rateWithHistoryToDomainModel(
         return rateWithoutContracts
     }
 
+    const withdrawnFromContractsOrErrors = rate.withdrawnFromContracts.map(
+        (contract) =>
+            contractWithHistoryToDomainModelWithoutRates(contract.contract)
+    )
+
+    const withdrawnFromContractsOrError = arrayOrFirstError(
+        withdrawnFromContractsOrErrors
+    )
+    if (withdrawnFromContractsOrError instanceof Error) {
+        return withdrawnFromContractsOrError
+    }
+
     if (
         rateWithoutContracts.status === 'SUBMITTED' ||
         rateWithoutContracts.status === 'RESUBMITTED'
     ) {
-        return rateWithoutContracts
+        return {
+            ...rateWithoutContracts,
+            withdrawnFromContracts: withdrawnFromContractsOrError,
+        }
     }
 
     // since we have a draft revision, we should also hold onto any set draftRates for later
@@ -273,6 +288,7 @@ function rateWithHistoryToDomainModel(
 
     return {
         ...rateWithoutContracts,
+        withdrawnFromContracts: withdrawnFromContractsOrError,
         draftContracts: draftContractsOrError,
     }
 }

--- a/services/app-api/src/postgres/contractAndRates/prismaFullContractRateHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaFullContractRateHelpers.ts
@@ -4,7 +4,13 @@ import { includeRateWithoutDraftContracts } from './prismaSubmittedRateHelpers'
 
 const includeFullContract = {
     ...includeContractWithoutDraftRates,
-
+    withdrawnRates: {
+        include: {
+            rate: {
+                include: includeRateWithoutDraftContracts,
+            },
+        },
+    },
     draftRates: {
         orderBy: {
             ratePosition: 'asc',
@@ -29,6 +35,14 @@ type ContractRevisionTableWithRates = ContractTableFullPayload['revisions'][0]
 
 const includeFullRate = {
     ...includeRateWithoutDraftContracts,
+    withdrawnFromContracts: {
+        include: {
+            contract: {
+                include: includeContractWithoutDraftRates,
+            },
+        },
+    },
+
     draftContracts: {
         include: {
             contract: {

--- a/services/app-api/src/postgres/contractAndRates/submitRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/submitRate.ts
@@ -114,5 +114,5 @@ async function submitRate(
     }
 }
 
-export { submitRate }
+export { submitRate, submitRateInsideTransaction }
 export type { SubmitRateArgsType }

--- a/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
@@ -2,6 +2,19 @@ import type { PrismaTransactionType } from '../prismaTypes'
 import type { RateType } from '../../domain-models'
 import { findRateWithHistory } from './findRateWithHistory'
 import type { PrismaClient } from '@prisma/client'
+import { includeFullContract } from './prismaFullContractRateHelpers'
+import {
+    getConsolidatedContractStatus,
+    getContractRateStatus,
+    getContractReviewStatus,
+    includeContractFormData,
+} from './prismaSharedContractRateHelpers'
+import { unlockContractInsideTransaction } from './unlockContract'
+import { UserInputPostgresError } from '../postgresErrors'
+import type { UpdateDraftContractRatesArgsType } from './updateDraftContractRates'
+import { updateDraftContractRatesInsideTransaction } from './updateDraftContractRates'
+import type { SubmitContractArgsType } from './submitContract'
+import { submitContractInsideTransaction } from './submitContract'
 
 type WithdrawRateArgsType = {
     rateID: string
@@ -15,6 +28,185 @@ const withdrawRateInsideTransaction = async (
 ): Promise<RateType | Error> => {
     const { rateID, updatedByID, updatedReason } = args
 
+    const rate = await tx.rateTable.findFirst({
+        where: {
+            id: rateID,
+        },
+        include: {
+            revisions: {
+                orderBy: {
+                    createdAt: 'desc',
+                },
+                include: {
+                    relatedSubmissions: {
+                        orderBy: {
+                            updatedAt: 'desc',
+                        },
+                        include: {
+                            submissionPackages: {
+                                include: {
+                                    contractRevision: {
+                                        include: includeContractFormData,
+                                    },
+                                },
+                                orderBy: {
+                                    ratePosition: 'desc',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    })
+
+    if (!rate) {
+        throw new Error('Oh no')
+    }
+
+    // Get the contractIDs of the latest submission package of each related submission
+    const latestRevision = rate.revisions[0]
+    const contractIDs = latestRevision.relatedSubmissions.map(
+        (sub) => sub.submissionPackages[0].contractRevision.contractID
+    )
+
+    //console.log(contractIDs)
+
+    // get data for every contract
+    const contracts = await tx.contractTable.findMany({
+        where: {
+            id: {
+                in: contractIDs,
+            },
+        },
+        include: includeFullContract,
+    })
+
+    // collect contractIDs we remove the rate from to make the new connection on the withdrawn rate table
+    const withdrawnFromContracts: { contractID: string }[] = []
+
+    // Remove rate from each contract
+    for (const contract of contracts) {
+        const consolidatedStatus = getConsolidatedContractStatus(
+            getContractRateStatus(contract.revisions),
+            getContractReviewStatus(contract)
+        )
+
+        // Any approved contracts returns an error to client
+        if (consolidatedStatus === 'APPROVED') {
+            return new Error(
+                `Rate is a child or linked to an APPROVED contract with ID: ${contract.id}`
+            )
+        }
+
+        // Draft and unlocked contracts are ignored, since other API will prevent them from resubmitting a withdrawn rate, breaking the link.
+        if (['SUBMITTED', 'RESUBMITTED'].includes(consolidatedStatus)) {
+            //contractsToUnlock.push(contract)
+
+            const unlockedContract = await unlockContractInsideTransaction(tx, {
+                contractID: contract.id,
+                unlockedByUserID: updatedByID,
+                unlockReason: `CMS withdrawing rate ${latestRevision.rateCertificationName} from this submission`,
+            })
+
+            if (unlockedContract instanceof Error) {
+                return unlockedContract
+            }
+
+            const previousRates = unlockedContract.draftRates
+            const rateToWithdrawIndex = previousRates
+                .map((rate) => rate.id)
+                .indexOf(rateID)
+
+            // Validate that the rate to withdraw is on the now unlocked contract
+            if (rateToWithdrawIndex === -1) {
+                return new UserInputPostgresError(
+                    `withdrawnRateID ${rateID} does not map to a current rate on this contract`
+                )
+            }
+
+            const updateRates: UpdateDraftContractRatesArgsType['rateUpdates']['update'] =
+                []
+            const linkRates: UpdateDraftContractRatesArgsType['rateUpdates']['link'] =
+                []
+
+            // prepare rate data for updating
+            previousRates.forEach((rate, idx) => {
+                if (rate.id === rateID) {
+                    return // we already know this is swapped, we will swap in replacement later, skip for now
+                }
+                // keep any existing linked rates besides replacement or withdrawn rate
+                if (rate.parentContractID !== contract.id) {
+                    linkRates.push({
+                        rateID: rate.id,
+                        ratePosition: idx + 1,
+                    })
+                } else {
+                    // keep any existing child rates and resubmit them unchanged
+                    updateRates.push({
+                        rateID: rate.id,
+                        formData:
+                            rate.packageSubmissions[0].rateRevision.formData,
+                        ratePosition: idx + 1,
+                    })
+                }
+            })
+
+            // arrange rate data for update draft contract rates
+            const updateContractRatesArgs: UpdateDraftContractRatesArgsType = {
+                contractID: contract.id,
+                rateUpdates: {
+                    create: [],
+                    update: [
+                        //  keep any already added child rates
+                        ...updateRates,
+                    ],
+                    delete: [],
+                    unlink: [
+                        // unlink the withdrawn child rate
+                        {
+                            rateID: rateID,
+                        },
+                    ],
+                    link: [
+                        // keep any other already added linked rates
+                        ...linkRates.sort(
+                            (a, b) => a.ratePosition - b.ratePosition
+                        ),
+                    ],
+                },
+            }
+
+            // update the contract to remove the withdrawn rate
+            const updateResult =
+                await updateDraftContractRatesInsideTransaction(
+                    tx,
+                    updateContractRatesArgs
+                )
+
+            if (updateResult instanceof Error) {
+                return updateResult
+            }
+
+            // resubmit contract
+            const resubmitContractArgs: SubmitContractArgsType = {
+                contractID: contract.id,
+                submittedByUserID: updatedByID,
+                submittedReason: `CMS withdrawn rate ${latestRevision.rateCertificationName} from this submission`,
+            }
+            const resubmitResult = await submitContractInsideTransaction(
+                tx,
+                resubmitContractArgs
+            )
+            if (resubmitResult instanceof Error) {
+                return resubmitResult
+            }
+
+            withdrawnFromContracts.push({ contractID: contract.id })
+        }
+    }
+
+    // Add review status action to rate and create new joins on withdrawn rate join table
     try {
         await tx.rateTable.update({
             where: {
@@ -27,6 +219,9 @@ const withdrawRateInsideTransaction = async (
                         updatedReason,
                         actionType: 'WITHDRAW',
                     },
+                },
+                withdrawnFromContracts: {
+                    create: withdrawnFromContracts,
                 },
             },
         })

--- a/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
@@ -15,6 +15,7 @@ import type { UpdateDraftContractRatesArgsType } from './updateDraftContractRate
 import { updateDraftContractRatesInsideTransaction } from './updateDraftContractRates'
 import type { SubmitContractArgsType } from './submitContract'
 import { submitContractInsideTransaction } from './submitContract'
+import { submitRateInsideTransaction } from './submitRate'
 
 type WithdrawRateArgsType = {
     rateID: string
@@ -192,7 +193,7 @@ const withdrawRateInsideTransaction = async (
             const resubmitContractArgs: SubmitContractArgsType = {
                 contractID: contract.id,
                 submittedByUserID: updatedByID,
-                submittedReason: `CMS withdrawn rate ${latestRevision.rateCertificationName} from this submission`,
+                submittedReason: `CMS has withdrawn rate ${latestRevision.rateCertificationName} from this submission`,
             }
             const resubmitResult = await submitContractInsideTransaction(
                 tx,
@@ -205,6 +206,14 @@ const withdrawRateInsideTransaction = async (
             withdrawnFromContracts.push({ contractID: contract.id })
         }
     }
+
+    // Resubmit the rate
+    await submitRateInsideTransaction(tx, {
+        rateID,
+        formData: undefined,
+        submittedByUserID: updatedByID,
+        submittedReason: 'CMS has withdrawn this rate',
+    })
 
     // Add review status action to rate and create new joins on withdrawn rate join table
     try {

--- a/services/app-api/src/resolvers/contract/submitContract.test.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.test.ts
@@ -7,7 +7,7 @@ import {
     updateTestHealthPlanFormData,
     updateTestStateAssignments,
 } from '../../testHelpers/gqlHelpers'
-import { SubmitContractDocument } from '../../gen/gqlClient'
+import {SubmitContractDocument, UpdateDraftContractRatesDocument} from '../../gen/gqlClient'
 import { testS3Client } from '../../../src/testHelpers/s3Helpers'
 
 import {
@@ -33,7 +33,7 @@ import {
     addLinkedRateToTestContract,
     addNewRateToTestContract,
     updateRatesInputFromDraftContract,
-    updateTestDraftRatesOnContract,
+    updateTestDraftRatesOnContract, withdrawTestRate,
 } from '../../testHelpers/gqlRateHelpers'
 import { testLDService } from '../../testHelpers/launchDarklyHelpers'
 import { latestFormData } from '../../testHelpers/healthPlanPackageHelpers'
@@ -1054,6 +1054,65 @@ describe('submitContract', () => {
         })
 
         expect(res.errors).toBeDefined()
+    })
+
+    it('returns an error if any rates are withdrawn', async () => {
+        const stateUser = testStateUser()
+        const cmsUser = testCMSUser()
+        const stateServer = await constructTestPostgresServer({
+            context: {
+                user: stateUser,
+            },
+        })
+
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+        })
+
+        // contractA is parent contract and submitted
+        const contractA = await createAndSubmitTestContractWithRate(stateServer)
+        const rateID = contractA.packageSubmissions[0].rateRevisions[0].rateID
+
+        // contract B is linked and in draft
+        const contractB = await createAndUpdateTestContractWithoutRates(stateServer)
+
+        // link rate to contract B
+        await stateServer.executeOperation({
+            query: UpdateDraftContractRatesDocument,
+            variables: {
+                input: {
+                    contractID: contractB.id,
+                    lastSeenUpdatedAt: contractB.draftRevision?.updatedAt,
+                    updatedRates: [
+                        {
+                            type: 'LINK',
+                            rateID: rateID,
+                        },
+                    ],
+                }
+            }
+        })
+
+        // withdraw rate
+        await withdrawTestRate(cmsServer, rateID, 'Withdraw invalid rate')
+
+        const errorSubmittingContractB = await stateServer.executeOperation({
+            query: SubmitContractDocument,
+            variables: {
+                input: {
+                    contractID: contractB.id,
+                    submittedReason: 'Initial submit',
+                },
+            },
+        })
+
+        // expect error trying to submit contract B linking to a withdrawn rate
+        expect(errorSubmittingContractB.errors).toBeDefined()
+        expect(errorSubmittingContractB.errors && errorSubmittingContractB.errors[0].message).toBe(
+            'Attempted to submit with a WITHDRAWN rate.'
+        )
     })
 
     describe('emails', () => {

--- a/services/app-api/src/resolvers/contract/submitContract.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.ts
@@ -255,26 +255,6 @@ export function submitContract(
             }
         }
 
-        // Validate that no rates, child or linked, is withdrawn
-        if (
-            parsedSubmissionType === 'CONTRACT_AND_RATES' &&
-            parsedContract.draftRates &&
-            parsedContract.draftRates.length > 0
-        ) {
-            for (const rate of parsedContract.draftRates) {
-                if (rate.consolidatedStatus === 'WITHDRAWN') {
-                    const errMessage = `Attempted to submit with a WITHDRAWN rate.`
-                    logError('submitContract', errMessage)
-                    throw new GraphQLError(errMessage, {
-                        extensions: {
-                            code: 'INTERNAL_SERVER_ERROR',
-                            cause: 'INVALID_PACKAGE_STATUS',
-                        },
-                    })
-                }
-            }
-        }
-
         const updateResult = await store.updateDraftContractWithRates({
             contractID: input.contractID,
             formData: {

--- a/services/app-api/src/resolvers/rate/withdrawRate.test.ts
+++ b/services/app-api/src/resolvers/rate/withdrawRate.test.ts
@@ -6,18 +6,27 @@ import {
 import { constructTestPostgresServer } from '../../testHelpers/gqlHelpers'
 import {
     createAndSubmitTestContractWithRate,
+    createAndUpdateTestContractWithoutRates,
     createAndUpdateTestContractWithRate,
+    fetchTestContractWithQuestions,
     submitTestContract,
     unlockTestContract,
 } from '../../testHelpers/gqlContractHelpers'
-import { WithdrawRateDocument } from '../../gen/gqlClient'
+import { withdrawTestRate } from '../../testHelpers/gqlRateHelpers'
+import {
+    WithdrawRateDocument,
+    UpdateDraftContractRatesDocument,
+    UnlockContractDocument,
+    SubmitContractDocument,
+} from '../../gen/gqlClient'
 import { mockStoreThatErrors } from '../../testHelpers/storeHelpers'
+import { expect } from 'vitest'
 
 describe('withdrawRate', () => {
-    it('can withdraw a rate without errors', async () => {
-        const stateUser = testStateUser()
-        const cmsUser = testCMSUser()
+    const stateUser = testStateUser()
+    const cmsUser = testCMSUser()
 
+    it('can withdraw a rate without errors', async () => {
         const stateServer = await constructTestPostgresServer({
             context: {
                 user: stateUser,
@@ -32,21 +41,21 @@ describe('withdrawRate', () => {
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
         const rateID = contract.packageSubmissions[0].rateRevisions[0].rateID
+        const withdrawnRate = await withdrawTestRate(
+            cmsServer,
+            rateID,
+            'Withdraw invalid rate'
+        )
 
-        const withdrawnRateResult = await cmsServer.executeOperation({
-            query: WithdrawRateDocument,
-            variables: {
-                input: {
-                    rateID: rateID,
-                    updatedReason: 'Withdraw invalid rate',
-                },
-            },
-        })
-
-        const withdrawnRate = withdrawnRateResult.data?.withdrawRate.rate
-
-        // expect no errors
-        expect(withdrawnRateResult.errors).toBeUndefined()
+        // expect rate to contain contract in withdrawn join table
+        expect(withdrawnRate.withdrawnFromContracts).toHaveLength(1)
+        expect(withdrawnRate.withdrawnFromContracts).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: contract.id,
+                }),
+            ])
+        )
 
         // expect withdrawn status
         expect(withdrawnRate).toEqual(
@@ -74,6 +83,405 @@ describe('withdrawRate', () => {
                 }),
             ])
         )
+
+        const contractWithWithdrawnRate = await fetchTestContractWithQuestions(
+            stateServer,
+            contract.id
+        )
+        expect(contractWithWithdrawnRate.withdrawnRates).toBeDefined()
+
+        // expect contract to be RESUBMITTED
+        expect(contractWithWithdrawnRate.consolidatedStatus).toEqual(
+            'RESUBMITTED'
+        )
+
+        // expect contract to contain the withdrawn rate
+        expect(contractWithWithdrawnRate?.withdrawnRates).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: rateID,
+                }),
+            ])
+        )
+
+        const packageSubmissions = contractWithWithdrawnRate.packageSubmissions
+
+        // expect withdrawn rate is no longer in latest package submission
+        expect(packageSubmissions[0].rateRevisions).not.toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    rateID,
+                }),
+            ])
+        )
+
+        // expect the withdrawn rate is on the previous packageSubmission
+        expect(packageSubmissions[1].rateRevisions).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    rateID,
+                }),
+            ])
+        )
+    })
+
+    it('can still unlock and resubmit after a rate has been withdrawn with expected packageSubmissions', async () => {
+        const stateServer = await constructTestPostgresServer({
+            context: {
+                user: stateUser,
+            },
+        })
+
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+        })
+
+        const contract = await createAndSubmitTestContractWithRate(stateServer)
+        const rateID = contract.packageSubmissions[0].rateRevisions[0].rateID
+        await withdrawTestRate(cmsServer, rateID, 'Withdraw invalid rate')
+
+        const unlockedContractResult = await cmsServer.executeOperation({
+            query: UnlockContractDocument,
+            variables: {
+                input: {
+                    contractID: contract.id,
+                    unlockedReason: 'Test unlock after withdrawing rate',
+                },
+            },
+        })
+
+        expect(unlockedContractResult.errors).toBeUndefined()
+
+        const resubmitContractResult = await stateServer.executeOperation({
+            query: SubmitContractDocument,
+            variables: {
+                input: {
+                    contractID: contract.id,
+                    submittedReason: 'Resubmit contract',
+                },
+            },
+        })
+
+        expect(resubmitContractResult.errors).toBeUndefined()
+
+        // expect withdrawn rate to still be in the withdrawn rate join table
+        const resubmittedContract =
+            resubmitContractResult.data?.submitContract.contract
+        expect(resubmittedContract.withdrawnRates).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: rateID,
+                }),
+            ])
+        )
+
+        const packageSubmissions = resubmittedContract.packageSubmissions
+
+        // expect withdrawn rate to be in the latest packageSubmissions.
+        expect(packageSubmissions[0].rateRevisions).not.toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    rateID,
+                }),
+            ])
+        )
+
+        // expect the withdrawn rate is not on the previous packageSubmission
+        expect(packageSubmissions[1].rateRevisions).not.toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    rateID,
+                }),
+            ])
+        )
+
+        // expect the withdrawn rate to be on the packageSubmission before the withdraw
+        expect(packageSubmissions[2].rateRevisions).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    rateID,
+                }),
+            ])
+        )
+    })
+
+    it('withdraws rate when linked to other contracts', async () => {
+        const stateServer = await constructTestPostgresServer({
+            context: {
+                user: stateUser,
+            },
+        })
+
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+        })
+
+        const contractA = await createAndSubmitTestContractWithRate(stateServer)
+        const rateID = contractA.packageSubmissions[0].rateRevisions[0].rateID
+
+        const contractB =
+            await createAndUpdateTestContractWithoutRates(stateServer)
+
+        // link rate to contract B
+        await stateServer.executeOperation({
+            query: UpdateDraftContractRatesDocument,
+            variables: {
+                input: {
+                    contractID: contractB.id,
+                    lastSeenUpdatedAt: contractB.draftRevision?.updatedAt,
+                    updatedRates: [
+                        {
+                            type: 'LINK',
+                            rateID: rateID,
+                        },
+                    ],
+                },
+            },
+        })
+
+        await submitTestContract(stateServer, contractB.id)
+
+        const withdrawnRate = await withdrawTestRate(
+            cmsServer,
+            rateID,
+            'Withdraw invalid rate'
+        )
+
+        // expect rate to contain both contracts in withdrawn join table
+        expect(withdrawnRate.withdrawnFromContracts).toHaveLength(2)
+        expect(withdrawnRate.withdrawnFromContracts).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: contractB.id,
+                }),
+                expect.objectContaining({
+                    id: contractA.id,
+                }),
+            ])
+        )
+
+        // expect review status action to be WITHDRAW
+        expect(withdrawnRate.reviewStatusActions).toHaveLength(1)
+        expect(withdrawnRate.reviewStatusActions).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    updatedAt: expect.any(Date),
+                    updatedBy: expect.objectContaining({
+                        role: cmsUser.role,
+                        email: cmsUser.email,
+                        givenName: cmsUser.givenName,
+                        familyName: cmsUser.familyName,
+                    }),
+                    updatedReason: 'Withdraw invalid rate',
+                    actionType: 'WITHDRAW',
+                    rateID,
+                }),
+            ])
+        )
+
+        const contractAWithWithdrawnRate = await fetchTestContractWithQuestions(
+            stateServer,
+            contractA.id
+        )
+        expect(contractAWithWithdrawnRate.withdrawnRates).toBeDefined()
+
+        // expect contract A to contain the withdrawn rate
+        expect(contractAWithWithdrawnRate?.withdrawnRates).toHaveLength(1)
+        expect(contractAWithWithdrawnRate?.withdrawnRates).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: rateID,
+                }),
+            ])
+        )
+
+        const contractBWithWithdrawnRate = await fetchTestContractWithQuestions(
+            stateServer,
+            contractB.id
+        )
+        expect(contractBWithWithdrawnRate.withdrawnRates).toBeDefined()
+
+        // expect contract B to contain the withdrawn rate
+        expect(contractBWithWithdrawnRate?.withdrawnRates).toHaveLength(1)
+        expect(contractBWithWithdrawnRate?.withdrawnRates).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: rateID,
+                }),
+            ])
+        )
+    })
+
+    it('does not update draft contract linked to withdrawn rate', async () => {
+        const stateServer = await constructTestPostgresServer({
+            context: {
+                user: stateUser,
+            },
+        })
+
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+        })
+
+        // contractA is parent contract and submitted
+        const contractA = await createAndSubmitTestContractWithRate(stateServer)
+        const rateID = contractA.packageSubmissions[0].rateRevisions[0].rateID
+
+        // contract B is linked and in draft
+        const contractB =
+            await createAndUpdateTestContractWithoutRates(stateServer)
+
+        // contract C is linked, submitted, then unlocked
+        const contractC =
+            await createAndUpdateTestContractWithoutRates(stateServer)
+
+        // link rate to contract B
+        await stateServer.executeOperation({
+            query: UpdateDraftContractRatesDocument,
+            variables: {
+                input: {
+                    contractID: contractB.id,
+                    lastSeenUpdatedAt: contractB.draftRevision?.updatedAt,
+                    updatedRates: [
+                        {
+                            type: 'LINK',
+                            rateID: rateID,
+                        },
+                    ],
+                },
+            },
+        })
+
+        // link rate to contract C, submit then unlock
+        await stateServer.executeOperation({
+            query: UpdateDraftContractRatesDocument,
+            variables: {
+                input: {
+                    contractID: contractC.id,
+                    lastSeenUpdatedAt: contractC.draftRevision?.updatedAt,
+                    updatedRates: [
+                        {
+                            type: 'LINK',
+                            rateID: rateID,
+                        },
+                    ],
+                },
+            },
+        })
+        await submitTestContract(stateServer, contractC.id)
+        await unlockTestContract(
+            cmsServer,
+            contractC.id,
+            'unlock to make updates'
+        )
+        const withdrawnRate = await withdrawTestRate(
+            cmsServer,
+            rateID,
+            'Withdraw invalid rate'
+        )
+
+        // expect rate to contain contract in withdrawn join table
+        expect(withdrawnRate.withdrawnFromContracts).toHaveLength(1)
+        expect(withdrawnRate.withdrawnFromContracts).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: contractA.id,
+                }),
+            ])
+        )
+
+        // expect withdrawn status
+        expect(withdrawnRate).toEqual(
+            expect.objectContaining({
+                reviewStatus: 'WITHDRAWN',
+                consolidatedStatus: 'WITHDRAWN',
+            })
+        )
+
+        // expect correct actions
+        expect(withdrawnRate.reviewStatusActions).toHaveLength(1)
+        expect(withdrawnRate.reviewStatusActions).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    updatedAt: expect.any(Date),
+                    updatedBy: expect.objectContaining({
+                        role: cmsUser.role,
+                        email: cmsUser.email,
+                        givenName: cmsUser.givenName,
+                        familyName: cmsUser.familyName,
+                    }),
+                    updatedReason: 'Withdraw invalid rate',
+                    actionType: 'WITHDRAW',
+                    rateID,
+                }),
+            ])
+        )
+
+        const contractAWithWithdrawnRate = await fetchTestContractWithQuestions(
+            stateServer,
+            contractA.id
+        )
+        expect(contractAWithWithdrawnRate.withdrawnRates).toHaveLength(1)
+
+        // expect contract A to be RESUBMITTED
+        expect(contractAWithWithdrawnRate.consolidatedStatus).toEqual(
+            'RESUBMITTED'
+        )
+
+        // expect contract A to contain the withdrawn rate
+        expect(contractAWithWithdrawnRate?.withdrawnRates).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: rateID,
+                }),
+            ])
+        )
+
+        const contractBResult = await fetchTestContractWithQuestions(
+            stateServer,
+            contractB.id
+        )
+        // expect no withdrawn rates
+        expect(contractBResult.withdrawnRates).toHaveLength(0)
+
+        // expect contract B to be DRAFT
+        expect(contractBResult.consolidatedStatus).toEqual('DRAFT')
+
+        //expect contract B to still contain withdrawn rate in DraftRates
+        expect(contractBResult?.draftRates).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: rateID,
+                    consolidatedStatus: 'WITHDRAWN',
+                }),
+            ])
+        )
+
+        const contractCResult = await fetchTestContractWithQuestions(
+            stateServer,
+            contractC.id
+        )
+        // expect no withdrawn rates
+        expect(contractCResult.withdrawnRates).toHaveLength(0)
+
+        // expect contract B to be DRAFT
+        expect(contractCResult.consolidatedStatus).toEqual('UNLOCKED')
+
+        //expect contract B to still contain withdrawn rate in DraftRates
+        expect(contractCResult?.draftRates).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: rateID,
+                    consolidatedStatus: 'WITHDRAWN',
+                }),
+            ])
+        )
     })
 })
 
@@ -81,7 +489,7 @@ describe('withdrawRate invalid status handling', () => {
     const stateUser = testStateUser()
     const cmsUser = testCMSUser()
 
-    it('returns error if rate is in invalid status to withdraw', async () => {
+    it("returns error if rate is in invalid status' to withdraw", async () => {
         const stateServer = await constructTestPostgresServer({
             context: {
                 user: stateUser,
@@ -112,7 +520,7 @@ describe('withdrawRate invalid status handling', () => {
         // expect error for attempting to withdraw a draft rate
         expect(failedWithdrawDraftRate.errors?.[0]).toBeDefined()
         expect(failedWithdrawDraftRate.errors?.[0].message).toBe(
-            'Attempted to withdraw rate with wrong status: DRAFT'
+            'Attempted to withdraw rate with wrong status. Rate: DRAFT, Parent contract: DRAFT'
         )
 
         await submitTestContract(stateServer, contractID)
@@ -131,7 +539,7 @@ describe('withdrawRate invalid status handling', () => {
         // expect error for attempting to withdraw an unlocked rate
         expect(failedWithdrawUnlockedRate.errors?.[0]).toBeDefined()
         expect(failedWithdrawUnlockedRate.errors?.[0].message).toBe(
-            'Attempted to withdraw rate with wrong status: UNLOCKED'
+            'Attempted to withdraw rate with wrong status. Rate: UNLOCKED, Parent contract: UNLOCKED'
         )
 
         await submitTestContract(stateServer, contractID, 'Resubmit')
@@ -170,7 +578,7 @@ describe('withdrawRate invalid status handling', () => {
         // expect error for attempting to withdraw a withdrawn rate
         expect(failedWithdrawWithdrawnRate.errors?.[0]).toBeDefined()
         expect(failedWithdrawWithdrawnRate.errors?.[0].message).toBe(
-            'Attempted to withdraw rate with wrong status: WITHDRAWN'
+            'Attempted to withdraw rate with wrong status. Rate: WITHDRAWN, Parent contract: RESUBMITTED'
         )
     })
 

--- a/services/app-api/src/testHelpers/gqlRateHelpers.ts
+++ b/services/app-api/src/testHelpers/gqlRateHelpers.ts
@@ -4,6 +4,7 @@ import {
     FetchRateWithQuestionsDocument,
     UnlockRateDocument,
     UpdateDraftContractRatesDocument,
+    WithdrawRateDocument,
 } from '../gen/gqlClient'
 import { must } from './assertionHelpers'
 import { defaultFloridaRateProgram } from './gqlHelpers'
@@ -456,6 +457,35 @@ const updateTestRate = async (
     )
 }
 
+const withdrawTestRate = async (
+    server: ApolloServer,
+    rateID: string,
+    updatedReason: string
+): Promise<RateType> => {
+    const withdrawResult = await server.executeOperation({
+        query: WithdrawRateDocument,
+        variables: {
+            input: {
+                rateID,
+                updatedReason,
+            },
+        },
+    })
+
+    if (withdrawResult.errors) {
+        console.info('errors', withdrawResult.errors)
+        throw new Error(
+            `withdrawRate mutation failed with errors ${withdrawResult.errors}`
+        )
+    }
+
+    if (withdrawResult.data === undefined || withdrawResult.data === null) {
+        throw new Error('withdrawRate returned nothing')
+    }
+
+    return withdrawResult.data.withdrawRate.rate
+}
+
 export {
     createTestDraftRateOnContract,
     createSubmitAndUnlockTestRate,
@@ -472,4 +502,5 @@ export {
     updateTestRate,
     formatRateDataForSending,
     fetchTestRateWithQuestionsById,
+    withdrawTestRate,
 }

--- a/services/app-graphql/src/mutations/approveContract.graphql
+++ b/services/app-graphql/src/mutations/approveContract.graphql
@@ -19,6 +19,16 @@ mutation approveContract($input: ApproveContractInput!) {
                 }
             }
 
+            withdrawnRates {
+                ...rateFieldsFragment,
+                revisions {
+                    ...rateRevisionFragment
+                }
+                packageSubmissions {
+                    ...ratePackageSubmissionsFragment
+                }
+            }
+
             packageSubmissions {
                 ...packageSubmissionsFragment
             }

--- a/services/app-graphql/src/mutations/submitContract.graphql
+++ b/services/app-graphql/src/mutations/submitContract.graphql
@@ -19,6 +19,16 @@ mutation submitContract($input: SubmitContractInput!) {
                 }
             }
 
+            withdrawnRates {
+                ...rateFieldsFragment,
+                revisions {
+                    ...rateRevisionFragment
+                }
+                packageSubmissions {
+                    ...ratePackageSubmissionsFragment
+                }
+            }
+
             packageSubmissions {
                 ...packageSubmissionsFragment
             }

--- a/services/app-graphql/src/mutations/submitRate.graphql
+++ b/services/app-graphql/src/mutations/submitRate.graphql
@@ -2,6 +2,13 @@ mutation submitRate($input: SubmitRateInput!) {
     submitRate(input: $input) {
         rate {
             ...rateFieldsFragment
+
+            withdrawnFromContracts {
+                ...contractFieldsFragment,
+                packageSubmissions {
+                    ...packageSubmissionsFragment
+                }
+            }
             
             revisions {
                 ...rateRevisionFragment

--- a/services/app-graphql/src/mutations/unlockContract.graphql
+++ b/services/app-graphql/src/mutations/unlockContract.graphql
@@ -19,6 +19,16 @@ mutation unlockContract($input: UnlockContractInput!) {
                 }
             }
 
+            withdrawnRates {
+                ...rateFieldsFragment,
+                revisions {
+                    ...rateRevisionFragment
+                }
+                packageSubmissions {
+                    ...ratePackageSubmissionsFragment
+                }
+            }
+
             packageSubmissions {
                 ...packageSubmissionsFragment
             }

--- a/services/app-graphql/src/mutations/unlockRate.graphql
+++ b/services/app-graphql/src/mutations/unlockRate.graphql
@@ -7,6 +7,13 @@ mutation unlockRate($input: UnlockRateInput!) {
                 ...rateRevisionFragment
             }
 
+            withdrawnFromContracts {
+                ...contractFieldsFragment,
+                packageSubmissions {
+                    ...packageSubmissionsFragment
+                }
+            }
+
             revisions {
                 ...rateRevisionFragment
             }

--- a/services/app-graphql/src/mutations/withdrawRate.graphql
+++ b/services/app-graphql/src/mutations/withdrawRate.graphql
@@ -2,6 +2,7 @@ mutation withdrawRate($input: WithdrawRateInput!) {
     withdrawRate(input: $input) {
         rate {
             ...rateFieldsFragment
+
             draftRevision {
                 ...rateRevisionFragment
             }

--- a/services/app-graphql/src/mutations/withdrawRate.graphql
+++ b/services/app-graphql/src/mutations/withdrawRate.graphql
@@ -10,6 +10,13 @@ mutation withdrawRate($input: WithdrawRateInput!) {
                 ...rateRevisionFragment
             }
 
+            withdrawnFromContracts {
+                ...contractFieldsFragment,
+                packageSubmissions {
+                    ...packageSubmissionsFragment
+                }
+            }
+
             packageSubmissions {
                 ...ratePackageSubmissionsFragment
             }

--- a/services/app-graphql/src/queries/fetchContract.graphql
+++ b/services/app-graphql/src/queries/fetchContract.graphql
@@ -19,6 +19,16 @@ query fetchContract($input: FetchContractInput!) {
                 }
             }
 
+            withdrawnRates {
+                ...rateFieldsFragment,
+                revisions {
+                    ...rateRevisionFragment
+                }
+                packageSubmissions {
+                    ...ratePackageSubmissionsFragment
+                }
+            }
+
             packageSubmissions {
                 ...packageSubmissionsFragment
             }

--- a/services/app-graphql/src/queries/fetchContractWithQuestions.graphql
+++ b/services/app-graphql/src/queries/fetchContractWithQuestions.graphql
@@ -19,6 +19,16 @@ query fetchContractWithQuestions($input: FetchContractInput!) {
                 }
             }
 
+            withdrawnRates {
+                ...rateFieldsFragment,
+                revisions {
+                    ...rateRevisionFragment
+                }
+                packageSubmissions {
+                    ...ratePackageSubmissionsFragment
+                }
+            }
+
             packageSubmissions {
                 ...packageSubmissionsFragment
             }

--- a/services/app-graphql/src/queries/fetchRate.graphql
+++ b/services/app-graphql/src/queries/fetchRate.graphql
@@ -11,6 +11,13 @@ query fetchRate($input: FetchRateInput!) {
                 ...rateRevisionFragment
             }
 
+            withdrawnFromContracts {
+                ...contractFieldsFragment,
+                packageSubmissions {
+                    ...packageSubmissionsFragment
+                }
+            }
+
             packageSubmissions {
                 ...ratePackageSubmissionsFragment
             }

--- a/services/app-graphql/src/queries/fetchRateWithQuestions.graphql
+++ b/services/app-graphql/src/queries/fetchRateWithQuestions.graphql
@@ -11,6 +11,13 @@ query fetchRateWithQuestions($input: FetchRateInput!) {
                 ...rateRevisionFragment
             }
 
+            withdrawnFromContracts {
+                ...contractFieldsFragment,
+                packageSubmissions {
+                    ...packageSubmissionsFragment
+                }
+            }
+
             packageSubmissions {
                 ...ratePackageSubmissionsFragment
             }

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -1770,6 +1770,9 @@ type Rate {
     "withdrawInfo is the who/when/why for this rate being withdrawn. Rates actively in use in the system will not have a withdrawInfo"
     withdrawInfo: UpdateInformation
 
+    "Contracts this withdrawn rates was the child or linked to"
+    withdrawnFromContracts: [Contract!]
+
     "The currently modifiable revision of the rate. Only present when rate has a status of DRAFT or UNLOCKED"
     draftRevision: RateRevision
 
@@ -1927,6 +1930,9 @@ type Contract {
     "reviewStatusActions are the who/when/why for review status changes on this contract"
     reviewStatusActions: [ContractReviewStatusActions!]
 
+    "Rates withdrawn from this contract submission"
+    withdrawnRates: [Rate!]
+
     """
     packageSubmissions are a snapshot of the contract and its related rates through time
     each packageSubmission was created by a submission of this contract and/or its related rates
@@ -2001,6 +2007,9 @@ type UnlockedContract {
     On submission they are cemented into a new ContractPackageSubmission
     """
     draftRates: [Rate!]!
+
+    "Rates withdrawn from this contract submission"
+    withdrawnRates: [Rate!]
 
     """
     packageSubmissions are a snapshot of the contract and its related rates through time

--- a/services/cypress/integration/adminWorkflow/settings.spec.ts
+++ b/services/cypress/integration/adminWorkflow/settings.spec.ts
@@ -87,7 +87,8 @@ describe('Admin user can view application level settings', () => {
         // Check to AL assignments have been saved.
         cy.findAllByRole('row').should('exist').eq(1).within(row => {
             cy.findByText('AL')
-            cy.findByText('Zuko Hotman, Azula Hotman')
+            cy.findByText('Zuko Hotman')
+            cy.findByText('Azula Hotman')
         })
 
         // Remove Azula from assignment

--- a/services/cypress/integration/adminWorkflow/settings.spec.ts
+++ b/services/cypress/integration/adminWorkflow/settings.spec.ts
@@ -87,8 +87,8 @@ describe('Admin user can view application level settings', () => {
         // Check to AL assignments have been saved.
         cy.findAllByRole('row').should('exist').eq(1).within(row => {
             cy.findByText('AL')
-            cy.findByText('Zuko Hotman')
-            cy.findByText('Azula Hotman')
+            cy.findByText(/Azula Hotman/)
+            cy.findByText(/Zuko Hotman/)
         })
 
         // Remove Azula from assignment


### PR DESCRIPTION
## Summary
[MCR-4847](https://jiraent.cms.gov/browse/MCR-4847)

Summary:
This work refactors the withdraw API to remove the withdrawn rates from a submitted submission. 

The API will:
- Find all contracts related to the rate that is being withdrawn.
- UNLOCKED and DRAFT contracts will be untouched
- If even one of the related submissions are APPROVED, it will return an error to the client, we do not want to withdraw a rate if it's a child or linked to a approved contract.
- SUBMITTED and RESUBMITTED contracts will be unlocked, rate being withdrawn will be removed, and then resubmitted.
- [🛑**READ THIS PLEASE**] Withdrawn rate is resubmitted, removing itself from an UNLOCKED or DRAFT contracts `draftRates`. This means in the UI any unlocked submission that had this rate, will no longer have it after withdrawing.
   - We should check with design if withdrawn rates should automatically gets removed from an unlocked or draft submission. For unlocked submission, if the rate was linked in a previous submission it will still be in previous submission summary.
      - If we do want to keep withdrawn rates on draft and unlocked submission so that the UI can display them as withdrawn and leaving it up to the state to remove them, then one way to do this is to not resubmit the withdrawn rate in the postgres function.
   - For an unlocked submission, the withdraw will not show up in the change history because we are not submitting this type of submission when withdrawing a rate.
- Finally add review action of `WITHDRAW` and connect to contracts it was withdrawn from on the new join table.

With this work, the withdrawn rate is now separated from the active rates on the submission. New unlocks and resubmits of any contract that was a parent or linked will no longer create a new revision for the withdrawn rate. The withdrawn rate and its former contracts still maintain a relationship on the join table to help with UI or un-withdraw actions.

AC:
- There is a new join table `WithdrawnRatesJoinTable` that stores the relationship between the withdrawn rate and their parent and linked to contracts.
- withdrawRate API updates all contracts, parent and linked, to remove the withdrawn rates from the contract and creates a new relationship between them using the new WithdrawnRatesJoinTable table.
- Both GraphQL return data of the parent and linked contracts no longer contains the withdrawn rate in its packageSubmission and now contains the withdraw rate in withdrawnRates field.
- Unlocking submission does not create new revision for withdrawn rates.

Additional work:
- Fix minor command typo in dev_tool

#### Related issues

#### Screenshots

#### Test cases covered

`resolvers/withdrawnRate.test.ts`
- `'can withdraw a rate without errors'` (UPDATE)
   - Added more assertions on `packageSubmission`
- `'can still unlock and resubmit after a rate has been withdrawn with expected packageSubmissions'`
- `'withdraws rate when linked to other contracts'`
- `'does not update draft contract linked to withdrawn rate'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
