### PR TITLE
MCR-4665: state is required to add new rate

### DIFF
--- a/services/app-api/prisma/migrations/20250106160752_add_create_at_timestamp_on_withdrawn_rates_join_table/migration.sql
+++ b/services/app-api/prisma/migrations/20250106160752_add_create_at_timestamp_on_withdrawn_rates_join_table/migration.sql
@@ -1,0 +1,4 @@
+BEGIN;
+-- AlterTable
+ALTER TABLE "WithdrawnRatesJoinTable" ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+COMMIT;

--- a/services/app-api/prisma/schema.prisma
+++ b/services/app-api/prisma/schema.prisma
@@ -85,6 +85,7 @@ model DraftRateJoinTable {
 
 // Relationship for withdrawn rates and contracts
 model WithdrawnRatesJoinTable {
+  createdAt  DateTime      @default(now())
   contractID String
   contract   ContractTable @relation(fields: [contractID], references: [id])
   rateID     String

--- a/services/app-web/src/components/Banner/IncompleteSubmissionBanner/IncompleteSubmissionBanner.tsx
+++ b/services/app-web/src/components/Banner/IncompleteSubmissionBanner/IncompleteSubmissionBanner.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect } from 'react'
+import classnames from 'classnames'
+import { Alert } from '@trussworks/react-uswds'
+import { useTealium } from '../../../hooks'
+import { extractText } from '../../TealiumLogging/tealiamLoggingHelpers'
+import styles from '../../ErrorAlert/ErrorAlert.module.scss'
+
+export type IncompleteSubmissionProps = {
+    message?: string
+    heading?: string
+} & React.JSX.IntrinsicElements['div']
+
+export const IncompleteSubmissionBanner = ({
+    heading = 'Incomplete Submission',
+    message = 'Submission is incomplete.',
+    className,
+    ...divProps
+}: IncompleteSubmissionProps): React.ReactElement => {
+    const { logAlertImpressionEvent } = useTealium()
+    const classes = classnames(styles.messageBodyText, className)
+    const loggingErrorMessage = extractText(message)
+
+    useEffect(() => {
+        logAlertImpressionEvent({
+            error_type: 'validation',
+            error_message: loggingErrorMessage,
+            type: 'error',
+            extension: 'react-uswds',
+        })
+    }, [loggingErrorMessage, logAlertImpressionEvent])
+
+    return (
+        <Alert
+            role="alert"
+            type="error"
+            heading={heading || 'Validation error'}
+            headingLevel="h4"
+            data-testid="error-alert"
+            validation
+            className={classes}
+            {...divProps}
+        >
+            <div className={styles.messageBodyText}>
+                <p className="usa-alert__text">{message}&nbsp;</p>
+            </div>
+        </Alert>
+    )
+}

--- a/services/app-web/src/components/Banner/index.ts
+++ b/services/app-web/src/components/Banner/index.ts
@@ -8,3 +8,4 @@ export { DocumentWarningBanner } from './DocumentWarningBanner/DocumentWarningBa
 export { RateReplacedBanner } from './RateReplacedBanner/RateReplacedBanner'
 export { RateWithdrawBanner } from './RateWithdrawBanner/RateWithdrawBanner'
 export { SubmissionApprovedBanner } from './SubmissionApprovedBanner/SubmissionApprovedBanner'
+export { IncompleteSubmissionBanner } from './IncompleteSubmissionBanner/IncompleteSubmissionBanner'

--- a/services/app-web/src/components/Modal/UnlockSubmitModal.tsx
+++ b/services/app-web/src/components/Modal/UnlockSubmitModal.tsx
@@ -120,6 +120,22 @@ const modalValueDictionary: { [Property in SharedModalType]: ModalValueType } =
         },
     }
 
