### PR TITLE
MCR-4891: Action section on submission summary page and add new feature flag

### DIFF
--- a/packages/common-code/src/featureFlags/flags.ts
+++ b/packages/common-code/src/featureFlags/flags.ts
@@ -53,6 +53,13 @@ const featureFlags = {
         flag: 'remove-parameter-store',
         defaultValue: false,
     },
+    /**
+     * Enables withdraw submission features
+     */
+    WITHDRAW_SUBMISSION: {
+        flag: 'withdraw-submission',
+        defaultValue: false
+    },
     // PERMANENT FLAGS
     /**
      Enables the modal that alerts the user to an expiring session

--- a/packages/mocks/src/apollo/contractPackageDataMock.ts
+++ b/packages/mocks/src/apollo/contractPackageDataMock.ts
@@ -7,11 +7,223 @@ import {
     UnlockedContract,
     CmsUser,
     StateUser,
-    Rate,
+    Rate, IndexContractQuestionsPayload,
 } from '../gen/gqlClient'
 import { s3DlUrl } from './documentDataMock'
 
 import { mockValidCMSUser, mockValidUser } from './userGQLMock'
+
+function mockEmptyContractQuestions(): IndexContractQuestionsPayload {
+    return {
+        DMCOQuestions: {
+            totalCount: 0,
+            edges: []
+        },
+        OACTQuestions: {
+            totalCount: 0,
+            edges: []
+        },
+        DMCPQuestions: {
+            totalCount: 0,
+            edges: []
+        }
+    }
+}
+
+function mockContractQuestions(
+    contractID: string
+): IndexContractQuestionsPayload {
+    return {
+        DMCOQuestions: {
+            totalCount: 2,
+            edges: [
+                {
+                    __typename: 'ContractQuestionEdge' as const,
+                    node: {
+                        __typename: 'ContractQuestion' as const,
+                        id: 'dmco-question-1-id',
+                        contractID,
+                        createdAt: new Date('2022-12-16'),
+                        addedBy: mockValidCMSUser({
+                            divisionAssignment: null,
+                        }) as CmsUser,
+                        round: 1,
+                        documents: [
+                            {
+                                s3URL: 's3://bucketname/key/dmco-question-1-document-1',
+                                name: 'dmco-question-1-document-1',
+                                downloadURL: expect.any(String),
+                            },
+                        ],
+                        division: 'DMCO',
+                        responses: [
+                            {
+                                __typename: 'QuestionResponse' as const,
+                                id: 'response-to-dmco-1-id',
+                                questionID: 'dmco-question-1-id',
+                                addedBy: mockValidUser() as StateUser,
+                                createdAt: new Date('2022-12-16'),
+                                documents: [
+                                    {
+                                        s3URL: 's3://bucketname/key/response-to-dmco-1-document-1',
+                                        name: 'response-to-dmco-1-document-1',
+                                        downloadURL: expect.any(String),
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+                {
+                    __typename: 'ContractQuestionEdge' as const,
+                    node: {
+                        __typename: 'ContractQuestion' as const,
+                        id: 'dmco-question-2-id',
+                        contractID,
+                        createdAt: new Date('2022-12-18'),
+                        addedBy: mockValidCMSUser() as CmsUser,
+                        round: 2,
+                        documents: [
+                            {
+                                s3URL: 's3://bucketname/key/dmco-question-2-document-1',
+                                name: 'dmco-question-2-document-1',
+                                downloadURL: expect.any(String),
+                            },
+                            {
+                                s3URL: 's3://bucketname/key/question-2-document-2',
+                                name: 'dmco-question-2-document-2',
+                                downloadURL: expect.any(String),
+                            },
+                        ],
+                        division: 'DMCO',
+                        responses: [],
+                    },
+                },
+            ],
+        },
+        DMCPQuestions: {
+            totalCount: 1,
+            edges: [
+                {
+                    __typename: 'ContractQuestionEdge' as const,
+                    node: {
+                        __typename: 'ContractQuestion' as const,
+                        id: 'dmcp-question-1-id',
+                        contractID,
+                        createdAt: new Date('2022-12-15'),
+                        round: 1,
+                        addedBy: mockValidCMSUser({
+                            divisionAssignment: 'DMCP',
+                        }) as CmsUser,
+                        documents: [
+                            {
+                                s3URL: 's3://bucketname/key/dmcp-question-1-document-1',
+                                name: 'dmcp-question-1-document-1',
+                                downloadURL: expect.any(String),
+                            },
+                        ],
+                        division: 'DMCP',
+                        responses: [
+                            {
+                                __typename: 'QuestionResponse' as const,
+                                id: 'response-to-dmcp-1-id',
+                                questionID: 'dmcp-question-1-id',
+                                addedBy: mockValidUser() as StateUser,
+                                createdAt: new Date('2022-12-16'),
+                                documents: [
+                                    {
+                                        s3URL: 's3://bucketname/key/response-to-dmcp-1-document-1',
+                                        name: 'response-to-dmcp-1-document-1',
+                                        downloadURL: expect.any(String),
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+        OACTQuestions: {
+            totalCount: 2,
+            edges: [
+                {
+                    __typename: 'ContractQuestionEdge' as const,
+                    node: {
+                        __typename: 'ContractQuestion' as const,
+                        id: 'oact-question-1-id',
+                        contractID,
+                        createdAt: new Date('2022-12-14'),
+                        addedBy: mockValidCMSUser({
+                            divisionAssignment: 'OACT',
+                        }) as CmsUser,
+                        round: 1,
+                        documents: [
+                            {
+                                s3URL: 's3://bucketname/key/oact-question-1-document-1',
+                                name: 'oact-question-1-document-1',
+                                downloadURL: expect.any(String),
+                            },
+                        ],
+                        division: 'OACT',
+                        responses: [
+                            {
+                                __typename: 'QuestionResponse' as const,
+                                id: 'response-to-oact-1-id',
+                                questionID: 'oact-question-1-id',
+                                addedBy: mockValidUser() as StateUser,
+                                createdAt: new Date('2022-12-17'),
+                                documents: [
+                                    {
+                                        s3URL: 's3://bucketname/key/response-to-oact-1-document-1',
+                                        name: 'response-to-oact-1-document-1',
+                                        downloadURL: expect.any(String),
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+                {
+                    __typename: 'ContractQuestionEdge' as const,
+                    node: {
+                        __typename: 'ContractQuestion' as const,
+                        id: 'oact-question-2-id',
+                        contractID: 'test-abc-123',
+                        createdAt: new Date('2022-12-17'),
+                        round: 2,
+                        addedBy: mockValidCMSUser({
+                            divisionAssignment: 'OACT',
+                        }) as CmsUser,
+                        documents: [
+                            {
+                                s3URL: 's3://bucketname/key/oact-question-1-document-1',
+                                name: 'oact-question-2-document-1',
+                                downloadURL: expect.any(String),
+                            },
+                        ],
+                        division: 'OACT',
+                        responses: [
+                            {
+                                __typename: 'QuestionResponse' as const,
+                                id: 'response-to-oact-2-id',
+                                questionID: 'oact-question-2-id',
+                                addedBy: mockValidUser() as StateUser,
+                                createdAt: new Date('2022-12-16'),
+                                documents: [
+                                    {
+                                        s3URL: 's3://bucketname/key/response-to-oact-1-document-1',
+                                        name: 'response-to-oact-2-document-1',
+                                        downloadURL: expect.any(String),
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+    }
+}
 
 function mockContractRevision(
     name?: string,
@@ -320,7 +532,7 @@ function mockContractPackageSubmittedWithQuestions(
     contractId?: string,
     partial?: Partial<Contract>
 ): Contract {
-    const contractID = contractId || '11'
+    const contractID = contractId || 'test-abc-123'
     return {
         status: 'SUBMITTED',
         reviewStatus: 'UNDER_REVIEW',
@@ -501,196 +713,7 @@ function mockContractPackageSubmittedWithQuestions(
                 ],
             },
         ],
-        questions: {
-            DMCOQuestions: {
-                totalCount: 2,
-                edges: [
-                    {
-                        __typename: 'ContractQuestionEdge' as const,
-                        node: {
-                            __typename: 'ContractQuestion' as const,
-                            id: 'dmco-question-1-id',
-                            contractID,
-                            round: 1,
-                            createdAt: new Date('2022-12-16'),
-                            addedBy: mockValidCMSUser({
-                                divisionAssignment: null,
-                            }) as CmsUser,
-                            documents: [
-                                {
-                                    s3URL: 's3://bucketname/key/dmco-question-1-document-1',
-                                    name: 'dmco-question-1-document-1',
-                                    downloadURL: expect.any(String),
-                                },
-                            ],
-                            division: 'DMCO',
-                            responses: [
-                                {
-                                    __typename: 'QuestionResponse' as const,
-                                    id: 'response-to-dmco-1-id',
-                                    questionID: 'dmco-question-1-id',
-                                    addedBy: mockValidUser() as StateUser,
-                                    createdAt: new Date('2022-12-16'),
-                                    documents: [
-                                        {
-                                            s3URL: 's3://bucketname/key/response-to-dmco-1-document-1',
-                                            name: 'response-to-dmco-1-document-1',
-                                            downloadURL: expect.any(String),
-                                        },
-                                    ],
-                                },
-                            ],
-                        },
-                    },
-                    {
-                        __typename: 'ContractQuestionEdge' as const,
-                        node: {
-                            __typename: 'ContractQuestion' as const,
-                            id: 'dmco-question-2-id',
-                            contractID,
-                            createdAt: new Date('2022-12-18'),
-                            addedBy: mockValidCMSUser() as CmsUser,
-                            round: 1,
-                            documents: [
-                                {
-                                    s3URL: 's3://bucketname/key/dmco-question-2-document-1',
-                                    name: 'dmco-question-2-document-1',
-                                    downloadURL: expect.any(String),
-                                },
-                                {
-                                    s3URL: 's3://bucketname/key/question-2-document-2',
-                                    name: 'dmco-question-2-document-2',
-                                    downloadURL: expect.any(String),
-                                },
-                            ],
-                            division: 'DMCO',
-                            responses: [],
-                        },
-                    },
-                ],
-            },
-            DMCPQuestions: {
-                totalCount: 1,
-                edges: [
-                    {
-                        __typename: 'ContractQuestionEdge' as const,
-                        node: {
-                            __typename: 'ContractQuestion' as const,
-                            id: 'dmcp-question-1-id',
-                            contractID,
-                            createdAt: new Date('2022-12-15'),
-                            round: 1,
-                            addedBy: mockValidCMSUser({
-                                divisionAssignment: 'DMCP',
-                            }) as CmsUser,
-                            documents: [
-                                {
-                                    s3URL: 's3://bucketname/key/dmcp-question-1-document-1',
-                                    name: 'dmcp-question-1-document-1',
-                                    downloadURL: expect.any(String),
-                                },
-                            ],
-                            division: 'DMCP',
-                            responses: [
-                                {
-                                    __typename: 'QuestionResponse' as const,
-                                    id: 'response-to-dmcp-1-id',
-                                    questionID: 'dmcp-question-1-id',
-                                    addedBy: mockValidUser() as StateUser,
-                                    createdAt: new Date('2022-12-16'),
-                                    documents: [
-                                        {
-                                            s3URL: 's3://bucketname/key/response-to-dmcp-1-document-1',
-                                            name: 'response-to-dmcp-1-document-1',
-                                            downloadURL: expect.any(String),
-                                        },
-                                    ],
-                                },
-                            ],
-                        },
-                    },
-                ],
-            },
-            OACTQuestions: {
-                totalCount: 2,
-                edges: [
-                    {
-                        __typename: 'ContractQuestionEdge' as const,
-                        node: {
-                            __typename: 'ContractQuestion' as const,
-                            id: 'oact-question-1-id',
-                            contractID,
-                            createdAt: new Date('2022-12-14'),
-                            round: 1,
-                            addedBy: mockValidCMSUser({
-                                divisionAssignment: 'OACT',
-                            }) as CmsUser,
-                            documents: [
-                                {
-                                    s3URL: 's3://bucketname/key/oact-question-1-document-1',
-                                    name: 'oact-question-1-document-1',
-                                    downloadURL: expect.any(String),
-                                },
-                            ],
-                            division: 'OACT',
-                            responses: [
-                                {
-                                    __typename: 'QuestionResponse' as const,
-                                    id: 'response-to-oact-1-id',
-                                    questionID: 'oact-question-1-id',
-                                    addedBy: mockValidUser() as StateUser,
-                                    createdAt: new Date('2022-12-17'),
-                                    documents: [
-                                        {
-                                            s3URL: 's3://bucketname/key/response-to-oact-1-document-1',
-                                            name: 'response-to-oact-1-document-1',
-                                            downloadURL: expect.any(String),
-                                        },
-                                    ],
-                                },
-                            ],
-                        },
-                    },
-                    {
-                        __typename: 'ContractQuestionEdge' as const,
-                        node: {
-                            __typename: 'ContractQuestion' as const,
-                            id: 'oact-question-2-id',
-                            contractID,
-                            createdAt: new Date('2022-12-17'),
-                            addedBy: mockValidCMSUser({
-                                divisionAssignment: 'OACT',
-                            }) as CmsUser,
-                            round: 2,
-                            documents: [
-                                {
-                                    s3URL: 's3://bucketname/key/oact-question-1-document-1',
-                                    name: 'oact-question-2-document-1',
-                                    downloadURL: expect.any(String),
-                                },
-                            ],
-                            division: 'OACT',
-                            responses: [
-                                {
-                                    __typename: 'QuestionResponse' as const,
-                                    id: 'response-to-oact-2-id',
-                                    questionID: 'oact-question-2-id',
-                                    addedBy: mockValidUser() as StateUser,
-                                    createdAt: new Date('2022-12-16'),
-                                    documents: [
-                                        {
-                                            s3URL: 's3://bucketname/key/response-to-oact-1-document-1',
-                                            name: 'response-to-oact-2-document-1',
-                                            downloadURL: expect.any(String),
-                                        },
-                                    ],
-                                },
-                            ],
-                        },
-                    },
-                ],
-            },
-        },
+        questions: mockContractQuestions(contractID),
         ...partial,
     }
 }
@@ -926,6 +949,7 @@ function mockContractWithLinkedRateDraft(
 function mockContractWithLinkedRateSubmitted(
     partial?: Partial<Contract>
 ): Contract {
+    const contractID = partial?.id ?? 'test-abc-123'
     return {
         __typename: 'Contract',
         initiallySubmittedAt: new Date('12/18/2023'),
@@ -935,7 +959,7 @@ function mockContractWithLinkedRateSubmitted(
         createdAt: new Date('12/1o/2023'),
         updatedAt: new Date('12/17/2023'),
         lastUpdatedForDisplay: new Date('12/17/2023'),
-        id: 'test-abc-123',
+        id: contractID,
         webURL: 'https://testmcreview.example/submissions/test-abc-123',
         stateCode: 'MN',
         state: mockMNState(),
@@ -962,7 +986,7 @@ function mockContractWithLinkedRateSubmitted(
                     createdAt: new Date('01/01/2024'),
                     updatedAt: new Date('12/31/2024'),
                     id: '123',
-                    contractID: 'test-abc-123',
+                    contractID: contractID,
                     submitInfo: {
                         updatedAt: new Date(),
                         updatedBy: {
@@ -1084,11 +1108,13 @@ function mockContractWithLinkedRateSubmitted(
                 ],
             },
         ],
+        questions: mockContractQuestions(contractID),
         ...partial,
     }
 }
 
 function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
+    const contractID = partial?.id ?? 'test-abc-123'
     return {
         status: 'SUBMITTED',
         reviewStatus: 'UNDER_REVIEW',
@@ -1099,7 +1125,7 @@ function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
         lastUpdatedForDisplay: new Date(),
         webURL: 'https://testmcreview.example/submissions/test-abc-123',
         initiallySubmittedAt: new Date('2024-11-27'),
-        id: 'test-abc-123',
+        id: contractID,
         stateCode: 'MN',
         state: mockMNState(),
         stateNumber: 5,
@@ -1129,7 +1155,7 @@ function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
                     createdAt: new Date('01/01/2024'),
                     updatedAt: '2024-12-18T16:54:39.173Z',
                     id: '123',
-                    contractID: 'test-abc-123',
+                    contractID: contractID,
                     submitInfo: {
                         __typename: 'UpdateInformation',
                         updatedAt: new Date(),
@@ -1276,6 +1302,7 @@ function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
                 ],
             },
         ],
+        questions: mockContractQuestions(contractID),
         ...partial,
     }
 }
@@ -1488,6 +1515,7 @@ function mockContractPackageApproved(
                 ],
             },
         ],
+        questions: mockContractQuestions(contractID),
         ...partial,
     }
 }
@@ -1500,196 +1528,7 @@ function mockContractPackageApprovedWithQuestions(
 
     return {
         ...mockContractPackageApproved(),
-        questions: {
-            DMCOQuestions: {
-                totalCount: 2,
-                edges: [
-                    {
-                        __typename: 'ContractQuestionEdge' as const,
-                        node: {
-                            __typename: 'ContractQuestion' as const,
-                            id: 'dmco-question-1-id',
-                            contractID,
-                            createdAt: new Date('2022-12-16'),
-                            addedBy: mockValidCMSUser({
-                                divisionAssignment: null,
-                            }) as CmsUser,
-                            round: 1,
-                            documents: [
-                                {
-                                    s3URL: 's3://bucketname/key/dmco-question-1-document-1',
-                                    name: 'dmco-question-1-document-1',
-                                    downloadURL: expect.any(String),
-                                },
-                            ],
-                            division: 'DMCO',
-                            responses: [
-                                {
-                                    __typename: 'QuestionResponse' as const,
-                                    id: 'response-to-dmco-1-id',
-                                    questionID: 'dmco-question-1-id',
-                                    addedBy: mockValidUser() as StateUser,
-                                    createdAt: new Date('2022-12-16'),
-                                    documents: [
-                                        {
-                                            s3URL: 's3://bucketname/key/response-to-dmco-1-document-1',
-                                            name: 'response-to-dmco-1-document-1',
-                                            downloadURL: expect.any(String),
-                                        },
-                                    ],
-                                },
-                            ],
-                        },
-                    },
-                    {
-                        __typename: 'ContractQuestionEdge' as const,
-                        node: {
-                            __typename: 'ContractQuestion' as const,
-                            id: 'dmco-question-2-id',
-                            contractID,
-                            createdAt: new Date('2022-12-18'),
-                            addedBy: mockValidCMSUser() as CmsUser,
-                            round: 2,
-                            documents: [
-                                {
-                                    s3URL: 's3://bucketname/key/dmco-question-2-document-1',
-                                    name: 'dmco-question-2-document-1',
-                                    downloadURL: expect.any(String),
-                                },
-                                {
-                                    s3URL: 's3://bucketname/key/question-2-document-2',
-                                    name: 'dmco-question-2-document-2',
-                                    downloadURL: expect.any(String),
-                                },
-                            ],
-                            division: 'DMCO',
-                            responses: [],
-                        },
-                    },
-                ],
-            },
-            DMCPQuestions: {
-                totalCount: 1,
-                edges: [
-                    {
-                        __typename: 'ContractQuestionEdge' as const,
-                        node: {
-                            __typename: 'ContractQuestion' as const,
-                            id: 'dmcp-question-1-id',
-                            contractID,
-                            createdAt: new Date('2022-12-15'),
-                            round: 1,
-                            addedBy: mockValidCMSUser({
-                                divisionAssignment: 'DMCP',
-                            }) as CmsUser,
-                            documents: [
-                                {
-                                    s3URL: 's3://bucketname/key/dmcp-question-1-document-1',
-                                    name: 'dmcp-question-1-document-1',
-                                    downloadURL: expect.any(String),
-                                },
-                            ],
-                            division: 'DMCP',
-                            responses: [
-                                {
-                                    __typename: 'QuestionResponse' as const,
-                                    id: 'response-to-dmcp-1-id',
-                                    questionID: 'dmcp-question-1-id',
-                                    addedBy: mockValidUser() as StateUser,
-                                    createdAt: new Date('2022-12-16'),
-                                    documents: [
-                                        {
-                                            s3URL: 's3://bucketname/key/response-to-dmcp-1-document-1',
-                                            name: 'response-to-dmcp-1-document-1',
-                                            downloadURL: expect.any(String),
-                                        },
-                                    ],
-                                },
-                            ],
-                        },
-                    },
-                ],
-            },
-            OACTQuestions: {
-                totalCount: 2,
-                edges: [
-                    {
-                        __typename: 'ContractQuestionEdge' as const,
-                        node: {
-                            __typename: 'ContractQuestion' as const,
-                            id: 'oact-question-1-id',
-                            contractID,
-                            createdAt: new Date('2022-12-14'),
-                            addedBy: mockValidCMSUser({
-                                divisionAssignment: 'OACT',
-                            }) as CmsUser,
-                            round: 1,
-                            documents: [
-                                {
-                                    s3URL: 's3://bucketname/key/oact-question-1-document-1',
-                                    name: 'oact-question-1-document-1',
-                                    downloadURL: expect.any(String),
-                                },
-                            ],
-                            division: 'OACT',
-                            responses: [
-                                {
-                                    __typename: 'QuestionResponse' as const,
-                                    id: 'response-to-oact-1-id',
-                                    questionID: 'oact-question-1-id',
-                                    addedBy: mockValidUser() as StateUser,
-                                    createdAt: new Date('2022-12-17'),
-                                    documents: [
-                                        {
-                                            s3URL: 's3://bucketname/key/response-to-oact-1-document-1',
-                                            name: 'response-to-oact-1-document-1',
-                                            downloadURL: expect.any(String),
-                                        },
-                                    ],
-                                },
-                            ],
-                        },
-                    },
-                    {
-                        __typename: 'ContractQuestionEdge' as const,
-                        node: {
-                            __typename: 'ContractQuestion' as const,
-                            id: 'oact-question-2-id',
-                            contractID: 'test-abc-123',
-                            createdAt: new Date('2022-12-17'),
-                            round: 2,
-                            addedBy: mockValidCMSUser({
-                                divisionAssignment: 'OACT',
-                            }) as CmsUser,
-                            documents: [
-                                {
-                                    s3URL: 's3://bucketname/key/oact-question-1-document-1',
-                                    name: 'oact-question-2-document-1',
-                                    downloadURL: expect.any(String),
-                                },
-                            ],
-                            division: 'OACT',
-                            responses: [
-                                {
-                                    __typename: 'QuestionResponse' as const,
-                                    id: 'response-to-oact-2-id',
-                                    questionID: 'oact-question-2-id',
-                                    addedBy: mockValidUser() as StateUser,
-                                    createdAt: new Date('2022-12-16'),
-                                    documents: [
-                                        {
-                                            s3URL: 's3://bucketname/key/response-to-oact-1-document-1',
-                                            name: 'response-to-oact-2-document-1',
-                                            downloadURL: expect.any(String),
-                                        },
-                                    ],
-                                },
-                            ],
-                        },
-                    },
-                ],
-            },
-        },
+        questions: mockContractQuestions(contractID),
         ...partial,
     }
 }
@@ -1798,6 +1637,7 @@ function mockContractPackageSubmittedWithRevisions(
                 rateRevisions: [mockRateRevision('1')],
             },
         ],
+        questions: mockContractQuestions(contractID),
         ...partial,
     }
 }
@@ -2219,6 +2059,7 @@ function mockContractPackageWithDifferentProgramsInRevisions(): Contract {
                 __typename: 'ContractPackageSubmission',
             },
         ],
+        questions: mockEmptyContractQuestions()
     }
 }
 
@@ -2547,6 +2388,22 @@ function mockContractPackageUnlockedWithUnlockedType(
                         __typename: 'RateRevision',
                         id: 'unlocked-rr-1234',
                         rateID: '456',
+                        rate: {
+                            __typename: 'Rate',
+                            id: 'unlocked-rate-123',
+                            webURL: 'https://testmcreview.example/rates/unlocked-rate-123',
+                            createdAt: new Date(),
+                            updatedAt: new Date(),
+                            status: 'SUBMITTED',
+                            reviewStatus: 'UNDER_REVIEW',
+                            consolidatedStatus: 'SUBMITTED',
+                            reviewStatusActions: [],
+                            stateCode: 'MN',
+                            revisions: [],
+                            state: mockMNState(),
+                            stateNumber: 5,
+                            parentContractID: contractID
+                        },
                         createdAt: new Date('01/01/2023'),
                         updatedAt: new Date('01/01/2023'),
                         submitInfo: {
@@ -2615,6 +2472,7 @@ function mockContractPackageUnlockedWithUnlockedType(
                 ],
             },
         ],
+        questions: mockEmptyContractQuestions(),
         ...partial,
     }
 }

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -537,9 +537,10 @@ describe('SubmissionSummary', () => {
 
             describe('CMS user unlock submission', () => {
                 it('renders the unlock button', async () => {
-                    const contract = mockContractPackageSubmittedWithQuestions({
-                        id: 'test-abc-123',
-                    })
+                    const contract =
+                        mockContractPackageSubmittedWithQuestions(
+                            'test-abc-123'
+                        )
 
                     renderWithProviders(
                         <Routes>

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -537,10 +537,9 @@ describe('SubmissionSummary', () => {
 
             describe('CMS user unlock submission', () => {
                 it('renders the unlock button', async () => {
-                    const contract =
-                        mockContractPackageUnlockedWithUnlockedType({
-                            id: 'test-abc-123',
-                        })
+                    const contract = mockContractPackageSubmittedWithQuestions({
+                        id: 'test-abc-123',
+                    })
 
                     renderWithProviders(
                         <Routes>
@@ -557,9 +556,6 @@ describe('SubmissionSummary', () => {
                                     fetchCurrentUserMock({
                                         user: mockUser(),
                                         statusCode: 200,
-                                    }),
-                                    fetchContractWithQuestionsMockSuccess({
-                                        contract,
                                     }),
                                     fetchContractWithQuestionsMockSuccess({
                                         contract,
@@ -746,10 +742,16 @@ describe('SubmissionSummary', () => {
 
                     await waitFor(() => {
                         expect(
-                            screen.getByRole('button', {
+                            screen.queryByRole('button', {
                                 name: 'Unlock submission',
                             })
-                        ).toBeDisabled()
+                        ).not.toBeInTheDocument()
+
+                        expect(
+                            screen.getByText(
+                                "No action can be taken on this submission in it's current status."
+                            )
+                        ).toBeInTheDocument()
                     })
                 })
 
@@ -995,12 +997,18 @@ describe('SubmissionSummary', () => {
                         })
                     ).not.toBeInTheDocument()
 
-                    // expect unlock button to be disabled
+                    // expect unlock button to be not on the page
                     expect(
-                        screen.getByRole('button', {
+                        screen.queryByRole('button', {
                             name: 'Unlock submission',
                         })
-                    ).toBeDisabled()
+                    ).not.toBeInTheDocument()
+
+                    expect(
+                        screen.getByText(
+                            "No action can be taken on this submission in it's current status."
+                        )
+                    ).toBeInTheDocument()
                 })
 
                 it('does not render released to state button for an approved submission', async () => {
@@ -1055,12 +1063,18 @@ describe('SubmissionSummary', () => {
                         })
                     ).toBeNull()
 
-                    // expect unlock button to be disabled
+                    // expect unlock button to be not on the page
                     expect(
-                        screen.getByRole('button', {
+                        screen.queryByRole('button', {
                             name: 'Unlock submission',
                         })
-                    ).toBeDisabled()
+                    ).not.toBeInTheDocument()
+
+                    expect(
+                        screen.getByText(
+                            "No action can be taken on this submission in it's current status."
+                        )
+                    ).toBeInTheDocument()
                 })
 
                 it('renders approval banner on approved submission', async () => {
@@ -1181,6 +1195,12 @@ describe('SubmissionSummary', () => {
                         name: 'Unlock submission',
                     })
                     expect(unlockBtn).not.toBeInTheDocument()
+
+                    expect(
+                        screen.getByText(
+                            "No action can be taken on this submission in it's current status."
+                        )
+                    ).toBeInTheDocument()
                 })
             })
         }

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -935,12 +935,12 @@ describe('SubmissionSummary', () => {
                         })
                     ).toBeInTheDocument()
 
-                    // expect unlock button to have outline style
+                    // expect unlock button
                     expect(
                         screen.getByRole('button', {
                             name: 'Unlock submission',
                         })
-                    ).toHaveClass('usa-button--outline')
+                    ).toHaveClass('usa-button')
                 })
                 it('does not render released to state link on unlocked submission', async () => {
                     const unlockedContract =

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -1,4 +1,4 @@
-import { Grid, GridContainer, Link, ModalRef } from '@trussworks/react-uswds'
+import { GridContainer, Link, ModalRef } from '@trussworks/react-uswds'
 import React, { useEffect, useRef, useState } from 'react'
 import { useAuth } from '../../contexts/AuthContext'
 import { ContractDetailsSummarySection } from '../StateSubmission/ReviewSubmit/ContractDetailsSummarySection'
@@ -11,6 +11,8 @@ import {
     DocumentWarningBanner,
     LinkWithLogging,
     NavLinkWithLogging,
+    SectionCard,
+    DoubleColumnGrid,
 } from '../../components'
 import { Loading } from '../../components'
 import { usePage } from '../../contexts/PageContext'
@@ -247,16 +249,36 @@ export const SubmissionSummary = (): React.ReactElement => {
                     <DocumentWarningBanner className={styles.banner} />
                 )}
 
-                {showSubmissionApproval && (
-                    <Grid className={styles.releaseToStateContainer} row>
-                        <NavLinkWithLogging
-                            className="usa-button"
-                            variant="unstyled"
-                            to={'./released-to-state'}
-                        >
-                            Released to state
-                        </NavLinkWithLogging>
-                    </Grid>
+                {hasCMSPermissions && (
+                    <SectionCard className={styles.actionsSection}>
+                        <h3>Actions</h3>
+                        <DoubleColumnGrid>
+                            {hasCMSPermissions && !showApprovalBanner && (
+                                <ModalOpenButton
+                                    modalRef={modalRef}
+                                    disabled={
+                                        ['DRAFT', 'UNLOCKED'].includes(
+                                            contract.status
+                                        ) ||
+                                        contract.reviewStatus === 'APPROVED'
+                                    }
+                                    className={styles.submitButton}
+                                    id="form-submit"
+                                >
+                                    Unlock submission
+                                </ModalOpenButton>
+                            )}
+                            {showSubmissionApproval && (
+                                <NavLinkWithLogging
+                                    className="usa-button bg-green"
+                                    variant="unstyled"
+                                    to={'./released-to-state'}
+                                >
+                                    Released to state
+                                </NavLinkWithLogging>
+                            )}
+                        </DoubleColumnGrid>
+                    </SectionCard>
                 )}
 
                 <SubmissionTypeSummarySection
@@ -288,23 +310,6 @@ export const SubmissionSummary = (): React.ReactElement => {
                     }
                     contract={contract}
                     submissionName={name}
-                    headerChildComponent={
-                        hasCMSPermissions && !showApprovalBanner ? (
-                            <ModalOpenButton
-                                modalRef={modalRef}
-                                disabled={
-                                    ['DRAFT', 'UNLOCKED'].includes(
-                                        contract.status
-                                    ) || contract.reviewStatus === 'APPROVED'
-                                }
-                                className={styles.submitButton}
-                                id="form-submit"
-                                outline={showSubmissionApproval}
-                            >
-                                Unlock submission
-                            </ModalOpenButton>
-                        ) : undefined
-                    }
                     statePrograms={statePrograms}
                     initiallySubmittedAt={contract.initiallySubmittedAt}
                     isStateUser={isStateUser}

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -1,4 +1,4 @@
-import { GridContainer, Link, ModalRef } from '@trussworks/react-uswds'
+import { GridContainer, Link, ModalRef, Grid } from '@trussworks/react-uswds'
 import React, { useEffect, useRef, useState } from 'react'
 import { useAuth } from '../../contexts/AuthContext'
 import { ContractDetailsSummarySection } from '../StateSubmission/ReviewSubmit/ContractDetailsSummarySection'
@@ -177,7 +177,7 @@ export const SubmissionSummary = (): React.ReactElement => {
 
     // Only show for CMS_USER or CMS_APPROVER_USER users
     // and if the submission isn't approved
-    const showSubmissionApproval =
+    const showApprovalBtn =
         submissionApprovalFlag &&
         hasCMSPermissions &&
         !['APPROVED', 'UNLOCKED'].includes(contract.consolidatedStatus)
@@ -185,6 +185,10 @@ export const SubmissionSummary = (): React.ReactElement => {
         submissionApprovalFlag &&
         contract.reviewStatus === 'APPROVED' &&
         latestContractAction
+    const showUnlockBtn =
+        hasCMSPermissions &&
+        ['SUBMITTED', 'RESUBMITTED'].includes(contract.consolidatedStatus)
+    const showNoActionsMsg = !showApprovalBtn && !showUnlockBtn
 
     const renderStatusAlerts = () => {
         if (showApprovalBanner) {
@@ -252,32 +256,39 @@ export const SubmissionSummary = (): React.ReactElement => {
                 {hasCMSPermissions && (
                     <SectionCard className={styles.actionsSection}>
                         <h3>Actions</h3>
-                        <DoubleColumnGrid>
-                            {hasCMSPermissions && !showApprovalBanner && (
-                                <ModalOpenButton
-                                    modalRef={modalRef}
-                                    disabled={
-                                        ['DRAFT', 'UNLOCKED'].includes(
-                                            contract.status
-                                        ) ||
-                                        contract.reviewStatus === 'APPROVED'
-                                    }
-                                    className={styles.submitButton}
-                                    id="form-submit"
-                                >
-                                    Unlock submission
-                                </ModalOpenButton>
-                            )}
-                            {showSubmissionApproval && (
-                                <NavLinkWithLogging
-                                    className="usa-button bg-green"
-                                    variant="unstyled"
-                                    to={'./released-to-state'}
-                                >
-                                    Released to state
-                                </NavLinkWithLogging>
-                            )}
-                        </DoubleColumnGrid>
+                        {showNoActionsMsg ? (
+                            <Grid>
+                                No action can be taken on this submission in
+                                it's current status.
+                            </Grid>
+                        ) : (
+                            <DoubleColumnGrid>
+                                {showUnlockBtn && (
+                                    <ModalOpenButton
+                                        modalRef={modalRef}
+                                        disabled={
+                                            ['DRAFT', 'UNLOCKED'].includes(
+                                                contract.status
+                                            ) ||
+                                            contract.reviewStatus === 'APPROVED'
+                                        }
+                                        className={styles.submitButton}
+                                        id="form-submit"
+                                    >
+                                        Unlock submission
+                                    </ModalOpenButton>
+                                )}
+                                {showApprovalBtn && (
+                                    <NavLinkWithLogging
+                                        className="usa-button bg-green"
+                                        variant="unstyled"
+                                        to={'./released-to-state'}
+                                    >
+                                        Released to state
+                                    </NavLinkWithLogging>
+                                )}
+                            </DoubleColumnGrid>
+                        )}
                     </SectionCard>
                 )}
 

--- a/services/cypress/support/submissionReviewCommands.ts
+++ b/services/cypress/support/submissionReviewCommands.ts
@@ -7,9 +7,7 @@ Cypress.Commands.add('unlockSubmission', (unlockReason) => {
     )
     cy.findByRole('button', { name: 'Unlock' }).click()
 
-    cy.findByRole('button', { name: 'Unlock submission'}).should(
-        'be.disabled', {timeout: 50_000 }
-    )
+    cy.findByText('No action can be taken on this submission in it\'s current status.').should('exist')
     cy.findAllByTestId('modalWindow').eq(1).should('be.hidden')
 
     // Unlock banner for CMS user to be present with correct data.


### PR DESCRIPTION
## Summary
[MCR-4891](https://jiraent.cms.gov/browse/MCR-4891)
- If I am logged in as a CMS user and I am viewing a submission summary 
Then I see an Actions section at the top of the page with the "Unlock" and "Release to state" buttons nested within it 
- If there is a banner at the top of the submission summary (like the unlock or submission edited banner) 
Then the Actions section will appear below the banner. 
- If I have performed an action on a submission, (such as "released to state" or "withdrawn") 
Then the Actions section will appear below the banner with the following copy included in the section, "No action can be taken on this submission in it's current status."([See Figma](https://www.figma.com/design/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?node-id=17311-87315&t=MhLXEukOumzpDzDc-1))

[MCR-4639](https://jiraent.cms.gov/browse/MCR-4638)
- Add submission withdraw feature flag to LD
- Add flag to codebase


#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

- No big changes here. 
   - Just make sure the action section contains all the buttons.
   - State, Businesses Owner, Admin, Helpdesk users do not see the actions section. 

<!---These are developer instructions on how to test or validate the work -->
