### PR TITLE
MCR-4096: CMS must enter a reason for undoing a rate withdrawal

### DIFF
--- a/services/app-web/src/pages/UndoRateWithdraw/UndoRateWithdraw.test.tsx
+++ b/services/app-web/src/pages/UndoRateWithdraw/UndoRateWithdraw.test.tsx
@@ -1,0 +1,73 @@
+import {
+    fetchCurrentUserMock,
+    mockRateSubmittedWithQuestions,
+    mockValidCMSUser,
+    fetchRateWithQuestionsMockSuccess,
+    fetchRateMockSuccess,
+} from '@mc-review/mocks'
+import { renderWithProviders } from '../../testHelpers'
+import { Routes, Route } from 'react-router'
+import { RateSummarySideNav } from '../SubmissionSideNav/RateSummarySideNav'
+import { RoutesRecord } from '@mc-review/constants'
+import { RateSummary } from '../RateSummary'
+import { UndoRateWithdraw } from './UndoRateWithdraw'
+import { screen, waitFor } from '@testing-library/react'
+
+describe('UndoRateWithdraw', () => {
+    it('renders form validation error when required reason field is missing', async () => {
+        const rate = mockRateSubmittedWithQuestions({
+            id: 'test-abc-123',
+            parentContractID: 'test-abc-123',
+        })
+
+        const { user } = renderWithProviders(
+            <Routes>
+                <Route element={<RateSummarySideNav />}>
+                    <Route
+                        path={RoutesRecord.RATES_SUMMARY}
+                        element={<RateSummary />}
+                    />
+                    <Route
+                        path={RoutesRecord.UNDO_RATE_WITHDRAW}
+                        element={<UndoRateWithdraw />}
+                    />
+                </Route>
+            </Routes>,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchRateWithQuestionsMockSuccess({ rate }),
+                        fetchRateMockSuccess({ id: 'test-abc-123' }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/rate-reviews/test-abc-123/undo-withdraw',
+                },
+                featureFlags: {
+                    'undo-withdraw-rate': true,
+                },
+            }
+        )
+
+        await waitFor(() => {
+            expect(
+                screen.queryByTestId('undoWithdrawReason')
+            ).toBeInTheDocument()
+        })
+
+        const withdrawBtn = screen.getByRole('button', {
+            name: 'Undo Withdraw',
+        })
+        await user.click(withdrawBtn)
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('You must provide a reason for this change.')
+            ).toBeInTheDocument()
+        })
+    })
+})

--- a/services/app-web/src/pages/UndoRateWithdraw/UndoRateWithdraw.tsx
+++ b/services/app-web/src/pages/UndoRateWithdraw/UndoRateWithdraw.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import styles from './UndoRateWithdraw.module.scss'
-import { ActionButton, Breadcrumbs } from '../../components'
+import { ActionButton, Breadcrumbs, PoliteErrorMessage } from '../../components'
 import { useFetchRateQuery } from '../../gen/gqlClient'
 import { ErrorOrLoadingPage } from '../StateSubmission'
 import { handleAndReturnErrorState } from '../StateSubmission/ErrorOrLoadingPage'
