### PR TITLE
MCR-5000: State cannot add rate cert date that is in the future.

### DIFF
--- a/packages/dates/src/calendarDate.ts
+++ b/packages/dates/src/calendarDate.ts
@@ -41,11 +41,24 @@ function formatRateNameDate(date: Date | undefined): string {
     return dayjs(date).tz('UTC').format('YYYYMMDD')
 }
 
-const formatUserInputDate = (initialValue?: string): string | undefined => {
+function formatUserInputDate(initialValue?: string): string | undefined {
     const dayjsValue = dayjs(initialValue)
     return initialValue && dayjsValue.isValid()
         ? dayjs(initialValue).format('YYYY-MM-DD')
         : initialValue // preserve undefined to show validations later
+}
+
+/**
+ * Returns the current date in the format YYYY-M-D.
+ * Uses the user's local timezone.
+ *
+ * @returns {string} Current date formatted as YYYY-M-D (year-month-day).
+ * Note: Month is not zero-padded (e.g., January returns 1, not 01).
+ * Note: Day is not zero-padded (e.g., the 1st returns 1, not 01).
+ */
+function getCurrentDate() {
+    const today = new Date()
+    return `${today.getFullYear()}-${today.getMonth()+1}-${today.getDate()}`
 }
 
 export {
@@ -53,4 +66,5 @@ export {
     formatRateNameDate,
     formatToPacificTime,
     formatUserInputDate,
+    getCurrentDate
 }

--- a/packages/dates/src/calendarDate.ts
+++ b/packages/dates/src/calendarDate.ts
@@ -48,23 +48,9 @@ function formatUserInputDate(initialValue?: string): string | undefined {
         : initialValue // preserve undefined to show validations later
 }
 
-/**
- * Returns the current date in the format YYYY-M-D.
- * Uses the user's local timezone.
- *
- * @returns {string} Current date formatted as YYYY-M-D (year-month-day).
- * Note: Month is not zero-padded (e.g., January returns 1, not 01).
- * Note: Day is not zero-padded (e.g., the 1st returns 1, not 01).
- */
-function getCurrentDate() {
-    const today = new Date()
-    return `${today.getFullYear()}-${today.getMonth()+1}-${today.getDate()}`
-}
-
 export {
     formatCalendarDate,
     formatRateNameDate,
     formatToPacificTime,
     formatUserInputDate,
-    getCurrentDate
 }

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
@@ -6,7 +6,6 @@ import {
     validateFileItemsList,
     validateFileItemsListSingleUpload,
 } from '../../../formHelpers/validators'
-import { getCurrentDate } from '@mc-review/dates';
 
 Yup.addMethod(Yup.date, 'validateDateFormat', validateDateFormat)
 
@@ -87,7 +86,7 @@ const SingleRateCertSchema = (_activeFeatureFlags: FeatureFlagSettings) =>
                         .typeError(
                             'The certified date must be in MM/DD/YYYY format'
                         )
-                        .max(getCurrentDate(), 'The certification date cannot be a future date')
+                        .max(dayjs(new Date()), 'The certification date cannot be a future date')
                 )
             }
         }),

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
@@ -6,6 +6,7 @@ import {
     validateFileItemsList,
     validateFileItemsListSingleUpload,
 } from '../../../formHelpers/validators'
+import { getCurrentDate } from '@mc-review/dates';
 
 Yup.addMethod(Yup.date, 'validateDateFormat', validateDateFormat)
 
@@ -86,6 +87,7 @@ const SingleRateCertSchema = (_activeFeatureFlags: FeatureFlagSettings) =>
                         .typeError(
                             'The certified date must be in MM/DD/YYYY format'
                         )
+                        .max(getCurrentDate(), 'The certification date cannot be a future date')
                 )
             }
         }),

--- a/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateFormFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateFormFields.tsx
@@ -18,7 +18,7 @@ import {
 
 import styles from '../StateSubmissionForm.module.scss'
 import { isDateRangeEmpty } from '../../../formHelpers'
-import { formatUserInputDate } from '@mc-review/dates'
+import { dayjs, formatUserInputDate } from '@mc-review/dates'
 import {
     ACCEPTED_RATE_SUPPORTING_DOCS_FILE_TYPES,
     ACCEPTED_RATE_CERTIFICATION_FILE_TYPES,
@@ -522,6 +522,7 @@ export const SingleRateFormFields = ({
                                     formatUserInputDate(val)
                                 )
                             }
+                            maxDate={dayjs(new Date()).format('YYYY-MM-DD')}
                         />
                     </FormGroup>
                 </>

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -444,6 +444,7 @@ const RateDetails = ({
                                     setFocusErrorSummaryHeading(true)
                                     handleSubmit(e)
                                 }}
+                                noValidate
                             >
                                 <fieldset className="usa-fieldset with-sections">
                                     <legend className="srOnly">


### PR DESCRIPTION
## Summary
[MCR-5000](https://jiraent.cms.gov/browse/MCR-5000)

- Add Yup validation for rate cert date so that the date cannot be after the current date..

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
