### PR TITLE
Fix !Ref for postgres secrets manager

### DIFF
--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -378,7 +378,7 @@ resources:
       DependsOn: PostgresAuroraV2
       Properties:
         SecretId: !Ref PostgresSecret
-        TargetId: ${self:custom.auroraArn}
+        TargetId: !Ref PostgresAuroraV2
         TargetType: AWS::RDS::DBCluster
 
     PostgresSecretsRotationSchedule:


### PR DESCRIPTION
## Summary

Looks like there was a subtle bug in the config for how we were referencing the secrets manager attachment after moving to logical DBs. This moves us back to using the reference to the Aurora DB for the `TargetID` for the secrets manager attachment. This should get promotes working again, and I'll do a follow up to make sure review environments have the proper targetId set from the environment again once this promotes.

#### Related issues
https://jiraent.cms.gov/browse/MCR-5220
