### PR TITLE
MCR-4791: Add rate withdraw actions to change history table

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
@@ -260,7 +260,7 @@ const withdrawRateInsideTransaction = async (
         rateID,
         formData: undefined,
         submittedByUserID: updatedByID,
-        submittedReason: 'CMS has withdrawn this rate',
+        submittedReason: 'CMS has withdrawn this rate. ' + updatedReason,
     })
 
     // Add review status action to rate and create new joins on withdrawn rate join table

--- a/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
@@ -125,7 +125,7 @@ const withdrawRateInsideTransaction = async (
             const unlockedContract = await unlockContractInsideTransaction(tx, {
                 contractID: contract.id,
                 unlockedByUserID: updatedByID,
-                unlockReason: `CMS withdrawing rate ${latestRateRev.rateCertificationName} from this submission. ${args.updatedReason}`,
+                unlockReason: `CMS withdrawing rate ${latestRateRev.rateCertificationName} from this submission. ${updatedReason}`,
             })
 
             if (unlockedContract instanceof Error) {
@@ -243,7 +243,7 @@ const withdrawRateInsideTransaction = async (
             const resubmitContractArgs: SubmitContractArgsType = {
                 contractID: contract.id,
                 submittedByUserID: updatedByID,
-                submittedReason: `CMS has withdrawn rate ${latestRateRev.rateCertificationName} from this submission. ${args.updatedReason}`,
+                submittedReason: `CMS has withdrawn rate ${latestRateRev.rateCertificationName} from this submission. ${updatedReason}`,
             }
             const resubmitResult = await submitContractInsideTransaction(
                 tx,

--- a/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
@@ -80,9 +80,6 @@ const withdrawRateInsideTransaction = async (
         ...new Set([...submittedContractsIds, ...draftContractsIds]),
     ]
 
-    // Get the contractIDs of the latest submission package of each related submission
-    const latestRateRev = rate.revisions[0]
-
     // get data for every contract
     const contracts = await tx.contractTable.findMany({
         where: {
@@ -125,7 +122,7 @@ const withdrawRateInsideTransaction = async (
             const unlockedContract = await unlockContractInsideTransaction(tx, {
                 contractID: contract.id,
                 unlockedByUserID: updatedByID,
-                unlockReason: `CMS withdrawing rate ${latestRateRev.rateCertificationName} from this submission`,
+                unlockReason: args.updatedReason,
             })
 
             if (unlockedContract instanceof Error) {
@@ -243,7 +240,7 @@ const withdrawRateInsideTransaction = async (
             const resubmitContractArgs: SubmitContractArgsType = {
                 contractID: contract.id,
                 submittedByUserID: updatedByID,
-                submittedReason: `CMS has withdrawn rate ${latestRateRev.rateCertificationName} from this submission`,
+                submittedReason: args.updatedReason,
             }
             const resubmitResult = await submitContractInsideTransaction(
                 tx,

--- a/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
@@ -80,6 +80,9 @@ const withdrawRateInsideTransaction = async (
         ...new Set([...submittedContractsIds, ...draftContractsIds]),
     ]
 
+    // Get the contractIDs of the latest submission package of each related submission
+    const latestRateRev = rate.revisions[0]
+
     // get data for every contract
     const contracts = await tx.contractTable.findMany({
         where: {
@@ -122,7 +125,7 @@ const withdrawRateInsideTransaction = async (
             const unlockedContract = await unlockContractInsideTransaction(tx, {
                 contractID: contract.id,
                 unlockedByUserID: updatedByID,
-                unlockReason: args.updatedReason,
+                unlockReason: `CMS withdrawing rate ${latestRateRev.rateCertificationName} from this submission. ${args.updatedReason}`,
             })
 
             if (unlockedContract instanceof Error) {
@@ -240,7 +243,7 @@ const withdrawRateInsideTransaction = async (
             const resubmitContractArgs: SubmitContractArgsType = {
                 contractID: contract.id,
                 submittedByUserID: updatedByID,
-                submittedReason: args.updatedReason,
+                submittedReason: `CMS has withdrawn rate ${latestRateRev.rateCertificationName} from this submission. ${args.updatedReason}`,
             }
             const resubmitResult = await submitContractInsideTransaction(
                 tx,

--- a/services/app-web/src/components/ChangeHistory/ChangeHistory.test.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistory.test.tsx
@@ -11,6 +11,7 @@ import {
     mockValidCMSUser,
     mockValidStateUser,
     mockContractPackageApproved,
+    mockContractWithLinkedRateSubmitted,
 } from '@mc-review/mocks'
 import { renderWithProviders } from '../../testHelpers'
 import { formatToPacificTime } from '@mc-review/dates'
@@ -93,6 +94,127 @@ describe('Change History', () => {
             })
         ).toBeInTheDocument()
         expect(screen.getByText('Approved')).toBeInTheDocument()
+    })
+
+    it('has expected text in the accordion titles and content for rate withdrawal', () => {
+        const contractWithWithdrawnRate = mockContractWithLinkedRateSubmitted({
+            packageSubmissions: [
+                {
+                    cause: 'CONTRACT_SUBMISSION',
+                    __typename: 'ContractPackageSubmission',
+                    submitInfo: {
+                        updatedAt: new Date('12/18/2023'),
+                        updatedBy: {
+                            email: 'example@state.com',
+                            role: 'STATE_USER',
+                            givenName: 'John',
+                            familyName: 'Vila',
+                        },
+                        updatedReason: 'withdraw rate',
+                    },
+                    submittedRevisions: [],
+                    contractRevision: {
+                        contractName: 'MCR-MN-0005-SNBC',
+                        createdAt: new Date('01/01/2024'),
+                        updatedAt: new Date('12/31/2024'),
+                        id: '123',
+                        contractID: 'test-abc-123',
+                        submitInfo: {
+                            updatedAt: new Date('12/18/2023'),
+                            updatedBy: {
+                                email: 'example@state.com',
+                                role: 'STATE_USER',
+                                givenName: 'John',
+                                familyName: 'Vila',
+                            },
+                            updatedReason: 'withdraw rate',
+                        },
+                        unlockInfo: {
+                            updatedAt: new Date('12/18/2023'),
+                            updatedBy: {
+                                email: 'example@state.com',
+                                role: 'STATE_USER',
+                                givenName: 'John',
+                                familyName: 'Vila',
+                            },
+                            updatedReason: 'withdraw rate',
+                        },
+                        formData: {
+                            programIDs: [
+                                'abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce',
+                            ],
+                            populationCovered: 'MEDICAID',
+                            submissionType: 'CONTRACT_AND_RATES',
+                            riskBasedContract: true,
+                            submissionDescription: 'A real submission',
+                            supportingDocuments: [
+                                {
+                                    s3URL: 's3://bucketname/key/contractsupporting1',
+                                    sha256: 'fakesha',
+                                    name: 'contractSupporting1',
+                                    dateAdded: new Date('01/15/2024'),
+                                },
+                                {
+                                    s3URL: 's3://bucketname/key/contractSupporting2',
+                                    sha256: 'fakesha',
+                                    name: 'contractSupporting2',
+                                    dateAdded: new Date('01/13/2024'),
+                                },
+                            ],
+                            stateContacts: [],
+                            contractType: 'AMENDMENT',
+                            contractExecutionStatus: 'EXECUTED',
+                            contractDocuments: [
+                                {
+                                    s3URL: 's3://bucketname/key/contract',
+                                    sha256: 'fakesha',
+                                    name: 'contract',
+                                    dateAdded: new Date('01/01/2024'),
+                                },
+                            ],
+                            contractDateStart: new Date(),
+                            contractDateEnd: new Date(),
+                            managedCareEntities: ['MCO'],
+                            federalAuthorities: ['STATE_PLAN'],
+                            inLieuServicesAndSettings: true,
+                            modifiedBenefitsProvided: true,
+                            modifiedGeoAreaServed: false,
+                            modifiedMedicaidBeneficiaries: true,
+                            modifiedRiskSharingStrategy: true,
+                            modifiedIncentiveArrangements: false,
+                            modifiedWitholdAgreements: false,
+                            modifiedStateDirectedPayments: true,
+                            modifiedPassThroughPayments: true,
+                            modifiedPaymentsForMentalDiseaseInstitutions: false,
+                            modifiedMedicalLossRatioStandards: true,
+                            modifiedOtherFinancialPaymentIncentive: false,
+                            modifiedEnrollmentProcess: true,
+                            modifiedGrevienceAndAppeal: false,
+                            modifiedNetworkAdequacyStandards: true,
+                            modifiedLengthOfContract: false,
+                            modifiedNonRiskPaymentArrangements: true,
+                            statutoryRegulatoryAttestation: true,
+                            statutoryRegulatoryAttestationDescription:
+                                'everything meets regulatory attestation',
+                        },
+                    },
+                    rateRevisions: [],
+                },
+            ],
+        })
+        renderWithProviders(
+            <ChangeHistory contract={contractWithWithdrawnRate} />
+        )
+        const submitInfo =
+            contractWithWithdrawnRate.packageSubmissions[0].submitInfo
+        const updatedAt = submitInfo.updatedAt
+        // API returns UTC timezone, we display timestamped dates in PT timezone so 1 day before on these tests.
+        expect(
+            screen.getByRole('button', {
+                name: `${formatToPacificTime(updatedAt)} - Submission`,
+            })
+        ).toBeInTheDocument()
+        expect(screen.getAllByText(/withdraw rate/)).toHaveLength(2)
     })
 
     it('has expected text in the accordion titles and content for ADMIN events', () => {


### PR DESCRIPTION
## Summary

- This PR updates the submission and unlock entries in the change history table to display the withdrawal reason

#### Related issues

https://jiraent.cms.gov/browse/MCR-4791
[Updated Designs](https://www.figma.com/design/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?node-id=16528-58296&t=1Qg2mXt2xAgZzvib-0)

#### Screenshots

<img width="872" alt="Screenshot 2025-01-09 at 3 08 43 PM" src="https://github.com/user-attachments/assets/aeb319f7-f458-4b2f-ad8c-2e3ed986b0f0" />


#### Test cases covered

ChangeHistory -> 'has expected text in the accordion titles and content for rate withdrawal'

## QA guidance

- login as a CMS user and withdraw a rate
- Check the submission summary page has captured the unlock and resubmit actions for the rate withdraw
- login as a state user
- Confirm the submission summary page has captured the unlock and resubmit actions for the rate withdraw
