### PR TITLE
Bump body parser config size

### DIFF
--- a/services/app-api/src/handlers/apollo_gql.ts
+++ b/services/app-api/src/handlers/apollo_gql.ts
@@ -448,6 +448,9 @@ async function initializeGQLHandler(): Promise<Handler> {
                 origin: true,
                 credentials: true,
             },
+            bodyParserConfig: {
+                limit: '10mb',
+            },
         },
     })
 


### PR DESCRIPTION
## Summary

We've been seeing some logs with payload sizes being too big (HTTP 413) from Apollo. It seems as if users are trying to paste long documents into form fields, and the middleware default in Express, which Apollo uses, is 100kb. This bumps the payload size to match API gateway limits.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4849
