### PR TITLE
MCR-2645 Use logical DB for review environments

### DIFF
--- a/.github/workflows/deploy-infra-to-env.yml
+++ b/.github/workflows/deploy-infra-to-env.yml
@@ -137,6 +137,7 @@ jobs:
           SUBNET_PUBLIC_A_ID: ${{ secrets.subnet_public_a_id }}
           IAM_PERMISSIONS_BOUNDARY: ${{ secrets.iam_permissions_boundary }}
           IAM_PATH: ${{ secrets.iam_path }}
+          DEV_AURORA_ARN: ${{ secrets.dev_aurora_arn }}
         run: |
           pushd services/postgres && npx serverless deploy --stage ${{ inputs.stage_name }}
 
@@ -145,7 +146,6 @@ jobs:
         env:
           STAGE_NAME: ${{ inputs.stage_name }}
           DEV_DB_SM_ARN: ${{ secrets.dev_db_sm_arn }}
-          DEV_AURORA_ARN: ${{ secrets.dev_aurora_arn }}
         run: |
           chmod +x services/postgres/db-manager.sh
           ./services/postgres/scripts/db-manager.sh create $STAGE_NAME $DEV_DB_SM_ARN $STAGE_NAME

--- a/.github/workflows/deploy-infra-to-env.yml
+++ b/.github/workflows/deploy-infra-to-env.yml
@@ -148,7 +148,7 @@ jobs:
           DEV_DB_SM_ARN: ${{ secrets.dev_db_sm_arn }}
         run: |
           chmod +x services/postgres/db-manager.sh
-          ./services/postgres/scripts/db-manager.sh create $STAGE_NAME $DEV_DB_SM_ARN $STAGE_NAME
+          ./services/postgres/db-manager.sh create $STAGE_NAME $DEV_DB_SM_ARN $STAGE_NAME
 
       - name: Upload VM scripts to S3
         run: |

--- a/.github/workflows/deploy-infra-to-env.yml
+++ b/.github/workflows/deploy-infra-to-env.yml
@@ -138,6 +138,7 @@ jobs:
           IAM_PERMISSIONS_BOUNDARY: ${{ secrets.iam_permissions_boundary }}
           IAM_PATH: ${{ secrets.iam_path }}
           DEV_AURORA_ARN: ${{ secrets.dev_aurora_arn }}
+          DEV_DB_SM_ARN: ${{ secrets.dev_db_sm_arn }}
         run: |
           pushd services/postgres && npx serverless deploy --stage ${{ inputs.stage_name }}
 

--- a/.github/workflows/deploy-infra-to-env.yml
+++ b/.github/workflows/deploy-infra-to-env.yml
@@ -46,6 +46,8 @@ on:
         required: true
       subnet_public_a_id:
         required: false
+      dev_db_sm_arn:
+        required: false
 
 permissions:
   id-token: write
@@ -135,6 +137,15 @@ jobs:
           IAM_PATH: ${{ secrets.iam_path }}
         run: |
           pushd services/postgres && npx serverless deploy --stage ${{ inputs.stage_name }}
+
+      - name: Create logical database
+        if: ${{ github.ref != 'refs/heads/main' }}
+        env:
+          STAGE_NAME: ${{ inputs.stage_name }}
+          DEV_DB_SM_ARN: ${{ secrets.dev_db_sm_arn }}
+        run: |
+          chmod +x services/postgres/db-manager.sh
+          ./services/postgres/scripts/db-manager.sh create $STAGE_NAME $DEV_DB_SM_ARN $STAGE_NAME
 
       - name: Upload VM scripts to S3
         run: |

--- a/.github/workflows/deploy-infra-to-env.yml
+++ b/.github/workflows/deploy-infra-to-env.yml
@@ -48,6 +48,8 @@ on:
         required: false
       dev_db_sm_arn:
         required: false
+      dev_aurora_arn:
+        required: false
 
 permissions:
   id-token: write
@@ -143,6 +145,7 @@ jobs:
         env:
           STAGE_NAME: ${{ inputs.stage_name }}
           DEV_DB_SM_ARN: ${{ secrets.dev_db_sm_arn }}
+          DEV_AURORA_ARN: ${{ secrets.dev_aurora_arn }}
         run: |
           chmod +x services/postgres/db-manager.sh
           ./services/postgres/scripts/db-manager.sh create $STAGE_NAME $DEV_DB_SM_ARN $STAGE_NAME

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -607,7 +607,7 @@ jobs:
             ${{github.workspace}}/coverage-cypress/lcov.info
   coverage:
     name: test-coverage
-    needs: [begin-deployment, cypress]
+    needs: [begin-deployment, deploy-infra, cypress]
     if: always() && needs.finishing-prep.result == 'success'
     runs-on: ubuntu-24.04
     permissions:
@@ -689,6 +689,14 @@ jobs:
         with:
           name: combined-test-coverage
           path: ./coverage-all/
