### PR TITLE
Add ECR permissions to github oidc

### DIFF
--- a/services/github-oidc/serverless.yml
+++ b/services/github-oidc/serverless.yml
@@ -47,6 +47,7 @@ params:
       - 'cognito-identity:*'
       - 'cognito-idp:*'
       - 'ec2:*'
+      - 'ecr:*'
       - 'events:*'
       - 'firehose:*'
       - 'iam:*'


### PR DESCRIPTION
## Summary

In order to get some of the resources for AWS CDK stood up we need to add  permissions for ECR to the github-oidc user. This adds it so that I can do some further testing in my branch.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4435
