### PR TITLE
Require 'admin=true' for cognito signup

### DIFF
--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -46,17 +46,6 @@ resources:
         - Fn::Equals:
             - ''
             - ${self:custom.sesSourceEmailAddress}
-    IsValOrProd:
-      Fn::Or:
-        - Fn::Equals:
-            - ${sls:stage}
-            - 'val'
-        - Fn::Equals:
-            - ${sls:stage}
-            - 'prod'
-        - Fn::Equals:
-            - ${sls:stage}
-            - 'mtsecfindingusers'
   Resources:
     CognitoUserPool:
       Type: AWS::Cognito::UserPool

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -63,10 +63,7 @@ resources:
       Properties:
         UserPoolName: ${sls:stage}-user-pool
         AdminCreateUserConfig:
-          AllowAdminCreateUserOnly: !If
-            - IsValOrProd
-            - true
-            - false
+          AllowAdminCreateUserOnly: true
         UsernameAttributes:
           - email
         AutoVerifiedAttributes:


### PR DESCRIPTION
## Summary

We received a pen test result detailing that our Cognito setup in `dev` allowed for users with the identity pool values that are bundled with our front end could sign up for an account using the aws CLI. This was known, as we previously made an exception for `dev` for this functionality as we use test users in our review environments for things like Cypress tests. So a user could create an account for themselves, but that account has no privileges associated with it. This is enough to trip a pen test finding though.

Turns out that at some point our script that adds these test users in review environments stopped needing this unprivileged signup. I was able to just turn on the `AllowAdminCreateUserOnly: true` for all stages in our `AWS::Cognito::UserPool` setup. CI still works, I can log into the review app, and I no longer can use the values bundled in our frontend to create an account:

```
❯ AWS_REGION=us-east-1 aws cognito-idp sign-up --client-id redacted --username mojo+pentest@truss.works --password 'Passw0rd123!'

An error occurred (NotAuthorizedException) when calling the SignUp operation: SignUp is not permitted for this user pool
```

This should close the finding out.

#### Related issues
https://jiraent.cms.gov/browse/MCR-5186
