### PR TITLE
MCR-4661: CMS receives withdrawn rate email notification

### DIFF
--- a/services/app-api/src/domain-models/contractAndRates/index.ts
+++ b/services/app-api/src/domain-models/contractAndRates/index.ts
@@ -36,6 +36,10 @@ export {
 } from './helpers'
 export type { ContractType, UnlockedContractType } from './contractTypes'
 export type { RateType } from './rateTypes'
+export type {
+    RateReviewActionType,
+    RateReviewType,
+} from './rateReviewActionType'
 
 export type { PackageStatusType, UpdateInfoType } from './updateInfoType'
 

--- a/services/app-api/src/domain-models/contractAndRates/rateReviewActionType.ts
+++ b/services/app-api/src/domain-models/contractAndRates/rateReviewActionType.ts
@@ -15,6 +15,7 @@ const rateReviewActionSchema = z.object({
 })
 
 type RateReviewActionType = z.infer<typeof rateReviewActionTypeSchema>
+type RateReviewType = z.infer<typeof rateReviewActionSchema>
 
-export type { RateReviewActionType }
+export type { RateReviewActionType, RateReviewType }
 export { rateReviewActionSchema }

--- a/services/app-api/src/domain-models/index.ts
+++ b/services/app-api/src/domain-models/index.ts
@@ -53,6 +53,8 @@ export type {
     ContractPackageSubmissionWithCauseType,
     RatePackageSubmissionWithCauseType,
     UnlockedContractType,
+    RateReviewActionType,
+    RateReviewType,
 } from './contractAndRates'
 
 export type {

--- a/services/app-api/src/emailer/emailer.ts
+++ b/services/app-api/src/emailer/emailer.ts
@@ -32,6 +32,7 @@ import { sendRateQuestionStateEmail } from './emails'
 import { sendRateQuestionCMSEmail } from './emails/sendRateQuestionCMSEmail'
 import { sendRateQuestionResponseCMSEmail } from './emails/sendRateQuestionResponseCMSEmail'
 import { sendRateQuestionResponseStateEmail } from './emails/sendRateQuestionResponseStateEmail'
+import { sendWithdrawnRateCMSEmail } from './emails/sendWithdrawnRateCMSEmail'
 
 // See more discussion of configuration in docs/Configuration.md
 type EmailConfiguration = {
@@ -175,6 +176,11 @@ type Emailer = {
     sendWithdrawnRateStateEmail: (
         rate: RateType,
         statePrograms: ProgramType[]
+    ) => Promise<void | Error>
+    sendWithdrawnRateCMSEmail: (
+        rate: RateType,
+        statePrograms: ProgramType[],
+        stateAnalystsEmails: StateAnalystsEmails
     ) => Promise<void | Error>
 }
 const localEmailerLogger = (emailData: EmailData) =>
@@ -502,7 +508,25 @@ function emailer(
             } else {
                 return await this.sendEmail(emailData)
             }
-        }
+        },
+        sendWithdrawnRateCMSEmail: async function (
+            rate,
+            statePrograms,
+            stateAnalystsEmails
+        ) {
+            const emailData = await sendWithdrawnRateCMSEmail(
+                config,
+                rate,
+                statePrograms,
+                stateAnalystsEmails
+            )
+
+            if (emailData instanceof Error) {
+                return emailData
+            } else {
+                return await this.sendEmail(emailData)
+            }
+        },
     }
 }
 

--- a/services/app-api/src/emailer/emails/__snapshots__/sendWithdrawnRateCMSEmail.test.ts.snap
+++ b/services/app-api/src/emailer/emails/__snapshots__/sendWithdrawnRateCMSEmail.test.ts.snap
@@ -1,0 +1,14 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`sendWithdrawnRateStateEmail > renders overall email for a withdrawn rate as expected 1`] = `
+"<h1 style="font-weight: normal;">Rate test-rate-certification-name was withdrawn by CMS</h1>
+<b>Withdrawn by:</b> zuko@example.com<br />
+<b>Withdrawn on:</b> 04/11/2024<br />
+<b>Reason for withdrawal:</b> Test withdraw<br />
+<b>Withdrawn from:</b>
+<ul>
+    <li>MCR-MN-0100-SNBC</li>
+    <li>MCR-MN-0222-SNBC</li>
+</ul>
+<a href="http://localhost/rates/test-rate">View withdrawn rate in MC-Review</a>"
+`;

