### PR TITLE
Fix typo in infra deploy

### DIFF
--- a/.github/workflows/deploy-infra-to-env.yml
+++ b/.github/workflows/deploy-infra-to-env.yml
@@ -159,7 +159,7 @@ jobs:
         env:
           SERVERLESS_ACCESS_KEY: ${{ secrets.serverless_license_key }}
           CLOUDFRONT_CERT_ARN: ${{ secrets.cloudfront_cert_arn }}
-          CLOUDFRONT_SB_DOMAIN_NAME: ${{ secrets.cloundfront_sb_domain_name }}
+          CLOUDFRONT_SB_DOMAIN_NAME: ${{ secrets.cloudfront_sb_domain_name }}
         run: |
           pushd services/ui && npx serverless deploy --stage ${{ inputs.stage_name }}
 
@@ -188,7 +188,7 @@ jobs:
         env:
           SERVERLESS_ACCESS_KEY: ${{ secrets.serverless_license_key }}
           CLOUDFRONT_CERT_ARN: ${{ secrets.cloudfront_cert_arn }}
-          CLOUDFRONT_SB_DOMAIN_NAME: ${{ secrets.cloundfront_sb_domain_name }}
+          CLOUDFRONT_SB_DOMAIN_NAME: ${{ secrets.cloudfront_sb_domain_name }}
         run: |
           pushd services/storybook && npx serverless deploy --stage ${{ inputs.stage_name }}
 


### PR DESCRIPTION
## Summary

There is a typo in the infra workflow CI file that caused an issue in dev/val/prod when merging the serverless v4 upgrade yesterday. I was originally going to land this with another fix for `app-api`, as that accidentally got left on serverless v3, but let's ship this first.