+
+      - name: Get AWS credentials
+        uses: ./.github/actions/get_aws_credentials
+        with:
+          region: ${{ vars.AWS_DEFAULT_REGION }}
+          account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
+          stage-name: ${{ needs.begin-deployment.outputs.stage-name }}
+          changed-services: ${{ needs.begin-deployment.outputs.changed-services }}
 
       - name: Delete logical database
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -694,7 +694,7 @@ jobs:
         env:
           STAGE_NAME: ${{ needs.begin-deployment.outputs.stage-name}}
           DEV_DB_SM_ARN: ${{ secrets.DEV_DB_SM_ARN }}
-          AWS_REGION: ${{ var.AWS_DEFAULT_REGION }}
+          AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}
         run: |
           chmod +x services/postgres/db-manager.sh
           ./services/postgres/db-manager.sh delete $STAGE_NAME $DEV_DB_SM_ARN $STAGE_NAME

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -689,20 +689,3 @@ jobs:
         with:
           name: combined-test-coverage
           path: ./coverage-all/
-
-      - name: Get AWS credentials
-        uses: ./.github/actions/get_aws_credentials
-        with:
-          region: ${{ vars.AWS_DEFAULT_REGION }}
-          account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
-          stage-name: ${{ needs.begin-deployment.outputs.stage-name }}
-          changed-services: ${{ needs.begin-deployment.outputs.changed-services }}
-
-      - name: Delete logical database
-        env:
-          STAGE_NAME: ${{ needs.begin-deployment.outputs.stage-name}}
-          DEV_DB_SM_ARN: ${{ secrets.DEV_DB_SM_ARN }}
-          AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}
-        run: |
-          chmod +x services/postgres/db-manager.sh
-          ./services/postgres/db-manager.sh delete $STAGE_NAME $DEV_DB_SM_ARN $STAGE_NAME

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -394,6 +394,15 @@ jobs:
         run: |
           ./scripts/invoke-migrate-lambda.sh app-api-$STAGE_NAME-migrate
 
+      - name: TEST DONT MERGE -- Delete logical database
+        env:
+          STAGE_NAME: ${{ needs.begin-deployment.outputs.stage-name }}
+          DEV_DB_SM_ARN: ${{ secrets.DEV_DB_SM_ARN }}
+          AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}
+        run: |
+          chmod +x services/postgres/db-manager.sh
+          ./services/postgres/db-manager.sh delete $STAGE_NAME $DEV_DB_SM_ARN $STAGE_NAME
+
       - name: get application endpoint
         id: save-app-endpoint
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -607,7 +607,7 @@ jobs:
             ${{github.workspace}}/coverage-cypress/lcov.info
   coverage:
     name: test-coverage
-    needs: [begin-deployment, cypress]
+    needs: [begin-deployment, cypress, deploy-infra]
     if: always() && needs.finishing-prep.result == 'success'
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -690,6 +690,14 @@ jobs:
           name: combined-test-coverage
           path: ./coverage-all/
 
+      - name: Get AWS credentials
+        uses: ./.github/actions/get_aws_credentials
+        with:
+          region: ${{ vars.AWS_DEFAULT_REGION }}
+          account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
+          stage-name: ${{ needs.begin-deployment.outputs.stage-name }}
+          changed-services: ${{ needs.begin-deployment.outputs.changed-services }}
+
       - name: Delete logical database
         env:
           STAGE_NAME: ${{ needs.begin-deployment.outputs.stage-name}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -607,7 +607,7 @@ jobs:
             ${{github.workspace}}/coverage-cypress/lcov.info
   coverage:
     name: test-coverage
-    needs: [cypress]
+    needs: [begin-deployment, cypress]
     if: always() && needs.finishing-prep.result == 'success'
     runs-on: ubuntu-24.04
     permissions:
@@ -689,3 +689,11 @@ jobs:
         with:
           name: combined-test-coverage
           path: ./coverage-all/
+
+      - name: Delete logical database
+        env:
+          STAGE_NAME: ${{ needs.begin-deployment.outputs.stage-name}}
+          DEV_DB_SM_ARN: ${{ secrets.DEV_DB_SM_ARN }}
+        run: |
+          chmod +x services/postgres/db-manager.sh
+          ./services/postgres/db-manager.sh delete $STAGE_NAME $DEV_DB_SM_ARN $STAGE_NAME

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -607,7 +607,7 @@ jobs:
             ${{github.workspace}}/coverage-cypress/lcov.info
   coverage:
     name: test-coverage
-    needs: [begin-deployment, cypress, deploy-infra]
+    needs: [begin-deployment, cypress]
     if: always() && needs.finishing-prep.result == 'success'
     runs-on: ubuntu-24.04
     permissions:
@@ -690,18 +690,11 @@ jobs:
           name: combined-test-coverage
           path: ./coverage-all/
 
-      - name: Get AWS credentials
-        uses: ./.github/actions/get_aws_credentials
-        with:
-          region: ${{ vars.AWS_DEFAULT_REGION }}
-          account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
-          stage-name: ${{ needs.begin-deployment.outputs.stage-name }}
-          changed-services: ${{ needs.begin-deployment.outputs.changed-services }}
-
       - name: Delete logical database
         env:
           STAGE_NAME: ${{ needs.begin-deployment.outputs.stage-name}}
           DEV_DB_SM_ARN: ${{ secrets.DEV_DB_SM_ARN }}
+          AWS_REGION: ${{ var.AWS_DEFAULT_REGION }}
         run: |
           chmod +x services/postgres/db-manager.sh
           ./services/postgres/db-manager.sh delete $STAGE_NAME $DEV_DB_SM_ARN $STAGE_NAME

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -272,7 +272,7 @@ jobs:
 
   deploy-infra:
     needs: [begin-deployment, build-clamav-layer]
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@mt-logical-dbs
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name}}
@@ -291,6 +291,7 @@ jobs:
       subnet_private_b_id: ${{ secrets.DEV_SUBNET_PRIVATE_B_ID }}
       subnet_private_c_id: ${{ secrets.DEV_SUBNET_PRIVATE_C_ID }}
       subnet_public_a_id: ${{ secrets.DEV_SUBNET_PUBLIC_A_ID }}
