### PR TITLE
MCR-5107: Update useZod flag usage for indexRates

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.ts
@@ -45,7 +45,7 @@ async function findAllRatesWithHistoryBySubmitInfo(
 
         const parsedRatesOrErrors: RateOrErrorArrayType = rates.map((rate) => ({
             rateID: rate.id,
-            rate: parseRateWithHistory(rate),
+            rate: parseRateWithHistory(rate, args?.useZod),
         }))
 
         return parsedRatesOrErrors

--- a/services/app-api/src/resolvers/rate/indexRates.ts
+++ b/services/app-api/src/resolvers/rate/indexRates.ts
@@ -60,13 +60,13 @@ export function indexRatesResolver(store: Store): QueryResolvers['indexRates'] {
                 ratesWithHistory =
                     await store.findAllRatesWithHistoryBySubmitInfo({
                         stateCode: user.stateCode,
-                        useZod: false,
+                        useZod: true,
                     })
             } else if (input && input.stateCode) {
                 ratesWithHistory =
                     await store.findAllRatesWithHistoryBySubmitInfo({
                         stateCode: input.stateCode,
-                        useZod: false,
+                        useZod: true,
                     })
             } else {
                 ratesWithHistory =


### PR DESCRIPTION
## Summary

Was seeing in prod that the rate reviews dashboard wasn't sped up with the last PR that landed. I did see that there was missing passthrough of the `useZod` flag. That's been updated in this PR, and locally saw about a 15% improvement. Once this lands, I will check what improvements are seen in prod

#### Related issues

https://jiraent.cms.gov/browse/MCR-5107