+// Temporary fix for MCR-4871 to validate contract and rates submission until we can refactor API to validate and move off of HPP helper functions in tests.
+const validateContractAndRatesSubmission = async (
+    submissionData: Contract,
+    callback: () => Promise<unknown>
+): Promise<unknown | Error> => {
+    if (
+        submissionData.draftRevision?.formData.submissionType ===
+            'CONTRACT_AND_RATES' &&
+        submissionData.draftRates &&
+        submissionData.draftRates.length === 0
+    ) {
+        return new Error('Your submission is missing information.')
+    }
+    return await callback()
+}
+
 export const UnlockSubmitModal = ({
     submissionData,
     submissionName,
@@ -203,17 +219,25 @@ export const UnlockSubmitModal = ({
                 console.info('submit rate not implemented yet')
                 break
             case 'SUBMIT_CONTRACT':
-                result = await submitMutationWrapperV2(
-                    submitContract,
-                    submissionData.id,
-                    unlockSubmitModalInput
+                result = await validateContractAndRatesSubmission(
+                    submissionData,
+                    () =>
+                        submitMutationWrapperV2(
+                            submitContract,
+                            submissionData.id,
+                            unlockSubmitModalInput
+                        )
                 )
                 break
             case 'RESUBMIT_CONTRACT':
-                result = await submitMutationWrapperV2(
-                    submitContract,
-                    submissionData.id,
-                    unlockSubmitModalInput
+                result = await validateContractAndRatesSubmission(
+                    submissionData,
+                    () =>
+                        submitMutationWrapperV2(
+                            submitContract,
+                            submissionData.id,
+                            unlockSubmitModalInput
+                        )
                 )
                 break
             case 'UNLOCK_CONTRACT':

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/RateDetailsSummarySection.tsx
@@ -96,6 +96,7 @@ export const RateDetailsSummarySection = ({
     const isSubmitted =
         contract.status === 'SUBMITTED' || contract.status === 'RESUBMITTED'
     const isCMSUser = hasCMSUserPermissions(loggedInUser)
+    const isStateUser = loggedInUser?.role === 'STATE_USER'
     const isAdminUser = loggedInUser?.role === 'ADMIN_USER'
     const isSubmittedOrCMSUser = isSubmitted || isCMSUser
     const isEditing = !isSubmittedOrCMSUser && editNavigateTo !== undefined
@@ -277,6 +278,18 @@ export const RateDetailsSummarySection = ({
             [styles.replaceRateWrapper]:
                 isAdminUser && !isLinkedRate && !isPreviousSubmission,
         })
+
+    const noRatesMessage = () => {
+        if (isStateUser) {
+            return 'You must contact your CMS point of contact and request an unlock.'
+        }
+
+        if (isCMSUser) {
+            return 'You must unlock the submission so the state can add a rate certification.'
+        }
+
+        return 'CMS must unlock the submission so the state can add a rate certification.'
+    }
 
     return (
         <SectionCard id="rateDetails" className={styles.summarySection}>
@@ -557,7 +570,9 @@ export const RateDetailsSummarySection = ({
                           </SectionCard>
                       )
                   })
-                : explainMissingData && <DataDetailMissingField />}
+                : isSubmitted && (
+                      <DataDetailMissingField requiredText={noRatesMessage()} />
+                  )}
         </SectionCard>
     )
 }

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/RateDetailsSummarySection.tsx
@@ -281,7 +281,9 @@ export const RateDetailsSummarySection = ({
 
     const noRatesMessage = () => {
         if (isStateUser) {
-            return 'You must contact your CMS point of contact and request an unlock.'
+            return isSubmitted
+                ? 'You must contact your CMS point of contact and request an unlock.'
+                : 'You must add a rate certification before you can resubmit.'
         }
 
         if (isCMSUser) {
@@ -570,7 +572,7 @@ export const RateDetailsSummarySection = ({
                           </SectionCard>
                       )
                   })
-                : isSubmitted && (
+                : (isSubmitted || isStateUser) && (
                       <DataDetailMissingField requiredText={noRatesMessage()} />
                   )}
         </SectionCard>

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.test.tsx
@@ -324,4 +324,45 @@ describe('ReviewSubmit', () => {
         ).not.toBeInTheDocument()
         expect(await screen.queryByText('SHARED')).not.toBeInTheDocument()
     })
+
+    it('renders inline error when contract and rates submissions does not have any rate certifications', async () => {
+        const unlockedContract = mockContractPackageUnlockedWithUnlockedType({
+            id: 'test-abc-123',
+        })
+        unlockedContract.draftRates = []
+
+        renderWithProviders(
+            <Routes>
+                <Route
+                    path={RoutesRecord.SUBMISSIONS_REVIEW_SUBMIT}
+                    element={<ReviewSubmit />}
+                />
+            </Routes>,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({ statusCode: 200 }),
+                        fetchContractMockSuccess({
+                            contract: unlockedContract,
+                        }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/submissions/test-abc-123/edit/review-and-submit',
+                },
+                featureFlags: {},
+            }
+        )
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('heading', { name: 'Rate details' })
+            ).toBeInTheDocument()
+            expect(
+                screen.getByText(
+                    'You must add a rate certification before you can resubmit.'
+                )
+            ).toBeInTheDocument()
+        })
+    })
 })

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ReviewSubmitV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/V2/ReviewSubmit/ReviewSubmitV2.tsx
@@ -87,7 +87,7 @@ export const ReviewSubmit = (): React.ReactElement => {
     if (!contractFormData) return <GenericErrorPage />
 
     const isContractActionAndRateCertification =
-        contract.draftRates && contract.draftRates.length > 0
+        contractFormData.submissionType === 'CONTRACT_AND_RATES'
     const programIDs = contractFormData?.programIDs
     const programs = statePrograms.filter((program) =>
         programIDs?.includes(program.id)

--- a/services/cypress/integration/stateWorkflow/stateSubmissionForm/submissionForm.spec.ts
+++ b/services/cypress/integration/stateWorkflow/stateSubmissionForm/submissionForm.spec.ts
@@ -150,7 +150,21 @@ describe('state user in state submission form', () => {
             const draftSubmissionId = pathnameArray[2]
             cy.navigateFormByDirectLink(`/submissions/${draftSubmissionId}/edit/review-and-submit`)
 
-            cy.submitStateSubmissionForm({success: false})
+            // Testing around temporary client-side validation for contract and rates submission.
+            // Ensures rate certification is included. Remove after MCR-4871 and use cy.submitStateSubmissionForm below.
+            cy.findByRole('heading', { level: 2, name: /Review and submit/ })
+            cy.findByRole('button', {
+                name: 'Submit',
+            }).safeClick()
+            
+            cy.findAllByTestId('modalWindow')
+            .eq(1)
+            .should('exist')
+            .within(() => {
+                cy.findByTestId('submit_contract-modal-submit').click()
+            })
+
+            // cy.submitStateSubmissionForm({success: false})
             cy.findByRole('heading', { level: 4, name: /Submission error/ })
         })
     })


