### PR TITLE
Bump vite-plugin-node-polyfills and serverless-offline

### DIFF
--- a/packages/hpp/package.json
+++ b/packages/hpp/package.json
@@ -20,7 +20,7 @@
         "@types/node": "^20.14.12",
         "buffer": "^6.0.3",
         "protobufjs": "^7.3.0",
-        "vite-plugin-node-polyfills": "^0.22.0"
+        "vite-plugin-node-polyfills": "^0.23.0"
     },
     "browser": {
         "buffer": "buffer/"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,8 +206,8 @@ importers:
         specifier: ^7.3.0
         version: 7.3.2
       vite-plugin-node-polyfills:
-        specifier: ^0.22.0
-        version: 0.22.0(rollup@4.31.0)(vite@6.2.0(@types/node@20.17.6)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))
+        specifier: ^0.23.0
+        version: 0.23.0(rollup@4.31.0)(vite@6.2.0(@types/node@20.17.6)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))
 
   packages/mocks:
     dependencies:
@@ -879,8 +879,8 @@ importers:
         specifier: ^4.0.4
         version: 4.0.4
       vite-plugin-node-polyfills:
-        specifier: ^0.22.0
-        version: 0.22.0(rollup@4.31.0)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))
+        specifier: ^0.23.0
+        version: 0.23.0(rollup@4.31.0)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))
       vite-plugin-svgr:
         specifier: ^4.3.0
         version: 4.3.0(rollup@4.31.0)(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))
@@ -13851,10 +13851,10 @@ packages:
   vite-plugin-graphql-loader@4.0.4:
     resolution: {integrity: sha512-lYnpQ2luV2fcuXmOJADljuktfMbDW00Y+6QS+Ek8Jz1Vdzlj/51LSGJwZqyjJ24a5YQ+o29Hr6el/5+nlZetvg==}
 
-  vite-plugin-node-polyfills@0.22.0:
-    resolution: {integrity: sha512-F+G3LjiGbG8QpbH9bZ//GSBr9i1InSTkaulfUHFa9jkLqVGORFBoqc2A/Yu5Mmh1kNAbiAeKeK+6aaQUf3x0JA==}
+  vite-plugin-node-polyfills@0.23.0:
+    resolution: {integrity: sha512-4n+Ys+2bKHQohPBKigFlndwWQ5fFKwaGY6muNDMTb0fSQLyBzS+jjUNRZG9sKF0S/Go4ApG6LFnUGopjkILg3w==}
     peerDependencies:
-      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
 
   vite-plugin-svgr@4.3.0:
     resolution: {integrity: sha512-Jy9qLB2/PyWklpYy0xk0UU3TlU0t2UMpJXZvf+hWII1lAmRHrOUKi11Uw8N3rxoNk7atZNYO3pR3vI1f7oi+6w==}
@@ -22015,9 +22015,9 @@ snapshots:
 
   '@rollup/plugin-inject@5.0.5(rollup@4.31.0)':
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.31.0)
+      '@rollup/pluginutils': 5.1.3(rollup@4.31.0)
       estree-walker: 2.0.2
-      magic-string: 0.30.10
+      magic-string: 0.30.17
     optionalDependencies:
       rollup: 4.31.0
 
@@ -32903,7 +32903,7 @@ snapshots:
       graphql-tag: 2.12.6(graphql@16.9.0)
       magic-string: 0.30.10
 
-  vite-plugin-node-polyfills@0.22.0(rollup@4.31.0)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)):
+  vite-plugin-node-polyfills@0.23.0(rollup@4.31.0)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)):
     dependencies:
       '@rollup/plugin-inject': 5.0.5(rollup@4.31.0)
       node-stdlib-browser: 1.2.0
@@ -32911,7 +32911,7 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  vite-plugin-node-polyfills@0.22.0(rollup@4.31.0)(vite@6.2.0(@types/node@20.17.6)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)):
+  vite-plugin-node-polyfills@0.23.0(rollup@4.31.0)(vite@6.2.0(@types/node@20.17.6)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)):
     dependencies:
       '@rollup/plugin-inject': 5.0.5(rollup@4.31.0)
       node-stdlib-browser: 1.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,7 +207,7 @@ importers:
         version: 7.3.2
       vite-plugin-node-polyfills:
         specifier: ^0.23.0
