### PR TITLE
MCR-4751: restrict existing api for withdrawn rates

### DIFF
--- a/services/app-api/src/resolvers/contract/unlockContract.ts
+++ b/services/app-api/src/resolvers/contract/unlockContract.ts
@@ -88,20 +88,6 @@ export function unlockContractResolver(
                 },
             })
         }
-        if (
-            unlockContractResult.status != 'UNLOCKED' &&
-            unlockContractResult.status != 'DRAFT'
-        ) {
-            const errMessage = `Programming Error: Got incorrect status from an unlocked contract.`
-            logError('unlockContract', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-            throw new GraphQLError(errMessage, {
-                extensions: {
-                    code: 'INTERNAL_SERVER_ERROR',
-                    cause: 'DB_ERROR',
-                },
-            })
-        }
 
         let stateAnalystsEmails: string[] = []
         // not great that state code type isn't being used in ContractType but I'll risk the conversion for now

--- a/services/app-api/src/resolvers/contract/updateDraftContractRates.ts
+++ b/services/app-api/src/resolvers/contract/updateDraftContractRates.ts
@@ -136,10 +136,12 @@ function updateDraftContractRates(
         }
         // state user is authorized
 
+        const editableStatuses = ['DRAFT', 'UNLOCKED']
+
         // Can only update a contract that is editable
         if (
             !contract.draftRevision ||
-            !(contract.status === 'DRAFT' || contract.status === 'UNLOCKED')
+            !editableStatuses.includes(contract.consolidatedStatus)
         ) {
             const errMsg =
                 'you cannot update a contract that is not DRAFT or UNLOCKED'
@@ -220,10 +222,7 @@ function updateDraftContractRates(
                 }
 
                 if (
-                    !(
-                        rateToUpdate.status === 'DRAFT' ||
-                        rateToUpdate.status === 'UNLOCKED'
-                    )
+                    !editableStatuses.includes(rateToUpdate.consolidatedStatus)
                 ) {
                     // eventually, this will be enough to cancel this. But until we have unlock-rate, you can edit UNLOCKED children of this contract.
                     const errmsg =
@@ -292,10 +291,12 @@ function updateDraftContractRates(
                         throw new Error(errmsg)
                     }
 
-                    if (rateToLink.status === 'DRAFT') {
-                        const errmsg =
-                            'Attempted to link a rate that has never been submitted: ' +
-                            rateUpdate.rateID
+                    if (
+                        ['DRAFT', 'WITHDRAWN'].includes(
+                            rateToLink.consolidatedStatus
+                        )
+                    ) {
+                        const errmsg = `Attempted to link a rate with an invalid status. Status: ${rateToLink.consolidatedStatus}. RateID: ${rateUpdate.rateID}`
                         logError('updateDraftContractRates', errmsg)
                         setErrorAttributesOnActiveSpan(errmsg, span)
                         throw new UserInputError(errmsg)

--- a/services/app-api/src/resolvers/questionResponse/createRateQuestion.ts
+++ b/services/app-api/src/resolvers/questionResponse/createRateQuestion.ts
@@ -69,9 +69,8 @@ export function createRateQuestionResolver(
             })
         }
 
-        // Draft rate will have no submitted revisions
-        if (rate.status === 'DRAFT') {
-            const errMessage = `Issue creating question for rate. Message: Cannot create question for rate in DRAFT status`
+        if (['DRAFT', 'WITHDRAWN'].includes(rate.consolidatedStatus)) {
+            const errMessage = `Issue creating question for rate. Message: Rate is in a invalid statius: ${rate.consolidatedStatus}`
             logError('createRateQuestion', errMessage)
             setErrorAttributesOnActiveSpan(errMessage, span)
             throw new UserInputError(errMessage)

--- a/services/app-api/src/resolvers/rate/submitRate.ts
+++ b/services/app-api/src/resolvers/rate/submitRate.ts
@@ -72,26 +72,24 @@ export function submitRate(
             })
         }
 
-        const draftRateRevision = unsubmittedRate.draftRevision
-
-        if (!draftRateRevision) {
-            throw new Error(
-                'PROGRAMMING ERROR: Status should not be submittable without a draft rate revision'
-            )
-        }
-
-        // make sure it is draft or unlocked
         if (
-            unsubmittedRate.status === 'SUBMITTED' ||
-            unsubmittedRate.status === 'RESUBMITTED'
+            !['UNLOCKED', 'DRAFT'].includes(unsubmittedRate.consolidatedStatus)
         ) {
-            const errMessage = `Attempted to submit a rate that is already submitted`
+            const errMessage = `Attempted to submit a rate with invalid status: ${unsubmittedRate.consolidatedStatus}`
             logError('submitRate', errMessage)
             setErrorAttributesOnActiveSpan(errMessage, span)
             throw new UserInputError(errMessage, {
                 argumentName: 'rateID',
                 cause: 'INVALID_PACKAGE_STATUS',
             })
+        }
+
+        const draftRateRevision = unsubmittedRate.draftRevision
+
+        if (!draftRateRevision) {
+            throw new Error(
+                'PROGRAMMING ERROR: Status should not be submittable without a draft rate revision'
+            )
         }
 
         // prepare to generate rate cert name - either use new form data coming down on submit or unsubmitted submission data already in database

--- a/services/app-api/src/resolvers/rate/unlockRate.ts
+++ b/services/app-api/src/resolvers/rate/unlockRate.ts
@@ -56,8 +56,8 @@ export function unlockRate(store: Store): MutationResolvers['unlockRate'] {
 
         const rate: RateType = initialRateResult
 
-        if (rate.draftRevision) {
-            const errMessage = `Attempted to unlock rate with wrong status`
+        if (!['SUBMITTED', 'RESUBMITTED'].includes(rate.consolidatedStatus)) {
+            const errMessage = `Attempted to unlock rate with wrong status: ${rate.consolidatedStatus}`
             logError('unlockRate', errMessage)
             setErrorAttributesOnActiveSpan(errMessage, span)
             throw new UserInputError(errMessage, {
@@ -90,7 +90,11 @@ export function unlockRate(store: Store): MutationResolvers['unlockRate'] {
             })
         }
 
-        if (contractResult.consolidatedStatus === 'APPROVED') {
+        if (
+            ['WITHDRAWN', 'APPROVED'].includes(
+                contractResult.consolidatedStatus
+            )
+        ) {
             const errMessage = `Attempted to unlock a rate that is associated with a contract with wrong status: ${contractResult.consolidatedStatus}`
             logError('unlockRate', errMessage)
             setErrorAttributesOnActiveSpan(errMessage, span)

--- a/services/app-web/src/pages/QuestionResponse/QATable/CMSQuestionResponseTable.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/CMSQuestionResponseTable.tsx
@@ -3,6 +3,7 @@ import {
     ContractQuestionList,
     Division,
     RateQuestionList,
+    ConsolidatedRateStatus,
 } from '../../../gen/gqlClient'
 import type { QuestionRounds } from './QuestionResponseRound'
 import { QuestionResponseRound } from './QuestionResponseRound'
@@ -13,17 +14,18 @@ import { IndexQuestionType } from '../QuestionResponseHelpers'
 
 type CMSQuestionResponseTableProps = {
     indexQuestions: IndexQuestionType
-    contractStatus?: ConsolidatedContractStatus
+    consolidatedStatus?: ConsolidatedContractStatus | ConsolidatedRateStatus
     userDivision?: Division
 }
 
 export const CMSQuestionResponseTable = ({
     indexQuestions,
-    contractStatus,
+    consolidatedStatus,
     userDivision,
 }: CMSQuestionResponseTableProps) => {
     const { loggedInUser } = useAuth()
-    const isApprovedContract = contractStatus === 'APPROVED'
+    const canAddQuestions =
+        !['APPROVED', 'WITHDRAWN'].includes(consolidatedStatus!) && userDivision
     const currentDivisionRounds = (): QuestionRounds => {
         if (!userDivision) {
             return []
@@ -101,7 +103,7 @@ export const CMSQuestionResponseTable = ({
                 data-testid={'usersDivisionQuestions'}
             >
                 <SectionHeader header="Your division's questions">
-                    {userDivision && !isApprovedContract && (
+                    {canAddQuestions && (
                         <NavLinkWithLogging
                             className="usa-button"
                             variant="unstyled"

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/ContractQuestionResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/ContractQuestionResponse.tsx
@@ -76,7 +76,7 @@ export const ContractQuestionResponse = () => {
                     <CMSQuestionResponseTable
                         indexQuestions={contract.questions}
                         userDivision={division}
-                        contractStatus={contract.consolidatedStatus}
+                        consolidatedStatus={contract.consolidatedStatus}
                     />
                 ) : (
                     <StateQuestionResponseTable

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/RateQuestionResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/RateQuestionResponse.tsx
@@ -92,6 +92,7 @@ export const RateQuestionResponse = () => {
                 {hasCMSPermissions ? (
                     <CMSQuestionResponseTable
                         indexQuestions={rate.questions}
+                        consolidatedStatus={rate.consolidatedStatus}
                         userDivision={division}
                     />
                 ) : (


### PR DESCRIPTION
## Summary

- Restrict API endpoints to account for withdrawn rates
   - updateDraftContractRates
   - unlockRate
   - submitRate
   - createRateQuestion
   - submitContract
- Remove `Add question` button on rate Q&A page if rate was withdrawn.

#### Related issues

#### Screenshots

#### Test cases covered

`submitContract.test.ts`
- `'submits a contract and removes existing rates on the contract'`

`updateDraftContractRatest.test.ts`
- `'doesnt allow linking a WITHDRAWN rate'`

`createRateQuestion.test.ts`
- `'returns an error if the rate is in invalid status for questions'`

`submitRate.test.ts`
- `'errors with invalid rate status'`

`unlockRate.test.ts`
- `'does not allow rates with wrong status to be unlocked'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
