### PR TITLE
Add backup retention check for rds

### DIFF
--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -70,6 +70,11 @@ custom:
     other: 0.5
     val: 1
     prod: 1
+  backupRetentionPeriod:
+    other: 0 # No backups for feature branches/PR review environments
+    main: 7
+    val: 7
+    prod: 30
   scriptable:
     hooks:
       before:package:createDeploymentArtifacts: pnpm build
@@ -133,7 +138,7 @@ resources:
         DBSubnetGroupName: !Ref PostgresSubnetGroup
         VpcSecurityGroupIds: ['${self:custom.sgId}']
         CopyTagsToSnapshot: true
-        BackupRetentionPeriod: 7
+        BackupRetentionPeriod: ${self:custom.backupRetentionPeriod.${opt:stage}, self:custom.backupRetentionPeriod.other}
         EnableCloudwatchLogsExports:
           - postgresql
         ServerlessV2ScalingConfiguration:

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -71,7 +71,7 @@ custom:
     val: 1
     prod: 1
   backupRetentionPeriod:
-    other: 0 # No backups for feature branches/PR review environments
+    other: 1
     main: 7
     val: 7
     prod: 30


### PR DESCRIPTION
## Summary

We're getting a lot of security alerts in our `dev` environment (~140) due to RDS snapshots not having encryption enabled. However, we really shouldn't even need snapshots in `dev`, as they're for the most part all review environments with test data from Cypress or manual testing. 

This disables all backups for review environments and sets regular intervals for the main `dev` account, as well as `val` and `prod`.

#### Related issues
https://jiraent.cms.gov/browse/MCR-5048