### PR TITLE
Refactor lambda zip function to handle 100+ files at a time

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -230,7 +230,7 @@ functions:
           method: post
           cors: true
           authorizer: aws_iam
-    timeout: 30
+    timeout: 60
     memorySize: ${self:custom.lambdaMemory.${sls:stage}, self:custom.lambdaMemory.default}
 
   cleanup:

--- a/services/app-api/src/handlers/bulk_download.ts
+++ b/services/app-api/src/handlers/bulk_download.ts
@@ -310,4 +310,4 @@ function parseContentDisposition(cd: string): string {
     return filename
 }
 
-export { main }
+module.exports = { main }

--- a/services/app-api/src/handlers/bulk_download.ts
+++ b/services/app-api/src/handlers/bulk_download.ts
@@ -296,9 +296,7 @@ const main: APIGatewayProxyHandler = async (event) => {
 
 // parses a content-disposition header for the filename
 function parseContentDisposition(cd: string): string {
-    console.info('original content-disposition: ' + cd)
     const [, filename] = cd.split('filename=')
-    console.info('original name: ' + filename)
     return filename
 }
 

--- a/services/app-api/src/handlers/bulk_download.ts
+++ b/services/app-api/src/handlers/bulk_download.ts
@@ -335,4 +335,4 @@ function parseContentDisposition(cd: string): string {
     return filename
 }
 
-export { main }
+module.exports = { main }

--- a/services/app-api/src/handlers/bulk_download.ts
+++ b/services/app-api/src/handlers/bulk_download.ts
@@ -273,8 +273,20 @@ const main: APIGatewayProxyHandler = async (event) => {
 
 // parses a content-disposition header for the filename
 function parseContentDisposition(cd: string): string {
-    const [, filename] = cd.split('filename=')
-    return filename
+    if (!cd) return ''
+
+    const matches = cd.match(/filename=["']?([^"';\n]*)["']?/i)
+    if (matches && matches[1]) {
+        return decodeURIComponent(matches[1].trim())
+    }
+
+    // If it's just a key/path, decode it directly
+    try {
+        return decodeURIComponent(cd.trim())
+    } catch (error) {
+        console.warn('Error decoding filename:', cd, error)
+        return cd.trim()
+    }
 }
 
 module.exports = { main }

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -168,7 +168,7 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
                 recordJSException(error)
                 return error
             }
-            return Storage.get(filename, { expires: 3600 })
+            return await Storage.get(filename, { expires: 3600 })
         },
     }
 }

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -188,19 +188,19 @@ const waitFor = (delay = 1000) =>
  * increase the time elapsed between retries in each cycle by order of 2^n; 
  * e.g. with default values for retryCount and maxRetries, attempt the request at 1s, 2s, 4s.
 */
-const retryWithBackoff = async <T>(
-    fn: () => Promise<T>,
+const retryWithBackoff = async (
+    fn: () => Promise<void | S3Error>,
     retryCount = 0,
     maxRetries = 4,
-    err: Error | null = null
-): Promise<T> => {
+    err: null | S3Error = null
+): Promise<void | S3Error> => {
     if (retryCount > maxRetries) {
         return Promise.reject(err)
     }
     const nextDelay = 2 ** retryCount * 1000
     await waitFor(nextDelay)
-    return fn().catch((error) =>
-        retryWithBackoff(fn, maxRetries, retryCount + 1, error)
+    return fn().catch((err) =>
+        retryWithBackoff(fn, retryCount + 1, maxRetries, err)
     )
 }
 

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -163,16 +163,12 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
                     response: true,
                     body: zipRequestParams,
                 })
-
-                return await retryWithBackoff(
-                    async () => Storage.get(filename, { expires: 3600 }),
-                    5
-                )
             } catch (err) {
                 const error = new Error('Could not get a bulk DL URL: ' + err)
                 recordJSException(error)
                 return error
             }
+            return Storage.get(filename, { expires: 3600 })
         },
     }
 }

--- a/services/cypress/integration/stateWorkflow/submissionSummary.spec.ts
+++ b/services/cypress/integration/stateWorkflow/submissionSummary.spec.ts
@@ -19,17 +19,18 @@ describe('State user can view submissions', () => {
 
         cy.findByRole('heading', {
             level: 2,
-            name: /Rate details/
+            name: /Rate details/,
         }).should('exist')
         cy.fillOutNewRateCertification()
         cy.fillOutAdditionalActuaryContact()
         cy.findByRole('radiogroup', {
-            name: /Actuaries' communication preference/
+            name: /Actuaries' communication preference/,
         })
             .should('exist')
             .within(() => {
-                cy.findByText("OACT can communicate directly with the state's actuaries but should copy the state on all written communication and all appointments for verbal discussions.")
-                .click()
+                cy.findByText(
+                    "OACT can communicate directly with the state's actuaries but should copy the state on all written communication and all appointments for verbal discussions."
+                ).click()
             })
         cy.navigateContractRatesForm('CONTINUE')
 
@@ -63,7 +64,8 @@ describe('State user can view submissions', () => {
             cy.findByText(`${submissionName} was sent to CMS`).should('exist')
             cy.get('table')
                 .findByRole('link', { name: submissionName })
-                .should('exist').click()
+                .should('exist')
+                .click()
             cy.url({ timeout: 10_000 }).should('contain', submissionId)
             cy.findByTestId('submission-summary').should('exist')
             cy.findByRole('heading', {
@@ -73,7 +75,9 @@ describe('State user can view submissions', () => {
             cy.findByText('Rate details').should('exist')
             cy.findByText('New rate certification').should('exist')
             cy.findByText('02/29/2024 to 02/28/2025').should('exist')
-            cy.findByText('Download all contract documents').should('exist')
+            cy.findByText('Download all contract documents', {
+                timeout: 20000,
+            }).should('exist')
             cy.findByRole('table', {
                 name: 'Contract',
             }).should('exist')
@@ -90,7 +94,9 @@ describe('State user can view submissions', () => {
             }).should('exist')
 
             // Double check we do not show any missing field text. This UI is not used for submitted packages
-           cy.findByText(/You must provide this information/).should('not.exist')
+            cy.findByText(/You must provide this information/).should(
+                'not.exist'
+            )
 
             // Link back to dashboard, submission visible in default program
             cy.findByText('Go to state dashboard').should('exist').click()


### PR DESCRIPTION
## Summary

A state made a submission with ~100 files in the contract section and the zip file download lambda started silently failing on this number of files. There were no logs in AWS indicating an error, just a silent shutdown of the lambda after a few dozen files were streamed into the zip, even after instrumenting the code a bunch.

This PR changes the approach of the zip lambda. Instead of reading from S3 and streaming the files into the zip, this just simply downloads everything to the temporary storage and then archives the files. I suspect that streaming all those files hit some limits and was causing the silent failures. This approach of just putting everything on to the filesystem first works fine and isn't noticeably slower for zip generation.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4852