-        version: 0.23.0(rollup@4.31.0)(vite@6.2.0(@types/node@20.17.6)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))
+        version: 0.23.0(rollup@4.31.0)(vite@6.2.0(@types/node@20.17.6)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
 
   packages/mocks:
     dependencies:
@@ -466,7 +466,7 @@ importers:
         version: 6.21.0(eslint@8.57.0)(typescript@4.9.5)
       '@vitest/coverage-v8':
         specifier: ^3.0.7
-        version: 3.0.7(vitest@3.0.7(@types/node@20.17.16)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))
+        version: 3.0.7(vitest@3.0.7(@types/node@20.17.16)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       eslint:
         specifier: ^8.3.0
         version: 8.57.0
@@ -504,8 +504,8 @@ importers:
         specifier: https://github.com/CMSgov/serverless-iam-helper
         version: git+https://git@github.com:CMSgov/serverless-iam-helper.git#ffcca526d127cf0e791f0d931d442f4131953483(serverless@3.39.0(encoding@0.1.13))
       serverless-offline:
-        specifier: ^13.9.0
-        version: 13.9.0(serverless@3.39.0(encoding@0.1.13))
+        specifier: ^14.4.0
+        version: 14.4.0(serverless@3.39.0(encoding@0.1.13))
       serverless-s3-bucket-helper:
         specifier: https://github.com/CMSgov/serverless-s3-bucket-helper
         version: git+https://git@github.com:CMSgov/serverless-s3-bucket-helper.git#3e519d15676de237ec8ede3ff9ae26abf3f3ef0a(serverless@3.39.0(encoding@0.1.13))
@@ -517,7 +517,7 @@ importers:
         version: 4.9.5
       vitest:
         specifier: ^3.0.7
-        version: 3.0.7(@types/node@20.17.16)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+        version: 3.0.7(@types/node@20.17.16)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
 
   services/app-graphql:
     dependencies:
@@ -639,7 +639,7 @@ importers:
         version: 4.2.1(@uswds/uswds@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@vitejs/plugin-react':
         specifier: ^4.3.0
-        version: 4.3.0(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))
+        version: 4.3.0(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       amazon-cognito-identity-js:
         specifier: ^6.3.12
         version: 6.3.12(encoding@0.1.13)
@@ -717,10 +717,10 @@ importers:
         version: 9.0.1
       vite:
         specifier: ^6.0.0
-        version: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+        version: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
       vite-tsconfig-paths:
         specifier: ^5.0.1
-        version: 5.0.1(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))
+        version: 5.0.1(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       web-vitals:
         specifier: ^3.0.1
         version: 3.5.1
@@ -760,7 +760,7 @@ importers:
         version: 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.24.8(@babel/core@7.24.7)))(typescript@4.9.5)
       '@storybook/react-vite':
         specifier: ^8.2.9
-        version: 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.31.0)(storybook@8.2.9(@babel/preset-env@7.24.8(@babel/core@7.24.7)))(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))
+        version: 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.31.0)(storybook@8.2.9(@babel/preset-env@7.24.8(@babel/core@7.24.7)))(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       '@testing-library/cypress':
         specifier: ^10.0.1
         version: 10.0.1(cypress@13.13.2)
@@ -880,13 +880,13 @@ importers:
         version: 4.0.4
       vite-plugin-node-polyfills:
         specifier: ^0.23.0
-        version: 0.23.0(rollup@4.31.0)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))
+        version: 0.23.0(rollup@4.31.0)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       vite-plugin-svgr:
         specifier: ^4.3.0
