### PR TITLE
[MCR-4909] cms and state sees confirmation banner about status change

### DIFF
--- a/services/app-web/src/components/Banner/StatusUpdatedBanner/StatusUpdatedBanner.test.tsx
+++ b/services/app-web/src/components/Banner/StatusUpdatedBanner/StatusUpdatedBanner.test.tsx
@@ -1,0 +1,13 @@
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '../../../testHelpers'
+import { StatusUpdatedBanner } from './StatusUpdatedBanner'
+
+test('renders status updated banner with no errors', () => {
+    renderWithProviders(<StatusUpdatedBanner />)
+
+    expect(screen.getByTestId('statusUpdatedBanner')).toBeInTheDocument()
+    expect(screen.getByText('Status updated')).toBeInTheDocument()
+    expect(
+        screen.getByText('Submission status updated to "Submitted"')
+    ).toBeInTheDocument()
+})

--- a/services/app-web/src/components/Banner/StatusUpdatedBanner/StatusUpdatedBanner.tsx
+++ b/services/app-web/src/components/Banner/StatusUpdatedBanner/StatusUpdatedBanner.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { Alert } from '@trussworks/react-uswds'
+import styles from '../Banner.module.scss'
+
+export const StatusUpdatedBanner = ({
+    className,
+}: React.HTMLAttributes<HTMLDivElement>) => {
+    return (
+        <Alert
+            role="alert"
+            type="success"
+            heading="Status updated"
+            headingLevel="h4"
+            data-testid="statusUpdatedBanner"
+            className={className}
+        >
+            <div className={styles.bannerBodyText}>
+                <p className="usa-alert__text">
+                    Submission status updated to "Submitted"
+                </p>
+            </div>
+        </Alert>
+    )
+}

--- a/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
@@ -537,7 +537,7 @@ describe('RateSummary', () => {
                     ],
                 },
                 routerProvider: {
-                    route: '/rates/1337?showUndowWithdrawBanner=true',
+                    route: '/rates/1337?showUndoWithdrawBanner=true',
                 },
             })
 

--- a/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
@@ -507,6 +507,47 @@ describe('RateSummary', () => {
             ).toBeInTheDocument()
         })
 
