### PR TITLE
MCR-4689: Chip only submission email copy change

### DIFF
--- a/services/app-api/src/emailer/emails/newContractStateEmail.test.ts
+++ b/services/app-api/src/emailer/emails/newContractStateEmail.test.ts
@@ -236,6 +236,31 @@ test('includes information about what is next', async () => {
     )
 })
 
+test('does not include information about what is next for CHIP-only submissions', async () => {
+    const sub = mockContract()
+    sub.packageSubmissions[0].contractRevision.formData.contractType =
+        'AMENDMENT'
+    sub.packageSubmissions[0].contractRevision.formData.populationCovered =
+        'CHIP'
+    const defaultStatePrograms = mockMNState().programs
+    const template = await newContractStateEmail(
+        sub,
+        defaultSubmitters,
+        testEmailConfig(),
+        defaultStatePrograms
+    )
+
+    if (template instanceof Error) {
+        throw template
+    }
+
+    expect(template.bodyText).not.toContain('What comes next:')
+    expect(template.bodyText).not.toContain('Check for completeness:')
+    expect(template.bodyText).not.toContain('CMS review:')
+    expect(template.bodyText).not.toContain('Questions:')
+    expect(template.bodyText).not.toContain('Decision:')
+})
+
 test('includes expected data summary for a contract and rates submission State email', async () => {
     const sub: ContractType = mockContract()
     sub.packageSubmissions[0].contractRevision.formData.contractDateStart =

--- a/services/app-api/src/emailer/emails/newContractStateEmail.ts
+++ b/services/app-api/src/emailer/emails/newContractStateEmail.ts
@@ -98,6 +98,7 @@ export const newContractStateEmail = async (
                         : formatCalendarDate(rate.formData.rateDateEnd, 'UTC'),
             })),
         submissionURL: contractURL,
+        isChipOnly: formData.populationCovered === 'CHIP',
     }
 
     const result = await renderTemplate<typeof data>(

--- a/services/app-api/src/emailer/etaTemplates/newContractStateEmail.eta
+++ b/services/app-api/src/emailer/etaTemplates/newContractStateEmail.eta
@@ -5,6 +5,7 @@
 If you need to make any changes, please contact CMS.
 <br /><br />
 
+<% if (!it.isChipOnly) {%>
 <div>What comes next:</div>
 <ol>
     <li>
@@ -22,4 +23,5 @@ If you need to make any changes, please contact CMS.
     </li>
 </ol>
 <br />
+<% } %>
 <%~ includeFile('./partialStateNeedAssistance', it) %>


### PR DESCRIPTION
## Summary
[MCR-4689](https://jiraent.cms.gov/browse/MCR-4689)

AC:
- The following section of the state submission confirmation email is REMOVED from CHIP-ONLY submissions: 
```html
What comes next:

   1. Check for completeness: CMS will review all documentation submitted to ensure all required materials were received.
   2. CMS review: Your submission will be reviewed by CMS for adherence to federal regulations.
   3. Questions: You may receive questions via email from CMS as they conduct their review.
   4. Decision: Once all questions have been addressed, CMS will contact you with their final recommendation.
```

#### Related issues

#### Screenshots
CHIP-only submission email
<img src="https://github.com/user-attachments/assets/cfd47188-e5cc-4b32-9354-d492287c6bc4" />

All other submissions

<img src="https://github.com/user-attachments/assets/4e0df055-ffd0-4864-b1ae-38426679dc31" />

#### Test cases covered

`newContractStateEmail.test.ts`
- `'does not include information about what is next for CHIP-only submissions'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
