### PR TITLE
MCR-5164: cms sees empty actions on rate summary

### DIFF
--- a/packages/mocks/src/apollo/rateDataMock.ts
+++ b/packages/mocks/src/apollo/rateDataMock.ts
@@ -255,6 +255,7 @@ function rateUnlockedWithHistoryMock(): Rate {
     })
 
     r1.status = 'UNLOCKED'
+    r1.consolidatedStatus = 'UNLOCKED'
     r1.draftRevision = draftRevision
 
     return r1

--- a/services/app-web/src/components/Banner/RateWithdrawBanner/RateWithdrawBanner.tsx
+++ b/services/app-web/src/components/Banner/RateWithdrawBanner/RateWithdrawBanner.tsx
@@ -30,7 +30,7 @@ export const RateWithdrawBanner = ({
         >
             <div className={styles.bannerBodyText}>
                 <p className="usa-alert__text">
-                    <b>Status:&nbsp;</b> Withdrawn
+                    <b>Status:&nbsp;</b>Withdrawn
                 </p>
                 <p className="usa-alert__text">
                     <b>Updated by:&nbsp;</b>

--- a/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
@@ -752,7 +752,7 @@ describe('RateSummary', () => {
             await waitFor(() => {
                 expect(
                     screen.getByText(
-                        "No action can be taken on this submission in it's current status."
+                        'No action can be taken on this submission in its current status.'
                     )
                 ).toBeInTheDocument()
             })
@@ -788,7 +788,7 @@ describe('RateSummary', () => {
             await waitFor(() => {
                 expect(
                     screen.getByText(
-                        "No action can be taken on this submission in it's current status."
+                        'No action can be taken on this submission in its current status.'
                     )
                 ).toBeInTheDocument()
             })
@@ -826,7 +826,7 @@ describe('RateSummary', () => {
             await waitFor(() => {
                 expect(
                     screen.getByText(
-                        "No action can be taken on this submission in it's current status."
+                        'No action can be taken on this submission in its current status.'
                     )
                 ).toBeInTheDocument()
             })
@@ -864,7 +864,7 @@ describe('RateSummary', () => {
             await waitFor(() => {
                 expect(
                     screen.getByText(
-                        "No action can be taken on this submission in it's current status."
+                        'No action can be taken on this submission in its current status.'
                     )
                 ).toBeInTheDocument()
             })

--- a/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
@@ -13,15 +13,13 @@ import {
     mockContractPackageSubmitted,
     rateDataMock,
     iterableNonCMSUsersMockData,
+    mockValidCMSUser,
 } from '@mc-review/mocks'
 import { RateSummary } from './RateSummary'
 import { RoutesRecord } from '@mc-review/constants'
 import { Location, Route, Routes } from 'react-router-dom'
 import { RateEdit } from '../RateEdit/RateEdit'
-import {
-    rateUnlockedWithHistoryMock,
-    rateWithHistoryMock,
-} from '@mc-review/mocks'
+import { rateWithHistoryMock } from '@mc-review/mocks'
 
 // Wrap test component in some top level routes to allow getParams to be tested
 const wrapInRoutes = (children: React.ReactNode) => {
@@ -292,42 +290,6 @@ describe('RateSummary', () => {
                     name: 'Unlock rate',
                 })
                 expect(unlockRateBtn).not.toBeInTheDocument()
-            })
-            it('disables the unlock button for CMS users when rate already unlocked', async () => {
-                const rateData = rateUnlockedWithHistoryMock()
-                renderWithProviders(wrapInRoutes(<RateSummary />), {
-                    apolloProvider: {
-                        mocks: [
-                            fetchCurrentUserMock({
-                                user: mockUser(),
-                                statusCode: 200,
-                            }),
-                            fetchRateWithQuestionsMockSuccess({
-                                rate: {
-                                    ...rateData,
-                                    id: '7a',
-                                    parentContractID: contract.id,
-                                },
-                            }),
-                            fetchContractMockSuccess({ contract }),
-                        ],
-                    },
-                    routerProvider: {
-                        route: '/rates/7a',
-                    },
-                    featureFlags: {
-                        'rate-edit-unlock': true,
-                        'withdraw-rate': true,
-                    },
-                })
-
-                await waitFor(() => {
-                    expect(
-                        screen.getByRole('button', {
-                            name: 'Unlock rate',
-                        })
-                    ).toHaveAttribute('aria-disabled', 'true')
-                })
             })
             it('should not display unlock rate button if parent contract has been approved', async () => {
                 const rate = rateDataMock()
@@ -709,5 +671,323 @@ describe('RateSummary', () => {
                 ).not.toBeInTheDocument()
             }
         )
+    })
+
+    describe('Action section tests', () => {
+        it('renders unlock and withdraw button on submitted rate', async () => {
+            const contract = mockContractPackageSubmitted({
+                consolidatedStatus: 'SUBMITTED',
+            })
+            const rateData = rateWithHistoryMock()
+            rateData.parentContractID = contract.id
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchContractMockSuccess({ contract }),
+                        fetchRateWithQuestionsMockSuccess({
+                            rate: {
+                                id: '1337',
+                                status: 'SUBMITTED',
+                                consolidatedStatus: 'SUBMITTED',
+                                parentContractID: contract.id,
+                                withdrawnFromContracts: [],
+                                reviewStatusActions: [],
+                            },
+                        }),
+                        fetchContractMockSuccess({ contract }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/rates/1337',
+                },
+                featureFlags: {
+                    'withdraw-rate': true,
+                    'undo-withdraw-rate': true,
+                },
+            })
+
+            await waitFor(() => {
+                expect(
+                    screen.getByRole('button', { name: 'Withdraw rate' })
+                ).toBeInTheDocument()
+                expect(
+                    screen.getByRole('button', { name: 'Unlock rate' })
+                ).toBeInTheDocument()
+            })
+        })
+        it('renders no actions message when rate is withdrawn with submission', async () => {
+            const contract = mockContractPackageSubmitted({
+                consolidatedStatus: 'WITHDRAWN',
+            })
+            const rateData = rateWithHistoryMock()
+            rateData.parentContractID = contract.id
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchContractMockSuccess({ contract }),
+                        fetchRateWithQuestionsMockSuccess({
+                            rate: {
+                                id: '1337',
+                                parentContractID: contract.id,
+                                consolidatedStatus: 'WITHDRAWN',
+                                withdrawnFromContracts: [],
+                            },
+                        }),
+                        fetchContractMockSuccess({ contract }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/rates/1337',
+                },
+            })
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText(
+                        "No action can be taken on this submission in it's current status."
+                    )
+                ).toBeInTheDocument()
+            })
+        })
+        it('renders no actions message when rate when submission is approved', async () => {
+            const contract = mockContractPackageSubmitted({
+                consolidatedStatus: 'APPROVED',
+            })
+            const rateData = rateWithHistoryMock()
+            rateData.parentContractID = contract.id
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchContractMockSuccess({ contract }),
+                        fetchRateWithQuestionsMockSuccess({
+                            rate: {
+                                id: '1337',
+                                parentContractID: contract.id,
+                            },
+                        }),
+                        fetchContractMockSuccess({ contract }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/rates/1337',
+                },
+            })
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText(
+                        "No action can be taken on this submission in it's current status."
+                    )
+                ).toBeInTheDocument()
+            })
+        })
+        it('renders no actions message when rate when unlocked', async () => {
+            const contract = mockContractPackageSubmitted({
+                consolidatedStatus: 'UNLOCKED',
+            })
+            const rateData = rateWithHistoryMock()
+            rateData.parentContractID = contract.id
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchContractMockSuccess({ contract }),
+                        fetchRateWithQuestionsMockSuccess({
+                            rate: {
+                                id: '1337',
+                                status: 'UNLOCKED',
+                                consolidatedStatus: 'UNLOCKED',
+                                parentContractID: contract.id,
+                            },
+                        }),
+                        fetchContractMockSuccess({ contract }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/rates/1337',
+                },
+            })
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText(
+                        "No action can be taken on this submission in it's current status."
+                    )
+                ).toBeInTheDocument()
+            })
+        })
+        it('renders no actions message when parent contract is unlocked', async () => {
+            const contract = mockContractPackageSubmitted({
+                consolidatedStatus: 'UNLOCKED',
+            })
+            const rateData = rateWithHistoryMock()
+            rateData.parentContractID = contract.id
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchContractMockSuccess({ contract }),
+                        fetchRateWithQuestionsMockSuccess({
+                            rate: {
+                                id: '1337',
+                                status: 'SUBMITTED',
+                                consolidatedStatus: 'SUBMITTED',
+                                parentContractID: contract.id,
+                            },
+                        }),
+                        fetchContractMockSuccess({ contract }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/rates/1337',
+                },
+            })
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText(
+                        "No action can be taken on this submission in it's current status."
+                    )
+                ).toBeInTheDocument()
+            })
+        })
+        it('renders undo withdraw button when withdrawn independently', async () => {
+            const contract = mockContractPackageSubmitted({
+                consolidatedStatus: 'WITHDRAWN',
+            })
+            const rateData = rateWithHistoryMock()
+            rateData.parentContractID = contract.id
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchContractMockSuccess({ contract }),
+                        fetchRateWithQuestionsMockSuccess({
+                            rate: {
+                                id: '1337',
+                                status: 'SUBMITTED',
+                                consolidatedStatus: 'WITHDRAWN',
+                                parentContractID: contract.id,
+                                withdrawnFromContracts: [contract],
+                                reviewStatusActions: [
+                                    {
+                                        rateID: '1337',
+                                        actionType: 'WITHDRAW',
+                                        updatedAt: new Date(),
+                                        updatedReason: 'Independent withdraw',
+                                        updatedBy: {
+                                            email: 'someone@example.com',
+                                            familyName: 'one',
+                                            givenName: 'some',
+                                            role: 'CMS_USER',
+                                        },
+                                    },
+                                ],
+                            },
+                        }),
+                        fetchContractMockSuccess({ contract }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/rates/1337',
+                },
+                featureFlags: {
+                    'withdraw-rate': true,
+                    'undo-withdraw-rate': true,
+                },
+            })
+
+            await waitFor(() => {
+                expect(screen.queryByRole('alert')).toBeInTheDocument()
+                expect(screen.queryByRole('alert')).toHaveTextContent(
+                    /Status: Withdrawn/
+                )
+            })
+
+            expect(
+                screen.getByRole('button', { name: 'Undo withdraw' })
+            ).toBeInTheDocument()
+        })
+        it('does not render withdraw button when withdrawn independently', async () => {
+            const contract = mockContractPackageSubmitted({
+                consolidatedStatus: 'WITHDRAWN',
+            })
+            const rateData = rateWithHistoryMock()
+            rateData.parentContractID = contract.id
+            renderWithProviders(wrapInRoutes(<RateSummary />), {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchContractMockSuccess({ contract }),
+                        fetchRateWithQuestionsMockSuccess({
+                            rate: {
+                                id: '1337',
+                                status: 'SUBMITTED',
+                                consolidatedStatus: 'WITHDRAWN',
+                                parentContractID: contract.id,
+                                withdrawnFromContracts: [contract],
+                                reviewStatusActions: [
+                                    {
+                                        rateID: '1337',
+                                        actionType: 'WITHDRAW',
+                                        updatedAt: new Date(),
+                                        updatedReason: 'Independent withdraw',
+                                        updatedBy: {
+                                            email: 'someone@example.com',
+                                            familyName: 'one',
+                                            givenName: 'some',
+                                            role: 'CMS_USER',
+                                        },
+                                    },
+                                ],
+                            },
+                        }),
+                        fetchContractMockSuccess({ contract }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/rates/1337',
+                },
+                featureFlags: {
+                    'withdraw-rate': true,
+                    'undo-withdraw-rate': true,
+                },
+            })
+
+            await waitFor(() => {
+                expect(screen.queryByRole('alert')).toBeInTheDocument()
+                expect(screen.queryByRole('alert')).toHaveTextContent(
+                    /Status: Withdrawn/
+                )
+            })
+
+            expect(
+                screen.getByRole('button', { name: 'Undo withdraw' })
+            ).toBeInTheDocument()
+        })
     })
 })