-        version: 4.3.0(rollup@4.31.0)(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))
+        version: 4.3.0(rollup@4.31.0)(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       vitest:
         specifier: ^3.0.7
-        version: 3.0.7(@types/node@20.14.12)(@vitest/ui@2.1.9)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+        version: 3.0.7(@types/node@20.14.12)(@vitest/ui@2.1.9)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
 
   services/cypress:
     dependencies:
@@ -1140,8 +1140,8 @@ importers:
         specifier: https://github.com/CMSgov/serverless-iam-helper.git
         version: git+https://git@github.com:CMSgov/serverless-iam-helper.git#ffcca526d127cf0e791f0d931d442f4131953483(serverless@4.2.3)
       serverless-offline:
-        specifier: ^13.9.0
-        version: 13.9.0(serverless@4.2.3)
+        specifier: ^14.4.0
+        version: 14.4.0(serverless@4.2.3)
       serverless-s3-bucket-helper:
         specifier: https://github.com/CMSgov/serverless-s3-bucket-helper
         version: git+https://git@github.com:CMSgov/serverless-s3-bucket-helper.git#3e519d15676de237ec8ede3ff9ae26abf3f3ef0a(serverless@4.2.3)
@@ -1159,7 +1159,7 @@ importers:
         version: 9.5.2(typescript@5.5.4)(webpack@5.93.0(esbuild@0.25.0))
       vitest:
         specifier: ^3.0.7
-        version: 3.0.7(@types/node@20.16.5)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+        version: 3.0.7(@types/node@20.16.5)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
 
 packages:
 
@@ -8142,6 +8142,10 @@ packages:
     resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
     engines: {node: '>=0.10'}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
@@ -9016,6 +9020,10 @@ packages:
   fecha@4.2.3:
     resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   fflate@0.7.3:
     resolution: {integrity: sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw==}
 
@@ -9188,6 +9196,10 @@ packages:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
     engines: {node: '>= 6'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   formidable@2.0.1:
     resolution: {integrity: sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==}
 
@@ -9322,6 +9334,9 @@ packages:
   get-symbol-description@1.0.2:
     resolution: {integrity: sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==}
     engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.10.0:
+    resolution: {integrity: sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==}
 
   get-uri@6.0.3:
     resolution: {integrity: sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==}
@@ -11216,6 +11231,10 @@ packages:
     resolution: {integrity: sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw==}
     engines: {node: '>=12.0.0'}
 
+  nock@13.5.6:
+    resolution: {integrity: sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==}
+    engines: {node: '>= 10.13'}
+
   node-abort-controller@3.0.1:
     resolution: {integrity: sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw==}
 
@@ -11231,6 +11250,10 @@ packages:
   node-dir@0.1.17:
     resolution: {integrity: sha512-tmPX422rYgofd4epzrNoOXiE8XFZYOcCq1vD7MAXCDO+O+zndlA2ztdKKMa+EeuBG5tHETpr4ml4RGgpqDCCAg==}
     engines: {node: '>= 0.10.5'}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
 
   node-fetch-native@1.6.4:
     resolution: {integrity: sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==}
@@ -11252,6 +11275,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
@@ -11958,6 +11985,10 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  propagate@2.0.1:
+    resolution: {integrity: sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==}
+    engines: {node: '>= 8'}
+
   property-expr@2.0.5:
     resolution: {integrity: sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==}
 
@@ -12399,6 +12430,9 @@ packages:
   resolve-id-refs@0.1.0:
     resolution: {integrity: sha512-hNS03NEmVpJheF7yfyagNh57XuKc0z+NkSO0oBbeO67o6IJKoqlDfnNIxhjp7aTWwjmSWZQhtiGrOgZXVyM90w==}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve.exports@2.0.2:
     resolution: {integrity: sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==}
     engines: {node: '>=10'}
@@ -12669,6 +12703,12 @@ packages:
     engines: {node: '>=18.12.0'}
     peerDependencies:
       serverless: ^3.2.0
+
+  serverless-offline@14.4.0:
+    resolution: {integrity: sha512-PKNDc33HwFH6qD/VIOjhhiu6bKffIIMTG4DjOR1Kh2lv3zriIuW5bCzPUzGS7aP/x7rQbz/LDNWxftzsp6uizQ==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      serverless: ^4.0.0
 
   serverless-plugin-scripts@1.0.2:
     resolution: {integrity: sha512-+OL9fFz5r6BXNHfpu9MDLehS/haC0fy/T3V5uJsTfLAnNsn+PzM6BmvefUfWG372hBT7piTbywB1Vl1+4LmI5Q==}
@@ -13394,6 +13434,10 @@ packages:
   traverse@0.6.6:
     resolution: {integrity: sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw==}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   trim-repeated@1.0.0:
     resolution: {integrity: sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==}
     engines: {node: '>=0.10.0'}
@@ -13510,6 +13554,11 @@ packages:
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+
+  tsx@4.19.3:
+    resolution: {integrity: sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tty-browserify@0.0.1:
     resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
@@ -15885,13 +15934,13 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.609.0)':
+  '@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.1)':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sts': 3.609.0
+      '@aws-sdk/client-sts': 3.726.1
       '@aws-sdk/core': 3.723.0
-      '@aws-sdk/credential-provider-node': 3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.1))(@aws-sdk/client-sts@3.609.0)
+      '@aws-sdk/credential-provider-node': 3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.1))(@aws-sdk/client-sts@3.726.1)
       '@aws-sdk/middleware-host-header': 3.723.0
       '@aws-sdk/middleware-logger': 3.723.0
       '@aws-sdk/middleware-recursion-detection': 3.723.0
