### PR TITLE
Use different ARNs for dev/val/prod when deploying logical DBs

### DIFF
--- a/.github/workflows/deploy-infra-to-env.yml
+++ b/.github/workflows/deploy-infra-to-env.yml
@@ -46,10 +46,10 @@ on:
         required: true
       subnet_public_a_id:
         required: false
-      dev_db_sm_arn:
-        required: false
-      dev_aurora_arn:
-        required: false
+      db_sm_arn:
+        required: true
+      aurora_arn:
+        required: true
 
 permissions:
   id-token: write
@@ -137,8 +137,8 @@ jobs:
           SUBNET_PUBLIC_A_ID: ${{ secrets.subnet_public_a_id }}
           IAM_PERMISSIONS_BOUNDARY: ${{ secrets.iam_permissions_boundary }}
           IAM_PATH: ${{ secrets.iam_path }}
-          DEV_AURORA_ARN: ${{ secrets.dev_aurora_arn }}
-          DEV_DB_SM_ARN: ${{ secrets.dev_db_sm_arn }}
+          AURORA_ARN: ${{ secrets.aurora_arn }}
+          DB_SM_ARN: ${{ secrets.db_sm_arn }}
         run: |
           pushd services/postgres && npx serverless deploy --stage ${{ inputs.stage_name }}
 
@@ -146,10 +146,10 @@ jobs:
         if: ${{ github.ref != 'refs/heads/main' }}
         env:
           STAGE_NAME: ${{ inputs.stage_name }}
-          DEV_DB_SM_ARN: ${{ secrets.dev_db_sm_arn }}
+          DB_SM_ARN: ${{ secrets.db_sm_arn }}
         run: |
           chmod +x services/postgres/db-manager.sh
-          ./services/postgres/db-manager.sh create $STAGE_NAME $DEV_DB_SM_ARN $STAGE_NAME
+          ./services/postgres/db-manager.sh create $STAGE_NAME $DB_SM_ARN $STAGE_NAME
 
       - name: Upload VM scripts to S3
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -272,7 +272,7 @@ jobs:
 
   deploy-infra:
     needs: [begin-deployment, build-clamav-layer]
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@mt-promote-2645-v2
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name}}
@@ -291,8 +291,8 @@ jobs:
       subnet_private_b_id: ${{ secrets.DEV_SUBNET_PRIVATE_B_ID }}
       subnet_private_c_id: ${{ secrets.DEV_SUBNET_PRIVATE_C_ID }}
       subnet_public_a_id: ${{ secrets.DEV_SUBNET_PUBLIC_A_ID }}
-      dev_db_sm_arn: ${{ secrets.DEV_DB_SM_ARN }}
-      dev_aurora_arn: ${{ secrets.DEV_AURORA_ARN }}
+      db_sm_arn: ${{ secrets.DEV_DB_SM_ARN }}
+      aurora_arn: ${{ secrets.DEV_AURORA_ARN }}
 
   deploy-app:
     needs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -272,7 +272,7 @@ jobs:
 
   deploy-infra:
     needs: [begin-deployment, build-clamav-layer]
-    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@mt-promote-2645-v2
+    uses: Enterprise-CMCS/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name}}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -182,8 +182,8 @@ jobs:
       subnet_private_b_id: ${{ secrets.DEV_SUBNET_PRIVATE_B_ID }}
       subnet_private_c_id: ${{ secrets.DEV_SUBNET_PRIVATE_C_ID }}
       subnet_public_a_id: ${{ secrets.DEV_SUBNET_PUBLIC_A_ID }}
-      dev_db_sm_arn: ${{ secrets.DEV_DB_SM_ARN }}
-      dev_aurora_arn: ${{ secrets.DEV_AURORA_ARN }}
+      db_sm_arn: ${{ secrets.DEV_DB_SM_ARN }}
+      aurora_arn: ${{ secrets.DEV_AURORA_ARN }}
 
   promote-app-dev:
     needs: [promote-infra-dev, build-prisma-client-lambda-layer, unit-tests]