--- a/services/app-api/src/emailer/emails/sendWithdrawnRateCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/sendWithdrawnRateCMSEmail.test.ts
@@ -1,0 +1,408 @@
+import {
+    mockContract,
+    mockContractRev,
+    mockMNState,
+    mockRate,
+    testEmailConfig,
+    testStateAnalystsEmails,
+} from '../../testHelpers/emailerHelpers'
+import { testCMSUser, testStateUser } from '../../testHelpers/userHelpers'
+import { sendWithdrawnRateCMSEmail } from './sendWithdrawnRateCMSEmail'
+
+const testRate = mockRate({
+    id: 'test-rate',
+    createdAt: new Date('2024-04-12'),
+    updatedAt: new Date('2024-04-12'),
+    status: 'RESUBMITTED',
+    reviewStatus: 'WITHDRAWN',
+    consolidatedStatus: 'WITHDRAWN',
+    parentContractID: 'parent-contract',
+    withdrawnFromContracts: [
+        {
+            ...mockContract({
+                id: 'parent-contract',
+                stateNumber: 100,
+                packageSubmissions: [
+                    {
+                        submitInfo: {
+                            updatedAt: new Date('2024-04-12'),
+                            updatedReason: 'CMS withdrew rate',
+                            updatedBy: testStateUser({
+                                email: 'cms@cms.com',
+                            }),
+                        },
+                        submittedRevisions: [],
+                        rateRevisions: [],
+                        contractRevision: mockContractRev({
+                            submitInfo: {
+                                updatedAt: new Date('2024-04-12'),
+                                updatedReason: 'CMS withdrew rate',
+                                updatedBy: testCMSUser({
+                                    email: 'cms@cms.com',
+                                }),
+                            },
+                            formData: {
+                                ...mockContractRev().formData,
+                                stateContacts: [
+                                    {
+                                        name: 'parent-contract-state-contact',
+                                        titleRole: 'state contact',
+                                        email: 'parent-contract-state-contact@state.com',
+                                    },
+                                ],
+                            },
+                        }),
+                    },
+                ],
+            }),
+        },
+        {
+            ...mockContract({
+                id: 'linked-contract',
+                stateNumber: 222,
+                packageSubmissions: [
+                    {
+                        submitInfo: {
+                            updatedAt: new Date('2024-04-12'),
+                            updatedReason: 'CMS withdrew rate',
+                            updatedBy: testCMSUser({
+                                email: 'cms@cms.com',
+                            }),
+                        },
+                        submittedRevisions: [],
+                        rateRevisions: [],
+                        contractRevision: mockContractRev({
+                            submitInfo: {
+                                updatedAt: new Date('2024-04-12'),
+                                updatedReason: 'CMS withdrew rate',
+                                updatedBy: testCMSUser({
+                                    email: 'cms@cms.com',
+                                }),
+                            },
+                            formData: {
+                                ...mockContractRev().formData,
+                                stateContacts: [
+                                    {
+                                        name: 'linked-contract-state-contact',
+                                        titleRole: 'state contact',
+                                        email: 'linked-contract-state-contact@state.com',
+                                    },
+                                    {
+                                        name: 'duplicate-state-contact',
+                                        titleRole: 'state contact',
+                                        email: 'duplicateContact@state-contact.com',
+                                    },
+                                    {
+                                        name: 'duplicate-state-contact',
+                                        titleRole: 'state contact',
+                                        email: 'duplicateContact@state-contact.com',
+                                    },
+                                ],
+                            },
+                        }),
+                    },
+                ],
+            }),
+        },
+    ],
+    packageSubmissions: [
+        {
+            submitInfo: {
+                updatedAt: new Date('2024-04-12'),
+                updatedReason: 'CMS withdrawn this rate',
+                updatedBy: testStateUser({
+                    email: 'parent-contract-submitter@state.com',
+                }),
+            },
+            submittedRevisions: [],
+            rateRevision: {
+                id: 'test-rate-revision',
+                rateID: 'test-rate',
+                submitInfo: {
+                    updatedAt: new Date('2024-04-12'),
+                    updatedReason: 'CMS withdrawn this rate',
+                    updatedBy: testStateUser({
+                        email: 'parent-contract-submitter@state.com',
+                    }),
+                },
+                createdAt: new Date('2024-04-12'),
+                updatedAt: new Date('2024-04-12'),
+                formData: {
+                    rateType: 'NEW',
+                    rateCapitationType: 'RATE_CELL',
+                    rateDateStart: new Date('2024-01-01'),
+                    rateDateEnd: new Date('2025-01-01'),
+                    rateDateCertified: new Date('2024-01-02'),
+                    rateCertificationName: 'test-rate-certification-name',
+                    rateProgramIDs: [mockMNState().programs[0].id],
+                    rateDocuments: [
+                        {
+                            s3URL: 's3://bucketname/key/test1',
+                            name: 'ratedoc1.doc',
+                            sha256: 'foobar',
+                        },
+                    ],
+                    supportingDocuments: [],
+                    certifyingActuaryContacts: [
+                        {
+                            name: 'Foo Person',
+                            titleRole: 'Bar Job',
+                            email: 'certifyingActuary@example.com',
+                            actuarialFirm: 'GUIDEHOUSE',
+                        },
+                    ],
+                    addtlActuaryContacts: [
+                        {
+                            name: 'Bar Person',
+                            titleRole: 'Baz Job',
+                            email: 'addtlActuaryContacts@example.com',
+                            actuarialFirm: 'OTHER',
+                            actuarialFirmOther: 'Some Firm',
+                        },
+                    ],
+                    actuaryCommunicationPreference: 'OACT_TO_ACTUARY',
+                },
+            },
+            contractRevisions: [],
+        },
+    ],
+    reviewStatusActions: [
+        {
+            rateID: 'test-rate',
+            updatedBy: testCMSUser(),
+            updatedReason: 'Test withdraw',
+            actionType: 'WITHDRAW',
+            updatedAt: new Date('2024-04-12'),
+        },
+    ],
+})
+
+const statePrograms = mockMNState().programs
+
+const stateAnalystsEmails = () => [...testStateAnalystsEmails]
+
+describe('sendWithdrawnRateStateEmail', () => {
+    it('includes expected CMS contacts in toAddress', async () => {
+        const template = await sendWithdrawnRateCMSEmail(
+            testEmailConfig(),
+            testRate,
+            statePrograms,
+            stateAnalystsEmails()
+        )
+
+        if (template instanceof Error) {
+            throw template
+        }
+
+        // Expect state analysts, DMCP submission emails, and OACT emails
+        expect(template.toAddresses).toEqual(
+            expect.arrayContaining([
+                ...stateAnalystsEmails(),
+                ...testEmailConfig().dmcpSubmissionEmails,
+                ...testEmailConfig().oactEmails,
+            ])
+        )
+    })
+
+    it('renders withdrawn rate with single withdrawn from contract as expected', async () => {
+        const singleContractRate = {
+            ...testRate,
+            withdrawnFromContracts: [
+                {
+                    ...mockContract({
+                        id: 'parent-contract',
+                        stateNumber: 100,
+                        packageSubmissions: [
+                            {
+                                submitInfo: {
+                                    updatedAt: new Date('2024-04-12'),
+                                    updatedReason: 'CMS withdrew rate',
+                                    updatedBy: testStateUser({
+                                        email: 'cms@cms.com',
+                                    }),
+                                },
+                                submittedRevisions: [],
+                                rateRevisions: [],
+                                contractRevision: mockContractRev({
+                                    submitInfo: {
+                                        updatedAt: new Date('2024-04-12'),
+                                        updatedReason: 'CMS withdrew rate',
+                                        updatedBy: testCMSUser({
+                                            email: 'cms@cms.com',
+                                        }),
+                                    },
+                                    formData: {
+                                        ...mockContractRev().formData,
+                                        stateContacts: [
+                                            {
+                                                name: 'parent-contract-state-contact',
+                                                titleRole: 'state contact',
+                                                email: 'parent-contract-state-contact@state.com',
+                                            },
+                                        ],
+                                    },
+                                }),
+                            },
+                        ],
+                    }),
+                },
+            ],
+        }
+        const template = await sendWithdrawnRateCMSEmail(
+            testEmailConfig(),
+            singleContractRate,
+            statePrograms,
+            stateAnalystsEmails()
+        )
+
+        if (template instanceof Error) {
+            throw template
+        }
+
+        // does not contain a ul element
+        expect(template.bodyHTML).not.toEqual(expect.stringContaining('<ul>'))
+
+        // expect single contract name
+        expect(template.bodyHTML).toEqual(
+            expect.stringContaining('MCR-MN-0100-SNBC')
+        )
+
+        // expect View the submission link
+        expect(template.bodyHTML).toEqual(
+            expect.stringContaining(
+                '<a href="http://localhost/rates/test-rate">View withdrawn rate in MC-Review</a>'
+            )
+        )
+    })
+
+    it('renders overall email for a withdrawn rate as expected', async () => {
+        const template = await sendWithdrawnRateCMSEmail(
+            testEmailConfig(),
+            testRate,
+            statePrograms,
+            stateAnalystsEmails()
+        )
+
+        if (template instanceof Error) {
+            throw template
+        }
+
+        expect(template.bodyHTML).toMatchSnapshot()
+    })
+})
+
+describe('sendWithdrawnRateStateEmail error handling', () => {
+    it('returns an error if rate consolidatedStatus is not WITHDRAWN', async () => {
+        const rateWithBadStatus = {
+            ...testRate,
+            consolidatedStatus: 'SUBMITTED' as const,
+        }
+        const template = await sendWithdrawnRateCMSEmail(
+            testEmailConfig(),
+            rateWithBadStatus,
+            statePrograms,
+            stateAnalystsEmails()
+        )
+
+        expect(template).toBeInstanceOf(Error)
+        expect((template as Error).message).toBe(
+            'Rate consolidated status is not WITHDRAWN'
+        )
+    })
+    it('returns an error if no reviewStatusActions are present', async () => {
+        const rateWithoutActions = {
+            ...testRate,
+            reviewStatusActions: [],
+        }
+        const template = await sendWithdrawnRateCMSEmail(
+            testEmailConfig(),
+            rateWithoutActions,
+            statePrograms,
+            stateAnalystsEmails()
+        )
+
+        expect(template).toBeInstanceOf(Error)
+        expect((template as Error).message).toBe(
+            'Rate does not any have review actions'
+        )
+    })
+    it('returns an error if latest reviewStatusActions action was not withdraw action', async () => {
+        const rateWithoutActions = {
+            ...testRate,
+            reviewStatusActions: [
+                {
+                    rateID: 'test-rate',
+                    updatedBy: testCMSUser(),
+                    updatedReason: 'Test under review',
+                    actionType: 'UNDER_REVIEW' as const,
+                    updatedAt: new Date('2024-04-11'),
+                },
+                {
+                    rateID: 'test-rate',
+                    updatedBy: testCMSUser(),
+                    updatedReason: 'Test under review',
+                    actionType: 'UNDER_REVIEW' as const,
+                    updatedAt: new Date('2024-04-15'),
+                },
+                {
+                    rateID: 'test-rate',
+                    updatedBy: testCMSUser(),
+                    updatedReason: 'Test withdraw',
+                    actionType: 'WITHDRAW' as const,
+                    updatedAt: new Date('2024-04-12'),
+                },
+            ],
+        }
+        const template = await sendWithdrawnRateCMSEmail(
+            testEmailConfig(),
+            rateWithoutActions,
+            statePrograms,
+            stateAnalystsEmails()
+        )
+        expect(template).toBeInstanceOf(Error)
+        expect((template as Error).message).toBe(
+            'Rate latest review action was not a withdraw action'
+        )
+    })
+    it('returns an error when parsing withdrawn from contract data fails', async () => {
+        const rateWithBadContractData = {
+            ...testRate,
+        }
+
+        if (!rateWithBadContractData.withdrawnFromContracts?.[0]) {
+            throw new Error('Expected rate to have withdrawn from contracts')
+        }
+
+        rateWithBadContractData.withdrawnFromContracts[0].packageSubmissions[0].contractRevision.formData.programIDs =
+            ['bad-program-id']
+
+        const template = await sendWithdrawnRateCMSEmail(
+            testEmailConfig(),
+            rateWithBadContractData,
+            statePrograms,
+            stateAnalystsEmails()
+        )
+
+        expect(template).toBeInstanceOf(Error)
+        expect((template as Error).message).toBe(
+            "Error parsing withdrawn from contract data for contract with ID: parent-contract. Can't find programs bad-program-id from state MN"
+        )
+    })
+    it('returns an error when rate has no withdrawn from contracts', async () => {
+        const rateWithoutContracts = {
+            ...testRate,
+            withdrawnFromContracts: [],
+        }
+        const template = await sendWithdrawnRateCMSEmail(
+            testEmailConfig(),
+            rateWithoutContracts,
+            statePrograms,
+            stateAnalystsEmails()
+        )
+
+        expect(template).toBeInstanceOf(Error)
+        expect((template as Error).message).toBe(
+            'Rate was withdrawn, but was not associated with any contracts'
+        )
+    })
+})