+        it('displays status banner upon undo rate withdraw', async () => {
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidStateUser(),
+                            statusCode: 200,
+                        }),
+                        fetchContractMockSuccess({ contract }),
+                        fetchRateWithQuestionsMockSuccess({
+                            rate: {
+                                id: '1337',
+                                parentContractID: contract.id,
+                                withdrawInfo: {
+                                    __typename: 'UpdateInformation',
+                                    updatedAt: new Date('2024-01-01'),
+                                    updatedBy: {
+                                        email: 'admin@example.com',
+                                        role: 'ADMIN_USER',
+                                        familyName: 'Hotman',
+                                        givenName: 'Iroh',
+                                    },
+                                    updatedReason:
+                                        'Admin as withdrawn this rate.',
+                                },
+                            },
+                        }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/rates/1337?showUndowWithdrawBanner=true',
+                },
+            })
+
+            await waitFor(() => {
+                expect(
+                    screen.queryByTestId('statusUpdatedBanner')
+                ).toBeInTheDocument()
+            })
+        })
+
         it('redirects to RateEdit component from RateSummary without errors for unlocked rate', async () => {
             renderWithProviders(
                 <Routes>

--- a/services/app-web/src/pages/RateSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.tsx
@@ -1,6 +1,6 @@
 import { GridContainer, Icon } from '@trussworks/react-uswds'
 import React, { useEffect, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import {
     ButtonWithLogging,
     DoubleColumnGrid,
@@ -28,6 +28,7 @@ import { featureFlags } from '@mc-review/common-code'
 import { UnlockRateButton } from '../../components/SubmissionSummarySection/RateDetailsSummarySection/UnlockRateButton'
 import { recordJSException } from '@mc-review/otel'
 import { handleApolloErrorsAndAddUserFacingMessages } from '@mc-review/helpers'
+import { StatusUpdatedBanner } from '../../components/Banner/StatusUpdatedBanner/StatusUpdatedBanner'
 
 export const RateSummary = (): React.ReactElement => {
     // Page level state
@@ -35,7 +36,20 @@ export const RateSummary = (): React.ReactElement => {
     const { updateHeading } = usePage()
     const navigate = useNavigate()
     const [rateName, setRateName] = useState<string | undefined>(undefined)
+    const [searchParams, setSearchParams] = useSearchParams()
+    const [showUndowWithdrawBanner, setUndowWithdrawBanner] =
+        useState<boolean>(false)
     const { id } = useParams() as { id: string }
+
+    useEffect(() => {
+        if (searchParams.get('showUndowWithdrawBanner') === 'true') {
+            setUndowWithdrawBanner(true)
+
+            //This ensures the banner goes away upon refresh or navigation
+            searchParams.delete('showUndowWithdrawBanner')
+            setSearchParams(searchParams, { replace: true })
+        }
+    }, [searchParams, setSearchParams])
 
     useEffect(() => {
         updateHeading({ customHeading: rateName })
@@ -228,6 +242,10 @@ export const RateSummary = (): React.ReactElement => {
                             <span>&nbsp;Back to dashboard</span>
                         </NavLinkWithLogging>
                     </div>
+                )}
+                {showUndowWithdrawBanner && (
+                    //Show status updated banner after undoing rate withdraw
+                    <StatusUpdatedBanner />
                 )}
 
                 {isCMSUser && (

--- a/services/app-web/src/pages/RateSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.tsx
@@ -37,16 +37,16 @@ export const RateSummary = (): React.ReactElement => {
     const navigate = useNavigate()
     const [rateName, setRateName] = useState<string | undefined>(undefined)
     const [searchParams, setSearchParams] = useSearchParams()
-    const [showUndowWithdrawBanner, setUndowWithdrawBanner] =
+    const [showUndoWithdrawBanner, setUndowWithdrawBanner] =
         useState<boolean>(false)
     const { id } = useParams() as { id: string }
 
     useEffect(() => {
-        if (searchParams.get('showUndowWithdrawBanner') === 'true') {
+        if (searchParams.get('showUndoWithdrawBanner') === 'true') {
             setUndowWithdrawBanner(true)
 
             //This ensures the banner goes away upon refresh or navigation
-            searchParams.delete('showUndowWithdrawBanner')
+            searchParams.delete('showUndoWithdrawBanner')
             setSearchParams(searchParams, { replace: true })
         }
     }, [searchParams, setSearchParams])
@@ -243,7 +243,7 @@ export const RateSummary = (): React.ReactElement => {
                         </NavLinkWithLogging>
                     </div>
                 )}
-                {showUndowWithdrawBanner && (
+                {showUndoWithdrawBanner && (
                     //Show status updated banner after undoing rate withdraw
                     <StatusUpdatedBanner />
                 )}

--- a/services/app-web/src/pages/RateSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.tsx
@@ -229,6 +229,10 @@ export const RateSummary = (): React.ReactElement => {
                         reasonForWithdraw={latestRateAction.updatedReason}
                     />
                 )}
+                {showUndoWithdrawBanner && (
+                    //Show status updated banner after undoing rate withdraw
+                    <StatusUpdatedBanner />
+                )}
                 {isStateUser && (
                     // state user does not see the RateSummarySideNav which has its own back button.
                     <div>
@@ -242,10 +246,6 @@ export const RateSummary = (): React.ReactElement => {
                             <span>&nbsp;Back to dashboard</span>
                         </NavLinkWithLogging>
                     </div>
-                )}
-                {showUndoWithdrawBanner && (
-                    //Show status updated banner after undoing rate withdraw
-                    <StatusUpdatedBanner />
                 )}
 
                 {isCMSUser && (

--- a/services/app-web/src/pages/UndoRateWithdraw/UndoRateWithdraw.tsx
+++ b/services/app-web/src/pages/UndoRateWithdraw/UndoRateWithdraw.tsx
@@ -105,7 +105,7 @@ export const UndoRateWithdraw = () => {
                     },
                 },
             })
-            navigate(`/rates/${id}?showUndowWithdrawBanner=true`)
+            navigate(`/rates/${id}?showUndoWithdrawBanner=true`)
         } catch (err) {
             recordJSException(
                 `UndoWithdrawRate: Apollo error reported. Error message: ${err}`

--- a/services/app-web/src/pages/UndoRateWithdraw/UndoRateWithdraw.tsx
+++ b/services/app-web/src/pages/UndoRateWithdraw/UndoRateWithdraw.tsx
@@ -105,7 +105,7 @@ export const UndoRateWithdraw = () => {
                     },
                 },
             })
-            navigate(`/rates/${id}`)
+            navigate(`/rates/${id}?showUndowWithdrawBanner=true`)
         } catch (err) {
             recordJSException(
                 `UndoWithdrawRate: Apollo error reported. Error message: ${err}`


### PR DESCRIPTION
## Summary

#### Related issues
[MCR-4909](https://jiraent.cms.gov/browse/MCR-4909)
#### Screenshots

https://github.com/user-attachments/assets/4da5b33c-a306-4deb-8ebd-c1c503e4716f


#### Test cases covered
Added tests to check for banner rendering
<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

1. Login as a CMS user
2. access the rate summary page and withdraw a rate
3. Should navigate back to the rate summary page and display the expected banner
4. The banner should disappear upon refresh or if you navigate away
5. sign out and sign in as the appropriate state user
6. Access the contract with the the withdrawn rate and the banner should display as expected

<!---These are developer instructions on how to test or validate the work -->