@@ -16185,9 +16234,9 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.726.0(@aws-sdk/client-sts@3.609.0)
+      '@aws-sdk/client-sso-oidc': 3.726.0(@aws-sdk/client-sts@3.726.1)
       '@aws-sdk/core': 3.723.0
-      '@aws-sdk/credential-provider-node': 3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.1))(@aws-sdk/client-sts@3.609.0)
+      '@aws-sdk/credential-provider-node': 3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.1))(@aws-sdk/client-sts@3.726.1)
       '@aws-sdk/middleware-host-header': 3.723.0
       '@aws-sdk/middleware-logger': 3.723.0
       '@aws-sdk/middleware-recursion-detection': 3.723.0
@@ -16476,15 +16525,15 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@aws-sdk/credential-provider-ini@3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.1))(@aws-sdk/client-sts@3.609.0)':
+  '@aws-sdk/credential-provider-ini@3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.1))(@aws-sdk/client-sts@3.726.1)':
     dependencies:
-      '@aws-sdk/client-sts': 3.609.0
+      '@aws-sdk/client-sts': 3.726.1
       '@aws-sdk/core': 3.723.0
       '@aws-sdk/credential-provider-env': 3.723.0
       '@aws-sdk/credential-provider-http': 3.723.0
       '@aws-sdk/credential-provider-process': 3.723.0
       '@aws-sdk/credential-provider-sso': 3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.1))
-      '@aws-sdk/credential-provider-web-identity': 3.723.0(@aws-sdk/client-sts@3.609.0)
+      '@aws-sdk/credential-provider-web-identity': 3.723.0(@aws-sdk/client-sts@3.726.1)
       '@aws-sdk/types': 3.723.0
       '@smithy/credential-provider-imds': 4.0.1
       '@smithy/property-provider': 4.0.1
@@ -16558,14 +16607,14 @@ snapshots:
       - '@aws-sdk/client-sts'
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.1))(@aws-sdk/client-sts@3.609.0)':
+  '@aws-sdk/credential-provider-node@3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.1))(@aws-sdk/client-sts@3.726.1)':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.723.0
       '@aws-sdk/credential-provider-http': 3.723.0
-      '@aws-sdk/credential-provider-ini': 3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.1))(@aws-sdk/client-sts@3.609.0)
+      '@aws-sdk/credential-provider-ini': 3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.1))(@aws-sdk/client-sts@3.726.1)
       '@aws-sdk/credential-provider-process': 3.723.0
       '@aws-sdk/credential-provider-sso': 3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.1))
-      '@aws-sdk/credential-provider-web-identity': 3.723.0(@aws-sdk/client-sts@3.609.0)
+      '@aws-sdk/credential-provider-web-identity': 3.723.0(@aws-sdk/client-sts@3.726.1)
       '@aws-sdk/types': 3.723.0
       '@smithy/credential-provider-imds': 4.0.1
       '@smithy/property-provider': 4.0.1
@@ -16699,9 +16748,9 @@ snapshots:
       '@smithy/types': 3.7.2
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.609.0)':
+  '@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.726.1)':
     dependencies:
-      '@aws-sdk/client-sts': 3.609.0
+      '@aws-sdk/client-sts': 3.726.1
       '@aws-sdk/core': 3.723.0
       '@aws-sdk/types': 3.723.0
       '@smithy/property-provider': 4.0.1
@@ -17399,7 +17448,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.723.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.1))':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.726.0(@aws-sdk/client-sts@3.609.0)
+      '@aws-sdk/client-sso-oidc': 3.726.0(@aws-sdk/client-sts@3.726.1)
       '@aws-sdk/types': 3.723.0
       '@smithy/property-provider': 4.0.1
       '@smithy/shared-ini-file-loader': 4.0.1
@@ -20620,13 +20669,13 @@ snapshots:
 
   '@josephg/resolvable@1.0.1': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.3.1(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.3.1(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       glob: 7.2.3
       glob-promise: 4.2.2(glob@7.2.3)
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@4.9.5)
-      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     optionalDependencies:
       typescript: 4.9.5
 
@@ -22942,7 +22991,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-vite@8.2.9(storybook@8.2.9(@babel/preset-env@7.24.8(@babel/core@7.24.7)))(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))':
+  '@storybook/builder-vite@8.2.9(storybook@8.2.9(@babel/preset-env@7.24.8(@babel/core@7.24.7)))(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@storybook/csf-plugin': 8.2.9(storybook@8.2.9(@babel/preset-env@7.24.8(@babel/core@7.24.7)))
       '@types/find-cache-dir': 3.2.1
