### PR TITLE
Fix destroy github action

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -48,12 +48,11 @@ jobs:
 
       - name: Delete logical database
         env:
-          STAGE_NAME: ${{ steps.stage-name.outputs.stage_name }}
           DEV_DB_SM_ARN: ${{ secrets.DEV_DB_SM_ARN }}
           AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}
         run: |
           chmod +x services/postgres/db-manager.sh
-          ./services/postgres/db-manager.sh delete $STAGE_NAME $DEV_DB_SM_ARN $STAGE_NAME
+          ./services/postgres/db-manager.sh delete $stage_name $DEV_DB_SM_ARN $stage_name
 
       - name: destroy all
         env:


### PR DESCRIPTION
## Summary

When we merged the PR to change how review environments use our DBs I missed that our `destroy` script uses lower_snake_case for the stage. This just uses `stage_name` over `STAGE_NAME` here.

#### Related issues
https://jiraent.cms.gov/browse/MCR-5210
