### PR TITLE
Add env variables needed for promote

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -272,7 +272,7 @@ jobs:
 
   deploy-infra:
     needs: [begin-deployment, build-clamav-layer]
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@mt-logical-dbs
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name}}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -182,6 +182,8 @@ jobs:
       subnet_private_b_id: ${{ secrets.DEV_SUBNET_PRIVATE_B_ID }}
       subnet_private_c_id: ${{ secrets.DEV_SUBNET_PRIVATE_C_ID }}
       subnet_public_a_id: ${{ secrets.DEV_SUBNET_PUBLIC_A_ID }}
+      dev_db_sm_arn: ${{ secrets.DEV_DB_SM_ARN }}
+      dev_aurora_arn: ${{ secrets.DEV_AURORA_ARN }}
 
   promote-app-dev:
     needs: [promote-infra-dev, build-prisma-client-lambda-layer, unit-tests]
@@ -230,6 +232,8 @@ jobs:
       subnet_private_b_id: ${{ secrets.VAL_SUBNET_PRIVATE_B_ID }}
       subnet_private_c_id: ${{ secrets.VAL_SUBNET_PRIVATE_C_ID }}
       subnet_public_a_id: ${{ secrets.VAL_SUBNET_PUBLIC_A_ID }}
+      dev_db_sm_arn: ${{ secrets.DEV_DB_SM_ARN }}
+      dev_aurora_arn: ${{ secrets.DEV_AURORA_ARN }}
 
   promote-app-val:
     needs: [promote-app-dev, promote-infra-val, unit-tests]
@@ -278,6 +282,8 @@ jobs:
       subnet_private_b_id: ${{ secrets.PROD_SUBNET_PRIVATE_B_ID }}
       subnet_private_c_id: ${{ secrets.PROD_SUBNET_PRIVATE_C_ID }}
       subnet_public_a_id: ${{ secrets.PROD_SUBNET_PUBLIC_A_ID }}
+      dev_db_sm_arn: ${{ secrets.DEV_DB_SM_ARN }}
+      dev_aurora_arn: ${{ secrets.DEV_AURORA_ARN }}
 
   promote-app-prod:
     needs: [promote-app-val, promote-infra-prod, unit-tests]

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -65,7 +65,6 @@ custom:
   databaseName: !Sub aurora_${self:service}_${sls:stage}_${AWS::AccountId}
   vpcId: ${env:VPC_ID}
   sgId: ${env:SG_ID}
-  devAuroraArn: ${env:CF_CONFIG_IGNORED_LOCALLY, env:DEV_AURORA_ARN}
   privateSubnets:
     - ${env:SUBNET_PRIVATE_A_ID}
     - ${env:SUBNET_PRIVATE_B_ID}
@@ -75,6 +74,7 @@ custom:
   iamPath: ${env:IAM_PATH}
   rotatorArn: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${sls:stage}-rotator'
   dbManagerArn: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:aurora_${self:service}_*'
+  devAuroraArn: ${env:CF_CONFIG_IGNORED_LOCALLY, env:DEV_AURORA_ARN}
   devDbSecretsArn: ${env:CF_CONFIG_IGNORED_LOCALLY, env:DEV_DB_SM_ARN}
   slackWebhookUrl: ${env:SLACK_WEBHOOK}
   serverlessTerminationProtection:


### PR DESCRIPTION
## Summary

The IAM permissions for the `postgres` serverless config now requires a couple environment variables to be passed to it. These really are only of concern for the dev environment, as it has to do with the new way of creating logical DBs in the dev AWS Aurora. However, serverless doesn't let us just skip deploying the lambda in higher environments or conditionally exclude parts of the IAM configs. This is something that can/will change when we move to CDK.

This also moves the git ref back to `main`. 

#### Related issues
https://jiraent.cms.gov/browse/MCR-2645
