### PR TITLE
Move branch ref back to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -272,7 +272,7 @@ jobs:
 
   deploy-infra:
     needs: [begin-deployment, build-clamav-layer]
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@mt-serverless-v4-init
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name}}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -160,7 +160,7 @@ jobs:
 
   promote-infra-dev:
     needs: [build-prisma-client-lambda-layer, build-clamav-layer, unit-tests]
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@mt-serverless-v4
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
     with:
       environment: dev
       stage_name: main
@@ -188,7 +188,7 @@ jobs:
 
   promote-infra-val:
     needs: [promote-app-dev, unit-tests]
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@mt-serverless-v4
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
     with:
       environment: val
       stage_name: val
@@ -216,7 +216,7 @@ jobs:
 
   promote-infra-prod:
     needs: [promote-app-val, unit-tests]
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@mt-serverless-v4
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
     with:
       environment: prod
       stage_name: prod


### PR DESCRIPTION
## Summary
This just puts the deploy and promote scripts back to referencing `main` for infra deploys.
