### PR TITLE
Update GitHub Actions Ubuntu to 24.04

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,34 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 4
+    groups:
+      aws-sdk:
+        applies-to: version-updates
+        patterns:
+          - '@aws-sdk/*'
+      prisma:
+        applies-to: version-updates
+        patterns:
+          - '@prisma/client'
+          - 'prisma'
+      otel:
+        applies-to: version-updates
+        patterns:
+          - '@opentelemetry/exporter-trace-otlp-http'
+          - '@opentelemetry/instrumentation'
+          - '@opentelemetry/exporter-metrics-otlp-http'
+          - '@opentelemetry/sdk-node'
+      opentelemetry-js:
+        applies-to: version-updates
+        patterns:
+          - '@opentelemetry/core'
+          - '@opentelemetry/resources'
+          - '@opentelemetry/sdk-trace-base'
+          - '@opentelemetry/sdk-trace-node'
+          - '@opentelemetry/semantic-conventions'
+          - '@opentelemetry/sdk-metrics'
+      storybook:
+        applies-to: version-updates
+        patterns:
+          - '@storybook/*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,34 +9,4 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    open-pull-requests-limit: 4
-    groups:
-      aws-sdk:
-        applies-to: version-updates
-        patterns:
-          - '@aws-sdk/*'
-      prisma:
-        applies-to: version-updates
-        patterns:
-          - '@prisma/client'
-          - 'prisma'
-      otel:
-        applies-to: version-updates
-        patterns:
-          - '@opentelemetry/exporter-trace-otlp-http'
-          - '@opentelemetry/instrumentation'
-          - '@opentelemetry/exporter-metrics-otlp-http'
-          - '@opentelemetry/sdk-node'
-      opentelemetry-js:
-        applies-to: version-updates
-        patterns:
-          - '@opentelemetry/core'
-          - '@opentelemetry/resources'
-          - '@opentelemetry/sdk-trace-base'
-          - '@opentelemetry/sdk-trace-node'
-          - '@opentelemetry/semantic-conventions'
-          - '@opentelemetry/sdk-metrics'
-      storybook:
-        applies-to: version-updates
-        patterns:
-          - '@storybook/*'
+    open-pull-requests-limit: 5

--- a/.github/workflows/deploy-infra-to-env.yml
+++ b/.github/workflows/deploy-infra-to-env.yml
@@ -55,7 +55,7 @@ jobs:
   github-oidc:
     if: ${{ contains(inputs.changed_services, 'github-oidc') }}
     environment: ${{ inputs.environment }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -104,7 +104,7 @@ jobs:
     needs: github-oidc
     if: ${{ always() && contains(inputs.changed_services, 'postgres') }}
     environment: ${{ inputs.environment }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -140,7 +140,7 @@ jobs:
     needs: github-oidc
     if: ${{ always() && contains(inputs.changed_services, 'ui') }}
     environment: ${{ inputs.environment }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -169,7 +169,7 @@ jobs:
     needs: github-oidc
     if: ${{ always() && contains(inputs.changed_services, 'storybook') }}
     environment: ${{ inputs.environment }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -198,7 +198,7 @@ jobs:
     needs: github-oidc
     if: ${{ always() && contains(inputs.changed_services, 'uploads') }}
     environment: ${{ inputs.environment }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -244,7 +244,7 @@ jobs:
     needs: github-oidc
     if: ${{ always() && contains(inputs.changed_services, 'infra-api') }}
     environment: ${{ inputs.environment }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -273,7 +273,7 @@ jobs:
     needs: [github-oidc, infra-api, ui, uploads]
     if: ${{ always() && contains(inputs.changed_services, 'ui-auth') }}
     environment: ${{ inputs.environment }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   begin-deployment:
     name: Begin Deployment
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       deployments: write
     outputs:
@@ -87,7 +87,7 @@ jobs:
 
   web-unit-tests:
     name: test - web unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -145,7 +145,7 @@ jobs:
 
   api-unit-tests:
     name: test - api unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     services:
       postgres:
         image: postgres:13.3
@@ -217,7 +217,7 @@ jobs:
 
   build-prisma-client-lambda-layer:
     name: build - postgres prisma layer
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -252,7 +252,7 @@ jobs:
 
   build-clamav-layer:
     name: build - clamav layer
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -272,7 +272,7 @@ jobs:
 
   deploy-infra:
     needs: [begin-deployment, build-clamav-layer]
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@mt-ubuntu22-gha
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name}}
@@ -308,7 +308,7 @@ jobs:
       needs.api-unit-tests.result == 'success' &&
       needs.build-prisma-client-lambda-layer.result == 'success' &&
       needs.begin-deployment.result == 'success'
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@mt-ubuntu22-gha
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name }}
@@ -351,7 +351,7 @@ jobs:
       && (needs.begin-deployment.result == 'success')
       && (needs.deploy-infra.result == 'success' || needs.deploy-infra.result == 'skipped')
       && (needs.deploy-app.result == 'success' || needs.deploy-app.result == 'skipped')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       application-endpoint: ${{ steps.save-app-endpoint.outputs.app-endpoint }}
       api-endpoint: ${{ steps.save-api-endpoint.outputs.api-endpoint }}
@@ -461,7 +461,7 @@ jobs:
     needs: [begin-deployment, deploy-app, finishing-prep]
     if: always() && needs.begin-deployment.result == 'success'
     name: End Deployment
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       deployments: write
     steps:
@@ -496,7 +496,7 @@ jobs:
     timeout-minutes: 25
     needs: [deploy-app, finishing-prep]
     if: always() && needs.finishing-prep.result == 'success'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
       options: --user 1001
@@ -607,7 +607,7 @@ jobs:
     name: test-coverage
     needs: [cypress]
     if: always() && needs.finishing-prep.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       deployments: write
     strategy:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   unit-tests:
     name: test - unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       app-version: ${{ steps.branch-name.outputs.app-version}}
       changed-services: "[
@@ -108,7 +108,7 @@ jobs:
 
   build-prisma-client-lambda-layer:
     name: build - postgres prisma layer
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -141,7 +141,7 @@ jobs:
 
   build-clamav-layer:
     name: build - clamav layer
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -305,7 +305,7 @@ jobs:
   cypress-prod:
     name: prod - cypress
     needs: [promote-app-prod]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
       options: --user 1001
@@ -371,7 +371,7 @@ jobs:
 
   slack:
     name: Slack notification on failure
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [cypress-prod, promote-app-val]
     if: always()
     steps:


### PR DESCRIPTION
## Summary

This bumps the VM that our GHA workflows run on to the LTS Ubuntu 24.04. I also removed the grouping configs for dependabot in CI, as we've been unable to ignore some major version updates we have tickets for due to the groupings.

#### Related issues
https://jiraent.cms.gov/browse/MCR-5095