### PR TITLE
MCR-4873: update the contract actions section on rate summary page

### DIFF
--- a/packages/mocks/src/apollo/contractPackageDataMock.ts
+++ b/packages/mocks/src/apollo/contractPackageDataMock.ts
@@ -1686,6 +1686,7 @@ function mockContractPackageApprovedWithQuestions(
 function mockContractPackageSubmittedWithRevisions(
     partial?: Partial<Contract>
 ): Contract {
+    const contractID = partial?.id || 'test-abc-123'
     return {
         __typename: 'Contract',
         status: 'SUBMITTED',
@@ -1696,7 +1697,7 @@ function mockContractPackageSubmittedWithRevisions(
         lastUpdatedForDisplay: new Date(),
         initiallySubmittedAt: new Date('2024-01-01'),
         mccrsID: null,
-        id: 'test-abc-123',
+        id: contractID,
         webURL: 'https://testmcreview.example/submissions/test-abc-123',
         stateCode: 'MN',
         state: mockMNState(),
@@ -1719,8 +1720,9 @@ function mockContractPackageSubmittedWithRevisions(
                     },
                     updatedReason: 'submit 3',
                 },
-                submittedRevisions: [mockContractRevision('3')],
+                submittedRevisions: [mockContractRevision('3', { contractID })],
                 contractRevision: mockContractRevision('3', {
+                    contractID,
                     unlockInfo: {
                         __typename: 'UpdateInformation',
                         updatedAt: '2024-03-01T17:54:39.173Z',
@@ -1749,8 +1751,9 @@ function mockContractPackageSubmittedWithRevisions(
                     },
                     updatedReason: 'submit 2',
                 },
-                submittedRevisions: [mockContractRevision('2')],
+                submittedRevisions: [mockContractRevision('2', { contractID })],
                 contractRevision: mockContractRevision('2', {
+                    contractID,
                     unlockInfo: {
                         __typename: 'UpdateInformation',
                         updatedAt: '2024-01-25T21:13:56.174Z',
@@ -1779,8 +1782,8 @@ function mockContractPackageSubmittedWithRevisions(
                     },
                     updatedReason: 'submit 1',
                 },
-                submittedRevisions: [mockContractRevision('1')],
-                contractRevision: mockContractRevision('1'),
+                submittedRevisions: [mockContractRevision('1', { contractID })],
+                contractRevision: mockContractRevision('1', { contractID }),
                 rateRevisions: [mockRateRevision('1')],
             },
         ],
@@ -2211,6 +2214,7 @@ function mockContractPackageWithDifferentProgramsInRevisions(): Contract {
 function mockContractPackageUnlockedWithUnlockedType(
     partial?: Partial<UnlockedContract>
 ): UnlockedContract {
+    const contractID = partial?.id ?? 'test-abc-123'
     return {
         status: 'UNLOCKED',
         reviewStatus: 'UNDER_REVIEW',
@@ -2220,7 +2224,7 @@ function mockContractPackageUnlockedWithUnlockedType(
         updatedAt: '2024-12-01T16:54:39.173Z',
         lastUpdatedForDisplay: '2024-12-01T16:54:39.173Z',
         initiallySubmittedAt: new Date('2023-01-01'),
-        id: 'test-abc-123',
+        id: contractID,
         webURL: 'https://testmcreview.example/submissions/test-abc-123',
         stateCode: 'MN',
         state: mockMNState(),
@@ -2228,7 +2232,7 @@ function mockContractPackageUnlockedWithUnlockedType(
         mccrsID: '1234',
         draftRevision: {
             __typename: 'ContractRevision',
-            contractID: 'test-abc-123',
+            contractID,
             submitInfo: null,
             unlockInfo: {
                 __typename: 'UpdateInformation',
@@ -2312,7 +2316,7 @@ function mockContractPackageUnlockedWithUnlockedType(
                 revisions: [],
                 state: mockMNState(),
                 stateNumber: 5,
-                parentContractID: 'test-abc-123',
+                parentContractID: contractID,
                 draftRevision: {
                     __typename: 'RateRevision',
                     id: 'unlocked-rr-123',
@@ -2401,7 +2405,7 @@ function mockContractPackageUnlockedWithUnlockedType(
                         contractName: 'MCR-MN-0005-SNBC',
                         createdAt: new Date('01/01/2024'),
                         updatedAt: '2023-01-01T16:54:39.173Z',
-                        contractID: 'test-abc-123',
+                        contractID,
                         submitInfo: {
                             __typename: 'UpdateInformation',
                             updatedAt: '2023-01-01T16:54:39.173Z',
@@ -2465,7 +2469,7 @@ function mockContractPackageUnlockedWithUnlockedType(
                 ],
                 contractRevision: {
                     __typename: 'ContractRevision',
-                    contractID: 'test-abc-123',
+                    contractID,
                     contractName: 'MCR-MN-0005-SNBC',
                     createdAt: new Date('01/01/2024'),
                     updatedAt: '2024-01-01T18:54:39.173Z',

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -1976,7 +1976,7 @@ type UnlockedContract {
     """
     consolidatedStatus: ConsolidatedContractStatus!
     "initiallySubmittedAt is the initial date this contract was submitted at. Is not changed by unlock or resubmission."
-    initiallySubmittedAt: Date
+    initiallySubmittedAt: DateTime
     "lastUpdatedForDisplay is the last time this contract was officially updated. When it's a draft it will be the last updatedAt date. Afterwards it will be the most recent submit or unlock or review action date."
     lastUpdatedForDisplay: DateTime!
     "stateCode is the state code (e.g. CA or TN) for the submitting state"

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -117,8 +117,21 @@ export const SingleRateSummarySection = ({
         rate.status === 'SUBMITTED' ||
         rate.status === 'RESUBMITTED' ||
         isCMSUser
+    const isWithdrawn = rate.consolidatedStatus === 'WITHDRAWN'
 
-    const linkedContracts = latestSubmission.contractRevisions
+    const withdrawnFromContractRevs =
+        rate.withdrawnFromContracts?.reduce((acc, contract) => {
+            const latestRevision =
+                contract.packageSubmissions?.[0].contractRevision
+            if (latestRevision) {
+                acc.push(latestRevision)
+            }
+            return acc
+        }, [] as ContractRevision[]) ?? []
+
+    const contractActions = isWithdrawn
+        ? withdrawnFromContractRevs
+        : latestSubmission.contractRevisions
 
     // TODO BULK DOWNLOAD
     // needs to be wrap in a standalone hook
@@ -338,7 +351,7 @@ export const SingleRateSummarySection = ({
                         <DataDetail
                             id="submittedWithContract"
                             label="Contract actions"
-                            children={relatedSubmissions(linkedContracts)}
+                            children={relatedSubmissions(contractActions)}
                         />
                     </Grid>
                 </dl>

--- a/services/app-web/src/pages/StateSubmission/RateDetails/rateDetailsHelpers.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/rateDetailsHelpers.ts
@@ -144,7 +144,6 @@ const convertIndexRatesGQLRateToRateForm = (getKey: S3ClientT['getKey'], rate?: 
     }
 }
 
-
 // Convert from GQL Rate to FormikRateForm object used in the form
 // if rate is not passed in, return an empty RateForm // we need to pass in the  s3 handler because 3 urls generated client-side
 // useLatestSubmission means to pull the latest submitted info rather than the draft info


### PR DESCRIPTION
## Summary
[MCR-4873](https://jiraent.cms.gov/browse/MCR-4873)

- After a rate is withdrawn the contract actions it was associated with should still appear in the contract actions section.

#### Related issues

#### Screenshots

#### Test cases covered

`SingleRateSummarySection.test.tsx`
- 'renders contract actions correctly after rate withdraw'

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
