### PR TITLE
MCR-5071: re-enable frontend caching between summary and dashboard

### DIFF
--- a/packages/mocks/src/apollo/rateDataMock.ts
+++ b/packages/mocks/src/apollo/rateDataMock.ts
@@ -438,7 +438,6 @@ function mockRateSubmittedWithQuestions(
         reviewStatusActions: [],
         createdAt: rate.createdAt ?? new Date(),
         updatedAt: rate.updatedAt ?? new Date(),
-        id: rateID,
         webURL: `https://testmcreview.example/rate/${rateID}`,
         stateCode: rate.stateCode ?? 'MN',
         state: rate.state ?? mockMNState(),
@@ -738,6 +737,7 @@ function mockRateSubmittedWithQuestions(
                 ],
             },
         },
+        ...rate
     }
 }
 

--- a/services/app-web/src/components/Modal/UnlockSubmitModal.tsx
+++ b/services/app-web/src/components/Modal/UnlockSubmitModal.tsx
@@ -6,8 +6,7 @@ import {
     Contract,
     useSubmitContractMutation,
     useUnlockContractMutation,
-    FetchHealthPlanPackageWithQuestionsDocument,
-    FetchContractDocument,
+    FetchContractWithQuestionsDocument,
 } from '../../gen/gqlClient'
 import { useFormik } from 'formik'
 import { usePrevious } from '../../hooks/usePrevious'
@@ -264,13 +263,7 @@ export const UnlockSubmitModal = ({
                 )
             } else {
                 await client.refetchQueries({
-                    include: [FetchContractDocument],
-                })
-                // TODO: Remove HPP code fully from here, this is a hack to get through linked rates
-                // neded because sidebar UI that also displays questions that assumes latest data fetched on this page
-                // and we haven't had to migrate that yet to contract and ratesyet
-                await client.refetchQueries({
-                    include: [FetchHealthPlanPackageWithQuestionsDocument],
+                    include: [FetchContractWithQuestionsDocument],
                 })
             }
         } else if (result instanceof Error) {
@@ -295,13 +288,7 @@ export const UnlockSubmitModal = ({
                 )
             } else {
                 await client.refetchQueries({
-                    include: [FetchContractDocument],
-                })
-                // TODO: Remove HPP code fully from here, this is a hack to get through linked rates
-                // neded because sidebar UI that also displays questions that assumes latest data fetched on this page
-                // and we haven't had to migrate that yet to contract and ratesyet
-                await client.refetchQueries({
-                    include: [FetchHealthPlanPackageWithQuestionsDocument],
+                    include: [FetchContractWithQuestionsDocument],
                 })
             }
         }

--- a/services/app-web/src/pages/CMSDashboard/SubmissionsDashboard/SubmissionsDashboard.tsx
+++ b/services/app-web/src/pages/CMSDashboard/SubmissionsDashboard/SubmissionsDashboard.tsx
@@ -11,25 +11,30 @@ import {
     ContractInDashboardType,
 } from '../../../components'
 import { ErrorFailedRequestPage } from '../../Errors/ErrorFailedRequestPage'
