### PR TITLE
Add more services to dependsOn in api gateway

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -247,11 +247,7 @@ resources:
     ApiGwWebAclAssociation:
       Type: AWS::WAFv2::WebACLAssociation
       DependsOn:
-        - ApiGatewayMethodHealthcheckOptions
-        - ApiGatewayMethodOtelOptions
-        - ApiGatewayMethodGraphqlOptions
-        - ApiGatewayMethodV1GraphqlExternalOptions
-        - ApiGatewayMethodZipOptions
+        # API Gateway methods
         - ApiGatewayMethodHealthcheckGet
         - ApiGatewayMethodOtelPost
         - ApiGatewayMethodGraphqlPost
@@ -259,6 +255,23 @@ resources:
         - ApiGatewayMethodV1GraphqlExternalPost
         - ApiGatewayMethodV1GraphqlExternalGet
         - ApiGatewayMethodZipPost
+        # API Gateway resources (paths and endpoints)
+        - ApiGatewayResourceHealthcheck
+        - ApiGatewayResourceOtel
+        - ApiGatewayResourceGraphql
+        - ApiGatewayResourceV1
+        - ApiGatewayResourceV1Graphql
+        - ApiGatewayResourceV1GraphqlExternal
+        - ApiGatewayResourceZip
+        # API Gateway authorizer
+        - ThirdUnderscorepartyUnderscoreapiUnderscoreauthorizerApiGatewayAuthorizer
+        # CORS OPTIONS methods
+        - ApiGatewayMethodHealthcheckOptions
+        - ApiGatewayMethodOtelOptions
+        - ApiGatewayMethodGraphqlOptions
+        - ApiGatewayMethodV1GraphqlExternalOptions
+        - ApiGatewayMethodZipOptions
+
       Properties:
         ResourceArn: arn:aws:apigateway:${self:provider.region}::/restapis/${self:custom.appApiGatewayId}/stages/${sls:stage}
         WebACLArn: ${self:custom.appApiWafAclArn}


### PR DESCRIPTION
## Summary

This adds additional services to the `dependsOn` clause in the `AWS::WAFv2::WebACLAssociation`. We were hitting issues in review branches that caused the WAF to fail it's attachment because the API Gateway wasn't fully deployed before the attachment was attempted. Previously we were able to just depend on the value in `ApiGatewayDeployment${sls:instanceId} `, which would mean we were waiting on the entire API Gateway deployment first. However, there is [a bug](https://github.com/serverless/serverless/issues/12894) in Serverless 4.2.3 that makes the `${sls:instanceId}` unpredictable within the same serverless deploy instantiation. Since versions `> 4.2.3` [break local development](https://github.com/serverless/serverless/discussions/12618) we are kinda stuck until we can finally ditch this tool altogether. 

This adds all the other resources associated with API Gateways in our config to the `dependsOn` clause.

#### Related Issues
https://jiraent.cms.gov/browse/MCR-5148
