### PR TITLE
Fix ui service's domain alias

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -46,6 +46,7 @@ export IAM_PERMISSIONS_BOUNDARY='arn:aws:iam::local:policy/local/developer-bound
 export IAM_PATH='/'
 export CLOUDFRONT_CERT_ARN='local'
 export CLOUDFRONT_SB_DOMAIN_NAME='local'
+export CLOUDFRONT_DOMAIN_NAME='local'
 
 # Sources a local overrides file. You can export any variables you
 # need for your local setup there. Any that match variables set here

--- a/.github/workflows/deploy-infra-to-env.yml
+++ b/.github/workflows/deploy-infra-to-env.yml
@@ -25,11 +25,11 @@ on:
       serverless_license_key:
         required: true
       cloudfront_cert_arn:
-        required: true
+        required: false
       cloudfront_domain_name:
-        required: true
+        required: false
       cloudfront_sb_domain_name:
-        required: true
+        required: false
       vpc_id:
         required: true
       sg_id:

--- a/.github/workflows/deploy-infra-to-env.yml
+++ b/.github/workflows/deploy-infra-to-env.yml
@@ -26,6 +26,8 @@ on:
         required: true
       cloudfront_cert_arn:
         required: true
+      cloudfront_domain_name:
+        required: true
       cloudfront_sb_domain_name:
         required: true
       vpc_id:
@@ -159,7 +161,7 @@ jobs:
         env:
           SERVERLESS_ACCESS_KEY: ${{ secrets.serverless_license_key }}
           CLOUDFRONT_CERT_ARN: ${{ secrets.cloudfront_cert_arn }}
-          CLOUDFRONT_SB_DOMAIN_NAME: ${{ secrets.cloudfront_sb_domain_name }}
+          CLOUDFRONT_DOMAIN_NAME: ${{ secrets.cloudfront_domain_name }}
         run: |
           pushd services/ui && npx serverless deploy --stage ${{ inputs.stage_name }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -335,7 +335,8 @@ jobs:
     env:
       SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_V4_LICENSE }}
       CLOUDFRONT_CERT_ARN: ${{ secrets.DEV_CERTIFICATE_ARN }}
-      CLOUDFRONT_SB_DOMAIN_NAME: ${{ secrets.DEV_CLOUDFRONT_SB_DOMAIN_NAME }}
+      CLOUDFRONT_SB_DOMAIN_NAME: ''
+      CLOUDFRONT_DOMAIN_NAME: ''
       VPC_ID: ${{ secrets.DEV_VPC_ID }}
       SG_ID: ${{ secrets.DEV_SG_ID }}
       SUBNET_PRIVATE_A_ID: ${{ secrets.DEV_SUBNET_PRIVATE_A_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -272,7 +272,7 @@ jobs:
 
   deploy-infra:
     needs: [begin-deployment, build-clamav-layer]
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@mt-fix-domain-name
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -283,7 +283,8 @@ jobs:
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK }}
       serverless_license_key: ${{ secrets.SERVERLESS_V4_LICENSE }}
-      cloudfront_cert_arn: ${{ secrets.DEV_CERTIFICATE_ARN}}
+      cloudfront_cert_arn: ${{ secrets.DEV_CERTIFICATE_ARN }}
+      cloudfront_domain_name: ${{ secrets.DEV_CLOUDFRONT_DOMAIN_NAME }}
       cloudfront_sb_domain_name: ${{ secrets.DEV_CLOUDFRONT_SB_DOMAIN_NAME }}
       vpc_id: ${{ secrets.DEV_VPC_ID }}
       sg_id: ${{ secrets.DEV_SG_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -283,9 +283,6 @@ jobs:
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK }}
       serverless_license_key: ${{ secrets.SERVERLESS_V4_LICENSE }}
