### PR TITLE
Refactor RDS snapshot lambda

### DIFF
--- a/services/app-api/src/handlers/cleanup.ts
+++ b/services/app-api/src/handlers/cleanup.ts
@@ -11,30 +11,60 @@ import {
 const main = async () => {
     const client = new RDSClient({ region: 'us-east-1' })
 
-    // find all snapshots in our account
-    const describeInput: DescribeDBClusterSnapshotsCommandInput = {}
-    const describeCommand = new DescribeDBClusterSnapshotsCommand(describeInput)
-    const snapshots = await client.send(describeCommand)
+    let snapshots
+    try {
+        // find all snapshots in our account
+        const describeInput: DescribeDBClusterSnapshotsCommandInput = {}
+        const describeCommand = new DescribeDBClusterSnapshotsCommand(
+            describeInput
+        )
+        snapshots = await client.send(describeCommand)
+    } catch (error) {
+        console.error('Error fetching DB cluster snapshots:', error)
+        throw error
+    }
 
     // find snapshots older than 30 days, filter them out
     const timestamp = new Date().getTime() - 30 * 24 * 60 * 60 * 1000 // d * hr * min * s * ms
     const oldSnapshots = snapshots.DBClusterSnapshots?.filter((snapshot) => {
         return (
             snapshot.SnapshotCreateTime != undefined &&
-            timestamp > snapshot.SnapshotCreateTime.getTime()
+            snapshot.SnapshotCreateTime.getTime() < timestamp
         )
     })
 
-    // delete the older snapshots
-    oldSnapshots?.forEach(async (snapshot) => {
-        const deleteInput: DeleteDBClusterSnapshotCommandInput = {
-            DBClusterSnapshotIdentifier: snapshot.DBClusterSnapshotIdentifier,
-        }
+    console.info(
+        `Found ${oldSnapshots?.length || 0} snapshots older than 30 days to delete`
+    )
 
-        const deleteCommand = new DeleteDBClusterSnapshotCommand(deleteInput)
-        const response = await client.send(deleteCommand)
-        console.info('Deleted old snapshot: ' + response)
-    })
+    if (!oldSnapshots || oldSnapshots.length === 0) {
+        console.info('No old snapshots to delete')
+        return
+    }
+
+    // Use Promise.all to wait for all delete operations to complete
+    try {
+        const deletePromises = oldSnapshots.map(async (snapshot) => {
+            const deleteInput: DeleteDBClusterSnapshotCommandInput = {
+                DBClusterSnapshotIdentifier:
+                    snapshot.DBClusterSnapshotIdentifier,
+            }
+            const deleteCommand = new DeleteDBClusterSnapshotCommand(
+                deleteInput
+            )
+            const response = await client.send(deleteCommand)
+            console.info(
+                `Deleted old snapshot: ${snapshot.DBClusterSnapshotIdentifier}`
+            )
+            return response
+        })
+
+        await Promise.all(deletePromises)
+        console.info('Successfully deleted all old snapshots')
+    } catch (error) {
+        console.error('Error deleting snapshots:', error)
+        throw error
+    }
 }
 
 module.exports = { main }


### PR DESCRIPTION
## Summary

We noticed a little while back that some older snapshots for RDS were not being cleaned out properly. It looks like it might be because I wrote the original cleanup script using a `forEach`, which might not finish before the lambda halts. This moves us to use a `Promise.all` approach so that we can make sure the lambda doesn't stop before the operations finish. 

#### Related issues
https://jiraent.cms.gov/browse/MCR-5114