--- a/services/app-api/src/emailer/emails/sendWithdrawnRateCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/sendWithdrawnRateCMSEmail.ts
@@ -1,0 +1,195 @@
+import { formatCalendarDate } from '@mc-review/dates'
+import type {
+    ProgramType,
+    RateRevisionType,
+    RateType,
+    RateReviewType,
+} from '../../domain-models'
+import type { EmailData, StateAnalystsEmails } from '../emailer'
+import type { EmailConfiguration } from '../emailer'
+import {
+    findContractPrograms,
+    renderTemplate,
+    stripHTMLFromTemplate,
+} from '../templateHelpers'
+import { packageName as generatePackageName } from '@mc-review/hpp'
+import { rateSummaryURL, submissionSummaryURL } from '../generateURLs'
+import { pruneDuplicateEmails } from '../formatters'
+
+type WithdrawnFromContractData = {
+    contractName: string
+    submissionURL: string
+}
+
+type WithdrawnRateEtaData = {
+    rateName: string
+    withdrawnBy: string //email
+    withdrawnDate: string // mm/dd/yyyy format in PT timezone.
+    withdrawnReason: string
+    withdrawnFromContractData: WithdrawnFromContractData[]
+    summaryURL: string // rate summary url
+}
+
+type ValidatedWithdrawnRate = {
+    latestRateRev: RateRevisionType
+    latestAction: RateReviewType
+    withdrawnFromContractData: WithdrawnFromContractData[]
+    stateContactEmails: string[]
+}
+
+/**
+ * Validates and parses a withdrawn rate, ensuring it meets specific criteria and extracting relevant data.
+ *
+ * @param {RateType} rate - The rate object to validate and parse.
+ * @param {ProgramType[]} statePrograms - An array of state programs to be used for validation.
+ * @param {EmailConfiguration} config - Configuration object containing email-related settings.
+ * @returns {Error | ValidatedWithdrawnRate} - Returns an Error object if validation fails, otherwise returns a ValidatedWithdrawnRate object containing parsed data.
+ **/
+export const validateAndParseWithdrawnRate = (
+    rate: RateType,
+    statePrograms: ProgramType[],
+    config: EmailConfiguration
+): Error | ValidatedWithdrawnRate => {
+    if (rate.consolidatedStatus !== 'WITHDRAWN') {
+        return new Error('Rate consolidated status is not WITHDRAWN')
+    }
+
+    //check to make sure rate has a withdrawn action
+    const reviewStatusActions = rate.reviewStatusActions
+
+    if (!reviewStatusActions || reviewStatusActions.length === 0) {
+        return new Error('Rate does not any have review actions')
+    }
+
+    const latestAction = reviewStatusActions.sort(
+        (a, b) =>
+            new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    )[0]
+
+    if (latestAction.actionType !== 'WITHDRAW') {
+        return new Error('Rate latest review action was not a withdraw action')
+    }
+
+    // These contracts will not include linked contracts that are unlocked or in draft
+    const withdrawnFromContracts = rate.withdrawnFromContracts
+
+    if (!withdrawnFromContracts || withdrawnFromContracts.length === 0) {
+        return new Error(
+            'Rate was withdrawn, but was not associated with any contracts'
+        )
+    }
+
+    const latestRateRev = rate.packageSubmissions[0].rateRevision
+    if (!latestRateRev) {
+        return new Error('Rate does not have a rate revision')
+    }
+
+    const withdrawnFromContractData: WithdrawnFromContractData[] = []
+    const stateContactEmails: string[] = []
+
+    for (const contract of withdrawnFromContracts) {
+        // Get latest revision to generate package name. Use draft revision if contract is unlocked.
+        const latestContractRev =
+            contract.consolidatedStatus === 'UNLOCKED'
+                ? contract.draftRevision!
+                : contract.packageSubmissions[0].contractRevision
+
+        const pkgPrograms = findContractPrograms(
+            latestContractRev,
+            statePrograms
+        )
+
+        if (pkgPrograms instanceof Error) {
+            return new Error(
+                `Error parsing withdrawn from contract data for contract with ID: ${contract.id}. ${pkgPrograms.message}`
+            )
+        }
+
+        const packageName = generatePackageName(
+            contract.stateCode,
+            contract.stateNumber,
+            latestContractRev.formData.programIDs,
+            pkgPrograms
+        )
+
+        const submissionURL = submissionSummaryURL(contract.id, config.baseUrl)
+
+        withdrawnFromContractData.push({
+            contractName: packageName,
+            submissionURL,
+        })
+
+        latestContractRev.formData.stateContacts.forEach((contact) => {
+            if (contact.email) stateContactEmails.push(contact.email)
+        })
+    }
+
+    return {
+        latestRateRev,
+        latestAction,
+        withdrawnFromContractData,
+        stateContactEmails,
+    }
+}
+
+export const sendWithdrawnRateCMSEmail = async (
+    config: EmailConfiguration,
+    rate: RateType,
+    statePrograms: ProgramType[],
+    stateAnalystsEmails: StateAnalystsEmails
+): Promise<EmailData | Error> => {
+    // validate the withdrawn rate
+    const withdrawnRateData = validateAndParseWithdrawnRate(
+        rate,
+        statePrograms,
+        config
+    )
+
+    if (withdrawnRateData instanceof Error) {
+        return withdrawnRateData
+    }
+
+    const { latestRateRev, latestAction, withdrawnFromContractData } =
+        withdrawnRateData
+
+    const toAddresses = pruneDuplicateEmails([
+        ...stateAnalystsEmails,
+        ...config.dmcpSubmissionEmails,
+        ...config.oactEmails,
+        ...config.devReviewTeamEmails,
+    ])
+
+    const summaryURL = rateSummaryURL(rate.id, config.baseUrl)
+
+    const etaData: WithdrawnRateEtaData = {
+        rateName: latestRateRev.formData.rateCertificationName!,
+        withdrawnBy: latestAction.updatedBy.email,
+        withdrawnDate: formatCalendarDate(
+            latestAction.updatedAt,
+            'America/Los_Angeles'
+        ),
+        withdrawnReason: latestAction.updatedReason,
+        withdrawnFromContractData,
+        summaryURL,
+    }
+
+    const template = await renderTemplate<WithdrawnRateEtaData>(
+        'sendWithdrawnRateCMSEmail',
+        etaData
+    )
+
+    if (template instanceof Error) {
+        return template
+    } else {
+        return {
+            toAddresses,
+            replyToAddresses: [],
+            sourceEmail: config.emailSource,
+            subject: `${
+                config.stage !== 'prod' ? `[${config.stage}] ` : ''
+            }${etaData.rateName} was withdrawn`,
+            bodyText: stripHTMLFromTemplate(template),
+            bodyHTML: template,
+        }
+    }
+}