@@ -22954,7 +23003,7 @@ snapshots:
       magic-string: 0.30.17
       storybook: 8.2.9(@babel/preset-env@7.24.8(@babel/core@7.24.7))
       ts-dedent: 2.2.0
-      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     optionalDependencies:
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -23041,11 +23090,11 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.2.9(@babel/preset-env@7.24.8(@babel/core@7.24.7))
 
-  '@storybook/react-vite@8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.31.0)(storybook@8.2.9(@babel/preset-env@7.24.8(@babel/core@7.24.7)))(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))':
+  '@storybook/react-vite@8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.31.0)(storybook@8.2.9(@babel/preset-env@7.24.8(@babel/core@7.24.7)))(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.3.1(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.3.1(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       '@rollup/pluginutils': 5.1.0(rollup@4.31.0)
-      '@storybook/builder-vite': 8.2.9(storybook@8.2.9(@babel/preset-env@7.24.8(@babel/core@7.24.7)))(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))
+      '@storybook/builder-vite': 8.2.9(storybook@8.2.9(@babel/preset-env@7.24.8(@babel/core@7.24.7)))(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       '@storybook/react': 8.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.24.8(@babel/core@7.24.7)))(typescript@4.9.5)
       find-up: 5.0.0
       magic-string: 0.30.10
@@ -23055,7 +23104,7 @@ snapshots:
       resolve: 1.22.8
       storybook: 8.2.9(@babel/preset-env@7.24.8(@babel/core@7.24.7))
       tsconfig-paths: 4.2.0
-      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - rollup
@@ -23773,18 +23822,18 @@ snapshots:
 
   '@vendia/serverless-express@4.10.1': {}
 
-  '@vitejs/plugin-react@4.3.0(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))':
+  '@vitejs/plugin-react@4.3.0(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/plugin-transform-react-jsx-self': 7.24.5(@babel/core@7.24.7)
       '@babel/plugin-transform-react-jsx-source': 7.24.1(@babel/core@7.24.7)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.0.7(vitest@3.0.7(@types/node@20.17.16)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))':
+  '@vitest/coverage-v8@3.0.7(vitest@3.0.7(@types/node@20.17.16)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -23798,7 +23847,7 @@ snapshots:
       std-env: 3.8.1
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.7(@types/node@20.17.16)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vitest: 3.0.7(@types/node@20.17.16)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -23816,7 +23865,7 @@ snapshots:
       std-env: 3.8.1
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.7(@types/node@20.14.12)(@vitest/ui@2.1.9)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vitest: 3.0.7(@types/node@20.14.12)(@vitest/ui@2.1.9)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -23827,29 +23876,29 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.7(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))':
+  '@vitest/mocker@3.0.7(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.0.7
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
 
-  '@vitest/mocker@3.0.7(vite@6.2.0(@types/node@20.16.5)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))':
+  '@vitest/mocker@3.0.7(vite@6.2.0(@types/node@20.16.5)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.0.7
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.0(@types/node@20.16.5)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.16.5)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
 
-  '@vitest/mocker@3.0.7(vite@6.2.0(@types/node@20.17.16)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))':
+  '@vitest/mocker@3.0.7(vite@6.2.0(@types/node@20.17.16)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.0.7
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.0(@types/node@20.17.16)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.17.16)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -23883,7 +23932,7 @@ snapshots:
       sirv: 3.0.0
       tinyglobby: 0.2.10
       tinyrainbow: 1.2.0
-      vitest: 3.0.7(@types/node@20.14.12)(@vitest/ui@2.1.9)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vitest: 3.0.7(@types/node@20.14.12)(@vitest/ui@2.1.9)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
 
   '@vitest/utils@2.1.9':
     dependencies:
@@ -25819,6 +25868,8 @@ snapshots:
     dependencies:
       assert-plus: 1.0.0
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-uri-to-buffer@6.0.2: {}
 
   data-urls@5.0.0:
@@ -26862,6 +26913,11 @@ snapshots:
 
   fecha@4.2.3: {}
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.2
+
   fflate@0.7.3: {}
 
   fflate@0.8.2: {}
@@ -27038,6 +27094,10 @@ snapshots:
       combined-stream: 1.0.8
       mime-types: 2.1.35
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   formidable@2.0.1:
     dependencies:
       dezalgo: 1.0.3
@@ -27191,6 +27251,10 @@ snapshots:
       call-bind: 1.0.7
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
+
+  get-tsconfig@4.10.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   get-uri@6.0.3:
     dependencies:
@@ -29665,6 +29729,14 @@ snapshots:
 
   nocache@3.0.4: {}
 
+  nock@13.5.6:
+    dependencies:
+      debug: 4.4.0(supports-color@8.1.1)
+      json-stringify-safe: 5.0.1
+      propagate: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   node-abort-controller@3.0.1: {}
 
   node-abort-controller@3.1.1: {}
@@ -29676,6 +29748,8 @@ snapshots:
   node-dir@0.1.17:
     dependencies:
       minimatch: 3.1.2
+
+  node-domexception@1.0.0: {}
 
   node-fetch-native@1.6.4: {}
 
@@ -29690,6 +29764,12 @@ snapshots:
       whatwg-url: 5.0.0
     optionalDependencies:
       encoding: 0.1.13
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-forge@1.3.1: {}
 
@@ -30459,6 +30539,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  propagate@2.0.1: {}
+
   property-expr@2.0.5: {}
 
   protobufjs-cli@1.1.3(protobufjs@7.3.2):
@@ -31038,6 +31120,8 @@ snapshots:
 
   resolve-id-refs@0.1.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   resolve.exports@2.0.2: {}
 
   resolve@1.22.10:
@@ -31371,37 +31455,6 @@ snapshots:
       lodash: 4.17.21
       serverless: 4.2.3
 
-  serverless-offline@13.9.0(serverless@3.39.0(encoding@0.1.13)):
-    dependencies:
-      '@aws-sdk/client-lambda': 3.750.0
-      '@hapi/boom': 10.0.1
-      '@hapi/h2o2': 10.0.4
-      '@hapi/hapi': 21.3.12
-      array-unflat-js: 0.1.3
-      boxen: 7.1.1
-      chalk: 5.4.1
-      desm: 1.3.1
-      execa: 8.0.1
-      fs-extra: 11.3.0
-      is-wsl: 3.1.0
-      java-invoke-local: 0.0.6
-      jose: 5.9.6
-      js-string-escape: 1.0.1
-      jsonpath-plus: 10.2.0
-      jsonschema: 1.5.0
-      jszip: 3.10.1
-      luxon: 3.5.0
-      node-schedule: 2.1.1
-      p-memoize: 7.1.1
-      serverless: 3.39.0(encoding@0.1.13)
-      velocityjs: 2.0.6
-      ws: 8.18.0
-    transitivePeerDependencies:
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   serverless-offline@13.9.0(serverless@4.2.3):
     dependencies:
       '@aws-sdk/client-lambda': 3.750.0
@@ -31425,6 +31478,76 @@ snapshots:
       node-schedule: 2.1.1
       p-memoize: 7.1.1
       serverless: 4.2.3
+      velocityjs: 2.0.6
+      ws: 8.18.0
+    transitivePeerDependencies:
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  serverless-offline@14.4.0(serverless@3.39.0(encoding@0.1.13)):
+    dependencies:
+      '@aws-sdk/client-lambda': 3.750.0
+      '@hapi/boom': 10.0.1
+      '@hapi/h2o2': 10.0.4
+      '@hapi/hapi': 21.3.12
+      array-unflat-js: 0.1.3
+      boxen: 7.1.1
+      chalk: 5.4.1
+      desm: 1.3.1
+      execa: 8.0.1
+      fs-extra: 11.3.0
+      is-wsl: 3.1.0
+      java-invoke-local: 0.0.6
+      jose: 5.9.6
+      js-string-escape: 1.0.1
+      jsonpath-plus: 10.2.0
+      jsonschema: 1.5.0
+      jszip: 3.10.1
+      luxon: 3.5.0
+      nock: 13.5.6
+      node-fetch: 3.3.2
+      node-schedule: 2.1.1
+      p-memoize: 7.1.1
+      serverless: 3.39.0(encoding@0.1.13)
+      tree-kill: 1.2.2
+      tsx: 4.19.3
+      velocityjs: 2.0.6
+      ws: 8.18.0
+    transitivePeerDependencies:
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  serverless-offline@14.4.0(serverless@4.2.3):
+    dependencies:
+      '@aws-sdk/client-lambda': 3.750.0
+      '@hapi/boom': 10.0.1
+      '@hapi/h2o2': 10.0.4
+      '@hapi/hapi': 21.3.12
+      array-unflat-js: 0.1.3
+      boxen: 7.1.1
+      chalk: 5.4.1
+      desm: 1.3.1
+      execa: 8.0.1
+      fs-extra: 11.3.0
+      is-wsl: 3.1.0
+      java-invoke-local: 0.0.6
+      jose: 5.9.6
+      js-string-escape: 1.0.1
+      jsonpath-plus: 10.2.0
+      jsonschema: 1.5.0
+      jszip: 3.10.1
+      luxon: 3.5.0
+      nock: 13.5.6
+      node-fetch: 3.3.2
+      node-schedule: 2.1.1
+      p-memoize: 7.1.1
+      serverless: 4.2.3
+      tree-kill: 1.2.2
+      tsx: 4.19.3
       velocityjs: 2.0.6
       ws: 8.18.0
     transitivePeerDependencies:
@@ -32384,6 +32507,8 @@ snapshots:
 
   traverse@0.6.6: {}
 
+  tree-kill@1.2.2: {}
+
   trim-repeated@1.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -32520,6 +32645,13 @@ snapshots:
     dependencies:
       tslib: 1.14.1
       typescript: 4.9.5
+
+  tsx@4.19.3:
+    dependencies:
+      esbuild: 0.25.0
+      get-tsconfig: 4.10.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tty-browserify@0.0.1: {}
 
@@ -32834,13 +32966,13 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.4.1
 
-  vite-node@3.0.7(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0):
+  vite-node@3.0.7(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@8.1.1)
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -32855,13 +32987,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.0.7(@types/node@20.16.5)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0):
+  vite-node@3.0.7(@types/node@20.16.5)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@8.1.1)
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.0(@types/node@20.16.5)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.16.5)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -32876,13 +33008,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.0.7(@types/node@20.17.16)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0):
+  vite-node@3.0.7(@types/node@20.17.16)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@8.1.1)
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.0(@types/node@20.17.16)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.17.16)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -32903,45 +33035,45 @@ snapshots:
       graphql-tag: 2.12.6(graphql@16.9.0)
       magic-string: 0.30.10
 
-  vite-plugin-node-polyfills@0.23.0(rollup@4.31.0)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)):
+  vite-plugin-node-polyfills@0.23.0(rollup@4.31.0)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)):
     dependencies:
       '@rollup/plugin-inject': 5.0.5(rollup@4.31.0)
       node-stdlib-browser: 1.2.0
-      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - rollup
 
-  vite-plugin-node-polyfills@0.23.0(rollup@4.31.0)(vite@6.2.0(@types/node@20.17.6)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)):
+  vite-plugin-node-polyfills@0.23.0(rollup@4.31.0)(vite@6.2.0(@types/node@20.17.6)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)):
     dependencies:
       '@rollup/plugin-inject': 5.0.5(rollup@4.31.0)
       node-stdlib-browser: 1.2.0
-      vite: 6.2.0(@types/node@20.17.6)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.17.6)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - rollup
 
-  vite-plugin-svgr@4.3.0(rollup@4.31.0)(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)):
+  vite-plugin-svgr@4.3.0(rollup@4.31.0)(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)):
     dependencies:
       '@rollup/pluginutils': 5.1.3(rollup@4.31.0)
       '@svgr/core': 8.1.0(typescript@4.9.5)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@4.9.5))
-      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@5.0.1(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)):
+  vite-tsconfig-paths@5.0.1(typescript@4.9.5)(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)):
     dependencies:
       debug: 4.3.6
       globrex: 0.1.2
       tsconfck: 3.0.3(typescript@4.9.5)
     optionalDependencies:
-      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0):
+  vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.0
       postcss: 8.5.3
@@ -32952,9 +33084,10 @@ snapshots:
       jiti: 1.21.0
       sass: 1.77.2
       terser: 5.39.0
+      tsx: 4.19.3
       yaml: 2.7.0
 
-  vite@6.2.0(@types/node@20.16.5)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0):
+  vite@6.2.0(@types/node@20.16.5)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.0
       postcss: 8.5.3
@@ -32965,9 +33098,10 @@ snapshots:
       jiti: 1.21.0
       sass: 1.77.2
       terser: 5.39.0
+      tsx: 4.19.3
       yaml: 2.7.0
 
-  vite@6.2.0(@types/node@20.17.16)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0):
+  vite@6.2.0(@types/node@20.17.16)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.0
       postcss: 8.5.3
@@ -32978,9 +33112,10 @@ snapshots:
       jiti: 1.21.0
       sass: 1.77.2
       terser: 5.39.0
+      tsx: 4.19.3
       yaml: 2.7.0
 
-  vite@6.2.0(@types/node@20.17.6)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0):
+  vite@6.2.0(@types/node@20.17.6)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.0
       postcss: 8.5.3