+      dev_db_sm_arm: ${{ secrets.DEV_DB_SM_ARN }}
 
   deploy-app:
     needs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -292,6 +292,7 @@ jobs:
       subnet_private_c_id: ${{ secrets.DEV_SUBNET_PRIVATE_C_ID }}
       subnet_public_a_id: ${{ secrets.DEV_SUBNET_PUBLIC_A_ID }}
       dev_db_sm_arn: ${{ secrets.DEV_DB_SM_ARN }}
+      dev_aurora_arn: ${{ secrets.DEV_AURORA_ARN }}
 
   deploy-app:
     needs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -291,7 +291,7 @@ jobs:
       subnet_private_b_id: ${{ secrets.DEV_SUBNET_PRIVATE_B_ID }}
       subnet_private_c_id: ${{ secrets.DEV_SUBNET_PRIVATE_C_ID }}
       subnet_public_a_id: ${{ secrets.DEV_SUBNET_PUBLIC_A_ID }}
-      dev_db_sm_arm: ${{ secrets.DEV_DB_SM_ARN }}
+      dev_db_sm_arn: ${{ secrets.DEV_DB_SM_ARN }}
 
   deploy-app:
     needs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -394,15 +394,6 @@ jobs:
         run: |
           ./scripts/invoke-migrate-lambda.sh app-api-$STAGE_NAME-migrate
 
-      - name: TEST DONT MERGE -- Delete logical database
-        env:
-          STAGE_NAME: ${{ needs.begin-deployment.outputs.stage-name }}
-          DEV_DB_SM_ARN: ${{ secrets.DEV_DB_SM_ARN }}
-          AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}
-        run: |
-          chmod +x services/postgres/db-manager.sh
-          ./services/postgres/db-manager.sh delete $STAGE_NAME $DEV_DB_SM_ARN $STAGE_NAME
-
       - name: get application endpoint
         id: save-app-endpoint
         env:

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -16,8 +16,14 @@ jobs:
     environment: dev
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 40
+
       - name: set stage_name
+        id: stage-name
+        shell: bash
         run: |
           echo "stage_name=$(./scripts/stage_name_for_branch.sh ${{ github.event.ref }})" >> $GITHUB_ENV
 
@@ -39,6 +45,15 @@ jobs:
           region: ${{ vars.AWS_DEFAULT_REGION }}
           account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
           stage-name: main
+
+      - name: Delete logical database
+        env:
+          STAGE_NAME: ${{ steps.stage-name.outputs.stage_name }}
+          DEV_DB_SM_ARN: ${{ secrets.DEV_DB_SM_ARN }}
+          AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}
+        run: |
+          chmod +x services/postgres/db-manager.sh
+          ./services/postgres/db-manager.sh delete $STAGE_NAME $DEV_DB_SM_ARN $STAGE_NAME
 
       - name: destroy all
         env:

--- a/services/postgres/db-manager.sh
+++ b/services/postgres/db-manager.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -u
+
+# Script to invoke the database manager lambda function
+# Usage: ./db-manager.sh create|delete stageName dbSecretArn
+
+action="$1"        # create or delete
+stage_name="$2"    # The stage/environment name for the database
+secret_arn="$3"    # ARN of the secrets manager secret for the main dev DB
+lambda_stage="${4:-dev}"  # Stage where the lambda is deployed, defaults to dev
+
+function_name="postgres-${lambda_stage}-dbManager"
+lambda_version="\$LATEST"
+cli_read_timeout=240
+
+# Ensure all required parameters are provided
+if [[ -z "$action" || -z "$stage_name" || -z "$secret_arn" ]]; then
+  echo "Usage: $0 create|delete stageName dbSecretArn" 1>&2
+  exit 1
+fi
+
+# Validate action parameter
+if [[ "$action" != "create" && "$action" != "delete" ]]; then
+  echo "Error: Action must be 'create' or 'delete'" 1>&2
+  exit 1
+fi
+
+# Create the payload JSON
+payload=$(cat <<EOF
+{
+  "action": "$action",
+  "stageName": "$stage_name",
+  "devDbSecretArn": "$secret_arn"
+}
+EOF
+)
+
+echo "Invoking Lambda function: $function_name"
+echo "Action: $action"
+echo "Stage: $stage_name"
+
+# Invoke the Lambda function
+if (set -x ; aws lambda invoke \
+      --qualifier "$lambda_version" \
+      --cli-read-timeout "$cli_read_timeout" \
+      --function-name "$function_name" \
+      --payload "$payload" \
+      --cli-binary-format raw-in-base64-out \
+      lambda_response.json) ; then
+  
+  # Check if the response is valid JSON
+  if ! jq empty lambda_response.json 2>/dev/null; then
+    echo "Error: Lambda function returned invalid JSON" 1>&2
+    cat lambda_response.json
+    exit 1
+  fi
+  
+  # Extract and check the status code
+  body=$(jq -r '.body' lambda_response.json)
+  if [[ -z "$body" || "$body" == "null" ]]; then
+    echo "Error: Lambda response missing body field" 1>&2
+    cat lambda_response.json
+    exit 1
+  fi
+  
+  # Parse the body which is a JSON string
+  status_code=$(echo "$body" | jq -r '.statusCode // 500')
+  
+  if [[ "$status_code" != "200" ]]; then
+    echo "Error: Database operation failed with status code $status_code" 1>&2
+    cat lambda_response.json
+    exit 1
+  fi
+  
+  echo "Database operation successful!"
+  echo "Response:"
+  echo "$body" | jq '.'
+else
+  echo "Error: Failed to invoke Lambda function" 1>&2
+  exit 1
+fi

--- a/services/postgres/db-manager.sh
+++ b/services/postgres/db-manager.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -u
+
 # Script to invoke the database manager lambda function
 # Usage: ./db-manager.sh create|delete stageName dbSecretArn
+
 action="$1"        # create or delete
 stage_name="$2"    # The stage/environment name for the database
 secret_arn="$3"    # ARN of the secrets manager secret for the main dev DB

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -38,6 +38,11 @@ provider:
           Action:
             - secretsmanager:GetRandomPassword # pragma: allowlist secret
           Resource: '*'
+        - Effect: 'Allow'
+          Action:
+            - secretsmanager:GetSecretValue # pragma: allowlist secret
+          Resource:
+            - '${self:custom.dbManagerArn}'
         - Effect: Allow
           Action:
             - ec2:CreateNetworkInterface
@@ -59,6 +64,7 @@ custom:
   iamPermissionsBoundary: ${env:IAM_PERMISSIONS_BOUNDARY}
   iamPath: ${env:IAM_PATH}
   rotatorArn: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${sls:stage}-rotator'
+  dbManagerArn: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${sls:stage}-dbManager'
   slackWebhookUrl: ${env:SLACK_WEBHOOK}
   serverlessTerminationProtection:
     stages:

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -51,7 +51,7 @@ provider:
             - secretsmanager:PutSecretValue # pragma: allowlist secret
             - secretsmanager:UpdateSecretVersionStage # pragma: allowlist secret
           Resource:
-            - '${self:custom.devDbSecretsArn}'
+            - '${self:custom.dbManagerArn}'
         - Effect: Allow
           Action:
             - ec2:CreateNetworkInterface

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -102,6 +102,15 @@ functions:
       subnetIds: ${self:custom.privateSubnets}
     environment:
       SECRETS_MANAGER_ENDPOINT: !Sub 'https://secretsmanager.${AWS::Region}.amazonaws.com'
+  dbManager:
+    handler: src/logicalDatabaseManager.handler
+    description: Manages logical databases in the shared dev PostgreSQL instance
+    timeout: 60
+    vpc:
+      securityGroupIds: ${self:custom.sgId}
+      subnetIds: ${self:custom.privateSubnets}
+    environment:
+      SECRETS_MANAGER_ENDPOINT: !Sub 'https://secretsmanager.${AWS::Region}.amazonaws.com'
 
 resources:
   Conditions:
@@ -109,7 +118,6 @@ resources:
       - !Equals ['${sls:stage}', 'main']
       - !Equals ['${sls:stage}', 'val']
       - !Equals ['${sls:stage}', 'prod']
-      - !Equals ['${sls:stage}', 'mtsechubsmrotation'] # Temporary addition for testing
 
   Resources:
     # VPC endpoint for rotation lambda
