### PR TITLE
Add tag to OIDC role

### DIFF
--- a/services/github-oidc/serverless.yml
+++ b/services/github-oidc/serverless.yml
@@ -59,6 +59,7 @@ params:
       - 'secretsmanager:*'
       - 'ssm:*'
       - 's3:*'
+      - 'tag:*'
       - 'wafv2:*'
       - 'securityhub:*'
 


### PR DESCRIPTION
## Summary
This is another permission the github oidc user needs to bootstrap AWS CDK.

#### Related issues
https://jiraent.cms.gov/browse/MCR-4435