+import { GenericErrorPage } from '../../Errors/GenericErrorPage'
 
 const SubmissionsDashboard = (): React.ReactElement => {
     const { loggedInUser } = useAuth()
-    const { loading, data, error } = useIndexContractsForDashboardQuery({
-        fetchPolicy: 'network-only',
+    const { data, loading, error } = useIndexContractsForDashboardQuery({
+        fetchPolicy: 'cache-and-network',
+        pollInterval: 300000,
     })
 
-    if (loading || !loggedInUser) {
+    if (!data && loading) {
         return <Loading />
-    } else if (error) {
+    } else if (!data && error) {
         return (
             <ErrorFailedRequestPage
                 error={error}
                 testID="submissions-dashboard"
             />
         )
+    } else if (!data || !loggedInUser) {
+        return <GenericErrorPage />
     }
+
     const submissionRows: ContractInDashboardType[] = []
-    data?.indexContracts.edges
+    data.indexContracts.edges
         .map((edge) => edge.node)
         .forEach((sub) => {
             // When a sub.reviewStatus has been moved out of 'UNDER_REVIEW'

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/ContractQuestionResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/ContractQuestionResponse.tsx
@@ -37,7 +37,7 @@ export const ContractQuestionResponse = () => {
                 contractID: id,
             },
         },
-        fetchPolicy: 'network-only',
+        fetchPolicy: 'cache-and-network',
     })
 
     const contract = data?.fetchContract.contract
@@ -48,15 +48,16 @@ export const ContractQuestionResponse = () => {
         updateHeading({ customHeading: contractName })
     }, [contractName, updateHeading])
 
-    if (loading) {
+    // Handle loading and error states for fetching data while using cached data
+    if (!data && loading) {
         return <ErrorOrLoadingPage state="LOADING" />
-    }
-
-    if (error) {
+    } else if (!data && error) {
         return <ErrorOrLoadingPage state={handleAndReturnErrorState(error)} />
-    }
-
-    if (contract?.status === 'DRAFT' || !contractRev || !contract.questions) {
+    } else if (
+        contract?.status === 'DRAFT' ||
+        !contractRev ||
+        !contract.questions
+    ) {
         return <GenericErrorPage />
     }
 

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/RateQuestionResponse.test.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/RateQuestionResponse.test.tsx
@@ -535,11 +535,11 @@ describe('RateQuestionResponse', () => {
                     mocks: [
                         fetchCurrentUserMock({
                             user: mockValidCMSUser({
-                                divisionAssignment: undefined,
+                                divisionAssignment: null,
                             }),
                             statusCode: 200,
                         }),
-                        fetchRateMockSuccess(rate),
+                        fetchRateWithQuestionsMockSuccess({ rate }),
                         fetchRateWithQuestionsMockSuccess({ rate }),
                     ],
                 },

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/RateQuestionResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/RateQuestionResponse.tsx
@@ -44,26 +44,24 @@ export const RateQuestionResponse = () => {
                 rateID: fetchRateID,
             },
         },
-        fetchPolicy: 'network-only',
+        fetchPolicy: 'cache-and-network',
     })
 
     useEffect(() => {
         updateHeading({ customHeading: rateName })
     }, [rateName, updateHeading])
 
-    if (loading) {
-        return <ErrorOrLoadingPage state="LOADING" />
-    }
-
-    if (error) {
-        return <ErrorOrLoadingPage state={handleAndReturnErrorState(error)} />
-    }
     const rate = data?.fetchRate.rate
     const rateRev = rate?.packageSubmissions?.[0]?.rateRevision
     const rateCertificationName =
         rateRev?.formData.rateCertificationName ?? undefined
 
-    if (
+    // Handle loading and error states for fetching data while using cached data
+    if (!data && loading) {
+        return <ErrorOrLoadingPage state="LOADING" />
+    } else if (!data && error) {
+        return <ErrorOrLoadingPage state={handleAndReturnErrorState(error)} />
+    } else if (
         rate?.status === 'DRAFT' ||
         !loggedInUser ||
         !rateRev ||

--- a/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
@@ -6,7 +6,7 @@ import {
 } from '../../testHelpers'
 import {
     fetchCurrentUserMock,
-    fetchRateMockSuccess,
+    fetchRateWithQuestionsMockSuccess,
     fetchContractMockSuccess,
     iterableCmsUsersMockData,
     mockValidStateUser,
@@ -47,9 +47,11 @@ describe('RateSummary', () => {
                                 statusCode: 200,
                             }),
                             fetchContractMockSuccess({ contract }),
-                            fetchRateMockSuccess({
-                                id: '7a',
-                                parentContractID: contract.id,
+                            fetchRateWithQuestionsMockSuccess({
+                                rate: {
+                                    id: '7a',
+                                    parentContractID: contract.id,
+                                },
                             }),
                             fetchContractMockSuccess({ contract }),
                         ],
@@ -75,20 +77,22 @@ describe('RateSummary', () => {
                                 statusCode: 200,
                             }),
                             fetchContractMockSuccess({ contract }),
-                            fetchRateMockSuccess({
-                                id: '1337',
-                                parentContractID: contract.id,
-                                withdrawInfo: {
-                                    __typename: 'UpdateInformation',
-                                    updatedAt: new Date('2024-01-01'),
-                                    updatedBy: {
-                                        email: 'admin@example.com',
-                                        role: 'ADMIN_USER',
-                                        familyName: 'Hotman',
-                                        givenName: 'Iroh',
+                            fetchRateWithQuestionsMockSuccess({
+                                rate: {
+                                    id: '1337',
+                                    parentContractID: contract.id,
+                                    withdrawInfo: {
+                                        __typename: 'UpdateInformation',
+                                        updatedAt: new Date('2024-01-01'),
+                                        updatedBy: {
+                                            email: 'admin@example.com',
+                                            role: 'ADMIN_USER',
+                                            familyName: 'Hotman',
+                                            givenName: 'Iroh',
+                                        },
+                                        updatedReason:
+                                            'Admin as withdrawn this rate.',
                                     },
-                                    updatedReason:
-                                        'Admin as withdrawn this rate.',
                                 },
                             }),
                         ],
@@ -100,18 +104,9 @@ describe('RateSummary', () => {
                 })
 
                 await waitFor(() => {
-                    expect(
-                        screen.queryByTestId('rate-summary')
-                    ).toBeInTheDocument()
+                    expect(screen.queryByRole('alert')).toBeInTheDocument()
                 })
 
-                expect(
-                    await screen.findByText(
-                        'Rates this rate certification covers'
-                    )
-                ).toBeInTheDocument()
-
-                expect(screen.getByRole('alert')).toHaveClass('usa-alert--info')
                 expect(
                     screen.getByTestId('rateWithdrawnBanner')
                 ).toHaveTextContent(/Withdrawn by: Administrator/)
@@ -147,9 +142,11 @@ describe('RateSummary', () => {
                                 user: mockUser(),
                                 statusCode: 200,
                             }),
-                            fetchRateMockSuccess({
-                                id: '7a',
-                                parentContractID: contract.id,
+                            fetchRateWithQuestionsMockSuccess({
+                                rate: {
+                                    id: '7a',
+                                    parentContractID: contract.id,
+                                },
                             }),
                             fetchContractMockSuccess({ contract }),
                         ],
@@ -182,9 +179,11 @@ describe('RateSummary', () => {
                                 user: mockUser(),
                                 statusCode: 200,
                             }),
-                            fetchRateMockSuccess({
-                                id: '7a',
-                                parentContractID: contract.id,
+                            fetchRateWithQuestionsMockSuccess({
+                                rate: {
+                                    id: '7a',
+                                    parentContractID: contract.id,
+                                },
                             }),
                             fetchContractMockSuccess({ contract }),
                         ],
@@ -231,9 +230,11 @@ describe('RateSummary', () => {
                                     user: mockUser(),
                                     statusCode: 200,
                                 }),
-                                fetchRateMockSuccess({
-                                    ...rateData,
-                                    id: '7a',
+                                fetchRateWithQuestionsMockSuccess({
+                                    rate: {
+                                        ...rateData,
+                                        id: '7a',
+                                    },
                                 }),
                                 fetchContractMockSuccess({ contract }),
                             ],
@@ -273,9 +274,11 @@ describe('RateSummary', () => {
                                 user: mockUser(),
                                 statusCode: 200,
                             }),
-                            fetchRateMockSuccess({
-                                ...rateData,
-                                id: '7a',
+                            fetchRateWithQuestionsMockSuccess({
+                                rate: {
+                                    ...rateData,
+                                    id: '7a',
+                                },
                             }),
                             fetchContractMockSuccess({ contract }),
                         ],
@@ -299,10 +302,12 @@ describe('RateSummary', () => {
                                 user: mockUser(),
                                 statusCode: 200,
                             }),
-                            fetchRateMockSuccess({
-                                ...rateData,
-                                id: '7a',
-                                parentContractID: contract.id,
+                            fetchRateWithQuestionsMockSuccess({
+                                rate: {
+                                    ...rateData,
+                                    id: '7a',
+                                    parentContractID: contract.id,
+                                },
                             }),
                             fetchContractMockSuccess({ contract }),
                         ],
@@ -334,11 +339,13 @@ describe('RateSummary', () => {
                                 user: mockUser(),
                                 statusCode: 200,
                             }),
-                            fetchRateMockSuccess({
-                                ...rate,
-                                id: '7a',
-                                parentContractID: contract.id,
-                                status: 'SUBMITTED',
+                            fetchRateWithQuestionsMockSuccess({
+                                rate: {
+                                    ...rate,
+                                    id: '7a',
+                                    parentContractID: contract.id,
+                                    status: 'SUBMITTED',
+                                },
                             }),
                             fetchContractMockSuccess({
                                 contract: {
@@ -378,11 +385,13 @@ describe('RateSummary', () => {
                                 user: mockUser(),
                                 statusCode: 200,
                             }),
-                            fetchRateMockSuccess({
-                                ...rate,
-                                id: '7a',
-                                parentContractID: contract.id,
-                                status: 'UNLOCKED',
+                            fetchRateWithQuestionsMockSuccess({
+                                rate: {
+                                    ...rate,
+                                    id: '7a',
+                                    parentContractID: contract.id,
+                                    status: 'UNLOCKED',
+                                },
                             }),
                             fetchContractMockSuccess({
                                 contract: {
@@ -425,7 +434,7 @@ describe('RateSummary', () => {
                             user: mockValidStateUser(),
                             statusCode: 200,
                         }),
-                        fetchRateMockSuccess(rate),
+                        fetchRateWithQuestionsMockSuccess({ rate }),
                         fetchContractMockSuccess({ contract }),
                     ],
                 },
@@ -453,19 +462,22 @@ describe('RateSummary', () => {
                             statusCode: 200,
                         }),
                         fetchContractMockSuccess({ contract }),
-                        fetchRateMockSuccess({
-                            id: '1337',
-                            parentContractID: contract.id,
-                            withdrawInfo: {
-                                __typename: 'UpdateInformation',
-                                updatedAt: new Date('2024-01-01'),
-                                updatedBy: {
-                                    email: 'admin@example.com',
-                                    role: 'ADMIN_USER',
-                                    familyName: 'Hotman',
-                                    givenName: 'Iroh',
+                        fetchRateWithQuestionsMockSuccess({
+                            rate: {
+                                id: '1337',
+                                parentContractID: contract.id,
+                                withdrawInfo: {
+                                    __typename: 'UpdateInformation',
+                                    updatedAt: new Date('2024-01-01'),
+                                    updatedBy: {
+                                        email: 'admin@example.com',
+                                        role: 'ADMIN_USER',
+                                        familyName: 'Hotman',
+                                        givenName: 'Iroh',
+                                    },
+                                    updatedReason:
+                                        'Admin as withdrawn this rate.',
                                 },
-                                updatedReason: 'Admin as withdrawn this rate.',
                             },
                         }),
                     ],
@@ -514,10 +526,12 @@ describe('RateSummary', () => {
                                 user: mockValidStateUser(),
                                 statusCode: 200,
                             }),
-                            fetchRateMockSuccess({
-                                id: '1337',
-                                parentContractID: contract.id,
-                                status: 'UNLOCKED',
+                            fetchRateWithQuestionsMockSuccess({
+                                rate: {
+                                    id: '1337',
+                                    parentContractID: contract.id,
+                                    status: 'UNLOCKED',
+                                },
                             }),
                             fetchContractMockSuccess({ contract }),
                         ],
@@ -550,9 +564,11 @@ describe('RateSummary', () => {
                             user: mockValidStateUser(),
                             statusCode: 200,
                         }),
-                        fetchRateMockSuccess({
-                            id: '1337',
-                            parentContractID: contract.id,
+                        fetchRateWithQuestionsMockSuccess({
+                            rate: {
+                                id: '1337',
+                                parentContractID: contract.id,
+                            },
                         }),
                         fetchContractMockSuccess({ contract }),
                     ],
@@ -575,9 +591,11 @@ describe('RateSummary', () => {
                             user: mockValidStateUser(),
                             statusCode: 200,
                         }),
-                        fetchRateMockSuccess({
-                            id: '7a',
-                            parentContractID: contract.id,
+                        fetchRateWithQuestionsMockSuccess({
+                            rate: {
+                                id: '7a',
+                                parentContractID: contract.id,
+                            },
                         }),
                         fetchContractMockSuccess({ contract }),
                     ],
@@ -608,11 +626,13 @@ describe('RateSummary', () => {
                                 user: mockUser(),
                                 statusCode: 200,
                             }),
-                            fetchRateMockSuccess({
-                                ...rate,
-                                id: '7a',
-                                parentContractID: contract.id,
-                                status: 'SUBMITTED',
+                            fetchRateWithQuestionsMockSuccess({
+                                rate: {
+                                    ...rate,
+                                    id: '7a',
+                                    parentContractID: contract.id,
+                                    status: 'SUBMITTED',
+                                },
                             }),
                             fetchContractMockSuccess({
                                 contract: {

--- a/services/app-web/src/pages/RateWithdraw/RateWithdraw.test.tsx
+++ b/services/app-web/src/pages/RateWithdraw/RateWithdraw.test.tsx
@@ -4,6 +4,7 @@ import {
     mockValidCMSUser,
     fetchContractMockSuccess,
     fetchRateMockSuccess,
+    fetchRateWithQuestionsMockSuccess,
     withdrawRateMockFailure,
     mockContractPackageSubmitted,
     mockRateSubmittedWithQuestions,
@@ -68,18 +69,13 @@ describe('RateWithdraw', () => {
                             user: mockValidCMSUser(),
                             statusCode: 200,
                         }),
-                        fetchContractMockSuccess({
-                            contract,
+                        fetchRateWithQuestionsMockSuccess({
+                            rate: withdrawnRate,
                         }),
                         fetchRateMockSuccess(rate),
                         withdrawRateMockSuccess({ rateData: rate }),
-                        fetchRateMockSuccess(withdrawnRate),
                         fetchContractMockSuccess({
                             contract,
-                        }),
-                        fetchCurrentUserMock({
-                            user: mockValidCMSUser(),
-                            statusCode: 200,
                         }),
                     ],
                 },
@@ -117,7 +113,6 @@ describe('RateWithdraw', () => {
     })
 
     it('renders generic API error on failed withdraw', async () => {
-        const contract = mockContractPackageSubmitted({ id: 'test-abc-123' })
         const rate = mockRateSubmittedWithQuestions({
             id: 'test-abc-123',
             parentContractID: 'test-abc-123',
@@ -143,9 +138,7 @@ describe('RateWithdraw', () => {
                             user: mockValidCMSUser(),
                             statusCode: 200,
                         }),
-                        fetchContractMockSuccess({
-                            contract,
-                        }),
+                        fetchRateWithQuestionsMockSuccess({ rate }),
                         fetchRateMockSuccess(rate),
                         withdrawRateMockFailure(),
                     ],
@@ -178,6 +171,10 @@ describe('RateWithdraw', () => {
     })
 
     it('renders form validation error when required withdraw reason field is missing', async () => {
+        const rate = mockRateSubmittedWithQuestions({
+            id: 'test-abc-123',
+            parentContractID: 'test-abc-123',
+        })
         const { user } = renderWithProviders(
             <Routes>
                 <Route element={<RateSummarySideNav />}>
@@ -198,6 +195,7 @@ describe('RateWithdraw', () => {
                             user: mockValidCMSUser(),
                             statusCode: 200,
                         }),
+                        fetchRateWithQuestionsMockSuccess({ rate }),
                         fetchRateMockSuccess({ id: 'test-abc-123' }),
                     ],
                 },

--- a/services/app-web/src/pages/SubmissionReleasedToState/ReleasedToState.test.tsx
+++ b/services/app-web/src/pages/SubmissionReleasedToState/ReleasedToState.test.tsx
@@ -75,10 +75,10 @@ describe('ReleasedToState', () => {
                         }),
                         fetchContractWithQuestionsMockSuccess({
                             contract,
-                        }),
+                        }), // fetch from sidenav
                         fetchContractMockSuccess({
                             contract,
-                        }),
+                        }), // fetch from released to state page
                         approveContractMockSuccess({
                             contractID: 'test-abc-123',
                             contractData: approvedContract,
@@ -91,13 +91,10 @@ describe('ReleasedToState', () => {
                         }),
                         fetchContractWithQuestionsMockSuccess({
                             contract: approvedContract,
-                        }),
-                        fetchContractMockSuccess({
+                        }), // fetch from sidenav
+                        fetchContractWithQuestionsMockSuccess({
                             contract: approvedContract,
-                        }),
-                        fetchContractMockSuccess({
-                            contract: approvedContract,
-                        }),
+                        }), // fetch from summary page
                     ],
                 },
                 routerProvider: {

--- a/services/app-web/src/pages/SubmissionSideNav/RateSummarySideNav.test.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/RateSummarySideNav.test.tsx
@@ -5,7 +5,7 @@ import { RateSummarySideNav } from './RateSummarySideNav'
 import { RateSummary } from '../RateSummary'
 import {
     fetchCurrentUserMock,
-    fetchRateMockSuccess,
+    fetchRateWithQuestionsMockSuccess,
     mockValidCMSUser,
     rateDataMock,
 } from '@mc-review/mocks'
@@ -37,7 +37,7 @@ describe('RateSummarySideNav', () => {
                         user: mockValidCMSUser(),
                         statusCode: 200,
                     }),
-                    fetchRateMockSuccess(rate),
+                    fetchRateWithQuestionsMockSuccess({ rate }),
                 ],
             },
             routerProvider: {
@@ -89,7 +89,7 @@ describe('RateSummarySideNav', () => {
                         user: mockValidCMSUser(),
                         statusCode: 200,
                     }),
-                    fetchRateMockSuccess(rate),
+                    fetchRateWithQuestionsMockSuccess({ rate }),
                 ],
             },
             routerProvider: {
@@ -128,7 +128,7 @@ describe('RateSummarySideNav', () => {
                             user: mockValidCMSUser(),
                             statusCode: 200,
                         }),
-                        fetchRateMockSuccess(rate),
+                        fetchRateWithQuestionsMockSuccess({ rate }),
                     ],
                 },
                 routerProvider: {

--- a/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.test.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.test.tsx
@@ -7,7 +7,6 @@ import { ContractQuestionResponse } from '../QuestionResponse'
 import { renderWithProviders } from '../../testHelpers'
 import { RoutesRecord } from '@mc-review/constants'
 import {
-    fetchContractMockSuccess,
     fetchCurrentUserMock,
     mockContractPackageSubmitted,
     mockContractPackageSubmittedWithQuestions,
@@ -244,7 +243,8 @@ describe('SubmissionSideNav', () => {
 
     it('sidebar nav links routes to correct pages', async () => {
         let testLocation: Location
-        const testContract = mockContractPackageSubmittedWithQuestions('15')
+        const contract = mockContractPackageSubmittedWithQuestions()
+        contract.id = '15'
 
         renderWithProviders(<CommonRoutes />, {
             apolloProvider: {
@@ -254,28 +254,16 @@ describe('SubmissionSideNav', () => {
                         statusCode: 200,
                     }),
                     fetchContractWithQuestionsMockSuccess({
-                        contract: {
-                            ...testContract,
-                            id: '15',
-                        },
+                        contract,
                     }),
                     fetchContractWithQuestionsMockSuccess({
-                        contract: {
-                            ...testContract,
-                            id: '15',
-                        },
+                        contract,
                     }),
-                    fetchContractMockSuccess({
-                        contract: {
-                            ...testContract,
-                            id: '15',
-                        },
+                    fetchContractWithQuestionsMockSuccess({
+                        contract,
                     }),
-                    fetchContractMockSuccess({
-                        contract: {
-                            ...testContract,
-                            id: '15',
-                        },
+                    fetchContractWithQuestionsMockSuccess({
+                        contract,
                     }),
                 ],
             },

--- a/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
@@ -63,10 +63,18 @@ export const SubmissionSideNav = () => {
                 contractID: id,
             },
         },
-        fetchPolicy: 'network-only',
+        fetchPolicy: 'cache-and-network',
     })
 
-    if (error) {
+    const contract = data?.fetchContract.contract
+
+    if (!data && loading) {
+        return (
+            <GridContainer>
+                <Loading />
+            </GridContainer>
+        )
+    } else if (!data && error) {
         const err = error
         console.error('Error from API fetch', error)
         if (err instanceof ApolloError) {
@@ -79,20 +87,7 @@ export const SubmissionSideNav = () => {
 
         recordJSException(err)
         return <GenericErrorPage /> // api failure or protobuf decode failure
-    }
-
-    if (loading) {
-        return (
-            <GridContainer>
-                <Loading />
-            </GridContainer>
-        )
-    }
-
-    const contract = data?.fetchContract.contract
-
-    // Display generic error page if getting logged in user returns undefined.
-    if (!loggedInUser || !contract) {
+    } else if (!loggedInUser || !contract) {
         return <GenericErrorPage />
     }
 

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -3,7 +3,6 @@ import { Route, Routes } from 'react-router'
 import { RoutesRecord } from '@mc-review/constants'
 import {
     fetchCurrentUserMock,
-    fetchContractMockSuccess,
     fetchContractWithQuestionsMockSuccess,
     mockValidUser,
     mockValidStateUser,
@@ -28,7 +27,9 @@ describe('SubmissionSummary', () => {
         '$userRole SubmissionSummary tests',
         ({ mockUser }) => {
             it('renders submission unlocked banner for CMS user', async () => {
-                const contract = mockContractPackageUnlockedWithUnlockedType()
+                const contract = mockContractPackageUnlockedWithUnlockedType({
+                    id: 'test-abc-123',
+                })
 
                 renderWithProviders(
                     <Routes>
@@ -46,15 +47,11 @@ describe('SubmissionSummary', () => {
                                     user: mockUser(),
                                     statusCode: 200,
                                 }),
-                                fetchContractMockSuccess({
-                                    contract:
-                                        mockContractPackageUnlockedWithUnlockedType(),
+                                fetchContractWithQuestionsMockSuccess({
+                                    contract,
                                 }),
                                 fetchContractWithQuestionsMockSuccess({
-                                    contract: {
-                                        ...contract,
-                                        id: 'test-abc-123',
-                                    },
+                                    contract,
                                 }),
                             ],
                         },
@@ -88,7 +85,9 @@ describe('SubmissionSummary', () => {
             })
 
             it('pulls the right version of UNLOCKED data for CMS users', async () => {
-                const contract = mockContractPackageUnlockedWithUnlockedType()
+                const contract = mockContractPackageUnlockedWithUnlockedType({
+                    id: 'test-abc-123',
+                })
 
                 renderWithProviders(
                     <Routes>
@@ -106,9 +105,11 @@ describe('SubmissionSummary', () => {
                                     statusCode: 200,
                                     user: mockUser(),
                                 }),
-                                fetchContractMockSuccess({
-                                    contract:
-                                        mockContractPackageUnlockedWithUnlockedType(),
+                                fetchContractWithQuestionsMockSuccess({
+                                    contract: {
+                                        ...contract,
+                                        id: 'test-abc-123',
+                                    },
                                 }),
                                 fetchContractWithQuestionsMockSuccess({
                                     contract: {
@@ -142,7 +143,9 @@ describe('SubmissionSummary', () => {
             })
 
             it('displays the legacy shared rates across submissions UI for CMS users when unlocked', async () => {
-                const contract = mockContractPackageUnlockedWithUnlockedType()
+                const contract = mockContractPackageUnlockedWithUnlockedType({
+                    id: 'test-abc-123',
+                })
 
                 renderWithProviders(
                     <Routes>
@@ -160,15 +163,11 @@ describe('SubmissionSummary', () => {
                                     statusCode: 200,
                                     user: mockUser(),
                                 }),
-                                fetchContractMockSuccess({
-                                    contract:
-                                        mockContractPackageUnlockedWithUnlockedType(),
+                                fetchContractWithQuestionsMockSuccess({
+                                    contract,
                                 }),
                                 fetchContractWithQuestionsMockSuccess({
-                                    contract: {
-                                        ...contract,
-                                        id: 'test-abc-123',
-                                    },
+                                    contract,
                                 }),
                             ],
                         },
@@ -186,7 +185,8 @@ describe('SubmissionSummary', () => {
             })
 
             it('renders add mccrs-id link for CMS user', async () => {
-                const contract = mockContractPackageSubmittedWithQuestions()
+                const contract =
+                    mockContractPackageSubmittedWithQuestions('test-abc-123')
 
                 renderWithProviders(
                     <Routes>
@@ -204,23 +204,14 @@ describe('SubmissionSummary', () => {
                                     statusCode: 200,
                                     user: mockUser(),
                                 }),
-                                fetchContractMockSuccess({
-                                    contract: {
-                                        ...contract,
-                                        id: 'test-abc-123',
-                                    },
+                                fetchContractWithQuestionsMockSuccess({
+                                    contract,
                                 }),
                                 fetchContractWithQuestionsMockSuccess({
-                                    contract: {
-                                        ...contract,
-                                        id: 'test-abc-123',
-                                    },
+                                    contract,
                                 }),
                                 fetchContractWithQuestionsMockSuccess({
-                                    contract: {
-                                        ...contract,
-                                        id: 'test-abc-123',
-                                    },
+                                    contract,
                                 }),
                             ],
                         },
@@ -238,8 +229,12 @@ describe('SubmissionSummary', () => {
             })
 
             it('renders edit mccrs-id link for CMS user when submission has a mccrs id', async () => {
-                const contract = mockContractPackageSubmittedWithQuestions()
-                contract.mccrsID = '1234'
+                const contract = mockContractPackageSubmittedWithQuestions(
+                    'test-abc-123',
+                    {
+                        mccrsID: '1234',
+                    }
+                )
                 renderWithProviders(
                     <Routes>
                         <Route element={<SubmissionSideNav />}>
@@ -256,29 +251,20 @@ describe('SubmissionSummary', () => {
                                     user: mockUser(),
                                     statusCode: 200,
                                 }),
-                                fetchContractMockSuccess({
-                                    contract: mockContractPackageSubmitted({
-                                        id: 'test-abc-123',
+                                fetchContractWithQuestionsMockSuccess({
+                                    contract: {
+                                        ...contract,
                                         mccrsID: '3333',
-                                    }),
-                                }),
-                                fetchContractWithQuestionsMockSuccess({
-                                    contract: {
-                                        ...contract,
-                                        id: 'test-abc-123',
                                     },
                                 }),
                                 fetchContractWithQuestionsMockSuccess({
-                                    contract: {
-                                        ...contract,
-                                        id: 'test-abc-123',
-                                    },
+                                    contract,
                                 }),
                                 fetchContractWithQuestionsMockSuccess({
-                                    contract: {
-                                        ...contract,
-                                        id: 'test-abc-123',
-                                    },
+                                    contract,
+                                }),
+                                fetchContractWithQuestionsMockSuccess({
+                                    contract,
                                 }),
                             ],
                         },
@@ -310,7 +296,9 @@ describe('SubmissionSummary', () => {
                         )
                     },
                 }
-                const contract = mockContractPackageSubmitted()
+                const contract = mockContractPackageSubmitted({
+                    id: 'test-abc-123',
+                })
                 renderWithProviders(
                     <Routes>
                         <Route element={<SubmissionSideNav />}>
@@ -328,12 +316,9 @@ describe('SubmissionSummary', () => {
                                     statusCode: 200,
                                 }),
                                 fetchContractWithQuestionsMockSuccess({
-                                    contract: {
-                                        ...contract,
-                                        id: 'test-abc-123',
-                                    },
+                                    contract,
                                 }),
-                                fetchContractMockSuccess({
+                                fetchContractWithQuestionsMockSuccess({
                                     contract,
                                 }),
                             ],
@@ -360,7 +345,9 @@ describe('SubmissionSummary', () => {
             })
 
             it('renders back to dashboard link for CMS users', async () => {
-                const contract = mockContractPackageUnlockedWithUnlockedType()
+                const contract = mockContractPackageUnlockedWithUnlockedType({
+                    id: 'test-abc-123',
+                })
 
                 renderWithProviders(
                     <Routes>
@@ -379,14 +366,10 @@ describe('SubmissionSummary', () => {
                                     statusCode: 200,
                                 }),
                                 fetchContractWithQuestionsMockSuccess({
-                                    contract: {
-                                        ...contract,
-                                        id: 'test-abc-123',
-                                    },
+                                    contract,
                                 }),
-                                fetchContractMockSuccess({
-                                    contract:
-                                        mockContractPackageUnlockedWithUnlockedType(),
+                                fetchContractWithQuestionsMockSuccess({
+                                    contract,
                                 }),
                             ],
                         },
@@ -405,7 +388,8 @@ describe('SubmissionSummary', () => {
             })
 
             it('renders the sidenav for CMS users', async () => {
-                const contract = mockContractPackageSubmittedWithQuestions('15')
+                const contract =
+                    mockContractPackageSubmittedWithQuestions('test-abc-123')
 
                 renderWithProviders(
                     <Routes>
@@ -424,22 +408,13 @@ describe('SubmissionSummary', () => {
                                     statusCode: 200,
                                 }),
                                 fetchContractWithQuestionsMockSuccess({
-                                    contract: {
-                                        ...contract,
-                                        id: 'test-abc-123',
-                                    },
+                                    contract,
                                 }),
                                 fetchContractWithQuestionsMockSuccess({
-                                    contract: {
-                                        ...contract,
-                                        id: 'test-abc-123',
-                                    },
+                                    contract,
                                 }),
-                                fetchContractMockSuccess({
-                                    contract: {
-                                        ...contract,
-                                        id: 'test-abc-123',
-                                    },
+                                fetchContractWithQuestionsMockSuccess({
+                                    contract,
                                 }),
                             ],
                         },
@@ -480,7 +455,7 @@ describe('SubmissionSummary', () => {
                                 fetchContractWithQuestionsMockSuccess({
                                     contract,
                                 }),
-                                fetchContractMockSuccess({
+                                fetchContractWithQuestionsMockSuccess({
                                     contract,
                                 }),
                             ],
@@ -511,7 +486,9 @@ describe('SubmissionSummary', () => {
             describe('Submission package data display', () => {
                 it('renders the OLD data for an unlocked submission for CMS user, ignoring unsubmitted changes from state user', async () => {
                     const contract =
-                        mockContractPackageUnlockedWithUnlockedType()
+                        mockContractPackageUnlockedWithUnlockedType({
+                            id: 'test-abc-123',
+                        })
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     contract.draftRevision!.formData.submissionDescription =
                         'NEW_DESCRIPTION'
@@ -535,12 +512,9 @@ describe('SubmissionSummary', () => {
                                         statusCode: 200,
                                     }),
                                     fetchContractWithQuestionsMockSuccess({
-                                        contract: {
-                                            ...contract,
-                                            id: 'test-abc-123',
-                                        },
+                                        contract,
                                     }),
-                                    fetchContractMockSuccess({
+                                    fetchContractWithQuestionsMockSuccess({
                                         contract,
                                     }),
                                 ],
@@ -564,7 +538,9 @@ describe('SubmissionSummary', () => {
             describe('CMS user unlock submission', () => {
                 it('renders the unlock button', async () => {
                     const contract =
-                        mockContractPackageUnlockedWithUnlockedType()
+                        mockContractPackageUnlockedWithUnlockedType({
+                            id: 'test-abc-123',
+                        })
 
                     renderWithProviders(
                         <Routes>
@@ -583,20 +559,13 @@ describe('SubmissionSummary', () => {
                                         statusCode: 200,
                                     }),
                                     fetchContractWithQuestionsMockSuccess({
-                                        contract: {
-                                            ...contract,
-                                            id: 'test-abc-123',
-                                        },
+                                        contract,
                                     }),
                                     fetchContractWithQuestionsMockSuccess({
-                                        contract: {
-                                            ...contract,
-                                            id: 'test-abc-123',
-                                        },
+                                        contract,
                                     }),
-                                    fetchContractMockSuccess({
-                                        contract:
-                                            mockContractPackageSubmitted(),
+                                    fetchContractWithQuestionsMockSuccess({
+                                        contract,
                                     }),
                                 ],
                             },
@@ -627,9 +596,10 @@ describe('SubmissionSummary', () => {
                     const ptDateFormatted = '02/02/2025'
 
                     const contract =
-                        mockContractPackageUnlockedWithUnlockedType()
-                    contract.id = 'test-abc-123'
-                    contract.initiallySubmittedAt = earlyMorningET.toDate()
+                        mockContractPackageUnlockedWithUnlockedType({
+                            id: 'test-abc-123',
+                            initiallySubmittedAt: earlyMorningET.toDate(),
+                        })
 
                     renderWithProviders(
                         <Routes>
@@ -650,7 +620,7 @@ describe('SubmissionSummary', () => {
                                     fetchContractWithQuestionsMockSuccess({
                                         contract,
                                     }),
-                                    fetchContractMockSuccess({
+                                    fetchContractWithQuestionsMockSuccess({
                                         contract,
                                     }),
                                 ],
@@ -667,6 +637,9 @@ describe('SubmissionSummary', () => {
                 })
 
                 it('extracts the correct document dates from the submission and displays them in tables', async () => {
+                    const contract = mockContractPackageSubmitted({
+                        id: 'test-abc-123',
+                    })
                     renderWithProviders(
                         <Routes>
                             <Route element={<SubmissionSideNav />}>
@@ -684,14 +657,10 @@ describe('SubmissionSummary', () => {
                                         statusCode: 200,
                                     }),
                                     fetchContractWithQuestionsMockSuccess({
-                                        contract: {
-                                            ...mockContractPackageSubmitted(),
-                                            id: 'test-abc-123',
-                                        },
+                                        contract,
                                     }),
-                                    fetchContractMockSuccess({
-                                        contract:
-                                            mockContractPackageSubmitted(),
+                                    fetchContractWithQuestionsMockSuccess({
+                                        contract,
                                     }),
                                 ],
                             },
@@ -739,6 +708,11 @@ describe('SubmissionSummary', () => {
                 })
 
                 it('disables the unlock button for an unlocked submission', async () => {
+                    const contract =
+                        mockContractPackageUnlockedWithUnlockedType({
+                            id: 'test-abc-123',
+                        })
+
                     renderWithProviders(
                         <Routes>
                             <Route element={<SubmissionSideNav />}>
@@ -756,14 +730,10 @@ describe('SubmissionSummary', () => {
                                         statusCode: 200,
                                     }),
                                     fetchContractWithQuestionsMockSuccess({
-                                        contract: {
-                                            ...mockContractPackageUnlockedWithUnlockedType(),
-                                            id: 'test-abc-123',
-                                        },
+                                        contract,
                                     }),
-                                    fetchContractMockSuccess({
-                                        contract:
-                                            mockContractPackageUnlockedWithUnlockedType(),
+                                    fetchContractWithQuestionsMockSuccess({
+                                        contract,
                                     }),
                                 ],
                             },
@@ -798,7 +768,7 @@ describe('SubmissionSummary', () => {
                                         user: mockUser(),
                                         statusCode: 200,
                                     }),
-                                    fetchContractMockSuccess({
+                                    fetchContractWithQuestionsMockSuccess({
                                         contract:
                                             mockContractPackageUnlockedWithUnlockedType(
                                                 {
@@ -861,7 +831,7 @@ describe('SubmissionSummary', () => {
                                     fetchContractWithQuestionsMockSuccess({
                                         contract,
                                     }),
-                                    fetchContractMockSuccess({
+                                    fetchContractWithQuestionsMockSuccess({
                                         contract,
                                     }),
                                 ],
@@ -935,7 +905,7 @@ describe('SubmissionSummary', () => {
                                     fetchContractWithQuestionsMockSuccess({
                                         contract,
                                     }),
-                                    fetchContractMockSuccess({
+                                    fetchContractWithQuestionsMockSuccess({
                                         contract,
                                     }),
                                 ],
@@ -996,7 +966,7 @@ describe('SubmissionSummary', () => {
                                     fetchContractWithQuestionsMockSuccess({
                                         contract: unlockedContract,
                                     }),
-                                    fetchContractMockSuccess({
+                                    fetchContractWithQuestionsMockSuccess({
                                         contract: unlockedContract,
                                     }),
                                 ],
@@ -1059,7 +1029,7 @@ describe('SubmissionSummary', () => {
                                     fetchContractWithQuestionsMockSuccess({
                                         contract: contract,
                                     }),
-                                    fetchContractMockSuccess({
+                                    fetchContractWithQuestionsMockSuccess({
                                         contract: contract,
                                     }),
                                 ],
@@ -1135,7 +1105,7 @@ describe('SubmissionSummary', () => {
                                     fetchContractWithQuestionsMockSuccess({
                                         contract,
                                     }),
-                                    fetchContractMockSuccess({
+                                    fetchContractWithQuestionsMockSuccess({
                                         contract,
                                     }),
                                 ],
@@ -1184,7 +1154,7 @@ describe('SubmissionSummary', () => {
                                     fetchContractWithQuestionsMockSuccess({
                                         contract,
                                     }),
-                                    fetchContractMockSuccess({
+                                    fetchContractWithQuestionsMockSuccess({
                                         contract,
                                     }),
                                 ],
@@ -1218,7 +1188,8 @@ describe('SubmissionSummary', () => {
 
     describe('STATE_USER SubmissionSummary tests', () => {
         it('renders without errors', async () => {
-            const contract = mockContractPackageSubmittedWithQuestions('15')
+            const contract =
+                mockContractPackageSubmittedWithQuestions('test-abc-123')
 
             renderWithProviders(
                 <Routes>
@@ -1235,17 +1206,11 @@ describe('SubmissionSummary', () => {
                             fetchCurrentUserMock({
                                 statusCode: 200,
                             }),
-                            fetchContractMockSuccess({
-                                contract: {
-                                    ...contract,
-                                    id: 'test-abc-123',
-                                },
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
                             }),
                             fetchContractWithQuestionsMockSuccess({
-                                contract: {
-                                    ...contract,
-                                    id: 'test-abc-123',
-                                },
+                                contract,
                             }),
                         ],
                     },
@@ -1280,7 +1245,7 @@ describe('SubmissionSummary', () => {
                             fetchCurrentUserMock({
                                 statusCode: 200,
                             }),
-                            fetchContractMockSuccess({
+                            fetchContractWithQuestionsMockSuccess({
                                 contract,
                             }),
                             fetchContractWithQuestionsMockSuccess({
@@ -1315,7 +1280,8 @@ describe('SubmissionSummary', () => {
         })
 
         it('does not render an add mccrs-id link for state user', async () => {
-            const contract = mockContractPackageSubmittedWithQuestions('15')
+            const contract =
+                mockContractPackageSubmittedWithQuestions('test-abc-123')
 
             renderWithProviders(
                 <Routes>
@@ -1333,17 +1299,11 @@ describe('SubmissionSummary', () => {
                                 user: mockValidUser(),
                                 statusCode: 200,
                             }),
-                            fetchContractMockSuccess({
-                                contract: {
-                                    ...mockContractPackageSubmitted(),
-                                    id: 'test-abc-123',
-                                },
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
                             }),
                             fetchContractWithQuestionsMockSuccess({
-                                contract: {
-                                    ...contract,
-                                    id: 'test-abc-123',
-                                },
+                                contract,
                             }),
                         ],
                     },
@@ -1362,6 +1322,9 @@ describe('SubmissionSummary', () => {
 
         it('redirects to review and submit page for State user', async () => {
             let testLocation: Location
+            const contract = mockContractPackageUnlockedWithUnlockedType({
+                id: 'test-abc-123',
+            })
 
             renderWithProviders(
                 <Routes>
@@ -1384,14 +1347,10 @@ describe('SubmissionSummary', () => {
                                 statusCode: 200,
                             }),
                             fetchContractWithQuestionsMockSuccess({
-                                contract: {
-                                    ...mockContractPackageUnlockedWithUnlockedType(),
-                                    id: 'test-abc-123',
-                                },
+                                contract,
                             }),
-                            fetchContractMockSuccess({
-                                contract:
-                                    mockContractPackageUnlockedWithUnlockedType(),
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
                             }),
                         ],
                     },
@@ -1412,7 +1371,8 @@ describe('SubmissionSummary', () => {
         })
 
         it('renders back to dashboard link for state users', async () => {
-            const contract = mockContractPackageSubmittedWithQuestions('15')
+            const contract =
+                mockContractPackageSubmittedWithQuestions('test-abc-123')
 
             renderWithProviders(
                 <Routes>
@@ -1430,16 +1390,10 @@ describe('SubmissionSummary', () => {
                                 statusCode: 200,
                             }),
                             fetchContractWithQuestionsMockSuccess({
-                                contract: {
-                                    ...contract,
-                                    id: 'test-abc-123',
-                                },
+                                contract,
                             }),
-                            fetchContractMockSuccess({
-                                contract: {
-                                    ...contract,
-                                    id: 'test-abc-123',
-                                },
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
                             }),
                         ],
                     },
@@ -1463,7 +1417,8 @@ describe('SubmissionSummary', () => {
         })
 
         it('renders the sidenav for State users', async () => {
-            const contract = mockContractPackageSubmittedWithQuestions('15')
+            const contract =
+                mockContractPackageSubmittedWithQuestions('test-abc-123')
 
             renderWithProviders(
                 <Routes>
@@ -1482,16 +1437,10 @@ describe('SubmissionSummary', () => {
                                 statusCode: 200,
                             }),
                             fetchContractWithQuestionsMockSuccess({
-                                contract: {
-                                    ...contract,
-                                    id: 'test-abc-123',
-                                },
+                                contract,
                             }),
-                            fetchContractMockSuccess({
-                                contract: {
-                                    ...contract,
-                                    id: 'test-abc-123',
-                                },
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
                             }),
                         ],
                     },
@@ -1532,7 +1481,7 @@ describe('SubmissionSummary', () => {
                             fetchContractWithQuestionsMockSuccess({
                                 contract,
                             }),
-                            fetchContractMockSuccess({
+                            fetchContractWithQuestionsMockSuccess({
                                 contract,
                             }),
                         ],
@@ -1586,7 +1535,7 @@ describe('SubmissionSummary', () => {
                             fetchContractWithQuestionsMockSuccess({
                                 contract,
                             }),
-                            fetchContractMockSuccess({
+                            fetchContractWithQuestionsMockSuccess({
                                 contract,
                             }),
                         ],
@@ -1659,7 +1608,7 @@ describe('SubmissionSummary', () => {
                             fetchContractWithQuestionsMockSuccess({
                                 contract,
                             }),
-                            fetchContractMockSuccess({
+                            fetchContractWithQuestionsMockSuccess({
                                 contract,
                             }),
                         ],
@@ -1715,7 +1664,7 @@ describe('SubmissionSummary', () => {
                                 fetchContractWithQuestionsMockSuccess({
                                     contract,
                                 }),
-                                fetchContractMockSuccess({
+                                fetchContractWithQuestionsMockSuccess({
                                     contract,
                                 }),
                             ],
@@ -1790,7 +1739,7 @@ describe('SubmissionSummary', () => {
                                 fetchContractWithQuestionsMockSuccess({
                                     contract,
                                 }),
-                                fetchContractMockSuccess({
+                                fetchContractWithQuestionsMockSuccess({
                                     contract,
                                 }),
                             ],
@@ -1849,7 +1798,7 @@ describe('SubmissionSummary', () => {
                                 fetchContractWithQuestionsMockSuccess({
                                     contract,
                                 }),
-                                fetchContractMockSuccess({
+                                fetchContractWithQuestionsMockSuccess({
                                     contract,
                                 }),
                             ],
@@ -1902,7 +1851,7 @@ describe('SubmissionSummary', () => {
                                 fetchContractWithQuestionsMockSuccess({
                                     contract,
                                 }),
-                                fetchContractMockSuccess({
+                                fetchContractWithQuestionsMockSuccess({
                                     contract,
                                 }),
                             ],


### PR DESCRIPTION
## Summary
[MCR-5071](https://jiraent.cms.gov/browse/MCR-5071)

This work re-enables frontend caching on the CMS and State submission dashboard, CMS rate dashboard, and summary pages. In addition, the dashboard pages have a 5-minute polling interval to refetch data.

AC:
- Reduce use of the loading indicator as the user travels between **cms submissions dashboard** and **cms rates dashboard**
- Reduce use of the loading indicator as the user travels between **dashboard pages and summary pages**
- NOTE: discussing with design and product, we are ok with not notifying the user that the data is being re-fetched while the cached data is on screen
   - This means on the dashboard page, new submissions or submission updates will update without any sort of loading indicator.
   - We also are not showing any type of error message if a re-fetch fails.

Additional work
- Add polling on dashboard pages set at 5-minute intervals.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

- To test this, while on the dashboard page, use a different window as incognito to make changes to a submission. Then, on the original window, navigate to a submission and back. There should be no loading state, and after a few moments, the submissions on the dashboard should update with the changes made.
- To test polling, do the same as above, except on the original window, do not navigate away and wait 5 minutes for the data to refresh.

<!---These are developer instructions on how to test or validate the work -->
