### PR TITLE
Move git ref back to 'main'

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -308,7 +308,7 @@ jobs:
       needs.api-unit-tests.result == 'success' &&
       needs.build-prisma-client-lambda-layer.result == 'success' &&
       needs.begin-deployment.result == 'success'
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@mt-cleanup-v4
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name }}


### PR DESCRIPTION
## Summary

This just puts the workflow ref back to `main` after the last PR #3172 merged.