@@ -32991,12 +33126,13 @@ snapshots:
       jiti: 1.21.0
       sass: 1.77.2
       terser: 5.39.0
+      tsx: 4.19.3
       yaml: 2.7.0
 
-  vitest@3.0.7(@types/node@20.14.12)(@vitest/ui@2.1.9)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0):
+  vitest@3.0.7(@types/node@20.14.12)(@vitest/ui@2.1.9)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.0.7
-      '@vitest/mocker': 3.0.7(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))
+      '@vitest/mocker': 3.0.7(vite@6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       '@vitest/pretty-format': 3.0.7
       '@vitest/runner': 3.0.7
       '@vitest/snapshot': 3.0.7
@@ -33012,8 +33148,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
-      vite-node: 3.0.7(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite-node: 3.0.7(@types/node@20.14.12)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.14.12
@@ -33033,10 +33169,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.0.7(@types/node@20.16.5)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0):
+  vitest@3.0.7(@types/node@20.16.5)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.0.7
-      '@vitest/mocker': 3.0.7(vite@6.2.0(@types/node@20.16.5)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))
+      '@vitest/mocker': 3.0.7(vite@6.2.0(@types/node@20.16.5)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       '@vitest/pretty-format': 3.0.7
       '@vitest/runner': 3.0.7
       '@vitest/snapshot': 3.0.7
@@ -33052,8 +33188,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.0(@types/node@20.16.5)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
-      vite-node: 3.0.7(@types/node@20.16.5)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.16.5)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite-node: 3.0.7(@types/node@20.16.5)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.16.5
@@ -33072,10 +33208,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.0.7(@types/node@20.17.16)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0):
+  vitest@3.0.7(@types/node@20.17.16)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.0.7
-      '@vitest/mocker': 3.0.7(vite@6.2.0(@types/node@20.17.16)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0))
+      '@vitest/mocker': 3.0.7(vite@6.2.0(@types/node@20.17.16)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       '@vitest/pretty-format': 3.0.7
       '@vitest/runner': 3.0.7
       '@vitest/snapshot': 3.0.7
@@ -33091,8 +33227,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.0(@types/node@20.17.16)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
-      vite-node: 3.0.7(@types/node@20.17.16)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.17.16)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite-node: 3.0.7(@types/node@20.17.16)(jiti@1.21.0)(sass@1.77.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.17.16

--- a/services/app-api/package.json
+++ b/services/app-api/package.json
@@ -91,7 +91,7 @@
         "serverless-associate-waf": "^1.2.1",
         "serverless-esbuild": "^1.52.1",
         "serverless-iam-helper": "https://github.com/CMSgov/serverless-iam-helper",
-        "serverless-offline": "^13.9.0",
+        "serverless-offline": "^14.4.0",
         "serverless-s3-bucket-helper": "https://github.com/CMSgov/serverless-s3-bucket-helper",
         "serverless-stack-termination-protection": "^2.0.2",
         "typescript": "4.9.5",

--- a/services/app-web/package.json
+++ b/services/app-web/package.json
@@ -181,7 +181,7 @@
         "stylelint": "^16.12.0",
         "stylelint-config-recommended-scss": "^14.1.0",
         "vite-plugin-graphql-loader": "^4.0.4",
-        "vite-plugin-node-polyfills": "^0.22.0",
+        "vite-plugin-node-polyfills": "^0.23.0",
         "vite-plugin-svgr": "^4.3.0",
         "vitest": "^3.0.7"
     }

--- a/services/uploads/package.json
+++ b/services/uploads/package.json
@@ -43,7 +43,7 @@
         "serverless": "4.2.3",
         "serverless-esbuild": "^1.52.1",
         "serverless-iam-helper": "https://github.com/CMSgov/serverless-iam-helper.git",
-        "serverless-offline": "^13.9.0",
+        "serverless-offline": "^14.4.0",
         "serverless-s3-bucket-helper": "https://github.com/CMSgov/serverless-s3-bucket-helper",
         "serverless-s3-local": "^0.8.4",
         "serverless-stack-termination-protection": "^2.0.2",


### PR DESCRIPTION
## Summary

As I've been going through the security vulnerability alerts I've just been pushing up easy changes for some intermediary dependencies. This bumps `vite-plugin-node-polyfills` and `serverless-offline`.

#### Related issues
https://jiraent.cms.gov/browse/MCR-5132
https://jiraent.cms.gov/browse/MCR-1795


