### PR TITLE
MCR-4095: Integration: CMS can undo a rate withdrawal

### DIFF
--- a/packages/mocks/src/apollo/withdrawRateGQLMock.ts
+++ b/packages/mocks/src/apollo/withdrawRateGQLMock.ts
@@ -1,7 +1,9 @@
 import {   
     Rate,
     WithdrawRateDocument,
+    UndoWithdrawnRateDocument,
     WithdrawRateMutation,
+    UndoWithdrawnRateMutation
 } from '../gen/gqlClient'
 import { MockedResponse } from '@apollo/client/testing'
 import { GraphQLError } from 'graphql/index'
@@ -63,6 +65,101 @@ const withdrawRateMockSuccess = (
     }
 }
 
+const undoWithdrawRateMockSuccess = (
+    params: {
+        rateID?: string
+        rateData?: Partial<Rate>
+        updatedReason?: string
+    } = {}
+): MockedResponse<UndoWithdrawnRateMutation> => {
+    const {
+        rateID = 'test-abc-123',
+        rateData,
+        updatedReason = 'Undo rate withdraw',
+    } = params
+    const rate = mockRateSubmittedWithQuestions({
+        __typename: 'Rate',
+        id: rateData?.id || rateID,
+        parentContractID: rateData?.parentContractID || 'parent-contract-id',
+        reviewStatus: 'UNDER_REVIEW',
+        consolidatedStatus: 'RESUBMITTED',
+        reviewStatusActions: [
+            {
+                __typename: 'RateReviewStatusActions',
+                actionType: 'UNDER_REVIEW',
+                rateID: rateID,
+                updatedReason,
+                updatedAt: new Date('2024-5-2'),
+                updatedBy: {
+                    __typename: 'UpdatedBy',
+                    email: 'cmsapprover@example.com',
+                    familyName: 'Smith',
+                    givenName: 'John',
+                    role: 'CMS_APPROVER_USER',
+                },
+            },
+            {
+                __typename: 'RateReviewStatusActions',
+                actionType: 'WITHDRAW',
+                rateID: rateID,
+                updatedReason: 'Withdrawing invalid rate',
+                updatedAt: new Date('2024-5-1'),
+                updatedBy: {
+                    __typename: 'UpdatedBy',
+                    email: 'cmsapprover@example.com',
+                    familyName: 'Smith',
+                    givenName: 'John',
+                    role: 'CMS_APPROVER_USER',
+                },
+            },
+        ],
+    })
+
+    return {
+        request: {
+            query: UndoWithdrawnRateDocument,
+            variables: {
+                input: {
+                    rateID: 'test-abc-123',
+                    updatedReason,
+                },
+            },
+        },
+        result: {
+            data: {
+                undoWithdrawRate: {
+                    rate,
+                },
+            },
+        },
+    }
+}
+
+const undoWithdrawRateMockFailure = (): MockedResponse<UndoWithdrawnRateMutation> => {
+    const graphQLError = new GraphQLError('Issue undoing a withdrawn rate', {
+        extensions: {
+            code: 'NOT_FOUND',
+            cause: 'DB_ERROR',
+        },
+    })
+
+    return {
+        request: {
+            query: UndoWithdrawnRateDocument,
+            variables: {
+                input: {
+                    rateID: 'test-abc-123',
+                    updatedReason: 'Undo withdraw rate'
+                },
+            },
+        },
+        result: {
+            data: null,
+            errors: [graphQLError],
+        },
+    }
+}
+
 const withdrawRateMockFailure = (): MockedResponse<WithdrawRateMutation> => {
     const graphQLError = new GraphQLError('Issue withdrawing rate', {
         extensions: {
@@ -88,4 +185,9 @@ const withdrawRateMockFailure = (): MockedResponse<WithdrawRateMutation> => {
     }
 }
 
-export { withdrawRateMockFailure, withdrawRateMockSuccess }
+export {
+    withdrawRateMockFailure,
+    withdrawRateMockSuccess,
+    undoWithdrawRateMockSuccess,
+    undoWithdrawRateMockFailure
+}

--- a/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
@@ -118,7 +118,7 @@ function getRateReviewStatus(
     rate: RateTableWithoutDraftContractsPayload
 ): RateReviewStatusType {
     // need to order actions from latest to earliest
-    const actions = rate.reviewStatusActions.sort(
+    const actions = [...rate.reviewStatusActions].sort(
         (actionA, actionB) =>
             actionB.updatedAt.getTime() - actionA.updatedAt.getTime()
     )

--- a/services/app-web/src/pages/UndoRateWithdraw/UndoRateWithdraw.test.tsx
+++ b/services/app-web/src/pages/UndoRateWithdraw/UndoRateWithdraw.test.tsx
@@ -4,6 +4,10 @@ import {
     mockValidCMSUser,
     fetchRateWithQuestionsMockSuccess,
     fetchRateMockSuccess,
+    mockContractPackageSubmitted,
+    undoWithdrawRateMockSuccess,
+    fetchContractMockSuccess,
+    undoWithdrawRateMockFailure,
 } from '@mc-review/mocks'
 import { renderWithProviders } from '../../testHelpers'
 import { Routes, Route } from 'react-router'
@@ -12,8 +16,234 @@ import { RoutesRecord } from '@mc-review/constants'
 import { RateSummary } from '../RateSummary'
 import { UndoRateWithdraw } from './UndoRateWithdraw'
 import { screen, waitFor } from '@testing-library/react'
+import { Rate } from '../../gen/gqlClient'
+import { Location } from 'react-router-dom'
 
 describe('UndoRateWithdraw', () => {
+    it('can undo rate withdraw', async () => {
+        let testLocation: Location
+        const contract = mockContractPackageSubmitted({
+            id: 'test-abc-123',
+        })
+        const rate = mockRateSubmittedWithQuestions({
+            id: 'test-abc-123',
+            parentContractID: 'test-abc-123',
+            reviewStatus: 'WITHDRAWN',
+            consolidatedStatus: 'WITHDRAWN',
+            reviewStatusActions: [
+                {
+                    __typename: 'RateReviewStatusActions',
+                    actionType: 'WITHDRAW',
+                    rateID: 'test-abc-123',
+                    updatedReason: 'a valid note',
+                    updatedAt: new Date(),
+                    updatedBy: {
+                        __typename: 'UpdatedBy',
+                        email: 'cmsapprover@example.com',
+                        familyName: 'Smith',
+                        givenName: 'John',
+                        role: 'CMS_APPROVER_USER',
+                    },
+                },
+            ],
+        })
+
+        const undoWithdrawnRate: Rate = {
+            ...rate,
+            reviewStatus: 'UNDER_REVIEW',
+            consolidatedStatus: 'RESUBMITTED',
+            reviewStatusActions: [
+                {
+                    __typename: 'RateReviewStatusActions',
+                    actionType: 'UNDER_REVIEW',
+                    rateID: rate.id,
+                    updatedReason: 'Undo withdraw rate',
+                    updatedAt: new Date(),
+                    updatedBy: {
+                        __typename: 'UpdatedBy',
+                        email: 'cmsapprover@example.com',
+                        familyName: 'Smith',
+                        givenName: 'John',
+                        role: 'CMS_APPROVER_USER',
+                    },
+                },
+                {
+                    __typename: 'RateReviewStatusActions',
+                    actionType: 'WITHDRAW',
+                    rateID: rate.id,
+                    updatedReason: 'a valid note',
+                    updatedAt: new Date(),
+                    updatedBy: {
+                        __typename: 'UpdatedBy',
+                        email: 'cmsapprover@example.com',
+                        familyName: 'Smith',
+                        givenName: 'John',
+                        role: 'CMS_APPROVER_USER',
+                    },
+                },
+            ],
+        }
+
+        const { user } = renderWithProviders(
+            <Routes>
+                <Route element={<RateSummarySideNav />}>
+                    <Route
+                        path={RoutesRecord.RATES_SUMMARY}
+                        element={<RateSummary />}
+                    />
+                    <Route
+                        path={RoutesRecord.UNDO_RATE_WITHDRAW}
+                        element={<UndoRateWithdraw />}
+                    />
+                </Route>
+            </Routes>,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchRateWithQuestionsMockSuccess({ rate }),
+                        fetchRateMockSuccess({ id: 'test-abc-123' }),
+                        undoWithdrawRateMockSuccess({
+                            rateID: 'test-abc-123',
+                            updatedReason: 'Undo withdraw rate',
+                        }),
+                        fetchContractMockSuccess({
+                            contract,
+                        }),
+                        fetchRateWithQuestionsMockSuccess({
+                            rate: undoWithdrawnRate,
+                        }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/rate-reviews/test-abc-123/undo-withdraw',
+                },
+                featureFlags: {
+                    'undo-withdraw-rate': true,
+                    'withdraw-rate': true,
+                },
+                location: (location) => (testLocation = location),
+            }
+        )
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('heading', { name: 'Undo withdraw' })
+            ).toBeInTheDocument()
+            expect(
+                screen.getByRole('button', { name: 'Undo withdraw' })
+            ).toBeInTheDocument()
+        })
+
+        const undoWithdrawBtn = screen.getByRole('button', {
+            name: 'Undo withdraw',
+        })
+        const undoReasonInput = screen.getByTestId('undoWithdrawReason')
+
+        await user.type(undoReasonInput, 'Undo withdraw rate')
+        await user.click(undoWithdrawBtn)
+
+        await waitFor(() => {
+            // expect redirect
+            expect(testLocation.pathname).toBe(`/rates/${contract.id}`)
+            // expect unlock rate button to exist
+            expect(
+                screen.getByRole('button', {
+                    name: 'Unlock rate',
+                })
+            ).toBeInTheDocument()
+            // expect withdraw rate button to exist
+            expect(
+                screen.getByRole('button', {
+                    name: 'Withdraw rate',
+                })
+            ).toBeInTheDocument()
+        })
+    })
+
+    it('renders generic API banner error on failed undo rate withdraw', async () => {
+        const rate = mockRateSubmittedWithQuestions({
+            id: 'test-abc-123',
+            parentContractID: 'test-abc-123',
+            reviewStatus: 'WITHDRAWN',
+            consolidatedStatus: 'WITHDRAWN',
+            reviewStatusActions: [
+                {
+                    __typename: 'RateReviewStatusActions',
+                    actionType: 'WITHDRAW',
+                    rateID: 'test-abc-123',
+                    updatedReason: 'a valid note',
+                    updatedAt: new Date(),
+                    updatedBy: {
+                        __typename: 'UpdatedBy',
+                        email: 'cmsapprover@example.com',
+                        familyName: 'Smith',
+                        givenName: 'John',
+                        role: 'CMS_APPROVER_USER',
+                    },
+                },
+            ],
+        })
+
+        const { user } = renderWithProviders(
+            <Routes>
+                <Route element={<RateSummarySideNav />}>
+                    <Route
+                        path={RoutesRecord.RATES_SUMMARY}
+                        element={<RateSummary />}
+                    />
+                    <Route
+                        path={RoutesRecord.UNDO_RATE_WITHDRAW}
+                        element={<UndoRateWithdraw />}
+                    />
+                </Route>
+            </Routes>,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchRateWithQuestionsMockSuccess({ rate }),
+                        fetchRateMockSuccess({ id: 'test-abc-123' }),
+                        undoWithdrawRateMockFailure(),
+                    ],
+                },
+                routerProvider: {
+                    route: '/rate-reviews/test-abc-123/undo-withdraw',
+                },
+                featureFlags: {
+                    'undo-withdraw-rate': true,
+                },
+            }
+        )
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('heading', { name: 'Undo withdraw' })
+            ).toBeInTheDocument()
+            expect(
+                screen.getByRole('button', { name: 'Undo withdraw' })
+            ).toBeInTheDocument()
+        })
+
+        const undoWithdrawBtn = screen.getByRole('button', {
+            name: 'Undo withdraw',
+        })
+        const undoReasonInput = screen.getByTestId('undoWithdrawReason')
+
+        await user.type(undoReasonInput, 'Undo withdraw rate')
+        await user.click(undoWithdrawBtn)
+
+        await waitFor(() => {
+            expect(screen.getByTestId('error-alert')).toBeInTheDocument()
+        })
+    })
+
     it('renders form validation error when required reason field is missing', async () => {
         const rate = mockRateSubmittedWithQuestions({
             id: 'test-abc-123',
@@ -60,7 +290,7 @@ describe('UndoRateWithdraw', () => {
         })
 
         const withdrawBtn = screen.getByRole('button', {
-            name: 'Undo Withdraw',
+            name: 'Undo withdraw',
         })
         await user.click(withdrawBtn)
 

--- a/services/app-web/src/pages/UndoRateWithdraw/UndoRateWithdraw.tsx
+++ b/services/app-web/src/pages/UndoRateWithdraw/UndoRateWithdraw.tsx
@@ -1,7 +1,15 @@
 import React, { useEffect, useState } from 'react'
 import styles from './UndoRateWithdraw.module.scss'
-import { ActionButton, Breadcrumbs, PoliteErrorMessage } from '../../components'
-import { useFetchRateQuery } from '../../gen/gqlClient'
+import {
+    ActionButton,
+    Breadcrumbs,
+    GenericApiErrorBanner,
+    PoliteErrorMessage,
+} from '../../components'
+import {
+    useFetchRateQuery,
+    useUndoWithdrawnRateMutation,
+} from '../../gen/gqlClient'
 import { ErrorOrLoadingPage } from '../StateSubmission'
 import { handleAndReturnErrorState } from '../StateSubmission/ErrorOrLoadingPage'
 import { RoutesRecord } from '@mc-review/constants'
@@ -43,6 +51,10 @@ export const UndoRateWithdraw = () => {
     const [rateName, setRateName] = useState<string | undefined>(undefined)
     const showFieldErrors = (error?: FormError): boolean | undefined =>
         shouldValidate && Boolean(error)
+    const [
+        undoWithdrawRate,
+        { error: undoWithdrawError, loading: undoWithdrawLoading },
+    ] = useUndoWithdrawnRateMutation()
 
     const formInitialValues: UndoRateWithdrawValues = {
         undoWithdrawReason: '',
@@ -85,8 +97,14 @@ export const UndoRateWithdraw = () => {
             link_type: 'link_other',
         })
         try {
-            console.info('Placeholder: Call undoRateWithdraw mutation')
-            console.info(values)
+            await undoWithdrawRate({
+                variables: {
+                    input: {
+                        rateID: rate.id,
+                        updatedReason: values.undoWithdrawReason,
+                    },
+                },
+            })
             navigate(`/rates/${id}`)
         } catch (err) {
             recordJSException(
@@ -127,6 +145,7 @@ export const UndoRateWithdraw = () => {
                             return handleSubmit(e)
                         }}
                     >
+                        {undoWithdrawError && <GenericApiErrorBanner />}
                         <fieldset className="usa-fieldset">
                             <h2>Undo withdraw</h2>
                             <FormGroup
@@ -190,8 +209,9 @@ export const UndoRateWithdraw = () => {
                                     parent_component_type="page body"
                                     link_url={`/rates/${id}`}
                                     animationTimeout={1000}
+                                    loading={undoWithdrawLoading}
                                 >
-                                    Undo Withdraw
+                                    Undo withdraw
                                 </ActionButton>
                             </ButtonGroup>
                         </PageActionsContainer>


### PR DESCRIPTION
## Summary
[MCR-4095](https://jiraent.cms.gov/browse/MCR-4905)

- If I click on "undo withdrawal"
Then if I navigate to the Rate Summary page I see the undo button is deactivated (or removed, depending on design feedback) and I see the "unlock rate" and "withdraw rate" buttons reappear in the actions section 
- If I click on "undo withdrawal" and I navigate to the rate dashboard 
Then I see the rate appear with a status of "Submitted" on the dashboard
- If I click on "undo withdrawal" and I navigate to the submissions containing the rate 
Then I see the rate appear as active with full rate details on the submissions it is a part of. 
- If I click cancel
then I'm navigated back to rate summary page and the rate remains withdrawn. 

Other work:
- Fix undo withdraw button text from `Undo Withdraw` -> `Undo withdraw`
- Fix `getRateReviewStatus` mutating the parameter `rate` that is passed in.

#### Related issues

#### Screenshots

#### Test cases covered

`UndoRateWithdraw.test.tsx`
- `'can undo rate withdraw'`
- `'renders generic API banner error on failed undo rate withdraw'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