@@ -136,6 +144,7 @@ resources:
 
     PostgresAuroraV2:
       Type: AWS::RDS::DBCluster
+      Condition: IsDevValProd
       DeletionPolicy: ${self:custom.deletionPolicy.${opt:stage}, self:custom.deletionPolicy.other}
       Properties:
         Engine: aurora-postgresql
@@ -154,6 +163,7 @@ resources:
 
     PostgresAuroraV2Instance:
       Type: AWS::RDS::DBInstance
+      Condition: IsDevValProd
       DeletionPolicy: ${self:custom.deletionPolicy.${opt:stage}, self:custom.deletionPolicy.other}
       Properties:
         Engine: aurora-postgresql

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -42,6 +42,12 @@ provider:
           Action:
             - secretsmanager:DescribeSecret # pragma: allowlist secret
             - secretsmanager:GetSecretValue # pragma: allowlist secret
+          Resource:
+            - '${self:custom.devDbSecretsArn}'
+        - Effect: 'Allow'
+          Action:
+            - secretsmanager:DescribeSecret # pragma: allowlist secret
+            - secretsmanager:GetSecretValue # pragma: allowlist secret
             - secretsmanager:PutSecretValue # pragma: allowlist secret
             - secretsmanager:UpdateSecretVersionStage # pragma: allowlist secret
           Resource:
@@ -67,6 +73,7 @@ custom:
   iamPermissionsBoundary: ${env:IAM_PERMISSIONS_BOUNDARY}
   iamPath: ${env:IAM_PATH}
   rotatorArn: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${sls:stage}-rotator'
+  dbManagerArn: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:aurora_${self:service}_*'
   devDbSecretsArn: ${env:CF_CONFIG_IGNORED_LOCALLY, env:DEV_DB_SM_ARN}
   slackWebhookUrl: ${env:SLACK_WEBHOOK}
   serverlessTerminationProtection:

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -64,7 +64,7 @@ custom:
   iamPermissionsBoundary: ${env:IAM_PERMISSIONS_BOUNDARY}
   iamPath: ${env:IAM_PATH}
   rotatorArn: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${sls:stage}-rotator'
-  devDbSecretsArn: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:aurora_postgres_main'
+  devDbSecretsArn: ${env:CF_CONFIG_IGNORED_LOCALLY, env:DEV_DB_SM_ARN}
   slackWebhookUrl: ${env:SLACK_WEBHOOK}
   serverlessTerminationProtection:
     stages:

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -367,7 +367,6 @@ resources:
     PostgresSecretsRotationSchedule:
       Type: AWS::SecretsManager::RotationSchedule
       DependsOn:
-        - PostgresAuroraV2
         - SecretsRDSAttachment
       Properties:
         SecretId:

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -50,6 +50,7 @@ custom:
   databaseName: !Sub aurora_${self:service}_${sls:stage}_${AWS::AccountId}
   vpcId: ${env:VPC_ID}
   sgId: ${env:SG_ID}
+  devAuroraArn: ${env:CF_CONFIG_IGNORED_LOCALLY, env:DEV_AURORA_ARN}
   privateSubnets:
     - ${env:SUBNET_PRIVATE_A_ID}
     - ${env:SUBNET_PRIVATE_B_ID}
@@ -118,6 +119,7 @@ resources:
       - !Equals ['${sls:stage}', 'main']
       - !Equals ['${sls:stage}', 'val']
       - !Equals ['${sls:stage}', 'prod']
+    IsReviewEnvironment: !Not [!Condition IsDevValProd]
 
   Resources:
     # VPC endpoint for rotation lambda
@@ -361,11 +363,12 @@ resources:
       Type: AWS::SecretsManager::SecretTargetAttachment
       Properties:
         SecretId: !Ref PostgresSecret
-        TargetId: !Sub 'arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:${PostgresAuroraV2}'
+        TargetId: ${self:custom.devAuroraArn}
         TargetType: AWS::RDS::DBCluster
 
     PostgresSecretsRotationSchedule:
       Type: AWS::SecretsManager::RotationSchedule
+      Condition: IsDevValProd
       DependsOn:
         - SecretsRDSAttachment
       Properties:
@@ -385,7 +388,10 @@ resources:
 
   Outputs:
     PostgresAuroraV2Arn:
-      Value: !Sub 'arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:${PostgresAuroraV2}'
+      Value: !If
+        - IsReviewEnvironment
+        - ${self:custom.devAuroraArn}
+        - !Sub 'arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:${PostgresAuroraV2}'
     PostgresVMScriptsBucket:
       Condition: IsDevValProd
       Value: !Ref PostgresVMScriptsBucket

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -50,6 +50,7 @@ provider:
             - secretsmanager:GetSecretValue # pragma: allowlist secret
             - secretsmanager:PutSecretValue # pragma: allowlist secret
             - secretsmanager:UpdateSecretVersionStage # pragma: allowlist secret
