### PR TITLE
Jumpbox command always prompt for password and allow empty password

### DIFF
--- a/dev_tool/src/jumpbox.ts
+++ b/dev_tool/src/jumpbox.ts
@@ -198,8 +198,6 @@ async function promptPassword(prompt: string): Promise<string> {
         type: 'password',
         name: 'password',
         message: prompt,
-        validate: (value: string): boolean | string =>
-            value.length > 0 ? true : 'Password cannot be empty',
     })
 
     return response.password
@@ -215,33 +213,13 @@ async function attemptSSHConnection(
 
     try {
         // Read the private key file
-        const privateKey = readFileSync(privateKeyPath, 'utf8')
+        const privateKey = await promptPassword('Enter SSH key password:')
 
-        try {
-            await ssh.connect({
-                host,
-                username,
-                privateKey,
-            })
-        } catch (err) {
-            if (
-                err instanceof Error &&
-                (err.message.includes('password') ||
-                    err.message.includes('encrypted'))
-            ) {
-                const keyPassword = await promptPassword(
-                    'Enter SSH key password:'
-                )
-                await ssh.connect({
-                    host,
-                    username,
-                    privateKey,
-                    passphrase: keyPassword,
-                })
-            } else {
-                throw err
-            }
-        }
+        await ssh.connect({
+            host,
+            username,
+            privateKey,
+        })
     } catch (err) {
         if (err instanceof Error) {
             throw new Error(`SSH connection failed: ${err.message}`)


### PR DESCRIPTION
## Summary
- This always prompts user for the ssh password. The way we checked to see if the error was about a missing password was brittle and could break if the error message changed at all. Since the error does not contain an error code we are limited how to address this. Always prompting is a quick solution for this. 

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
