### PR TITLE
MCR-4887: add new application settings table

### DIFF
--- a/services/app-api/prisma/migrations/20250122005954_add_application_and_email_settings_table/migration.sql
+++ b/services/app-api/prisma/migrations/20250122005954_add_application_and_email_settings_table/migration.sql
@@ -1,0 +1,75 @@
+BEGIN;
+
+-- CreateTable
+CREATE TABLE "ApplicationSettings" (
+    "id" INTEGER NOT NULL DEFAULT 1,
+    "emailSettingsId" INTEGER DEFAULT 1,
+
+    CONSTRAINT "ApplicationSettings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EmailSettings" (
+    "id" INTEGER NOT NULL DEFAULT 1,
+    "emailSource" TEXT NOT NULL DEFAULT 'mc-review@cms.hhs.gov',
+    "devReviewTeamEmails" TEXT[] DEFAULT ARRAY['mc-review@cms.hhs.gov']::TEXT[],
+    "cmsReviewHelpEmailAddress" TEXT[] DEFAULT ARRAY['MCOGDMCOActions <mc-review-qa+MCOGDMCOActionsHelp@truss.works>']::TEXT[],
+    "cmsRateHelpEmailAddress" TEXT[] DEFAULT ARRAY['MMCratesetting <mc-review-qa+MMCratesettingHelp@truss.works>']::TEXT[],
+    "oactEmails" TEXT[] DEFAULT ARRAY['OACT Dev1 <mc-review-qa+OACTdev1@truss.works>', 'OACT Dev2 <mc-review-qa+OACTdev2@truss.works>']::TEXT[],
+    "dmcpReviewEmails" TEXT[] DEFAULT ARRAY['DMCP Review Dev1 <mc-review-qa+DMCPreviewdev1@truss.works>', 'DMCP Review Dev2 <mc-review-qa+DMCPreivewdev2@truss.works>']::TEXT[],
+    "dmcpSubmissionEmails" TEXT[] DEFAULT ARRAY['DMCP Submission Dev1 <mc-review-qa+DMCPsubmissiondev1@truss.works>', 'DMCP Submission Dev2 <mc-review-qa+DMCPsubmissiondev2@truss.works>']::TEXT[],
+    "dmcoEmails" TEXT[] DEFAULT ARRAY['DMCO Dev1 <mc-review-qa+DMCO1@truss.works>', 'DMCO Dev2 <mc-review-qa+DMCO2@truss.works>']::TEXT[],
+    "helpDeskEmail" TEXT[] DEFAULT ARRAY['MC_Review_HelpDesk@cms.hhs.gov']::TEXT[],
+    "applicationSettingsId" INTEGER DEFAULT 1,
+
+    CONSTRAINT "EmailSettings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ApplicationSettings_emailSettingsId_key" ON "ApplicationSettings"("emailSettingsId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ApplicationSettings_id_key" ON "ApplicationSettings"("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EmailSettings_applicationSettingsId_key" ON "EmailSettings"("applicationSettingsId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EmailSettings_id_key" ON "EmailSettings"("id");
+
+-- AddForeignKey
+ALTER TABLE "EmailSettings" ADD CONSTRAINT "EmailSettings_applicationSettingsId_fkey" FOREIGN KEY ("applicationSettingsId") REFERENCES "ApplicationSettings"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Insert Initial Records
+INSERT INTO "ApplicationSettings" ("id", "emailSettingsId") 
+VALUES (1, 1)
+ON CONFLICT ("id") DO NOTHING;
+
+INSERT INTO "EmailSettings" (
+    "id",
+    "emailSource",
+    "devReviewTeamEmails",
+    "cmsReviewHelpEmailAddress",
+    "cmsRateHelpEmailAddress",
+    "oactEmails",
+    "dmcpReviewEmails",
+    "dmcpSubmissionEmails",
+    "dmcoEmails",
+    "helpDeskEmail",
+    "applicationSettingsId"
+) VALUES (
+    1,
+    'mc-review@cms.hhs.gov',
+    ARRAY['mc-review@cms.hhs.gov'],
+    ARRAY['MCOGDMCOActions <mc-review-qa+MCOGDMCOActionsHelp@truss.works>'],
+    ARRAY['MMCratesetting <mc-review-qa+MMCratesettingHelp@truss.works>'],
+    ARRAY['OACT Dev1 <mc-review-qa+OACTdev1@truss.works>', 'OACT Dev2 <mc-review-qa+OACTdev2@truss.works>'],
+    ARRAY['DMCP Review Dev1 <mc-review-qa+DMCPreviewdev1@truss.works>', 'DMCP Review Dev2 <mc-review-qa+DMCPreivewdev2@truss.works>'],
+    ARRAY['DMCP Submission Dev1 <mc-review-qa+DMCPsubmissiondev1@truss.works>', 'DMCP Submission Dev2 <mc-review-qa+DMCPsubmissiondev2@truss.works>'],
+    ARRAY['DMCO Dev1 <mc-review-qa+DMCO1@truss.works>', 'DMCO Dev2 <mc-review-qa+DMCO2@truss.works>'],
+    ARRAY['MC_Review_HelpDesk@cms.hhs.gov'],
+    1
+)
+ON CONFLICT ("id") DO NOTHING;
+
+COMMIT;

--- a/services/app-api/prisma/schema.prisma
+++ b/services/app-api/prisma/schema.prisma
@@ -19,6 +19,32 @@ model ProtoMigrationsTable {
   migrationName String @id
 }
 
+model ApplicationSettings {
+  id Int @id  @default(1)
+  emailSettings EmailSettings?
+  emailSettingsId Int? @unique @default(1)
+
+  @@unique([id])
+}
+
+model EmailSettings {
+  id          Int      @id @default(1)
+  emailSource String @default("mc-review@cms.hhs.gov")
+  devReviewTeamEmails String[] @default(["mc-review@cms.hhs.gov"])
+  cmsReviewHelpEmailAddress String[] @default(["MCOGDMCOActions <mc-review-qa+MCOGDMCOActionsHelp@truss.works>"])
+  cmsRateHelpEmailAddress String[] @default(["MMCratesetting <mc-review-qa+MMCratesettingHelp@truss.works>"])
+  oactEmails String[] @default(["OACT Dev1 <mc-review-qa+OACTdev1@truss.works>","OACT Dev2 <mc-review-qa+OACTdev2@truss.works>"])
+  dmcpReviewEmails String[] @default(["DMCP Review Dev1 <mc-review-qa+DMCPreviewdev1@truss.works>", "DMCP Review Dev2 <mc-review-qa+DMCPreivewdev2@truss.works>"])
+  dmcpSubmissionEmails String[] @default(["DMCP Submission Dev1 <mc-review-qa+DMCPsubmissiondev1@truss.works>", "DMCP Submission Dev2 <mc-review-qa+DMCPsubmissiondev2@truss.works>"])
+  dmcoEmails String[] @default(["DMCO Dev1 <mc-review-qa+DMCO1@truss.works>", "DMCO Dev2 <mc-review-qa+DMCO2@truss.works>"])
+  helpDeskEmail String[] @default(["MC_Review_HelpDesk@cms.hhs.gov"])
+
+  applicationSettings ApplicationSettings? @relation(fields: [applicationSettingsId], references: [id])
+  applicationSettingsId Int? @unique @default(1)
+
+  @@unique([id])
+}
+
 model HealthPlanRevisionTable {
   id              String                 @id
   createdAt       DateTime

--- a/services/app-api/src/postgres/prismaClient.ts
+++ b/services/app-api/src/postgres/prismaClient.ts
@@ -1,14 +1,69 @@
 import { PrismaClient } from '@prisma/client'
 
-async function NewPrismaClient(connURL: string): Promise<PrismaClient | Error> {
-    try {
-        const prismaClient = new PrismaClient({
-            datasources: {
-                db: {
-                    url: connURL,
+const errorMessages = {
+    delete: 'Deletion of records is not allowed',
+    create: 'Creation of new records is not allowed',
+}
+
+/**
+ * Creates an extended instance of the PrismaClient with custom behavior for certain operations.
+ *
+ * This function extends the PrismaClient to throw errors when attempting to perform
+ * create or delete operations on the `applicationSettings` and `emailSettings` models.
+ *
+ * @returns {PrismaClient} An extended instance of the PrismaClient with the custom behavior.
+ */
+function extendedPrismaClient() {
+    return new PrismaClient().$extends({
+        query: {
+            applicationSettings: {
+                delete: () => {
+                    throw new Error(
+                        `ApplicationSettings: ${errorMessages.delete}`
+                    )
+                },
+                deleteMany: () => {
+                    throw new Error(
+                        `ApplicationSettings: ${errorMessages.delete}`
+                    )
+                },
+                create: () => {
+                    throw new Error(
+                        `ApplicationSettings: ${errorMessages.create}`
+                    )
+                },
+                createMany: () => {
+                    throw new Error(
+                        `ApplicationSettings: ${errorMessages.create}`
+                    )
                 },
             },
-        })
+            emailSettings: {
+                delete: () => {
+                    throw new Error(`EmailSettings: ${errorMessages.delete}`)
+                },
+                deleteMany: () => {
+                    throw new Error(`EmailSettings: ${errorMessages.delete}`)
+                },
+                create: () => {
+                    throw new Error(`EmailSettings: ${errorMessages.create}`)
+                },
+                createMany: () => {
+                    throw new Error(`EmailSettings: ${errorMessages.create}`)
+                },
+            },
+        },
+    })
+}
+
+type ExtendedPrismaClient = ReturnType<typeof extendedPrismaClient>
+
+async function NewPrismaClient(
+    connURL: string
+): Promise<ExtendedPrismaClient | Error> {
+    try {
+        const prismaClient = extendedPrismaClient()
+
         return prismaClient
     } catch (e: unknown) {
         if (e instanceof Error) {

--- a/services/app-api/src/postgres/prismaClient.ts
+++ b/services/app-api/src/postgres/prismaClient.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client'
+import { type Prisma, PrismaClient } from '@prisma/client'
 
 const errorMessages = {
     delete: 'Deletion of records is not allowed',
@@ -6,15 +6,16 @@ const errorMessages = {
 }
 
 /**
- * Creates an extended instance of the PrismaClient with custom behavior for certain operations.
+ * Extends PrismaClient with custom behavior for specific models.
  *
- * This function extends the PrismaClient to throw errors when attempting to perform
- * create or delete operations on the `applicationSettings` and `emailSettings` models.
+ * Overrides delete and create operations on `applicationSettings` and `emailSettings`
+ * models to throw custom error messages.
  *
- * @returns {PrismaClient} An extended instance of the PrismaClient with the custom behavior.
+ * @param {Prisma.PrismaClientOptions} optionArgs - PrismaClient configuration options.
+ * @returns {PrismaClient} A new PrismaClient instance with extended behavior.
  */
-function extendedPrismaClient() {
-    return new PrismaClient().$extends({
+function extendedPrismaClient(optionArgs: Prisma.PrismaClientOptions) {
+    return new PrismaClient(optionArgs).$extends({
         query: {
             applicationSettings: {
                 delete: () => {
@@ -62,7 +63,13 @@ async function NewPrismaClient(
     connURL: string
 ): Promise<ExtendedPrismaClient | Error> {
     try {
-        const prismaClient = extendedPrismaClient()
+        const prismaClient = extendedPrismaClient({
+            datasources: {
+                db: {
+                    url: connURL,
+                },
+            },
+        })
 
         return prismaClient
     } catch (e: unknown) {


### PR DESCRIPTION
## Summary
[MCR-4887](https://jiraent.cms.gov/browse/MCR-4887)

AC:
- Add `ApplicationSettings` table
- Add `EmailSettings` Table
   - Add the following fields with default values from `dev`
      - emailSource String
      - devReviewTeamEmail String[]
      - helpDeskEmail String[]
      - cmsReviewHelpEmailAddress String[]
      - cmsRateHelpEmailAddress String[]
      - oactEmails String[]
      - dmcpReviewEmails String[]
      - dmcpSubmissionEmails String[]
      - dmcoEmails String[]
- Insert 1 record for each table with a 1:1 relationship
- Restrict duplicate rows (Singleton table) for both tables.
- Restrict Prisma delete method from this table using Prisma [client-extensions](https://www.prisma.io/docs/orm/prisma-client/client-extensions#example-use-cases-for-extended-clients)

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
