### PR TITLE
Force postgres dev re-run

### DIFF
--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -92,7 +92,7 @@ custom:
     val: 'Retain'
     prod: 'Retain'
   auroraMinCapacity:
-    other: 0.5
+    other: 1
     val: 1
     prod: 1
   esbuild:


### PR DESCRIPTION
## Summary

We had a lot of stale branches and some failed `destroy` actions, which I went through and manually removed. I need to re-run the postgres CloudFormation action in `dev`, so this is a minimal change to bump resources on this DB. It's probably good for us to have slightly more minimal resources here, as we're now using this dev db a lot more than we previously were since all review environments connect to it.