@@ -16,12 +16,38 @@ import {
 import { PageActionsContainer } from '../StateSubmission/PageActions'
 import { usePage } from '../../contexts/PageContext'
 import { GenericErrorPage } from '../Errors/GenericErrorPage'
+import { Formik, FormikErrors } from 'formik'
+import * as Yup from 'yup'
+import { useTealium } from '../../hooks'
+import { recordJSException } from '@mc-review/otel'
+
+type UndoRateWithdrawValues = {
+    undoWithdrawReason: string
+}
+
+const UndoRateWithdrawSchema = Yup.object().shape({
+    undoWithdrawReason: Yup.string().required(
+        'You must provide a reason for this change.'
+    ),
+})
+
+type FormError =
+    FormikErrors<UndoRateWithdrawValues>[keyof FormikErrors<UndoRateWithdrawValues>]
 
 export const UndoRateWithdraw = () => {
     const { id } = useParams() as { id: string }
     const { updateHeading } = usePage()
+    const { logFormSubmitEvent } = useTealium()
     const navigate = useNavigate()
+    const [shouldValidate, setShouldValidate] = React.useState(false)
     const [rateName, setRateName] = useState<string | undefined>(undefined)
+    const showFieldErrors = (error?: FormError): boolean | undefined =>
+        shouldValidate && Boolean(error)
+
+    const formInitialValues: UndoRateWithdrawValues = {
+        undoWithdrawReason: '',
+    }
+
     const { data, loading, error } = useFetchRateQuery({
         variables: {
             input: {
@@ -51,6 +77,24 @@ export const UndoRateWithdraw = () => {
         setRateName(rateCertificationName)
     }
 
+    const undoWithdrawRateAction = async (values: UndoRateWithdrawValues) => {
+        logFormSubmitEvent({
+            heading: 'Undo withdraw',
+            form_name: 'Undo withdraw',
+            event_name: 'form_field_submit',
+            link_type: 'link_other',
+        })
+        try {
+            console.info('Placeholder: Call undoRateWithdraw mutation')
+            console.info(values)
+            navigate(`/rates/${id}`)
+        } catch (err) {
+            recordJSException(
+                `UndoWithdrawRate: Apollo error reported. Error message: ${err}`
+            )
+        }
+    }
+
     return (
         <div className={styles.undoRateWithdrawContainer}>
             <Breadcrumbs
@@ -67,66 +111,93 @@ export const UndoRateWithdraw = () => {
                     },
                 ]}
             />
-            <Form
-                id="UndoRateWithdrawForm"
-                className={styles.formContainer}
-                aria-label="Undo rate withdraw"
-                aria-describedby="form-guidance"
-                onSubmit={(e) => {
-                    return e
-                }}
+            <Formik
+                initialValues={formInitialValues}
+                onSubmit={(values) => undoWithdrawRateAction(values)}
+                validationSchema={UndoRateWithdrawSchema}
             >
-                <fieldset className="usa-fieldset">
-                    <h2>Undo withdraw</h2>
-                    <FormGroup className="margin-top-0">
-                        <Label
-                            htmlFor="rateWithdrawReason"
-                            className="margin-bottom-0 text-bold"
-                        >
-                            Reason for change
-                        </Label>
-                        <p className="margin-bottom-0 margin-top-05 usa-hint">
-                            Required
-                        </p>
-                        <p className="margin-bottom-0 margin-top-05 usa-hint">
-                            Provide a reason for this change. Clicking 'Undo
-                            withdraw' will move the rate back to the status of
-                            Submitted.
-                        </p>
-                        <Textarea
-                            name="undoWithdrawReason"
-                            id="undoWithdrawReason"
-                            data-testid="undoWithdrawReason"
-                            aria-labelledby="undoWithdrawReason"
-                            aria-required
-                        ></Textarea>
-                    </FormGroup>
-                </fieldset>
-                <PageActionsContainer>
-                    <ButtonGroup type="default">
-                        <ActionButton
-                            type="button"
-                            variant="outline"
-                            data-testid="page-actions-left-secondary"
-                            parent_component_type="page body"
-                            link_url={`/rates/${id}`}
-                            onClick={() => navigate(`/rates/${id}`)}
-                        >
-                            Cancel
-                        </ActionButton>
-                        <ActionButton
-                            type="submit"
-                            variant="default"
-                            data-testid="page-actions-right-primary"
-                            parent_component_type="page body"
-                            link_url={`/rates/${id}`}
-                            animationTimeout={1000}
-                        >
-                            Undo Withdraw
-                        </ActionButton>
-                    </ButtonGroup>
-                </PageActionsContainer>
-            </Form>
+                {({ handleSubmit, handleChange, errors, values }) => (
+                    <Form
+                        id="UndoRateWithdrawForm"
+                        className={styles.formContainer}
+                        aria-label="Undo rate withdraw"
+                        aria-describedby="form-guidance"
+                        onSubmit={(e) => {
+                            setShouldValidate(true)
+                            return handleSubmit(e)
+                        }}
+                    >
+                        <fieldset className="usa-fieldset">
+                            <h2>Undo withdraw</h2>
+                            <FormGroup
+                                error={showFieldErrors(
+                                    errors.undoWithdrawReason
+                                )}
+                                className="margin-top-0"
+                            >
+                                <Label
+                                    htmlFor="rateWithdrawReason"
+                                    className="margin-bottom-0 text-bold"
+                                >
+                                    Reason for change
+                                </Label>
+                                <p className="margin-bottom-0 margin-top-05 usa-hint">
+                                    Required
+                                </p>
+                                <p className="margin-bottom-0 margin-top-05 usa-hint">
+                                    Provide a reason for this change. Clicking
+                                    'Undo withdraw' will move the rate back to
+                                    the status of Submitted.
+                                </p>
+                                {showFieldErrors(errors.undoWithdrawReason) && (
+                                    <PoliteErrorMessage formFieldLabel="Reason for withdrawing">
+                                        {errors.undoWithdrawReason}
+                                    </PoliteErrorMessage>
+                                )}
+                                <Textarea
+                                    name="undoWithdrawReason"
+                                    id="undoWithdrawReason"
+                                    data-testid="undoWithdrawReason"
+                                    aria-labelledby="undoWithdrawReason"
+                                    error={showFieldErrors(
+                                        errors.undoWithdrawReason
+                                    )}
+                                    onChange={handleChange}
+                                    defaultValue={values.undoWithdrawReason}
+                                    aria-required
+                                ></Textarea>
+                            </FormGroup>
+                        </fieldset>
+                        <PageActionsContainer>
+                            <ButtonGroup type="default">
+                                <ActionButton
+                                    type="button"
+                                    variant="outline"
+                                    data-testid="page-actions-left-secondary"
+                                    parent_component_type="page body"
+                                    link_url={`/rates/${id}`}
+                                    onClick={() => navigate(`/rates/${id}`)}
+                                >
+                                    Cancel
+                                </ActionButton>
+                                <ActionButton
+                                    type="submit"
+                                    variant="default"
+                                    disabled={showFieldErrors(
+                                        errors.undoWithdrawReason
+                                    )}
+                                    data-testid="page-actions-right-primary"
+                                    parent_component_type="page body"
+                                    link_url={`/rates/${id}`}
+                                    animationTimeout={1000}
+                                >
+                                    Undo Withdraw
+                                </ActionButton>
+                            </ButtonGroup>
+                        </PageActionsContainer>
+                    </Form>
+                )}
+            </Formik>
         </div>
     )
 }


### PR DESCRIPTION
## Summary
[MCR-4096](https://jiraent.cms.gov/browse/MCR-4906)

- If I am on the undo rate withdrawal page ([Figma](https://www.figma.com/design/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?node-id=17402-62380&t=FVfI0NKnbWJg5YLS-4))
then I see a single step form field with the label "Undo withdraw" and an open text form field with the label "Reason for change."
- If I do not enter a reason and I try to undo 
then I receive an inline error message "You must provide a reason for this change" 
- If I enter a reason and click undo withdraw
Then I'm taken back to the rate summary page, and the status is changed on the API and on the dashboard for the rate. 
  - This last AC is also on [MCR-4095](https://jiraent.cms.gov/browse/MCR-4905) and more suitable for that PR. For now, this work will allow the user to undo withdraw without calling the API and redirect to the summary page.

#### Related issues

#### Screenshots

#### Test cases covered

`UndoRateWithdraw.test.tsx`
- `'renders form validation error when required reason field is missing'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