-      cloudfront_cert_arn: ${{ secrets.DEV_CERTIFICATE_ARN }}
-      cloudfront_domain_name: ${{ secrets.DEV_CLOUDFRONT_DOMAIN_NAME }}
-      cloudfront_sb_domain_name: ${{ secrets.DEV_CLOUDFRONT_SB_DOMAIN_NAME }}
       vpc_id: ${{ secrets.DEV_VPC_ID }}
       sg_id: ${{ secrets.DEV_SG_ID }}
       iam_permissions_boundary: ${{ secrets.DEV_IAM_PERMISSIONS_BOUNDARY }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -172,6 +172,7 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK }}
       serverless_license_key: ${{ secrets.SERVERLESS_V4_LICENSE }}
       cloudfront_cert_arn: ${{ secrets.DEV_CERTIFICATE_ARN}}
+      cloudfront_domain_name: ${{ secrets.DEV_CLOUDFRONT_DOMAIN_NAME }}
       cloudfront_sb_domain_name: ${{ secrets.DEV_CLOUDFRONT_SB_DOMAIN_NAME }}
       vpc_id: ${{ secrets.DEV_VPC_ID }}
       sg_id: ${{ secrets.DEV_SG_ID }}
@@ -219,6 +220,7 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK }}
       serverless_license_key: ${{ secrets.SERVERLESS_V4_LICENSE }}
       cloudfront_cert_arn: ${{ secrets.VAL_CERTIFICATE_ARN}}
+      cloudfront_domain_name: ${{ secrets.VAL_CLOUDFRONT_DOMAIN_NAME }}
       cloudfront_sb_domain_name: ${{ secrets.VAL_CLOUDFRONT_SB_DOMAIN_NAME }}
       vpc_id: ${{ secrets.VAL_VPC_ID }}
       sg_id: ${{ secrets.VAL_SG_ID }}
@@ -266,6 +268,7 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK }}
       serverless_license_key: ${{ secrets.SERVERLESS_V4_LICENSE }}
       cloudfront_cert_arn: ${{ secrets.PROD_CERTIFICATE_ARN}}
+      cloudfront_domain_name: ${{ secrets.PROD_CLOUDFRONT_DOMAIN_NAME }}
       cloudfront_sb_domain_name: ${{ secrets.PROD_CLOUDFRONT_SB_DOMAIN_NAME }}
       vpc_id: ${{ secrets.PROD_VPC_ID }}
       sg_id: ${{ secrets.PROD_SG_ID }}

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -14,7 +14,7 @@ plugins:
 custom:
   region: ${aws:region}
   cloudfrontCertificateArn: ${env:CLOUDFRONT_CERT_ARN}
-  cloudfrontStorybookDomainName: ${env:CLOUDFRONT_SB_DOMAIN_NAME}
+  cloudfrontDomainName: ${env:CLOUDFRONT_DOMAIN_NAME}
   serverlessTerminationProtection:
     stages:
       - dev
@@ -33,7 +33,7 @@ resources:
         - Fn::Not:
             - Fn::Equals:
                 - ''
-                - ${self:custom.cloudfrontStorybookDomainName}
+                - ${self:custom.cloudfrontDomainName}
   Resources:
     S3Bucket:
       Type: AWS::S3::Bucket
@@ -115,7 +115,7 @@ resources:
           Aliases:
             Fn::If:
               - CreateCustomCloudFrontDomain
-              - - ${self:custom.cloudfrontStorybookDomainName}
+              - - ${self:custom.cloudfrontDomainName}
               - !Ref AWS::NoValue
           Origins:
             - DomainName: !GetAtt S3Bucket.DomainName
@@ -179,5 +179,5 @@ resources:
       Value:
         Fn::If:
           - CreateCustomCloudFrontDomain
-          - https://${self:custom.cloudfrontStorybookDomainName}/
+          - https://${self:custom.cloudfrontDomainName}/
           - !Sub https://${CloudFrontDistribution.DomainName}


### PR DESCRIPTION
## Summary

When #3136 landed there was an accidental change for the domain name configuration in the `ui` service, which sets the CloudFront distribution's alias. This is preventing our certificates from being attached properly in `promote`. This reverts the configuration change from #3136 and uses the proper config value for the domain alias.

These env variables are added to the GitHub Actions workflow and are in our secrets here in GitHub.