--- a/services/app-api/src/emailer/emails/sendWithdrawnRateStateEmail.ts
+++ b/services/app-api/src/emailer/emails/sendWithdrawnRateStateEmail.ts
@@ -2,14 +2,9 @@ import { formatCalendarDate } from '@mc-review/dates'
 import type { ProgramType, RateType } from '../../domain-models'
 import type { EmailData } from '../emailer'
 import type { EmailConfiguration } from '../emailer'
-import {
-    findContractPrograms,
-    renderTemplate,
-    stripHTMLFromTemplate,
-} from '../templateHelpers'
-import { packageName as generatePackageName } from '@mc-review/hpp'
-import { submissionSummaryURL } from '../generateURLs'
+import { renderTemplate, stripHTMLFromTemplate } from '../templateHelpers'
 import { pruneDuplicateEmails } from '../formatters'
+import { validateAndParseWithdrawnRate } from './sendWithdrawnRateCMSEmail'
 
 type WithdrawnFromContractData = {
     contractName: string
@@ -29,76 +24,23 @@ export const sendWithdrawnRateStateEmail = async (
     rate: RateType,
     statePrograms: ProgramType[]
 ): Promise<EmailData | Error> => {
-    if (rate.consolidatedStatus !== 'WITHDRAWN') {
-        return new Error('Rate consolidated status is not WITHDRAWN')
+    // validate the withdrawn rate
+    const withdrawnRateData = validateAndParseWithdrawnRate(
+        rate,
+        statePrograms,
+        config
+    )
+
+    if (withdrawnRateData instanceof Error) {
+        return withdrawnRateData
     }
 
-    //check to make sure rate has a withdrawn action
-    const latestRateRev = rate.packageSubmissions[0].rateRevision
-    const reviewStatusActions = rate.reviewStatusActions
-
-    if (!reviewStatusActions || reviewStatusActions.length === 0) {
-        return new Error('Rate does not any have review actions')
-    }
-
-    const latestAction = reviewStatusActions.sort(
-        (a, b) =>
-            new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
-    )[0]
-
-    if (latestAction.actionType !== 'WITHDRAW') {
-        return new Error('Rate latest review action was not a withdraw action')
-    }
-
-    // These contracts will not include linked contracts that are unlocked or in draft
-    const withdrawnFromContracts = rate.withdrawnFromContracts
-
-    if (!withdrawnFromContracts || withdrawnFromContracts.length === 0) {
-        return new Error(
-            'Rate was withdrawn, but was not associated with any contracts'
-        )
-    }
-
-    const stateContactEmails: string[] = []
-    const withdrawnFromContractData = []
-
-    // parse contract data and collect state contact emails
-    for (const contract of withdrawnFromContracts) {
-        // Get latest revision to generate package name. Use draft revision if contract is unlocked.
-        const latestContractRev =
-            contract.consolidatedStatus === 'UNLOCKED'
-                ? contract.draftRevision!
-                : contract.packageSubmissions[0].contractRevision
-
-        const pkgPrograms = findContractPrograms(
-            latestContractRev,
-            statePrograms
-        )
-
-        if (pkgPrograms instanceof Error) {
-            return new Error(
-                `Error parsing withdrawn from contract data for contract with ID: ${contract.id}. ${pkgPrograms.message}`
-            )
-        }
-
-        const packageName = generatePackageName(
-            contract.stateCode,
-            contract.stateNumber,
-            latestContractRev.formData.programIDs,
-            pkgPrograms
-        )
-
-        const submissionURL = submissionSummaryURL(contract.id, config.baseUrl)
-
-        withdrawnFromContractData.push({
-            contractName: packageName,
-            submissionURL,
-        })
-
-        latestContractRev.formData.stateContacts.forEach((contact) => {
-            if (contact.email) stateContactEmails.push(contact.email)
-        })
-    }
+    const {
+        latestRateRev,
+        latestAction,
+        withdrawnFromContractData,
+        stateContactEmails,
+    } = withdrawnRateData
 
     const toAddresses = pruneDuplicateEmails([
         ...stateContactEmails,

--- a/services/app-api/src/emailer/etaTemplates/sendWithdrawnRateCMSEmail.eta
+++ b/services/app-api/src/emailer/etaTemplates/sendWithdrawnRateCMSEmail.eta
@@ -1,0 +1,16 @@
+<h1 style=<%~'"font-weight: normal;"'%>>Rate <%= it.rateName %> was withdrawn by CMS</h1>
+<b>Withdrawn by:</b> <%= it.withdrawnBy %><br />
+<b>Withdrawn on:</b> <%= it.withdrawnDate %><br />
+<b>Reason for withdrawal:</b> <%= it.withdrawnReason %><br />
+<b>Withdrawn from:</b>
+<% if (it.withdrawnFromContractData.length > 1) { %>
+<ul>
+<% it.withdrawnFromContractData.forEach(function(contract){ %>
+    <li><%= contract.contractName %></li>
+<% }) %>
+</ul>
+<% } else { %>
+<%= it.withdrawnFromContractData[0].contractName %><br />
+<br />
+<% } %>
+<a href="<%= it.summaryURL %>">View withdrawn rate in MC-Review</a>

--- a/services/app-api/src/emailer/generateURLs.ts
+++ b/services/app-api/src/emailer/generateURLs.ts
@@ -1,18 +1,20 @@
 import { URL } from 'url'
 import { compile } from 'path-to-regexp'
-
 import { RoutesRecord } from '@mc-review/constants'
+
+function generateUrl(id: string, base: string, pattern: string): string {
+    const toPath = compile(pattern, { encode: encodeURIComponent })
+    const path = toPath({ id })
+
+    return new URL(path, base).href
+}
 
 // Generates the correct url for the review and submit page for a given package id
 // React Router uses the path-to-regexp library to generate URLs, we import it here to avoid loading
 // all of react-router into our bundle.
 function reviewAndSubmitURL(id: string, base: string): string {
     const pattern = RoutesRecord.SUBMISSIONS_REVIEW_SUBMIT
-    const toPath = compile(pattern, { encode: encodeURIComponent })
-    const path = toPath({ id })
-    const url = new URL(path, base).href
-
-    return url
+    return generateUrl(id, base, pattern)
 }
 
 // Generates the correct url for the submission summary page for a given package id
@@ -20,20 +22,17 @@ function reviewAndSubmitURL(id: string, base: string): string {
 // all of react-router into our bundle.
 function submissionSummaryURL(id: string, base: string): string {
     const pattern = RoutesRecord.SUBMISSIONS_SUMMARY
-    const toPath = compile(pattern, { encode: encodeURIComponent })
-    const path = toPath({ id })
-    const url = new URL(path, base).href
-
-    return url
+    return generateUrl(id, base, pattern)
 }
 
 function submissionQuestionResponseURL(id: string, base: string): string {
     const pattern = RoutesRecord.SUBMISSIONS_CONTRACT_QUESTIONS_AND_ANSWERS
-    const toPath = compile(pattern, { encode: encodeURIComponent })
-    const path = toPath({ id })
-    const url = new URL(path, base).href
+    return generateUrl(id, base, pattern)
+}
 
-    return url
+function rateSummaryURL(id: string, base: string): string {
+    const pattern = RoutesRecord.RATES_SUMMARY
+    return generateUrl(id, base, pattern)
 }
 
 function rateQuestionResponseURL(
@@ -51,11 +50,7 @@ function rateQuestionResponseURL(
 
 function rateSummaryQuestionResponseURL(rateID: string, base: string): string {
     const pattern = RoutesRecord.RATES_SUMMARY_QUESTIONS_AND_ANSWERS
-    const toPath = compile(pattern, { encode: encodeURIComponent })
-    const path = toPath({ id: rateID })
-    const url = new URL(path, base).href
-
-    return url
+    return generateUrl(rateID, base, pattern)
 }
 
 export {
@@ -64,4 +59,5 @@ export {
     submissionQuestionResponseURL,
     rateQuestionResponseURL,
     rateSummaryQuestionResponseURL,
+    rateSummaryURL,
 }

--- a/services/app-api/src/resolvers/rate/withdrawRate.test.ts
+++ b/services/app-api/src/resolvers/rate/withdrawRate.test.ts
@@ -771,7 +771,7 @@ describe('withdrawRate', () => {
         )
     }, 10000)
 
-    it('sends an email to state contacts when a rate is withdrawn', async () => {
+    it('sends emails to state and CMS when a rate is withdrawn', async () => {
         const emailConfig = testEmailConfig()
         const mockEmailer = testEmailer(emailConfig)
         const stateUser = testStateUser()
@@ -848,22 +848,42 @@ describe('withdrawRate', () => {
 
         await withdrawTestRate(cmsServer, rateID, 'Withdraw invalid rate')
 
-        // expect email to contain correct subject
+        // expect CMS email to contain correct subject
         expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
             3,
             expect.objectContaining({
                 subject: expect.stringContaining(`${rateName} was withdrawn`),
                 sourceEmail: emailConfig.emailSource,
-                toAddresses: expect.arrayContaining(
-                    Array.from(stateReceiverEmails)
-                ),
+                toAddresses: expect.arrayContaining([
+                    ...testEmailConfig().dmcpSubmissionEmails,
+                    ...testEmailConfig().oactEmails,
+                ]),
                 bodyHTML: expect.stringContaining(contractAName),
             })
         )
 
-        // expect contract B to be in the email
+        // expect contract B to be in the CMS email
         expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
             3,
+            expect.objectContaining({
+                bodyHTML: expect.stringContaining(contractBName),
+            })
+        )
+
+        // expect state email to contain correct subject
+        expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
+            4,
+            expect.objectContaining({
+                subject: expect.stringContaining(`${rateName} was withdrawn`),
+                sourceEmail: emailConfig.emailSource,
+                toAddresses: expect.arrayContaining(stateReceiverEmails),
+                bodyHTML: expect.stringContaining(contractAName),
+            })
+        )
+
+        // expect contract B to be in the state email
+        expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
+            4,
             expect.objectContaining({
                 bodyHTML: expect.stringContaining(contractBName),
             })


### PR DESCRIPTION
## Summary
[MCR-4661](https://jiraent.cms.gov/browse/MCR-4661)

AC:
- If a rate is withdrawn, then withdrawal notification emails are sent to the following CMS inboxes:
   - DMCO staff assigned to the state of the rate submission
   - [MMCRatesetting@cms.hhs.gov](mailto:MMCRatesetting@cms.hhs.gov) (excluding PR state).
   - [OACTMedicaidManagedCare@cms.hhs.gov](mailto:OACTMedicaidManagedCare@cms.hhs.gov) (excluding PR state)

Other work:
- Fixed another transaction in `withdrawRate` postgres function that needed to be thrown
- Added a summary for `withdraRate` postgres function.
- Refactored withdrawn rate email validation into a common function
- Abstracted out common code generating urls for emails.
#### Related issues

#### Screenshots

<img src="https://github.com/user-attachments/assets/442a0440-dda6-4ae4-a6e2-7e6424319178" width="550"/>
<img src="https://github.com/user-attachments/assets/b45cdc7a-e4d6-4667-bc88-18f9cec0aad9" width="550"/>

#### Test cases covered

- `sendWithdrawnRateCMSEmail.test.ts`
  - Same tests as state email function, but looking for CMS emails.

- `withdrawRate.test.ts`
   - `'sends an email to state contacts when a rate is withdrawn'` -> `'sends emails to state and CMS when a rate is withdrawn'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