### PR DESCRIPTION
## Summary
[MCR-4665](https://jiraent.cms.gov/browse/MCR-4665)
[State View Figma](https://www.figma.com/design/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?node-id=5-7392&p=f)
[CMS View Figma](https://www.figma.com/design/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?node-id=16547-93337)

- If a contract and rate submission only contains rates that have a status of withdrawn and the submission is unlocked, 
The state user is required to add a rate on the Rate Details page and review/submit page or will see validation errors. ([See Figma file|https://www.figma.com/design/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?node-id=16540-87248&t=at7k9ONpopMPy07u-1)]
- As a State user, If the contract is in a submitted state with only withdrawn rate there is a error banner to direct me to contact CMS to unlock ([See Figma file](https://www.figma.com/design/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?node-id=16547-91095&t=at7k9ONpopMPy07u-1))
- As a CMS user,  If the contract is in a submitted state with only withdrawn rates there is an error banner and inline error that instructs CMS to unlock the submission for the state to complete the missing requirements ([See Figma file](https://www.figma.com/design/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?node-id=16547-93337&t=T4tsVszeyjPGtMJg-0))
- As a Admin, BusinessOwner, or Helpdesk, If the contract is in a submitted state with only withdrawn rates there is an error banner and inline error that notifies me the submission is incomplete and details on how to correct the error.
   - Banner and inline error message: `'CMS must unlock the submission so the state can add a rate certification.'`

Other work:
- Added `createdAt` field to the `WithdrawnRatesJoinTable`.
   - There will probably be a need for timestamps on these records. I ran into that issue with `SubmissionPackageJoinTable` where I could not query these records in order by `createdAt` since this table does not contain one.
- Added client side validation of contract and rate submissions to ensure they contain rates.
   - This is a temporary fix for [MCR-4871](https://jiraent.cms.gov/browse/MCR-4871), The permanent fix, is to do this validation in the API, but there is a lot of refactoring of tests needed for that. See [MCR-4871](https://jiraent.cms.gov/browse/MCR-4871) for more details

#### Related issues

#### Screenshots

#### Test cases covered

- `UnlockSubmitModal.test.tsx`
   - `'displays validation error when submitting contract and rates submission without a rate'`

- `ReviewSubmit.test.tsx`
   - `'renders inline error on contract and rates submissions without rates'`

- `SubmissionSummary.test.tsx`
   - Reorganized tests by user type.
      - `'renders incomplete submission UI on submitted submission without rates'`
      - `'does not render incomplete submission UI on unlocked submission without rates'`
   - State users
      - `'renders incomplete submission UI on submitted submission without rates'`
   - Admin, Business Owner, and Helpdesk users
      - `'renders incomplete submission UI on submitted submission without rates'`
      - `'does not render incomplete submission UI on unlocked submission without rates'`
<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