+            - secretsmanager:DeleteSecret # pragma: allowlist secret
           Resource:
             - '${self:custom.dbManagerArn}'
         - Effect: Allow

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -40,7 +40,10 @@ provider:
           Resource: '*'
         - Effect: 'Allow'
           Action:
+            - secretsmanager:DescribeSecret # pragma: allowlist secret
             - secretsmanager:GetSecretValue # pragma: allowlist secret
+            - secretsmanager:PutSecretValue # pragma: allowlist secret
+            - secretsmanager:UpdateSecretVersionStage # pragma: allowlist secret
           Resource:
             - '${self:custom.devDbSecretsArn}'
         - Effect: Allow

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -42,7 +42,7 @@ provider:
           Action:
             - secretsmanager:GetSecretValue # pragma: allowlist secret
           Resource:
-            - '${self:custom.dbManagerArn}'
+            - '${self:custom.devDbSecretsArn}'
         - Effect: Allow
           Action:
             - ec2:CreateNetworkInterface
@@ -64,7 +64,7 @@ custom:
   iamPermissionsBoundary: ${env:IAM_PERMISSIONS_BOUNDARY}
   iamPath: ${env:IAM_PATH}
   rotatorArn: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${sls:stage}-rotator'
-  dbManagerArn: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${sls:stage}-dbManager'
+  devDbSecretsArn: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:aurora_postgres_main'
   slackWebhookUrl: ${env:SLACK_WEBHOOK}
   serverlessTerminationProtection:
     stages:

