### PR TITLE
Add DependsOn for Aurora

### DIFF
--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -178,6 +178,7 @@ resources:
 
     PostgresAuroraV2Instance:
       Type: AWS::RDS::DBInstance
+      DependsOn: PostgresAuroraV2
       Condition: IsDevValProd
       DeletionPolicy: ${self:custom.deletionPolicy.${opt:stage}, self:custom.deletionPolicy.other}
       Properties:

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -186,9 +186,6 @@ resources:
         DBInstanceClass: db.serverless
         DBClusterIdentifier: !Ref PostgresAuroraV2
         AutoMinorVersionUpgrade: true
-        Tags:
-          - Key: TemporaryTag
-            Value: DeleteTagAfterMerge
 
     PostgresVMScriptsBucket:
       Type: 'AWS::S3::Bucket'
@@ -378,6 +375,7 @@ resources:
 
     SecretsRDSAttachment:
       Type: AWS::SecretsManager::SecretTargetAttachment
+      DependsOn: PostgresAuroraV2
       Properties:
         SecretId: !Ref PostgresSecret
         TargetId: ${self:custom.auroraArn}


### PR DESCRIPTION
## Summary

For some reason serverless via cloudformation is not waiting on the aurora cluster before creating the writer instance. That makes sense looking at the config -- there is no `DependsOn` between the two configs. I'm not sure why this worked before, but we do need this dependency there.

#### Related issues

https://jiraent.cms.gov/browse/MCR-5220