### PR TITLE
Fix promote after Serverless v4 merge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -272,7 +272,7 @@ jobs:
 
   deploy-infra:
     needs: [begin-deployment, build-clamav-layer]
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@mt-sls-v4
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name}}
@@ -310,7 +310,7 @@ jobs:
       needs.api-unit-tests.result == 'success' &&
       needs.build-prisma-client-lambda-layer.result == 'success' &&
       needs.begin-deployment.result == 'success'
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@mt-sls-v4
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -195,6 +195,7 @@ jobs:
     secrets:
       aws_account_id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
+      serverless_license_key: ${{ secrets.SERVERLESS_V4_LICENSE }}
       vpc_id: ${{ secrets.DEV_VPC_ID }}
       sg_id: ${{ secrets.DEV_SG_ID }}
       iam_permissions_boundary: ${{ secrets.DEV_IAM_PERMISSIONS_BOUNDARY }}
@@ -241,6 +242,7 @@ jobs:
     secrets:
       aws_account_id: ${{ secrets.VAL_AWS_ACCOUNT_ID }}
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
+      serverless_license_key: ${{ secrets.SERVERLESS_V4_LICENSE }}
       vpc_id: ${{ secrets.VAL_VPC_ID }}
       sg_id: ${{ secrets.VAL_SG_ID }}
       iam_permissions_boundary: ${{ secrets.VAL_IAM_PERMISSIONS_BOUNDARY }}
@@ -287,6 +289,7 @@ jobs:
     secrets:
       aws_account_id: ${{ secrets.PROD_AWS_ACCOUNT_ID }}
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
+      serverless_license_key: ${{ secrets.SERVERLESS_V4_LICENSE }}
       vpc_id: ${{ secrets.PROD_VPC_ID }}
       sg_id: ${{ secrets.PROD_SG_ID }}
       iam_permissions_boundary: ${{ secrets.PROD_IAM_PERMISSIONS_BOUNDARY }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31813,7 +31813,7 @@ snapshots:
 
   serverless-offline@13.9.0(serverless@4.2.3):
     dependencies:
-      '@aws-sdk/client-lambda': 3.744.0
+      '@aws-sdk/client-lambda': 3.749.0
       '@hapi/boom': 10.0.1
       '@hapi/h2o2': 10.0.4
       '@hapi/hapi': 21.3.12


### PR DESCRIPTION
## Summary

There were a couple places where promote was missing the Serverless v4 license injection. This also moves the git branch ref back to `main` from the previous branch.

