### PR TITLE
Fix undoWithdraw API

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/undoWithdrawRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/undoWithdrawRate.ts
@@ -35,22 +35,6 @@ const undoWithdrawRateInsideTransaction = async (
 ): Promise<RateType | Error> => {
     const { rateID, updatedByID, updatedReason } = args
 
-    // Update the review status first
-    await tx.rateTable.update({
-        where: {
-            id: rateID,
-        },
-        data: {
-            reviewStatusActions: {
-                create: {
-                    updatedByID,
-                    updatedReason,
-                    actionType: 'UNDER_REVIEW',
-                },
-            },
-        },
-    })
-
     // Unlock rate
     const rateUnlockInfo = await tx.updateInfoTable.create({
         data: {
@@ -210,6 +194,22 @@ const undoWithdrawRateInsideTransaction = async (
             throw resubmitResult
         }
     }
+
+    // Update the review status first
+    await tx.rateTable.update({
+        where: {
+            id: rateID,
+        },
+        data: {
+            reviewStatusActions: {
+                create: {
+                    updatedByID,
+                    updatedReason,
+                    actionType: 'UNDER_REVIEW',
+                },
+            },
+        },
+    })
 
     // Add a reviewStatus action and remove all contracts from withdrawnFromContracts
     await tx.rateTable.update({

--- a/services/app-api/src/postgres/contractAndRates/undoWithdrawRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/undoWithdrawRate.ts
@@ -195,7 +195,7 @@ const undoWithdrawRateInsideTransaction = async (
         }
     }
 
-    // Update the review status first
+    // Update the review status
     await tx.rateTable.update({
         where: {
             id: rateID,


### PR DESCRIPTION
## Summary

There was a bug when a contract had only a single rate and it was withdrawn, then un-withdrawn. I had mistakenly put creating thew new review action type for the rate at the top of `undoWithdrawRateInsideTransaction`, which would not work because `unlockContractInsideTransaction` will see it as a submitted rate and try to unlock it again.

Moving this block code for creating review action to after the rates have been reattached to the contract fixes the code. I initially had this code block at the bottom, but I believe I was thinking it made more sense to un-withdrawal it before reattaching it.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
