### PR TITLE
Fix program dropdown help link to mail to

### DIFF
--- a/services/app-web/src/components/ErrorAlert/ContactSupportLink.tsx
+++ b/services/app-web/src/components/ErrorAlert/ContactSupportLink.tsx
@@ -5,18 +5,20 @@ import { LinkWithLogging } from '../TealiumLogging/Link'
 type ContactSupportLinkProps = {
     alternateText?: string
     className?: string
+    variant?: 'nav' | 'unstyled' | 'external'
 }
 
 export const ContactSupportLink = ({
     alternateText,
     className,
+    variant = 'unstyled',
 }: ContactSupportLinkProps): React.ReactElement => {
     const stringConstants = useStringConstants()
     const displayText = alternateText ?? 'email the help desk'
     return (
         <LinkWithLogging
             className={className}
-            variant="unstyled"
+            variant={variant}
             href={stringConstants.MAIL_TO_SUPPORT_HREF}
             target="_blank"
             rel="noreferrer"

--- a/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateFormFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateFormFields.tsx
@@ -35,6 +35,7 @@ import {
 import { ActuaryContactFields } from '../Contacts'
 import { FormikRateForm, RateDetailFormConfig } from './V2/RateDetailsV2'
 import { useFocus } from '../../../hooks/useFocus'
+import { ContactSupportLink } from '../../../components/ErrorAlert/ContactSupportLink'
 const isRateTypeEmpty = (rateForm: FormikRateForm): boolean =>
     rateForm.rateType === undefined
 const isRateTypeAmendment = (rateForm: FormikRateForm): boolean =>
@@ -226,14 +227,10 @@ export const SingleRateFormFields = ({
                     <span className={styles.requiredOptionalText}>
                         This information will be used to generate the rate name
                     </span>
-                    <LinkWithLogging
-                        aria-label="Managed care programs guidance (opens in new window)"
-                        href={'/help#managed-care-programs-guidance'}
+                    <ContactSupportLink
+                        alternateText="Contact the Help Desk to edit this list"
                         variant="external"
-                        target="_blank"
-                    >
-                        Contact the Help Desk to edit this list
-                    </LinkWithLogging>
+                    />
                 </div>
                 <PoliteErrorMessage formFieldLabel="What rates are included in this certification?">
                     {showFieldErrors('rateProgramIDs')}

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
@@ -14,7 +14,6 @@ import {
     FieldTextarea,
     FieldYesNo,
     FormNotificationContainer,
-    LinkWithLogging,
     PoliteErrorMessage,
     ReactRouterLinkWithLogging,
 } from '../../../components'
@@ -54,6 +53,7 @@ import { useErrorSummary } from '../../../hooks/useErrorSummary'
 import { useContractForm } from '../../../hooks/useContractForm'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { featureFlags } from '@mc-review/common-code'
+import { ContactSupportLink } from '../../../components/ErrorAlert/ContactSupportLink'
 
 export interface SubmissionTypeFormValues {
     populationCovered?: PopulationCoveredType
@@ -556,17 +556,10 @@ export const SubmissionType = ({
                                                 >
                                                     Required
                                                 </span>
-                                                <LinkWithLogging
-                                                    aria-label="Managed care programs guidance (opens in new window)"
-                                                    href={
-                                                        '/help#managed-care-programs-guidance'
-                                                    }
+                                                <ContactSupportLink
+                                                    alternateText="Contact the Help Desk to edit state programs list"
                                                     variant="external"
-                                                    target="_blank"
-                                                >
-                                                    Contact the Help Desk to
-                                                    edit state programs list
-                                                </LinkWithLogging>
+                                                />
                                             </div>
                                             {showFieldErrors(
                                                 errors.programIDs


### PR DESCRIPTION
## Summary
[MCR-4868](https://jiraent.cms.gov/browse/MCR-4868)

The two links above contract programs and rate program dropdown was suppose to be mailto links.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
