### PR TITLE
MCR-4647: Add status column to rate dashboard 

### DIFF
--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -1,5 +1,6 @@
 export * from './routes'
 export * from './contract'
+export * from './rate'
 export * from './errors'
 export * from './localStorage'
 export * from './statutoryRegulatoryAttestation'

--- a/packages/constants/src/rate.ts
+++ b/packages/constants/src/rate.ts
@@ -1,0 +1,11 @@
+import { ConsolidatedRateStatus } from './gen/gqlClient'
+
+const ConsolidatedRateStatusRecord: Record<ConsolidatedRateStatus, string> = {
+    DRAFT: 'Draft',
+    SUBMITTED: 'Submitted',
+    RESUBMITTED: 'Submitted',
+    UNLOCKED: 'Unlocked',
+    WITHDRAWN: 'Withdrawn'
+}
+
+export { ConsolidatedRateStatusRecord }

--- a/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsDashboard.tsx
+++ b/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsDashboard.tsx
@@ -80,6 +80,7 @@ const RateReviewsDashboard = (): React.ReactElement => {
                 id: rate.id,
                 name: displayRateFormData.rateCertificationName || missingField,
                 rateNumber: rate.stateNumber,
+                consolidatedStatus: rate.consolidatedStatus,
                 programs: programs.filter(
                     (program) =>
                         (displayRateFormData?.rateProgramIDs &&

--- a/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsTable.test.tsx
+++ b/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsTable.test.tsx
@@ -25,6 +25,7 @@ describe('RateReviewsTable', () => {
             name: 'rate-1-certification-name',
             rateNumber: 1,
             programs: [statePrograms[0]],
+            consolidatedStatus: 'SUBMITTED',
             submittedAt: '2023-10-16',
             rateDateStart: new Date('2023-10-16'),
             rateDateEnd: new Date('2024-10-16'),
@@ -38,6 +39,7 @@ describe('RateReviewsTable', () => {
             name: 'rate-2-certification-name',
             rateNumber: 1,
             programs: [statePrograms[0]],
+            consolidatedStatus: 'WITHDRAWN',
             submittedAt: '2023-11-18',
             rateDateStart: new Date('2023-11-18'),
             rateDateEnd: new Date('2024-11-18'),
@@ -50,6 +52,7 @@ describe('RateReviewsTable', () => {
             id: 'rate-3-id',
             name: 'rate-3-certification-name',
             programs: [statePrograms[0]],
+            consolidatedStatus: 'UNLOCKED',
             rateNumber: 2,
             submittedAt: '2023-12-01',
             rateDateStart: new Date('2023-12-01'),
@@ -104,14 +107,24 @@ describe('RateReviewsTable', () => {
                 expect(tableRows).toHaveLength(4)
 
                 // expect rows to be in order where latest updatedAt is first in the array
+                // expect statuses to be drawn from the consolidatedStatus field
                 expect(
                     within(tableRows[1]).getByText('rate-3-certification-name')
+                ).toBeInTheDocument()
+                expect(
+                    within(tableRows[1]).getByText('Unlocked')
                 ).toBeInTheDocument()
                 expect(
                     within(tableRows[2]).getByText('rate-2-certification-name')
                 ).toBeInTheDocument()
                 expect(
+                    within(tableRows[2]).getByText('Withdrawn')
+                ).toBeInTheDocument()
+                expect(
                     within(tableRows[3]).getByText('rate-1-certification-name')
+                ).toBeInTheDocument()
+                expect(
+                    within(tableRows[3]).getByText('Submitted')
                 ).toBeInTheDocument()
             })
             it('renders rates table correctly without filters, captions and no rates', async () => {


### PR DESCRIPTION
## Summary

As a CMS user, I want to know when I am looking at the rate dashboard when a rate has a status of withdrawn so I know not to focus my attention on that rate. 

AC:

- If I am looking at the rate review dashboard I see a status column as the rightmost column on the dashboard
- If a rate's parent submission is unlocked then I see rate status of “unlocked” for that rate review
- If rate is withdrawn then I see rate status of “withdrawn"
- If a rate is not withdrawn and or unlocked then the rate has a status of "submitted" 
- note: "approved: rate status has been descoped for purposes of this ticket and will be added at a later date

#### Related issues

https://jiraent.cms.gov/browse/MCR-4647

#### Screenshots

<img width="1098" alt="Screenshot 2025-01-06 at 11 37 26 AM" src="https://github.com/user-attachments/assets/d42b1fa6-2549-49af-809e-8ffee8c760a1" />


#### Test cases covered

RateReviewsTable -> expect that the status field is present and as expected 

