### PR TITLE
Move app-web to Serverless v4

### DIFF
--- a/.github/workflows/deploy-app-to-env.yml
+++ b/.github/workflows/deploy-app-to-env.yml
@@ -26,6 +26,8 @@ on:
         required: true
       nr_license_key:
         required: true
+      serverless_license_key:
+        required: true
 
 permissions:
   id-token: write
@@ -62,6 +64,7 @@ jobs:
         env:
           NODE_OPTIONS: --max_old_space_size=6000
           VITE_APP_AUTH_MODE: ${{ inputs.vite_app_auth_mode }}
+          SERVERLESS_ACCESS_KEY: ${{ secrets.serverless_license_key }}
         run: |
           pushd services/app-web && npx serverless deploy --stage ${{ inputs.stage_name }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -300,7 +300,7 @@ jobs:
       needs.api-unit-tests.result == 'success' &&
       needs.build-prisma-client-lambda-layer.result == 'success' &&
       needs.begin-deployment.result == 'success'
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@mt-sls-v4-web
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name }}
@@ -311,6 +311,7 @@ jobs:
     secrets:
       aws_account_id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
+      serverless_license_key: ${{ secrets.SERVERLESS_V4_LICENSE }}
 
   finishing-prep:
     name: Finishing Prep

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -900,8 +900,8 @@ importers:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
       serverless:
-        specifier: ^3.39.0
-        version: 3.39.0(encoding@0.1.13)
+        specifier: 4.2.3
+        version: 4.2.3
       serverless-cf-invalidate-proxy:
         specifier: ^1.0.1
         version: 1.0.1
@@ -910,7 +910,7 @@ importers:
         version: 1.0.2
       serverless-s3-sync:
         specifier: ^3.3.0
-        version: 3.3.0(serverless@3.39.0(encoding@0.1.13))
+        version: 3.3.0(serverless@4.2.3)
       serverless-stack-termination-protection:
         specifier: ^2.0.2
         version: 2.0.2
@@ -7403,6 +7403,9 @@ packages:
     resolution: {integrity: sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==}
     engines: {node: '>=4'}
 
+  axios-proxy-builder@0.1.2:
+    resolution: {integrity: sha512-6uBVsBZzkB3tCC8iyx59mCjQckhB8+GQrI9Cop8eC7ybIsvs/KtnNgEBfRMSEa7GqK2VBGUzgjNYMdPIfotyPA==}
+
   axios@0.26.0:
     resolution: {integrity: sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==}
 
@@ -12661,6 +12664,10 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
+
   ripemd160@2.0.2:
     resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
 
@@ -12899,6 +12906,11 @@ packages:
   serverless@3.39.0:
     resolution: {integrity: sha512-FHI3fhe4TRS8+ez/KA7HmO3lt3fAynO+N1pCCzYRThMWG0J8RWCI0BI+K0mw9+sEV+QpBCpZRZbuGyUaTsaQew==}
     engines: {node: '>=12.0'}
+    hasBin: true
+
+  serverless@4.2.3:
+    resolution: {integrity: sha512-Rt4Y9LqVEV7OGPKGfB//sCQXjG6irAqa545OuXef7SPWD+bm/diCh93sCqCkON7IdYpzWkmIBeQVdF3Q58bU6Q==}
+    engines: {node: '>=18.0.0'}
     hasBin: true
 
   set-blocking@2.0.0:
@@ -14415,6 +14427,10 @@ packages:
 
   xml2js@0.5.0:
     resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
+    engines: {node: '>=4.0.0'}
+
+  xml2js@0.6.2:
+    resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
     engines: {node: '>=4.0.0'}
 
   xmlbuilder@11.0.1:
@@ -24850,6 +24866,10 @@ snapshots:
 
   axe-core@4.7.0: {}
 
+  axios-proxy-builder@0.1.2:
+    dependencies:
+      tunnel: 0.0.6
+
   axios@0.26.0:
     dependencies:
       follow-redirects: 1.15.6
@@ -31411,6 +31431,10 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.4.5
+
   ripemd160@2.0.2:
     dependencies:
       hash-base: 3.1.0
@@ -31756,13 +31780,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  serverless-s3-sync@3.3.0(serverless@3.39.0(encoding@0.1.13)):
+  serverless-s3-sync@3.3.0(serverless@4.2.3):
     dependencies:
       '@auth0/s3': 1.0.0
       bluebird: 3.7.2
       mime: 2.6.0
       minimatch: 3.1.2
-      serverless: 3.39.0(encoding@0.1.13)
+      serverless: 4.2.3
 
   serverless-scriptable-plugin@1.3.1:
     dependencies:
@@ -31840,6 +31864,15 @@ snapshots:
       - debug
       - encoding
       - utf-8-validate
+
+  serverless@4.2.3:
+    dependencies:
+      axios: 1.7.9
+      axios-proxy-builder: 0.1.2
+      rimraf: 5.0.10
+      xml2js: 0.6.2
+    transitivePeerDependencies:
+      - debug
 
   set-blocking@2.0.0: {}
 
@@ -33651,6 +33684,11 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xml2js@0.5.0:
+    dependencies:
+      sax: 1.2.4
+      xmlbuilder: 11.0.1
+
+  xml2js@0.6.2:
     dependencies:
       sax: 1.2.4
       xmlbuilder: 11.0.1

--- a/services/app-web/package.json
+++ b/services/app-web/package.json
@@ -180,7 +180,7 @@
         "prettier": "^3.4.2",
         "react-select-event": "^5.5.0",
         "react-test-renderer": "^18.2.0",
-        "serverless": "^3.39.0",
+        "serverless": "4.2.3",
         "serverless-cf-invalidate-proxy": "^1.0.1",
         "serverless-plugin-scripts": "^1.0.2",
         "serverless-s3-sync": "^3.3.0",

--- a/services/app-web/serverless.yml
+++ b/services/app-web/serverless.yml
@@ -1,6 +1,6 @@
 service: app-web
 
-frameworkVersion: '^3.19.0'
+frameworkVersion: '4.2.3'
 
 provider:
   name: aws


### PR DESCRIPTION
## Summary

This moves `app-web` to using Serverless v4 for deploys.

#### Related issues
https://jiraent.cms.gov/browse/MCR-5053