--- a/services/app-web/src/pages/RateSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.tsx
@@ -333,8 +333,8 @@ export const RateSummary = (): React.ReactElement => {
                         <h3>Actions</h3>
                         {showNoActionsMessage ? (
                             <Grid>
-                                No action can be taken on this submission in
-                                it's current status.
+                                No action can be taken on this submission in its
+                                current status.
                             </Grid>
                         ) : (
                             <MultiColumnGrid columns={2}>

--- a/services/app-web/src/pages/RateWithdraw/RateWithdraw.test.tsx
+++ b/services/app-web/src/pages/RateWithdraw/RateWithdraw.test.tsx
@@ -105,11 +105,13 @@ describe('RateWithdraw', () => {
 
         await waitFor(() => {
             expect(screen.getByTestId('rateWithdrawBanner')).toBeInTheDocument()
-            const unlockBtn = screen.getByRole('button', {
-                name: 'Unlock rate',
-            })
-            expect(unlockBtn).toHaveAttribute('aria-disabled', 'true')
         })
+
+        expect(
+            screen.getByText(
+                "No action can be taken on this submission in it's current status."
+            )
+        ).toBeInTheDocument()
     })
 
     it('renders generic API error on failed withdraw', async () => {

--- a/services/app-web/src/pages/RateWithdraw/RateWithdraw.test.tsx
+++ b/services/app-web/src/pages/RateWithdraw/RateWithdraw.test.tsx
@@ -109,7 +109,7 @@ describe('RateWithdraw', () => {
 
         expect(
             screen.getByText(
-                "No action can be taken on this submission in it's current status."
+                'No action can be taken on this submission in its current status.'
             )
         ).toBeInTheDocument()
     })

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -750,7 +750,7 @@ describe('SubmissionSummary', () => {
 
                         expect(
                             screen.getByText(
-                                "No action can be taken on this submission in it's current status."
+                                'No action can be taken on this submission in its current status.'
                             )
                         ).toBeInTheDocument()
                     })
@@ -1007,7 +1007,7 @@ describe('SubmissionSummary', () => {
 
                     expect(
                         screen.getByText(
-                            "No action can be taken on this submission in it's current status."
+                            'No action can be taken on this submission in its current status.'
                         )
                     ).toBeInTheDocument()
                 })
@@ -1073,7 +1073,7 @@ describe('SubmissionSummary', () => {
 
                     expect(
                         screen.getByText(
-                            "No action can be taken on this submission in it's current status."
+                            'No action can be taken on this submission in its current status.'
                         )
                     ).toBeInTheDocument()
                 })
@@ -1199,7 +1199,7 @@ describe('SubmissionSummary', () => {
 
                     expect(
                         screen.getByText(
-                            "No action can be taken on this submission in it's current status."
+                            'No action can be taken on this submission in its current status.'
                         )
                     ).toBeInTheDocument()
                 })
@@ -1330,7 +1330,7 @@ describe('SubmissionSummary', () => {
 
                     expect(
                         screen.getByText(
-                            "No action can be taken on this submission in it's current status."
+                            'No action can be taken on this submission in its current status.'
                         )
                     ).toBeInTheDocument()
                 })

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -271,8 +271,8 @@ export const SubmissionSummary = (): React.ReactElement => {
                         <h3>Actions</h3>
                         {showNoActionsMsg ? (
                             <Grid>
-                                No action can be taken on this submission in
-                                it's current status.
+                                No action can be taken on this submission in its
+                                current status.
                             </Grid>
                         ) : (
                             <MultiColumnGrid columns={3}>

--- a/services/cypress/support/submissionReviewCommands.ts
+++ b/services/cypress/support/submissionReviewCommands.ts
@@ -7,7 +7,7 @@ Cypress.Commands.add('unlockSubmission', (unlockReason) => {
     )
     cy.findByRole('button', { name: 'Unlock' }).click()
 
-    cy.findByText('No action can be taken on this submission in it\'s current status.').should('exist')
+    cy.findByText('No action can be taken on this submission in its current status.').should('exist')
     cy.findAllByTestId('modalWindow').eq(1).should('be.hidden')
 
     // Unlock banner for CMS user to be present with correct data.


### PR DESCRIPTION
## Summary
[MCR-5164](https://jiraent.cms.gov/browse/MCR-5164)

AC:
- If I am logged in as a CMS user and I am viewing a rate summary that has been independently withdrawn or unlocked
Then the Actions section will appear below the banner with the following copy included in the section, "No action can be taken on this rate certification in it’s current status."
- If I am logged in as a CMS user and I am viewing a rate summary that has been withdrawn alongside a submission (dependent withdrawal)
Then the Actions section will appear below the banner with the following copy included in the section, "No action can be taken on this rate certification in it’s current status." (You will have to use graphql-explorer to use submission withdraw)
- If I am logged in as a CMS user and I am viewing a rate summary that has been approved alongside a submission ("released to state")
Then the Actions section will appear below the banner with the following copy included in the section, "No action can be taken on this rate certification in its current status."

Other:
- Fix typo in action section message when no actions can be taken.

#### Related issues

#### Screenshots

#### Test cases covered

`RateSummary.test.tsx`
- `'renders unlock and withdraw button on submitted rate'`
- `'renders no actions message when rate is withdrawn with submission'`
- `'renders no actions message when rate when submission is approved'`
- `'renders no actions message when rate when unlocked'`
- `'renders no actions message when parent contract is unlocked'`
- `'renders undo withdraw button when withdrawn independently'`
- `'does not render withdraw button when withdrawn independently'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
