### PR TITLE
MCR-5021: Refactor zod parse in indexContracts and indexRates

### DIFF
--- a/services/app-api/src/domain-models/contractAndRates/contractTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/contractTypes.ts
@@ -12,15 +12,19 @@ import {
 } from './formDataTypes'
 
 const contractSchema = contractWithoutDraftRatesSchema.extend({
-    withdrawnRates: z.array(rateWithoutDraftContractsSchema).optional(),
-    draftRates: z.array(rateWithoutDraftContractsSchema).optional(),
+    withdrawnRates: z.lazy(() =>
+        z.array(rateWithoutDraftContractsSchema).optional()
+    ),
+    draftRates: z.lazy(() =>
+        z.array(rateWithoutDraftContractsSchema).optional()
+    ),
 })
 
 const unlockedContractSchema = contractSchema.extend({
     status: unlockedContractStatusSchema,
     // Since this is a contract in UNLOCKED status, there will be a draftRevision and draftRates
-    draftRevision: contractRevisionSchema,
-    draftRates: z.array(rateWithoutDraftContractsSchema),
+    draftRevision: z.lazy(() => contractRevisionSchema),
+    draftRates: z.lazy(() => z.array(rateWithoutDraftContractsSchema)),
 })
 
 const draftContractSchema = contractSchema.extend({

--- a/services/app-api/src/domain-models/contractAndRates/rateTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/rateTypes.ts
@@ -7,8 +7,12 @@ import { rateRevisionSchema } from './revisionTypes'
 import { pruneDuplicateEmails } from '../../emailer/formatters'
 
 const rateSchema = rateWithoutDraftContractsSchema.extend({
-    withdrawnFromContracts: z.array(contractWithoutDraftRatesSchema).optional(),
-    draftContracts: z.array(contractWithoutDraftRatesSchema).optional(),
+    withdrawnFromContracts: z.lazy(() =>
+        z.array(contractWithoutDraftRatesSchema).optional()
+    ),
+    draftContracts: z.lazy(() =>
+        z.array(contractWithoutDraftRatesSchema).optional()
+    ),
 })
 
 type RateType = z.infer<typeof rateSchema>

--- a/services/app-api/src/postgres/contractAndRates/findAllContractsWithHistoryBySubmitInfo.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllContractsWithHistoryBySubmitInfo.ts
@@ -3,9 +3,9 @@ import { NotFoundError } from '../postgresErrors'
 import { parseContractWithHistory } from './parseContractWithHistory'
 import { includeFullContract } from './prismaFullContractRateHelpers'
 import type { ContractOrErrorArrayType } from './findAllContractsWithHistoryByState'
-
 async function findAllContractsWithHistoryBySubmitInfo(
-    client: PrismaTransactionType
+    client: PrismaTransactionType,
+    useZod: boolean = true
 ): Promise<ContractOrErrorArrayType | NotFoundError | Error> {
     try {
         const contracts = await client.contractTable.findMany({
@@ -30,13 +30,14 @@ async function findAllContractsWithHistoryBySubmitInfo(
             return new NotFoundError(err)
         }
 
-        const parsedContracts: ContractOrErrorArrayType = contracts.map(
-            (contract) => ({
+        let parsedContracts: ContractOrErrorArrayType = []
+        for (const contract of contracts) {
+            const parsed = {
                 contractID: contract.id,
-                contract: parseContractWithHistory(contract),
-            })
-        )
-
+                contract: parseContractWithHistory(contract, useZod),
+            }
+            parsedContracts = parsedContracts.concat(parsed)
+        }
         return parsedContracts
     } catch (err) {
         console.error('PRISMA ERROR', err)

--- a/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.ts
@@ -12,6 +12,7 @@ type RateOrErrorArrayType = RateOrErrorType[]
 
 type FindAllRatesWithHistoryBySubmitType = {
     stateCode?: string
+    useZod?: boolean
 }
 
 async function findAllRatesWithHistoryBySubmitInfo(

--- a/services/app-api/src/postgres/contractAndRates/parseContractWithHistory.ts
+++ b/services/app-api/src/postgres/contractAndRates/parseContractWithHistory.ts
@@ -57,7 +57,8 @@ function arrayOrFirstError<T>(
 // Contract with submit and unlock info. Changes to the data of this contract, or changes
 // to the data or relations of associate revisions will all surface as new ContractRevisions
 function parseContractWithHistory(
-    contract: ContractTableFullPayload
+    contract: ContractTableFullPayload,
+    useZod: boolean = true
 ): ContractType | Error {
     const contractWithHistory = contractWithHistoryToDomainModel(contract)
     if (contractWithHistory instanceof Error) {
@@ -67,14 +68,21 @@ function parseContractWithHistory(
         return contractWithHistory
     }
 
-    const parseContract = contractSchema.safeParse(contractWithHistory)
-    if (!parseContract.success) {
-        const error = `ERROR: attempting to parse prisma contract with history failed: ${parseContract.error}`
-        console.warn(error, contractWithHistory, parseContract.error)
-        return parseContract.error
-    }
+    // useZod flag allows us to skip parsing in parts of the code
+    // where converting to the domain model is enough
+    // such as when calling indexContract and indexRates
+    if (useZod) {
+        const parseContract = contractSchema.safeParse(contractWithHistory)
+        if (!parseContract.success) {
+            const error = `ERROR: attempting to parse prisma contract with history failed: ${parseContract.error}`
+            console.warn(error, contractWithHistory, parseContract.error)
+            return parseContract.error
+        }
 
-    return parseContract.data
+        return parseContract.data
+    } else {
+        return contractWithHistory
+    }
 }
 
 function contractRevisionToDomainModel(

--- a/services/app-api/src/postgres/postgresStore.ts
+++ b/services/app-api/src/postgres/postgresStore.ts
@@ -1,5 +1,4 @@
 import type {
-    PrismaClient,
     Division,
     RateRevisionTable,
     ContractRevisionTable,
@@ -83,7 +82,7 @@ import type { WithdrawRateArgsType } from './contractAndRates/withdrawRate'
 import { withdrawRate } from './contractAndRates/withdrawRate'
 import { findEmailSettings } from './settings/findEmailSettings'
 import { updateEmailSettings } from './settings/updateEmailSettings'
-import type  { ExtendedPrismaClient } from './prismaClient'
+import type { ExtendedPrismaClient } from './prismaClient'
 
 type Store = {
     findPrograms: (
@@ -186,9 +185,9 @@ type Store = {
         stateCode: string
     ) => Promise<ContractOrErrorArrayType | Error>
 
-    findAllContractsWithHistoryBySubmitInfo: () => Promise<
-        ContractOrErrorArrayType | Error
-    >
+    findAllContractsWithHistoryBySubmitInfo: (
+        useZod?: boolean
+    ) => Promise<ContractOrErrorArrayType | Error>
     findAllRatesWithHistoryBySubmitInfo: (
         args?: FindAllRatesWithHistoryBySubmitType
     ) => Promise<RateOrErrorArrayType | Error>
@@ -291,8 +290,8 @@ function NewPostgresStore(client: ExtendedPrismaClient): Store {
             updateDraftContractRates(client, args),
         findAllContractsWithHistoryByState: (args) =>
             findAllContractsWithHistoryByState(client, args),
-        findAllContractsWithHistoryBySubmitInfo: () =>
-            findAllContractsWithHistoryBySubmitInfo(client),
+        findAllContractsWithHistoryBySubmitInfo: (args) =>
+            findAllContractsWithHistoryBySubmitInfo(client, args),
         findAllRatesWithHistoryBySubmitInfo: (args) =>
             findAllRatesWithHistoryBySubmitInfo(client, args),
         replaceRateOnContract: (args) => replaceRateOnContract(client, args),

--- a/services/app-api/src/resolvers/contract/indexContracts.ts
+++ b/services/app-api/src/resolvers/contract/indexContracts.ts
@@ -100,7 +100,7 @@ export function indexContractsResolver(
             return formatContracts(parsedContracts)
         } else if (hasAdminPermissions(user) || hasCMSPermissions(user)) {
             const contractsWithHistory =
-                await store.findAllContractsWithHistoryBySubmitInfo()
+                await store.findAllContractsWithHistoryBySubmitInfo(false)
 
             if (contractsWithHistory instanceof Error) {
                 const errMessage = `Issue finding contracts with history by submit info. Message: ${contractsWithHistory.message}`

--- a/services/app-api/src/resolvers/rate/indexRates.ts
+++ b/services/app-api/src/resolvers/rate/indexRates.ts
@@ -60,15 +60,19 @@ export function indexRatesResolver(store: Store): QueryResolvers['indexRates'] {
                 ratesWithHistory =
                     await store.findAllRatesWithHistoryBySubmitInfo({
                         stateCode: user.stateCode,
+                        useZod: false,
                     })
             } else if (input && input.stateCode) {
                 ratesWithHistory =
                     await store.findAllRatesWithHistoryBySubmitInfo({
                         stateCode: input.stateCode,
+                        useZod: false,
                     })
             } else {
                 ratesWithHistory =
-                    await store.findAllRatesWithHistoryBySubmitInfo()
+                    await store.findAllRatesWithHistoryBySubmitInfo({
+                        useZod: false,
+                    })
             }
             if (ratesWithHistory instanceof Error) {
                 const errMessage = `Issue finding rates with history Message: ${ratesWithHistory.message}`


### PR DESCRIPTION
## Summary
This PR:
- Use [zod's lazy](https://zod.dev/?id=recursive-types) method on the top level `contractSchema` and `rateSchema`
- Add `useZod` optional parameter,   and turn off parse for both indexContracts and indexRates

Note: I recorded the load time on prod for the submission and rate review dashboard times below. Once this merges, I will recheck the load times

Submission dashboard: 3444 ms
Rate review dashboard: 2557 ms 
#### Related issues
https://jiraent.cms.gov/browse/MCR-5021