@@ -232,8 +232,8 @@ jobs:
       subnet_private_b_id: ${{ secrets.VAL_SUBNET_PRIVATE_B_ID }}
       subnet_private_c_id: ${{ secrets.VAL_SUBNET_PRIVATE_C_ID }}
       subnet_public_a_id: ${{ secrets.VAL_SUBNET_PUBLIC_A_ID }}
-      dev_db_sm_arn: ${{ secrets.DEV_DB_SM_ARN }}
-      dev_aurora_arn: ${{ secrets.DEV_AURORA_ARN }}
+      db_sm_arn: ${{ secrets.VAL_DB_SM_ARN }}
+      aurora_arn: ${{ secrets.VAL_AURORA_ARN }}
 
   promote-app-val:
     needs: [promote-app-dev, promote-infra-val, unit-tests]
@@ -282,8 +282,8 @@ jobs:
       subnet_private_b_id: ${{ secrets.PROD_SUBNET_PRIVATE_B_ID }}
       subnet_private_c_id: ${{ secrets.PROD_SUBNET_PRIVATE_C_ID }}
       subnet_public_a_id: ${{ secrets.PROD_SUBNET_PUBLIC_A_ID }}
-      dev_db_sm_arn: ${{ secrets.DEV_DB_SM_ARN }}
-      dev_aurora_arn: ${{ secrets.DEV_AURORA_ARN }}
+      db_sm_arn: ${{ secrets.PROD_DB_SM_ARN }}
+      aurora_arn: ${{ secrets.PROD_AURORA_ARN }}
 
   promote-app-prod:
     needs: [promote-app-val, promote-infra-prod, unit-tests]

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -43,7 +43,7 @@ provider:
             - secretsmanager:DescribeSecret # pragma: allowlist secret
             - secretsmanager:GetSecretValue # pragma: allowlist secret
           Resource:
-            - '${self:custom.devDbSecretsArn}'
+            - '${self:custom.dbSecretsArn}'
         - Effect: 'Allow'
           Action:
             - secretsmanager:DescribeSecret # pragma: allowlist secret
@@ -74,8 +74,8 @@ custom:
   iamPath: ${env:IAM_PATH}
   rotatorArn: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${sls:stage}-rotator'
   dbManagerArn: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:aurora_${self:service}_*'
-  devAuroraArn: ${env:CF_CONFIG_IGNORED_LOCALLY, env:DEV_AURORA_ARN}
-  devDbSecretsArn: ${env:CF_CONFIG_IGNORED_LOCALLY, env:DEV_DB_SM_ARN}
+  auroraArn: ${env:CF_CONFIG_IGNORED_LOCALLY, env:AURORA_ARN}
+  dbSecretsArn: ${env:CF_CONFIG_IGNORED_LOCALLY, env:DB_SM_ARN}
   slackWebhookUrl: ${env:SLACK_WEBHOOK}
   serverlessTerminationProtection:
     stages:
@@ -380,7 +380,7 @@ resources:
       Type: AWS::SecretsManager::SecretTargetAttachment
       Properties:
         SecretId: !Ref PostgresSecret
-        TargetId: ${self:custom.devAuroraArn}
+        TargetId: ${self:custom.auroraArn}
         TargetType: AWS::RDS::DBCluster
 
     PostgresSecretsRotationSchedule:
@@ -407,7 +407,7 @@ resources:
     PostgresAuroraV2Arn:
       Value: !If
         - IsReviewEnvironment
-        - ${self:custom.devAuroraArn}
+        - ${self:custom.auroraArn}
         - !Sub 'arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:${PostgresAuroraV2}'
     PostgresVMScriptsBucket:
       Condition: IsDevValProd


### PR DESCRIPTION
## Summary

Another cleanup from merging #3237. We need to have the ARNs be valid for the environment that serverless is deploying into, otherwise CloudFormation fails to promote. We need to use these for now since we can't easily exclude deploying this logical DB lambda from val/prod. We do have safeguard checks in place for higher environments though, which will exit the lambda if the stage matches val or prod.