--- a/services/postgres/src/logicalDatabaseManager.ts
+++ b/services/postgres/src/logicalDatabaseManager.ts
@@ -1,0 +1,328 @@
+import { SecretsManager } from './secrets'
+import { DatabaseClient } from './db'
+import { randomBytes } from 'crypto'
+import { SecretDict } from './types'
+import { Client } from 'pg'
+import {
+    DeleteSecretCommand,
+    SecretsManagerClient,
+} from '@aws-sdk/client-secrets-manager'
+
+interface LambdaEvent {
+    action: 'create' | 'delete'
+    stageName: string
+    devDbSecretArn: string
+    dbNamePrefix?: string
+    prSecretName?: string
+}
+
+interface LambdaResponse {
+    statusCode: number
+    body: string
+}
+
+class DatabaseOperationError extends Error {
+    constructor(
+        message: string,
+        public readonly operation: string,
+        public readonly cause?: Error
+    ) {
+        super(message)
+        this.name = 'DatabaseOperationError'
+    }
+}
+
+export const handler = async (event: LambdaEvent): Promise<LambdaResponse> => {
+    console.info('Event:', JSON.stringify(event, null, 2))
+
+    const { action, stageName, devDbSecretArn, dbNamePrefix, prSecretName } =
+        event
+
+    if (!action) {
+        throw new Error('Action is required (create or delete)')
+    }
+
+    if (!stageName) {
+        throw new Error('Stage name is required')
+    }
+
+    if (!devDbSecretArn) {
+        throw new Error('Dev database secret ARN is required')
+    }
+
+    const prefix = dbNamePrefix || process.env.DB_NAME_PREFIX || 'reviewapp'
+    const dbName = `${prefix}_${stageName}`
+    const userName = `${prefix}_user_${stageName}`
+    const secretName = prSecretName || `aurora_postgres_${stageName}`
+
+    const manager = new LogicalDatabaseManager()
+
+    try {
+        if (action === 'create') {
+            return await manager.createLogicalDatabase(
+                devDbSecretArn,
+                dbName,
+                userName,
+                secretName
+            )
+        } else if (action === 'delete') {
+            return await manager.deleteLogicalDatabase(
+                devDbSecretArn,
+                dbName,
+                userName,
+                secretName
+            )
+        } else {
+            throw new Error(
+                `Invalid action: ${action}. Must be 'create' or 'delete'`
+            )
+        }
+    } catch (error) {
+        console.error(`Error in ${action} operation:`, error)
+        throw error
+    }
+}
+
+class LogicalDatabaseManager {
+    private secrets: SecretsManager
+    private dbClient: DatabaseClient
+    private secretsClient: SecretsManagerClient
+
+    constructor() {
+        this.secrets = new SecretsManager()
+        this.dbClient = new DatabaseClient()
+        this.secretsClient = new SecretsManagerClient({})
+    }
+
+    /**
+     * Create a logical database in the shared PostgreSQL instance
+     */
+    async createLogicalDatabase(
+        secretArn: string,
+        dbName: string,
+        userName: string,
+        prSecretName: string
+    ): Promise<LambdaResponse> {
+        let dbCredentials: SecretDict
+        let client: Client | null = null
+
+        try {
+            // Get the shared database credentials
+            dbCredentials = await this.secrets.getSecretDict(
+                secretArn,
+                'AWSCURRENT'
+            )
+
+            // Connect using our shared DatabaseClient which handles SSL correctly
+            client = await this.dbClient.connect(dbCredentials)
+
+            if (!client) {
+                throw new DatabaseOperationError(
+                    `Failed to connect to database using credentials from ${secretArn}`,
+                    'createLogicalDatabase'
+                )
+            }
+
+            console.info('Connected to PostgreSQL')
+
+            // Check if database already exists
+            const checkResult = await client.query(
+                'SELECT 1 FROM pg_database WHERE datname = $1',
+                [dbName]
+            )
+
+            if (checkResult.rowCount === 0) {
+                console.info(`Creating database ${dbName}`)
+
+                // Create the database if it doesn't exist
+                // Use double quotes to preserve case sensitivity
+                await client.query(`CREATE DATABASE "${dbName}"`)
+
+                console.info(`Database ${dbName} created successfully`)
+            } else {
+                console.info(`Database ${dbName} already exists`)
+            }
+
+            // Check if user exists
+            const userCheckResult = await client.query(
+                'SELECT 1 FROM pg_roles WHERE rolname = $1',
+                [userName]
+            )
+
+            let password: string
+
+            if (userCheckResult.rowCount === 0) {
+                // Generate a random password
+                password = await this.secrets.generatePassword()
+
+                console.info(`Creating user ${userName}`)
+                await client.query(
+                    `CREATE USER ${userName} WITH PASSWORD '${password}'`
+                )
+                await client.query(
+                    `GRANT ALL PRIVILEGES ON DATABASE "${dbName}" TO ${userName}`
+                )
+
+                console.info(`User ${userName} created successfully`)
+            } else {
+                console.info(`User ${userName} already exists`)
+
+                // Reset password for existing user using our DbClient's method
+                password = await this.secrets.generatePassword()
+                await this.dbClient.updatePassword(client, userName, password)
+
+                console.info(`Password for user ${userName} reset`)
+            }
+
+            // Create or update the PR secret with logical database connection info
+            // Use the same secret name that your application would expect for a PR environment
+            const secretValue: SecretDict = {
+                username: userName,
+                password: password,
+                engine: 'postgres',
+                host: dbCredentials.host,
+                port: dbCredentials.port || 5432,
+                dbname: dbName,
+                ssl: true,
+            }
+
+            try {
+                // Check if secret exists
+                await this.secrets.describeSecret(prSecretName)
+
+                // Store the token for the update
+                const token = randomBytes(32).toString('hex')
+
+                // Update existing secret with AWSPENDING
+                await this.secrets.putSecret(prSecretName, token, secretValue)
+
+                // Move AWSPENDING to AWSCURRENT
+                await this.secrets.updateSecretStage(prSecretName, token)
+
+                console.info(
+                    `Secret ${prSecretName} updated with logical database credentials`
+                )
+            } catch (error) {
+                // Secret doesn't exist, create it
+                const token = randomBytes(32).toString('hex')
+                await this.secrets.putSecret(prSecretName, token, secretValue)
+                await this.secrets.updateSecretStage(prSecretName, token)
+
+                console.info(
+                    `Secret ${prSecretName} created with logical database credentials`
+                )
+            }
+
+            return {
+                statusCode: 200,
+                body: JSON.stringify({
+                    message: `Database ${dbName} and user ${userName} setup complete`,
+                    secretName: prSecretName,
+                    dbName: dbName,
+                }),
+            }
+        } catch (error) {
+            console.error('Error in createLogicalDatabase:', error)
+            throw new DatabaseOperationError(
+                `Failed to create logical database ${dbName}`,
+                'createLogicalDatabase',
+                error instanceof Error ? error : new Error(String(error))
+            )
+        } finally {
+            if (client) {
+                await client.end()
+                console.info('PostgreSQL connection closed')
+            }
+        }
+    }
+
+    /**
+     * Delete a logical database from a shared PostgreSQL instance
+     */
+    async deleteLogicalDatabase(
+        secretArn: string,
+        dbName: string,
+        userName: string,
+        prSecretName: string
+    ): Promise<LambdaResponse> {
+        let dbCredentials: SecretDict
+        let client: Client | null = null
+
+        try {
+            // Get the shared database credentials
+            dbCredentials = await this.secrets.getSecretDict(
+                secretArn,
+                'AWSCURRENT'
+            )
+
+            // Connect using our shared DatabaseClient
+            client = await this.dbClient.connect(dbCredentials)
+
+            if (!client) {
+                throw new DatabaseOperationError(
+                    `Failed to connect to database using credentials from ${secretArn}`,
+                    'deleteLogicalDatabase'
+                )
+            }
+
+            console.info('Connected to PostgreSQL')
+
+            // Terminate all connections to the database
+            await client.query(
+                `
+                SELECT pg_terminate_backend(pg_stat_activity.pid)
+                FROM pg_stat_activity
+                WHERE pg_stat_activity.datname = $1
+            `,
+                [dbName]
+            )
+
+            console.info(`Terminated all connections to ${dbName}`)
+
+            // Drop the database
+            await client.query(`DROP DATABASE IF EXISTS "${dbName}"`)
+            console.info(`Database ${dbName} dropped`)
+
+            // Drop the user
+            await client.query(`DROP USER IF EXISTS ${userName}`)
+            console.info(`User ${userName} dropped`)
+
+            // Delete the secret (same one that would have been used for the PR environment)
+            try {
+                // Delete the secret directly using the AWS SDK
+                await this.secretsClient.send(
+                    new DeleteSecretCommand({
+                        SecretId: prSecretName,
+                        ForceDeleteWithoutRecovery: true,
+                    })
+                )
+
+                console.info(`Secret ${prSecretName} deleted`)
+            } catch (error) {
+                console.info(
+                    `Secret ${prSecretName} not found or already deleted:`,
+                    error
+                )
+            }
+
+            return {
+                statusCode: 200,
+                body: JSON.stringify({
+                    message: `Database ${dbName} and user ${userName} deleted successfully`,
+                }),
+            }
+        } catch (error) {
+            console.error('Error in deleteLogicalDatabase:', error)
+            throw new DatabaseOperationError(
+                `Failed to delete logical database ${dbName}`,
+                'deleteLogicalDatabase',
+                error instanceof Error ? error : new Error(String(error))
+            )
+        } finally {
+            if (client) {
+                await client.end()
+                console.info('PostgreSQL connection closed')
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Up until now we've been deploying a fully unique environment for git branches and PRs, which includes standing up an individual Aurora Postgres instance just like we have in dev/val/prod. However, this approach causes an increase of resources in our `dev` AWS account (Aurora, networking, snapshots, etc.). 

This change will now have us deploy a logical DB that is a part of the main `dev` database and will not stand up a separate Aurora instance for review environments. It uses a lambda in the `postgres` service to add or delete the logical database. When a new branch is created, the `postgres` deploy step will create the infrastructure and then call the lambda to 1) generate a new AWS secrets manager secret 2) log into the `dev` db to create the new user 3) create the new database inside the `dev` Aurora instance. Once a PR is merged or the branch is deleted, that DB will be dropped from inside the main `dev` Aurora instance. 

This reduces resources in AWS and will bring down our costs. It also should make CI faster, particularly on first run, as we won't be deploying a new Aurora DB in the environment.

#### Related issues
https://jiraent.cms.gov/browse/MCR-2645

#### Testing Guidance

Just need to make sure the application is working as expected, which should be covered by Cypress. I've already verified that we are getting data as expected into this logical DB that is in the main `dev` Aurora instance:

```sh
reviewapp_mtlogicaldbs=> select * from "User";
                  id                  | givenName | familyName |       email       |       role        | stateCode | divisionAssignment |        createdAt        |        updatedAt
--------------------------------------+-----------+------------+-------------------+-------------------+-----------+--------------------+-------------------------+-------------------------
 84b84438-e041-708d-8082-211425e3cf68 | Aang      | Avatar     | aang@example.com  | STATE_USER        | MN        |                    | 2025-03-13 17:48:19.733 | 2025-03-13 17:48:19.733
 b4787438-70f1-704f-6a14-b6864da67d40 | Iroh      | Uncle      | iroh@example.com  | ADMIN_USER        |           |                    | 2025-03-13 17:48:24.954 | 2025-03-13 17:48:24.954
 341834d8-b0d1-7013-bcc6-8b2ef9ca4a67 | Azula     | Hotman     | azula@example.com | CMS_APPROVER_USER |           | DMCO               | 2025-03-13 17:48:48.209 | 2025-03-13 17:48:57.001
 1478c4a8-50b1-707d-5462-ffcaec152744 | Zuko      | Hotman     | zuko@example.com  | CMS_USER          |           | DMCO               | 2025-03-13 17:48:23.117 | 2025-03-13 17:49:20.425
(4 rows)
```

And I've verified that the cleanup works in a test run. 

Before the delete part of the lambda was run:
```bash
=> SELECT datname FROM pg_database WHERE datname LIKE 'reviewapp_%';
        datname
------------------------
 reviewapp_mtlogicaldbs
(1 row)

=> SELECT rolname FROM pg_roles WHERE rolname LIKE 'reviewapp_user_%';
           rolname
-----------------------------
 reviewapp_user_mtlogicaldbs
(1 row)
```
after
```bash
=> SELECT rolname FROM pg_roles WHERE rolname LIKE 'reviewapp_user_%';
 rolname
---------
(0 rows)

=> SELECT datname FROM pg_database WHERE datname LIKE 'reviewapp_%';
 datname
---------
(0 rows)
```
