### PR TITLE
MCR-4862: update-withdrawRate-api-to-drop-withdrawn-rates

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/bin/bash
-. "$(dirname "$0")/_/husky.sh"
-
 # In a continuing effort to print errors when they are needed, we check for
 # all pre-commit dependency requirements here.
 requirements=("protolint" "shellcheck" "detect-secrets")

--- a/services/app-api/src/emailer/emails/sendWithdrawnRateStateEmail.ts
+++ b/services/app-api/src/emailer/emails/sendWithdrawnRateStateEmail.ts
@@ -55,7 +55,10 @@ export const sendWithdrawnRateStateEmail = async (
 
     // parse contract data and collect state contact emails
     for (const contract of withdrawnFromContracts) {
-        const latestContractRev = contract.packageSubmissions[0].contractRevision
+        const latestContractRev = contract.consolidatedStatus === 'UNLOCKED' ?
+            contract.draftRevision! :
+        contract.packageSubmissions[0].contractRevision
+
         const pkgPrograms = findContractPrograms(latestContractRev, statePrograms)
 
         if (pkgPrograms instanceof Error) {

--- a/services/app-api/src/emailer/emails/sendWithdrawnRateStateEmail.ts
+++ b/services/app-api/src/emailer/emails/sendWithdrawnRateStateEmail.ts
@@ -1,29 +1,33 @@
-import { formatCalendarDate } from '@mc-review/dates';
-import { ProgramType, RateType } from "../../domain-models";
-import { EmailData } from "../emailer";
-import { EmailConfiguration } from "../emailer";
-import { findContractPrograms, renderTemplate, stripHTMLFromTemplate } from "../templateHelpers";
+import { formatCalendarDate } from '@mc-review/dates'
+import type { ProgramType, RateType } from '../../domain-models'
+import type { EmailData } from '../emailer'
+import type { EmailConfiguration } from '../emailer'
+import {
+    findContractPrograms,
+    renderTemplate,
+    stripHTMLFromTemplate,
+} from '../templateHelpers'
 import { packageName as generatePackageName } from '@mc-review/hpp'
-import { submissionSummaryURL } from '../generateURLs';
-import { pruneDuplicateEmails } from '../formatters';
+import { submissionSummaryURL } from '../generateURLs'
+import { pruneDuplicateEmails } from '../formatters'
 
 type WithdrawnFromContractData = {
-    contractName: string,
+    contractName: string
     submissionURL: string
 }
 
 type WithdrawnRateEtaData = {
-    rateName: string,
-    withdrawnBy: string, //email
-    withdrawnDate: string, // mm/dd/yyyy format in PT timezone.
-    withdrawnReason: string,
+    rateName: string
+    withdrawnBy: string //email
+    withdrawnDate: string // mm/dd/yyyy format in PT timezone.
+    withdrawnReason: string
     withdrawnFromContractData: WithdrawnFromContractData[]
 }
 
 export const sendWithdrawnRateStateEmail = async (
-  config: EmailConfiguration,
-  rate: RateType,
-  statePrograms: ProgramType[]
+    config: EmailConfiguration,
+    rate: RateType,
+    statePrograms: ProgramType[]
 ): Promise<EmailData | Error> => {
     if (rate.consolidatedStatus !== 'WITHDRAWN') {
         return new Error('Rate consolidated status is not WITHDRAWN')
@@ -37,7 +41,10 @@ export const sendWithdrawnRateStateEmail = async (
         return new Error('Rate does not any have review actions')
     }
 
-    const latestAction = reviewStatusActions.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0]
+    const latestAction = reviewStatusActions.sort(
+        (a, b) =>
+            new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    )[0]
 
     if (latestAction.actionType !== 'WITHDRAW') {
         return new Error('Rate latest review action was not a withdraw action')
@@ -47,7 +54,9 @@ export const sendWithdrawnRateStateEmail = async (
     const withdrawnFromContracts = rate.withdrawnFromContracts
 
     if (!withdrawnFromContracts || withdrawnFromContracts.length === 0) {
-        return new Error('Rate was withdrawn, but was not associated with any contracts')
+        return new Error(
+            'Rate was withdrawn, but was not associated with any contracts'
+        )
     }
 
     const stateContactEmails: string[] = []
@@ -55,14 +64,21 @@ export const sendWithdrawnRateStateEmail = async (
 
     // parse contract data and collect state contact emails
     for (const contract of withdrawnFromContracts) {
-        const latestContractRev = contract.consolidatedStatus === 'UNLOCKED' ?
-            contract.draftRevision! :
-        contract.packageSubmissions[0].contractRevision
+        // Get latest revision to generate package name. Use draft revision if contract is unlocked.
+        const latestContractRev =
+            contract.consolidatedStatus === 'UNLOCKED'
+                ? contract.draftRevision!
+                : contract.packageSubmissions[0].contractRevision
 
-        const pkgPrograms = findContractPrograms(latestContractRev, statePrograms)
+        const pkgPrograms = findContractPrograms(
+            latestContractRev,
+            statePrograms
+        )
 
         if (pkgPrograms instanceof Error) {
-            return new Error(`Error parsing withdrawn from contract data for contract with ID: ${contract.id}. ${pkgPrograms.message}`)
+            return new Error(
+                `Error parsing withdrawn from contract data for contract with ID: ${contract.id}. ${pkgPrograms.message}`
+            )
         }
 
         const packageName = generatePackageName(
@@ -76,7 +92,7 @@ export const sendWithdrawnRateStateEmail = async (
 
         withdrawnFromContractData.push({
             contractName: packageName,
-            submissionURL
+            submissionURL,
         })
 
         latestContractRev.formData.stateContacts.forEach((contact) => {
@@ -86,18 +102,24 @@ export const sendWithdrawnRateStateEmail = async (
 
     const toAddresses = pruneDuplicateEmails([
         ...stateContactEmails,
-        ...config.devReviewTeamEmails
+        ...config.devReviewTeamEmails,
     ])
 
     const etaData: WithdrawnRateEtaData = {
         rateName: latestRateRev.formData.rateCertificationName!,
         withdrawnBy: latestAction.updatedBy.email,
-        withdrawnDate: formatCalendarDate(latestAction.updatedAt, 'America/Los_Angeles'),
+        withdrawnDate: formatCalendarDate(
+            latestAction.updatedAt,
+            'America/Los_Angeles'
+        ),
         withdrawnReason: latestAction.updatedReason,
         withdrawnFromContractData,
     }
 
-    const template = await renderTemplate<WithdrawnRateEtaData>('sendWithdrawnRateStateEmail', etaData)
+    const template = await renderTemplate<WithdrawnRateEtaData>(
+        'sendWithdrawnRateStateEmail',
+        etaData
+    )
 
     if (template instanceof Error) {
         return template
@@ -110,7 +132,7 @@ export const sendWithdrawnRateStateEmail = async (
                 config.stage !== 'prod' ? `[${config.stage}] ` : ''
             }${etaData.rateName} was withdrawn`,
             bodyText: stripHTMLFromTemplate(template),
-            bodyHTML: template
+            bodyHTML: template,
         }
     }
 }

--- a/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
@@ -1,5 +1,5 @@
 import type { PrismaTransactionType } from '../prismaTypes'
-import type { RateType } from '../../domain-models'
+import type { RateType, UnlockedContractType } from '../../domain-models'
 import { findRateWithHistory } from './findRateWithHistory'
 import type { PrismaClient } from '@prisma/client'
 import { includeFullContract } from './prismaFullContractRateHelpers'
@@ -7,7 +7,6 @@ import {
     getConsolidatedContractStatus,
     getContractRateStatus,
     getContractReviewStatus,
-    includeContractFormData,
 } from './prismaSharedContractRateHelpers'
 import { unlockContractInsideTransaction } from './unlockContract'
 import { NotFoundError, UserInputPostgresError } from '../postgresErrors'
@@ -16,6 +15,7 @@ import { updateDraftContractRatesInsideTransaction } from './updateDraftContract
 import type { SubmitContractArgsType } from './submitContract'
 import { submitContractInsideTransaction } from './submitContract'
 import { submitRateInsideTransaction } from './submitRate'
+import { parseContractWithHistory } from './parseContractWithHistory'
 
 type WithdrawRateArgsType = {
     rateID: string
@@ -34,6 +34,11 @@ const withdrawRateInsideTransaction = async (
             id: rateID,
         },
         include: {
+            draftContracts: {
+                select: {
+                    contractID: true,
+                }
+            },
             revisions: {
                 orderBy: {
                     createdAt: 'desc',
@@ -47,11 +52,14 @@ const withdrawRateInsideTransaction = async (
                             submissionPackages: {
                                 include: {
                                     contractRevision: {
-                                        include: includeContractFormData,
+                                        select: {
+                                            id: true,
+                                            contractID: true,
+                                        },
                                     },
                                 },
                                 orderBy: {
-                                    ratePosition: 'desc',
+                                    ratePosition: 'asc',
                                 },
                             },
                         },
@@ -68,9 +76,10 @@ const withdrawRateInsideTransaction = async (
 
     // Get the contractIDs of the latest submission package of each related submission
     const latestRevision = rate.revisions[0]
-    const contractIDs = latestRevision.relatedSubmissions.map(
-        (sub) => sub.submissionPackages[0].contractRevision.contractID
-    )
+    const contractIDs = [...new Set([
+        ...latestRevision.relatedSubmissions.map(sub => sub.submissionPackages[0].contractRevision.contractID),
+        ...rate.draftContracts.map(contract => contract.contractID)
+     ])];
 
     // get data for every contract
     const contracts = await tx.contractTable.findMany({
@@ -79,7 +88,9 @@ const withdrawRateInsideTransaction = async (
                 in: contractIDs,
             },
         },
-        include: includeFullContract,
+        include: {
+            ...includeFullContract
+        },
     })
 
     // collect contractIDs we remove the rate from to make the new connection on the withdrawn rate table
@@ -87,22 +98,28 @@ const withdrawRateInsideTransaction = async (
 
     // Remove rate from each contract
     for (const contract of contracts) {
+        // Used to track original status of the contract
         const consolidatedStatus = getConsolidatedContractStatus(
             getContractRateStatus(contract.revisions),
             getContractReviewStatus(contract)
         )
 
-        // Any approved contracts returns an error to client
+        // Throw error if any contract is approved
         if (consolidatedStatus === 'APPROVED') {
-            return new Error(
+            throw new Error(
                 `Rate is a child or linked to an APPROVED contract with ID: ${contract.id}`
             )
         }
 
-        // Draft and unlocked contracts are ignored, since other API will prevent them from resubmitting a withdrawn rate, breaking the link.
-        if (['SUBMITTED', 'RESUBMITTED'].includes(consolidatedStatus)) {
-            //contractsToUnlock.push(contract)
+        const updateRates: UpdateDraftContractRatesArgsType['rateUpdates']['update'] =
+            []
+        const linkRates: UpdateDraftContractRatesArgsType['rateUpdates']['link'] =
+            []
 
+        let previousRates = []
+
+        // If the contract is locked, unlock it and set previousRates. 
+        if (['SUBMITTED', 'RESUBMITTED'].includes(consolidatedStatus)) {
             const unlockedContract = await unlockContractInsideTransaction(tx, {
                 contractID: contract.id,
                 unlockedByUserID: updatedByID,
@@ -113,76 +130,103 @@ const withdrawRateInsideTransaction = async (
                 throw unlockedContract
             }
 
-            const previousRates = unlockedContract.draftRates
-            const rateToWithdrawIndex = previousRates
-                .map((rate) => rate.id)
-                .indexOf(rateID)
+            previousRates = unlockedContract.draftRates
 
-            // Validate that the rate to withdraw is on the now unlocked contract
-            if (rateToWithdrawIndex === -1) {
-                return new UserInputPostgresError(
-                    `withdrawnRateID ${rateID} does not map to a current rate on this contract`
+            // Add contract to connect on withdrawn rate join table
+            withdrawnFromContracts.push({ contractID: contract.id })
+        } else {
+            // parse the contract to get the draft rates in domain type
+            const parsedContract = parseContractWithHistory(contract)
+
+            if (parsedContract instanceof Error) {
+                throw parsedContract
+            }
+
+            if (!parsedContract.draftRates) {
+                throw new Error(
+                    `Contract ${contract.id} is missing draft rates`
                 )
             }
-            
-            // remove the rate to withdraw from previousRates
-            previousRates.splice(rateToWithdrawIndex, 1)
 
-            const updateRates: UpdateDraftContractRatesArgsType['rateUpdates']['update'] =
-                []
-            const linkRates: UpdateDraftContractRatesArgsType['rateUpdates']['link'] =
-                []
+            const lastRecentSubmission = parsedContract.packageSubmissions[0]
 
-            previousRates.forEach((rate, idx) => {
-                // keep any existing linked rates besides replacement or withdrawn rate
-                if (rate.parentContractID !== contract.id) {
-                    linkRates.push({
-                        rateID: rate.id,
-                        ratePosition: idx + 1,
-                    })
-                } else {
-                    // keep any existing child rates and resubmit them unchanged
-                    updateRates.push({
-                        rateID: rate.id,
-                        formData:
-                            rate.packageSubmissions[0].rateRevision.formData,
-                        ratePosition: idx + 1,
-                    })
+            // Do not connect on withdrawn rate join table if contract has never been submitted with the rate to be withdrawn.
+            if (consolidatedStatus === 'UNLOCKED' && lastRecentSubmission) {
+                const wasSubmittedWithWithdrawnRate = lastRecentSubmission.rateRevisions.find(rr => rr.rateID === rateID)
+                // If Unlocked contract was last submitted with rate to be withdrawn, add to withdrawn rate join table
+                if (wasSubmittedWithWithdrawnRate) {
+                    withdrawnFromContracts.push({ contractID: contract.id })
                 }
-            })
-
-            // arrange rate data for update draft contract rates
-            const updateContractRatesArgs: UpdateDraftContractRatesArgsType = {
-                contractID: contract.id,
-                rateUpdates: {
-                    create: [],
-                    update: [
-                        //  keep any already added child rates
-                        ...updateRates,
-                    ],
-                    delete: [],
-                    unlink: [],
-                    link: [
-                        // keep any other already added linked rates
-                        ...linkRates.sort(
-                            (a, b) => a.ratePosition - b.ratePosition
-                        ),
-                    ],
-                },
             }
 
-            // update the contract to remove the withdrawn rate
-            const updateResult =
-                await updateDraftContractRatesInsideTransaction(
-                    tx,
-                    updateContractRatesArgs
-                )
+            previousRates = parsedContract.draftRates
+        }
 
-            if (updateResult instanceof Error) {
-                throw updateResult
+        const rateToWithdrawIndex = previousRates
+            .map((rate) => rate.id)
+            .indexOf(rateID)
+
+        // Validate that the rate to withdraw is on the now unlocked contract
+        if (rateToWithdrawIndex === -1) {
+            throw new UserInputPostgresError(
+                `withdrawnRateID ${rateID} does not map to a current rate on this contract`
+            )
+        }
+        
+        // remove the rate to withdraw from previousRates. Removing it now prevents gaps in ratePosition.
+        previousRates.splice(rateToWithdrawIndex, 1)
+
+        previousRates.forEach((rate, idx) => {
+            // keep any existing linked rates besides withdrawn rate
+            if (rate.parentContractID !== contract.id) {
+                linkRates.push({
+                    rateID: rate.id,
+                    ratePosition: idx + 1,
+                })
+            } else {
+                // keep any existing child rates and resubmit them unchanged
+                updateRates.push({
+                    rateID: rate.id,
+                    formData:
+                        rate.packageSubmissions[0].rateRevision.formData,
+                    ratePosition: idx + 1,
+                })
             }
+        })
 
-            // resubmit contract
+        // arrange rate data for update draft contract rates
+        const updateContractRatesArgs: UpdateDraftContractRatesArgsType = {
+            contractID: contract.id,
+            rateUpdates: {
+                create: [],
+                update: [
+                    //  keep any already added child rates
+                    ...updateRates,
+                ],
+                delete: [],
+                unlink: [],
+                link: [
+                    // keep any other already added linked rates
+                    ...linkRates.sort(
+                        (a, b) => a.ratePosition - b.ratePosition
+                    ),
+                ],
+            },
+        }
+
+        // update the contract to remove the withdrawn rate
+        const updateResult =
+            await updateDraftContractRatesInsideTransaction(
+                tx,
+                updateContractRatesArgs
+            )
+
+        if (updateResult instanceof Error) {
+            throw updateResult
+        }
+
+        // Resubmit contract if it was unlocked in this loop
+        if (['SUBMITTED', 'RESUBMITTED'].includes(consolidatedStatus)) {
             const resubmitContractArgs: SubmitContractArgsType = {
                 contractID: contract.id,
                 submittedByUserID: updatedByID,
@@ -195,8 +239,6 @@ const withdrawRateInsideTransaction = async (
             if (resubmitResult instanceof Error) {
                 throw resubmitResult
             }
-
-            withdrawnFromContracts.push({ contractID: contract.id })
         }
     }
 
@@ -245,6 +287,7 @@ const withdrawRate = async (
             if (withdrawResult instanceof Error) {
                 return withdrawResult
             }
+
             return withdrawResult
         })
     } catch (err) {

--- a/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
@@ -256,30 +256,25 @@ const withdrawRateInsideTransaction = async (
     })
 
     // Add review status action to rate and create new joins on withdrawn rate join table
-    try {
-        await tx.rateTable.update({
-            where: {
-                id: rateID,
-            },
-            data: {
-                reviewStatusActions: {
-                    create: {
-                        updatedByID,
-                        updatedReason,
-                        actionType: 'WITHDRAW',
-                    },
-                },
-                withdrawnFromContracts: {
-                    create: withdrawnFromContracts,
+    await tx.rateTable.update({
+        where: {
+            id: rateID,
+        },
+        data: {
+            reviewStatusActions: {
+                create: {
+                    updatedByID,
+                    updatedReason,
+                    actionType: 'WITHDRAW',
                 },
             },
-        })
+            withdrawnFromContracts: {
+                create: withdrawnFromContracts,
+            },
+        },
+    })
 
-        return findRateWithHistory(tx, rateID)
-    } catch (err) {
-        console.error('PRISMA ERROR: Error withdrawing rate', err)
-        return new Error(err)
-    }
+    return findRateWithHistory(tx, rateID)
 }
 
 const withdrawRate = async (

--- a/services/app-api/src/resolvers/contract/submitContract.test.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.test.ts
@@ -747,7 +747,7 @@ describe('submitContract', () => {
         )
         expect(ds1.rateRevisions).toHaveLength(0)
         expect(ds1.cause).toBe('CONTRACT_SUBMISSION')
-    }, 10000)
+    }, 15000)
 
     it('returns the correct dateAdded for documents', async () => {
         const ldService = testLDService({})


### PR DESCRIPTION
## Summary
[MCR-4862](https://jiraent.cms.gov/browse/MCR-4862)

- Withdrawn rates on unlocked or draft submission are silently removed when calling the withdrawRate API
- Unlocked submissions with an withdrawn rate that was a part of its last recent submission is connected to the rate via the WithdrawnRatesJoinTable.
- `sendWithdrawnRateStateEmail` sends emails to unlocked submissions that had withdrawn rate (when it was not withdrawn) on its last submission.

Other work:
- Update `pre-commit` to work on vscode. Not sure if pre-commit hooks worked for everyone else, but it did not for me when using vscode. The error log for pre-commit said to delete the portion of the script.

#### Related issues

#### Screenshots

#### Test cases covered

`withdrawRate.test.ts`
- (UPDATED) `'does not update draft contract linked to withdrawn rate'` -> `'removes rate from DRAFT and UNLOCKED contracts linked to rate'`
- (UPDATED) `'sends an email to state contacts when a rate is withdrawn'` - Added assertion to test that unlocked submission is listed in the email.

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

- Test that unlocked and draft submissions that linked to withdrawn rates are no longer on the submission in the review and submit page.

<!---These are developer instructions on how to test or validate the work -->
