### PR TITLE
MCR-4770: filter withdrawn rates out of linkedRateSelect component

### DIFF
--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect/LinkRateSelect.tsx
@@ -58,17 +58,21 @@ export const LinkRateSelect = ({
     const [_field, _meta, helpers] = useField({ name }) // useField only relevant for non-autofill implementations
 
     const rates = data?.indexRates.edges.map((e) => e.node) || []
-
     // Sort rates by latest submission in desc order and remove withdrawn
-    rates
+    // Do not display withdrawn rates as an option of a linked rate to select
+    const updatedRates = rates
         .sort(
             (a, b) =>
                 new Date(b.revisions[0].submitInfo?.updatedAt).getTime() -
                 new Date(a.revisions[0].submitInfo?.updatedAt).getTime()
         )
-        .filter((rate) => rate.withdrawInfo === undefined)
+        .filter(
+            (rate) =>
+                rate.withdrawInfo === undefined ||
+                rate.consolidatedStatus !== 'WITHDRAWN'
+        )
 
-    const rateNames: LinkRateOptionType[] = rates.map((rate) => {
+    const rateNames: LinkRateOptionType[] = updatedRates.map((rate) => {
         const revision = rate.revisions[0]
         const rateProgramIDs =
             revision.formData.rateProgramIDs.length > 0


### PR DESCRIPTION
## Summary

As a state user, 
I want to not even have the option to add a withdrawn rate to a new or unlocked submission 
so that I can't inadvertently add a withdrawn link rate to a submission that needs review. 

AC: 

1. If I am on the rate details page and I am adding a linked rate 
Then I do not see the withdrawn rate appear in the rate dropdown of existing rates. 

#### Related issues
https://jiraent.cms.gov/browse/MCR-4770
#### Screenshots

#### Test cases covered

RateDetails: withdrawn rate is omitted from the linked rates dropdown

