### PR TITLE
Fix withdrawRate API bugs

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
@@ -181,29 +181,22 @@ const withdrawRateInsideTransaction = async (
         // remove the rate to withdraw from previousRates. Removing it here prevents gaps in ratePosition.
         previousRates.splice(rateToWithdrawIndex, 1)
 
+        // Collect rates we keep on the contract
         previousRates.forEach((rate, idx) => {
-            // keep any existing linked rates besides withdrawn rate
             if (rate.parentContractID !== contract.id) {
                 linkRates.push({
                     rateID: rate.id,
                     ratePosition: idx + 1,
                 })
             } else {
-                // keep any existing child rates and resubmit them unchanged
-                let formData
-
-                // get the formData from correct source based on rate status
-                if (rate.consolidatedStatus === 'DRAFT') {
-                    if (!rate.draftRevision) {
-                        throw new Error(
-                            `Draft rate ${rate.id} is missing draft revision`
-                        )
-                    }
-
-                    formData = rate.draftRevision?.formData
-                } else {
-                    formData = rate.packageSubmissions[0].rateRevision.formData
+                // We unlocked any contract that was submitted. Now all rates are drafts so we use draftRevision to get form data.
+                if (!rate.draftRevision) {
+                    throw new Error(
+                        `Draft rate ${rate.id} is missing draft revision`
+                    )
                 }
+
+                const formData = rate.draftRevision?.formData
 
                 updateRates.push({
                     rateID: rate.id,


### PR DESCRIPTION
## Summary
- Bug 1
   - In the postgres function when it's collecting rates to keep on the contract, it was overwriting unlocked rates with its previously submitted revision form data.
      - The fix was to use the draft rates draft form data for all of the rates we are keeping. This is because all the contracts are unlocked at this point of the code.
   - I also added an assertion to make sure that kept rates did not have their formData modified after withdraw.
- Bug 2
   - The initial query of the rate to get draft and submitted contracts it was linked to was incorrect. I had originally used `submissionPackages` to get the contracts it was submitted with, where the first in the array was the most recent submission. This was incorrect because I had used `ratePosition` for ordering which was a typo, but after looking at the `SubmissionPackageJoinTable` it had no timestamp on it so sorting these records was not straight forward.
      - **TLDR**: Queried the wrong rate submission version to get contracts it was submitted with in order to remove the rate from it and resubmit.
   - I could have dug deeper and used the `submissionPackages.submission` to get the most recent, but the easier way is just to use `submittedContracts`.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

- I pulled down prod and unlocked every rate with no issues
- Couple test cases to validate that withdraw worked and kept rates are unmodified.
   - Withdraw rate from multi-rate submission
      - Liked to other submissions with a combination of unlocked, draft, resubmited.
   - Withdraw two rates linked to the same contract

<!---These are developer instructions on how to test or validate the work -->
