### PR TITLE
MCR-5207: reassign parent contract on withdrawn contracts child rates

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/findAllRatesStripped.test.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesStripped.test.ts
@@ -17,187 +17,206 @@ import {
     testRateFormInputData,
 } from '../../testHelpers/gqlRateHelpers'
 import { expect } from 'vitest'
+import { EXTENDED_TIMEOUT } from '../../testHelpers/assertionHelpers'
 
-it('returns all rates with stripped down data', async () => {
-    const client = await sharedTestPrismaClient()
+it(
+    'returns all rates with stripped down data',
+    async () => {
+        const client = await sharedTestPrismaClient()
 
-    const stateServer = await constructTestPostgresServer({
-        context: {
-            user: testStateUser(),
-        },
-    })
-
-    const cmsServer = await constructTestPostgresServer({
-        context: {
-            user: testCMSUser(),
-        },
-    })
-
-    const submittedContractA =
-        await createAndSubmitTestContractWithRate(stateServer)
-    const rateAID =
-        submittedContractA.packageSubmissions[0].rateRevisions[0].rateID
-
-    await unlockTestContract(cmsServer, submittedContractA.id, 'unlock 1')
-    await submitTestContract(stateServer, submittedContractA.id, 'submit 2')
-
-    await unlockTestContract(cmsServer, submittedContractA.id, 'unlock 2')
-
-    const contractB = await createAndUpdateTestContractWithoutRates(stateServer)
-    // link rate contract B
-    must(
-        await stateServer.executeOperation({
-            query: UpdateDraftContractRatesDocument,
-            variables: {
-                input: {
-                    contractID: contractB.id,
-                    lastSeenUpdatedAt: contractB.draftRevision?.updatedAt,
-                    updatedRates: [
-                        {
-                            type: 'LINK',
-                            rateID: rateAID,
-                        },
-                        {
-                            type: 'CREATE',
-                            formData: testRateFormInputData(),
-                        },
-                    ],
-                },
+        const stateServer = await constructTestPostgresServer({
+            context: {
+                user: testStateUser(),
             },
         })
-    )
 
-    const submittedContractB = await submitTestContract(
-        stateServer,
-        contractB.id
-    )
-    const rateBID = submittedContractB.packageSubmissions[0].rateRevisions.find(
-        (rate) => rate.rateID !== rateAID
-    )?.rateID
-
-    if (!rateBID) {
-        throw new Error('Unexpected error: rateBID should exist, but does not.')
-    }
-
-    await withdrawTestRate(cmsServer, rateBID, 'Withdraw invalid rate')
-
-    const strippedRatesOrErrors = must(await findAllRatesStripped(client))
-    const strippedRates: StrippedRateType[] = []
-    strippedRatesOrErrors.forEach((rate) => {
-        if (!(rate.rate instanceof Error)) {
-            strippedRates.push(rate.rate)
-        }
-    })
-
-    const rateAFromArray = strippedRates.find((rate) => rate.id === rateAID)
-    const rateBFromArray = strippedRates.find((rate) => rate.id === rateBID)
-
-    // expect rateA to have expected data
-    expect(
-        rateAFromArray?.latestSubmittedRevision.submitInfo?.updatedReason
-    ).toBe('submit 2')
-    expect(rateAFromArray?.initiallySubmittedAt).toStrictEqual(
-        submittedContractA.initiallySubmittedAt
-    )
-    expect(rateAFromArray?.parentContractID).toEqual(submittedContractA.id)
-    expect(rateAFromArray?.status).toBe('UNLOCKED')
-    expect(rateAFromArray?.consolidatedStatus).toBe('UNLOCKED')
-    expect(rateAFromArray?.draftRevision?.unlockInfo?.updatedReason).toBe(
-        'unlock 2'
-    )
-
-    // expect rateB to have expected data as a withdrawn rate
-    expect(
-        rateBFromArray?.latestSubmittedRevision.submitInfo?.updatedReason
-    ).toContain('CMS has withdrawn this rate. Withdraw invalid rate')
-    expect(rateBFromArray?.initiallySubmittedAt).toStrictEqual(
-        submittedContractB.initiallySubmittedAt
-    )
-    expect(rateBFromArray?.parentContractID).toEqual(submittedContractB.id)
-    expect(rateBFromArray?.status).toBe('RESUBMITTED')
-    expect(rateBFromArray?.consolidatedStatus).toBe('WITHDRAWN')
-    expect(
-        rateBFromArray?.latestSubmittedRevision?.unlockInfo?.updatedReason
-    ).toContain('Withdraw invalid')
-    expect(rateBFromArray?.reviewStatusActions?.length).toBe(1)
-    expect(rateBFromArray?.reviewStatusActions?.[0].actionType).toBe('WITHDRAW')
-
-    // Undo the rate withdraw
-    await undoWithdrawTestRate(cmsServer, rateBID, 'Undo withdraw rateB')
-
-    const strippedRatesOrErrorsAgain = must(await findAllRatesStripped(client))
-    const strippedRatesAgain: StrippedRateType[] = []
-    strippedRatesOrErrorsAgain.forEach((rate) => {
-        if (!(rate.rate instanceof Error)) {
-            strippedRatesAgain.push(rate.rate)
-        }
-    })
-
-    const rateBFromArrayAgain = strippedRatesAgain.find(
-        (rate) => rate.id === rateBID
-    )
-
-    if (!rateBFromArrayAgain) {
-        throw new Error('Expected to find rateB')
-    }
-
-    // expect rateB to have expected data after undo withdraw rate
-    expect(
-        rateBFromArrayAgain.latestSubmittedRevision.submitInfo?.updatedReason
-    ).toContain('Undo withdraw rateB')
-    expect(rateBFromArrayAgain.initiallySubmittedAt).toStrictEqual(
-        submittedContractB.initiallySubmittedAt
-    )
-    expect(rateBFromArrayAgain.parentContractID).toEqual(submittedContractB.id)
-    expect(rateBFromArrayAgain.status).toBe('RESUBMITTED')
-    expect(rateBFromArrayAgain.consolidatedStatus).toBe('RESUBMITTED')
-    expect(
-        rateBFromArrayAgain.latestSubmittedRevision?.unlockInfo?.updatedReason
-    ).toContain('Undo withdraw rateB')
-    expect(rateBFromArrayAgain.reviewStatusActions?.length).toBe(2)
-    expect(rateBFromArrayAgain.reviewStatusActions?.[0].actionType).toBe(
-        'UNDER_REVIEW'
-    )
-    expect(rateBFromArrayAgain.reviewStatusActions?.[1].actionType).toBe(
-        'WITHDRAW'
-    )
-
-    const selectedStrippedRates = must(
-        await findAllRatesStripped(client, {
-            rateIDs: [rateBFromArrayAgain.id],
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: testCMSUser(),
+            },
         })
-    )
 
-    // Expect only rate B to return
-    expect(selectedStrippedRates).toHaveLength(1)
-    expect(selectedStrippedRates[0].rateID).toBe(rateBFromArrayAgain.id)
+        const submittedContractA =
+            await createAndSubmitTestContractWithRate(stateServer)
+        const rateAID =
+            submittedContractA.packageSubmissions[0].rateRevisions[0].rateID
 
-    const emptySelectedStrippedRatesOrError = must(
-        await findAllRatesStripped(client)
-    )
-    const emptySelectedStrippedRates: StrippedRateType[] = []
-    emptySelectedStrippedRatesOrError.forEach((rate) => {
-        if (!(rate.rate instanceof Error)) {
-            emptySelectedStrippedRates.push(rate.rate)
+        await unlockTestContract(cmsServer, submittedContractA.id, 'unlock 1')
+        await submitTestContract(stateServer, submittedContractA.id, 'submit 2')
+
+        await unlockTestContract(cmsServer, submittedContractA.id, 'unlock 2')
+
+        const contractB =
+            await createAndUpdateTestContractWithoutRates(stateServer)
+        // link rate contract B
+        must(
+            await stateServer.executeOperation({
+                query: UpdateDraftContractRatesDocument,
+                variables: {
+                    input: {
+                        contractID: contractB.id,
+                        lastSeenUpdatedAt: contractB.draftRevision?.updatedAt,
+                        updatedRates: [
+                            {
+                                type: 'LINK',
+                                rateID: rateAID,
+                            },
+                            {
+                                type: 'CREATE',
+                                formData: testRateFormInputData(),
+                            },
+                        ],
+                    },
+                },
+            })
+        )
+
+        const submittedContractB = await submitTestContract(
+            stateServer,
+            contractB.id
+        )
+        const rateBID =
+            submittedContractB.packageSubmissions[0].rateRevisions.find(
+                (rate) => rate.rateID !== rateAID
+            )?.rateID
+
+        if (!rateBID) {
+            throw new Error(
+                'Unexpected error: rateBID should exist, but does not.'
+            )
         }
-    })
 
-    // Expect our only two rate
-    const rateAFromArrayEmptyArray = emptySelectedStrippedRates.find(
-        (rate) => rate.id === rateAID
-    )
-    const rateBFromArrayEmptyArray = emptySelectedStrippedRates.find(
-        (rate) => rate.id === rateBID
-    )
+        await withdrawTestRate(cmsServer, rateBID, 'Withdraw invalid rate')
 
-    // expect both our rates, we cannot expect on length of rates because DB data persists between tests.
-    expect(rateAFromArrayEmptyArray).toBeDefined()
-    expect(rateBFromArrayEmptyArray).toBeDefined()
+        const strippedRatesOrErrors = must(await findAllRatesStripped(client))
+        const strippedRates: StrippedRateType[] = []
+        strippedRatesOrErrors.forEach((rate) => {
+            if (!(rate.rate instanceof Error)) {
+                strippedRates.push(rate.rate)
+            }
+        })
 
-    const notRealRateSelectedOrError = must(
-        await findAllRatesStripped(client, { rateIDs: ['not-a-real-rate-id'] })
-    )
+        const rateAFromArray = strippedRates.find((rate) => rate.id === rateAID)
+        const rateBFromArray = strippedRates.find((rate) => rate.id === rateBID)
 
-    // ID should not exist so we expect no results
-    expect(notRealRateSelectedOrError).toHaveLength(0)
-}, 10000)
+        // expect rateA to have expected data
+        expect(
+            rateAFromArray?.latestSubmittedRevision.submitInfo?.updatedReason
+        ).toBe('submit 2')
+        expect(rateAFromArray?.initiallySubmittedAt).toStrictEqual(
+            submittedContractA.initiallySubmittedAt
+        )
+        expect(rateAFromArray?.parentContractID).toEqual(submittedContractA.id)
+        expect(rateAFromArray?.status).toBe('UNLOCKED')
+        expect(rateAFromArray?.consolidatedStatus).toBe('UNLOCKED')
+        expect(rateAFromArray?.draftRevision?.unlockInfo?.updatedReason).toBe(
+            'unlock 2'
+        )
+
+        // expect rateB to have expected data as a withdrawn rate
+        expect(
+            rateBFromArray?.latestSubmittedRevision.submitInfo?.updatedReason
+        ).toContain('CMS has withdrawn this rate. Withdraw invalid rate')
+        expect(rateBFromArray?.initiallySubmittedAt).toStrictEqual(
+            submittedContractB.initiallySubmittedAt
+        )
+        expect(rateBFromArray?.parentContractID).toEqual(submittedContractB.id)
+        expect(rateBFromArray?.status).toBe('RESUBMITTED')
+        expect(rateBFromArray?.consolidatedStatus).toBe('WITHDRAWN')
+        expect(
+            rateBFromArray?.latestSubmittedRevision?.unlockInfo?.updatedReason
+        ).toContain('Withdraw invalid')
+        expect(rateBFromArray?.reviewStatusActions?.length).toBe(1)
+        expect(rateBFromArray?.reviewStatusActions?.[0].actionType).toBe(
+            'WITHDRAW'
+        )
+
+        // Undo the rate withdraw
+        await undoWithdrawTestRate(cmsServer, rateBID, 'Undo withdraw rateB')
+
+        const strippedRatesOrErrorsAgain = must(
+            await findAllRatesStripped(client)
+        )
+        const strippedRatesAgain: StrippedRateType[] = []
+        strippedRatesOrErrorsAgain.forEach((rate) => {
+            if (!(rate.rate instanceof Error)) {
+                strippedRatesAgain.push(rate.rate)
+            }
+        })
+
+        const rateBFromArrayAgain = strippedRatesAgain.find(
+            (rate) => rate.id === rateBID
+        )
+
+        if (!rateBFromArrayAgain) {
+            throw new Error('Expected to find rateB')
+        }
+
+        // expect rateB to have expected data after undo withdraw rate
+        expect(
+            rateBFromArrayAgain.latestSubmittedRevision.submitInfo
+                ?.updatedReason
+        ).toContain('Undo withdraw rateB')
+        expect(rateBFromArrayAgain.initiallySubmittedAt).toStrictEqual(
+            submittedContractB.initiallySubmittedAt
+        )
+        expect(rateBFromArrayAgain.parentContractID).toEqual(
+            submittedContractB.id
+        )
+        expect(rateBFromArrayAgain.status).toBe('RESUBMITTED')
+        expect(rateBFromArrayAgain.consolidatedStatus).toBe('RESUBMITTED')
+        expect(
+            rateBFromArrayAgain.latestSubmittedRevision?.unlockInfo
+                ?.updatedReason
+        ).toContain('Undo withdraw rateB')
+        expect(rateBFromArrayAgain.reviewStatusActions?.length).toBe(2)
+        expect(rateBFromArrayAgain.reviewStatusActions?.[0].actionType).toBe(
+            'UNDER_REVIEW'
+        )
+        expect(rateBFromArrayAgain.reviewStatusActions?.[1].actionType).toBe(
+            'WITHDRAW'
+        )
+
+        const selectedStrippedRates = must(
+            await findAllRatesStripped(client, {
+                rateIDs: [rateBFromArrayAgain.id],
+            })
+        )
+
+        // Expect only rate B to return
+        expect(selectedStrippedRates).toHaveLength(1)
+        expect(selectedStrippedRates[0].rateID).toBe(rateBFromArrayAgain.id)
+
+        const emptySelectedStrippedRatesOrError = must(
+            await findAllRatesStripped(client)
+        )
+        const emptySelectedStrippedRates: StrippedRateType[] = []
+        emptySelectedStrippedRatesOrError.forEach((rate) => {
+            if (!(rate.rate instanceof Error)) {
+                emptySelectedStrippedRates.push(rate.rate)
+            }
+        })
+
+        // Expect our only two rate
+        const rateAFromArrayEmptyArray = emptySelectedStrippedRates.find(
+            (rate) => rate.id === rateAID
+        )
+        const rateBFromArrayEmptyArray = emptySelectedStrippedRates.find(
+            (rate) => rate.id === rateBID
+        )
+
+        // expect both our rates, we cannot expect on length of rates because DB data persists between tests.
+        expect(rateAFromArrayEmptyArray).toBeDefined()
+        expect(rateBFromArrayEmptyArray).toBeDefined()
+
+        const notRealRateSelectedOrError = must(
+            await findAllRatesStripped(client, {
+                rateIDs: ['not-a-real-rate-id'],
+            })
+        )
+
+        // ID should not exist so we expect no results
+        expect(notRealRateSelectedOrError).toHaveLength(0)
+    },
+    EXTENDED_TIMEOUT
+)

--- a/services/app-api/src/postgres/contractAndRates/findAllRatesStripped.test.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesStripped.test.ts
@@ -17,206 +17,189 @@ import {
     testRateFormInputData,
 } from '../../testHelpers/gqlRateHelpers'
 import { expect } from 'vitest'
-import { EXTENDED_TIMEOUT } from '../../testHelpers/assertionHelpers'
 
-it(
-    'returns all rates with stripped down data',
-    async () => {
-        const client = await sharedTestPrismaClient()
+it('returns all rates with stripped down data', async () => {
+    const client = await sharedTestPrismaClient()
 
-        const stateServer = await constructTestPostgresServer({
-            context: {
-                user: testStateUser(),
-            },
-        })
+    const stateServer = await constructTestPostgresServer({
+        context: {
+            user: testStateUser(),
+        },
+    })
 
-        const cmsServer = await constructTestPostgresServer({
-            context: {
-                user: testCMSUser(),
-            },
-        })
+    const cmsServer = await constructTestPostgresServer({
+        context: {
+            user: testCMSUser(),
+        },
+    })
 
-        const submittedContractA =
-            await createAndSubmitTestContractWithRate(stateServer)
-        const rateAID =
-            submittedContractA.packageSubmissions[0].rateRevisions[0].rateID
+    const submittedContractA =
+        await createAndSubmitTestContractWithRate(stateServer)
+    const rateAID =
+        submittedContractA.packageSubmissions[0].rateRevisions[0].rateID
 
-        await unlockTestContract(cmsServer, submittedContractA.id, 'unlock 1')
-        await submitTestContract(stateServer, submittedContractA.id, 'submit 2')
+    await unlockTestContract(cmsServer, submittedContractA.id, 'unlock 1')
+    await submitTestContract(stateServer, submittedContractA.id, 'submit 2')
 
-        await unlockTestContract(cmsServer, submittedContractA.id, 'unlock 2')
+    await unlockTestContract(cmsServer, submittedContractA.id, 'unlock 2')
 
-        const contractB =
-            await createAndUpdateTestContractWithoutRates(stateServer)
-        // link rate contract B
-        must(
-            await stateServer.executeOperation({
-                query: UpdateDraftContractRatesDocument,
-                variables: {
-                    input: {
-                        contractID: contractB.id,
-                        lastSeenUpdatedAt: contractB.draftRevision?.updatedAt,
-                        updatedRates: [
-                            {
-                                type: 'LINK',
-                                rateID: rateAID,
-                            },
-                            {
-                                type: 'CREATE',
-                                formData: testRateFormInputData(),
-                            },
-                        ],
-                    },
+    const contractB = await createAndUpdateTestContractWithoutRates(stateServer)
+    // link rate contract B
+    must(
+        await stateServer.executeOperation({
+            query: UpdateDraftContractRatesDocument,
+            variables: {
+                input: {
+                    contractID: contractB.id,
+                    lastSeenUpdatedAt: contractB.draftRevision?.updatedAt,
+                    updatedRates: [
+                        {
+                            type: 'LINK',
+                            rateID: rateAID,
+                        },
+                        {
+                            type: 'CREATE',
+                            formData: testRateFormInputData(),
+                        },
+                    ],
                 },
-            })
-        )
+            },
+        })
+    )
 
-        const submittedContractB = await submitTestContract(
-            stateServer,
-            contractB.id
-        )
-        const rateBID =
-            submittedContractB.packageSubmissions[0].rateRevisions.find(
-                (rate) => rate.rateID !== rateAID
-            )?.rateID
+    const submittedContractB = await submitTestContract(
+        stateServer,
+        contractB.id
+    )
+    const rateBID = submittedContractB.packageSubmissions[0].rateRevisions.find(
+        (rate) => rate.rateID !== rateAID
+    )?.rateID
 
-        if (!rateBID) {
-            throw new Error(
-                'Unexpected error: rateBID should exist, but does not.'
-            )
+    if (!rateBID) {
+        throw new Error('Unexpected error: rateBID should exist, but does not.')
+    }
+
+    await withdrawTestRate(cmsServer, rateBID, 'Withdraw invalid rate')
+
+    const strippedRatesOrErrors = must(await findAllRatesStripped(client))
+    const strippedRates: StrippedRateType[] = []
+    strippedRatesOrErrors.forEach((rate) => {
+        if (!(rate.rate instanceof Error)) {
+            strippedRates.push(rate.rate)
         }
+    })
 
-        await withdrawTestRate(cmsServer, rateBID, 'Withdraw invalid rate')
+    const rateAFromArray = strippedRates.find((rate) => rate.id === rateAID)
+    const rateBFromArray = strippedRates.find((rate) => rate.id === rateBID)
 
-        const strippedRatesOrErrors = must(await findAllRatesStripped(client))
-        const strippedRates: StrippedRateType[] = []
-        strippedRatesOrErrors.forEach((rate) => {
-            if (!(rate.rate instanceof Error)) {
-                strippedRates.push(rate.rate)
-            }
-        })
+    // expect rateA to have expected data
+    expect(
+        rateAFromArray?.latestSubmittedRevision.submitInfo?.updatedReason
+    ).toBe('submit 2')
+    expect(rateAFromArray?.initiallySubmittedAt).toStrictEqual(
+        submittedContractA.initiallySubmittedAt
+    )
+    expect(rateAFromArray?.parentContractID).toEqual(submittedContractA.id)
+    expect(rateAFromArray?.status).toBe('UNLOCKED')
+    expect(rateAFromArray?.consolidatedStatus).toBe('UNLOCKED')
+    expect(rateAFromArray?.draftRevision?.unlockInfo?.updatedReason).toBe(
+        'unlock 2'
+    )
 
-        const rateAFromArray = strippedRates.find((rate) => rate.id === rateAID)
-        const rateBFromArray = strippedRates.find((rate) => rate.id === rateBID)
+    // expect rateB to have expected data as a withdrawn rate
+    expect(
+        rateBFromArray?.latestSubmittedRevision.submitInfo?.updatedReason
+    ).toContain('CMS has withdrawn this rate. Withdraw invalid rate')
+    expect(rateBFromArray?.initiallySubmittedAt).toStrictEqual(
+        submittedContractB.initiallySubmittedAt
+    )
+    expect(rateBFromArray?.parentContractID).toEqual(submittedContractB.id)
+    expect(rateBFromArray?.status).toBe('RESUBMITTED')
+    expect(rateBFromArray?.consolidatedStatus).toBe('WITHDRAWN')
+    expect(
+        rateBFromArray?.latestSubmittedRevision?.unlockInfo?.updatedReason
+    ).toContain('Withdraw invalid')
+    expect(rateBFromArray?.reviewStatusActions?.length).toBe(1)
+    expect(rateBFromArray?.reviewStatusActions?.[0].actionType).toBe('WITHDRAW')
 
-        // expect rateA to have expected data
-        expect(
-            rateAFromArray?.latestSubmittedRevision.submitInfo?.updatedReason
-        ).toBe('submit 2')
-        expect(rateAFromArray?.initiallySubmittedAt).toStrictEqual(
-            submittedContractA.initiallySubmittedAt
-        )
-        expect(rateAFromArray?.parentContractID).toEqual(submittedContractA.id)
-        expect(rateAFromArray?.status).toBe('UNLOCKED')
-        expect(rateAFromArray?.consolidatedStatus).toBe('UNLOCKED')
-        expect(rateAFromArray?.draftRevision?.unlockInfo?.updatedReason).toBe(
-            'unlock 2'
-        )
+    // Undo the rate withdraw
+    await undoWithdrawTestRate(cmsServer, rateBID, 'Undo withdraw rateB')
 
-        // expect rateB to have expected data as a withdrawn rate
-        expect(
-            rateBFromArray?.latestSubmittedRevision.submitInfo?.updatedReason
-        ).toContain('CMS has withdrawn this rate. Withdraw invalid rate')
-        expect(rateBFromArray?.initiallySubmittedAt).toStrictEqual(
-            submittedContractB.initiallySubmittedAt
-        )
-        expect(rateBFromArray?.parentContractID).toEqual(submittedContractB.id)
-        expect(rateBFromArray?.status).toBe('RESUBMITTED')
-        expect(rateBFromArray?.consolidatedStatus).toBe('WITHDRAWN')
-        expect(
-            rateBFromArray?.latestSubmittedRevision?.unlockInfo?.updatedReason
-        ).toContain('Withdraw invalid')
-        expect(rateBFromArray?.reviewStatusActions?.length).toBe(1)
-        expect(rateBFromArray?.reviewStatusActions?.[0].actionType).toBe(
-            'WITHDRAW'
-        )
-
-        // Undo the rate withdraw
-        await undoWithdrawTestRate(cmsServer, rateBID, 'Undo withdraw rateB')
-
-        const strippedRatesOrErrorsAgain = must(
-            await findAllRatesStripped(client)
-        )
-        const strippedRatesAgain: StrippedRateType[] = []
-        strippedRatesOrErrorsAgain.forEach((rate) => {
-            if (!(rate.rate instanceof Error)) {
-                strippedRatesAgain.push(rate.rate)
-            }
-        })
-
-        const rateBFromArrayAgain = strippedRatesAgain.find(
-            (rate) => rate.id === rateBID
-        )
-
-        if (!rateBFromArrayAgain) {
-            throw new Error('Expected to find rateB')
+    const strippedRatesOrErrorsAgain = must(await findAllRatesStripped(client))
+    const strippedRatesAgain: StrippedRateType[] = []
+    strippedRatesOrErrorsAgain.forEach((rate) => {
+        if (!(rate.rate instanceof Error)) {
+            strippedRatesAgain.push(rate.rate)
         }
+    })
 
-        // expect rateB to have expected data after undo withdraw rate
-        expect(
-            rateBFromArrayAgain.latestSubmittedRevision.submitInfo
-                ?.updatedReason
-        ).toContain('Undo withdraw rateB')
-        expect(rateBFromArrayAgain.initiallySubmittedAt).toStrictEqual(
-            submittedContractB.initiallySubmittedAt
-        )
-        expect(rateBFromArrayAgain.parentContractID).toEqual(
-            submittedContractB.id
-        )
-        expect(rateBFromArrayAgain.status).toBe('RESUBMITTED')
-        expect(rateBFromArrayAgain.consolidatedStatus).toBe('RESUBMITTED')
-        expect(
-            rateBFromArrayAgain.latestSubmittedRevision?.unlockInfo
-                ?.updatedReason
-        ).toContain('Undo withdraw rateB')
-        expect(rateBFromArrayAgain.reviewStatusActions?.length).toBe(2)
-        expect(rateBFromArrayAgain.reviewStatusActions?.[0].actionType).toBe(
-            'UNDER_REVIEW'
-        )
-        expect(rateBFromArrayAgain.reviewStatusActions?.[1].actionType).toBe(
-            'WITHDRAW'
-        )
+    const rateBFromArrayAgain = strippedRatesAgain.find(
+        (rate) => rate.id === rateBID
+    )
 
-        const selectedStrippedRates = must(
-            await findAllRatesStripped(client, {
-                rateIDs: [rateBFromArrayAgain.id],
-            })
-        )
+    if (!rateBFromArrayAgain) {
+        throw new Error('Expected to find rateB')
+    }
 
-        // Expect only rate B to return
-        expect(selectedStrippedRates).toHaveLength(1)
-        expect(selectedStrippedRates[0].rateID).toBe(rateBFromArrayAgain.id)
+    // expect rateB to have expected data after undo withdraw rate
+    expect(
+        rateBFromArrayAgain.latestSubmittedRevision.submitInfo?.updatedReason
+    ).toContain('Undo withdraw rateB')
+    expect(rateBFromArrayAgain.initiallySubmittedAt).toStrictEqual(
+        submittedContractB.initiallySubmittedAt
+    )
+    expect(rateBFromArrayAgain.parentContractID).toEqual(submittedContractB.id)
+    expect(rateBFromArrayAgain.status).toBe('RESUBMITTED')
+    expect(rateBFromArrayAgain.consolidatedStatus).toBe('RESUBMITTED')
+    expect(
+        rateBFromArrayAgain.latestSubmittedRevision?.unlockInfo?.updatedReason
+    ).toContain('Undo withdraw rateB')
+    expect(rateBFromArrayAgain.reviewStatusActions?.length).toBe(2)
+    expect(rateBFromArrayAgain.reviewStatusActions?.[0].actionType).toBe(
+        'UNDER_REVIEW'
+    )
+    expect(rateBFromArrayAgain.reviewStatusActions?.[1].actionType).toBe(
+        'WITHDRAW'
+    )
 
-        const emptySelectedStrippedRatesOrError = must(
-            await findAllRatesStripped(client)
-        )
-        const emptySelectedStrippedRates: StrippedRateType[] = []
-        emptySelectedStrippedRatesOrError.forEach((rate) => {
-            if (!(rate.rate instanceof Error)) {
-                emptySelectedStrippedRates.push(rate.rate)
-            }
+    const selectedStrippedRates = must(
+        await findAllRatesStripped(client, {
+            rateIDs: [rateBFromArrayAgain.id],
         })
+    )
 
-        // Expect our only two rate
-        const rateAFromArrayEmptyArray = emptySelectedStrippedRates.find(
-            (rate) => rate.id === rateAID
-        )
-        const rateBFromArrayEmptyArray = emptySelectedStrippedRates.find(
-            (rate) => rate.id === rateBID
-        )
+    // Expect only rate B to return
+    expect(selectedStrippedRates).toHaveLength(1)
+    expect(selectedStrippedRates[0].rateID).toBe(rateBFromArrayAgain.id)
 
-        // expect both our rates, we cannot expect on length of rates because DB data persists between tests.
-        expect(rateAFromArrayEmptyArray).toBeDefined()
-        expect(rateBFromArrayEmptyArray).toBeDefined()
+    const emptySelectedStrippedRatesOrError = must(
+        await findAllRatesStripped(client)
+    )
+    const emptySelectedStrippedRates: StrippedRateType[] = []
+    emptySelectedStrippedRatesOrError.forEach((rate) => {
+        if (!(rate.rate instanceof Error)) {
+            emptySelectedStrippedRates.push(rate.rate)
+        }
+    })
 
-        const notRealRateSelectedOrError = must(
-            await findAllRatesStripped(client, {
-                rateIDs: ['not-a-real-rate-id'],
-            })
-        )
+    // Expect our only two rate
+    const rateAFromArrayEmptyArray = emptySelectedStrippedRates.find(
+        (rate) => rate.id === rateAID
+    )
+    const rateBFromArrayEmptyArray = emptySelectedStrippedRates.find(
+        (rate) => rate.id === rateBID
+    )
 
-        // ID should not exist so we expect no results
-        expect(notRealRateSelectedOrError).toHaveLength(0)
-    },
-    EXTENDED_TIMEOUT
-)
+    // expect both our rates, we cannot expect on length of rates because DB data persists between tests.
+    expect(rateAFromArrayEmptyArray).toBeDefined()
+    expect(rateBFromArrayEmptyArray).toBeDefined()
+
+    const notRealRateSelectedOrError = must(
+        await findAllRatesStripped(client, {
+            rateIDs: ['not-a-real-rate-id'],
+        })
+    )
+
+    // ID should not exist so we expect no results
+    expect(notRealRateSelectedOrError).toHaveLength(0)
+})

--- a/services/app-api/src/postgres/contractAndRates/findRateRelatedContracts.test.ts
+++ b/services/app-api/src/postgres/contractAndRates/findRateRelatedContracts.test.ts
@@ -12,188 +12,198 @@ import { must } from '../../testHelpers'
 import { UpdateDraftContractRatesDocument } from '../../gen/gqlClient'
 import { testRateFormInputData } from '../../testHelpers/gqlRateHelpers'
 import { findRateRelatedContracts } from './findRateRelatedContracts'
+import { EXTENDED_TIMEOUT } from '../../testHelpers/assertionHelpers'
 
-it('returns related contracts with correct status', async () => {
-    const client = await sharedTestPrismaClient()
+it(
+    'returns related contracts with correct status',
+    async () => {
+        const client = await sharedTestPrismaClient()
 
-    const stateServer = await constructTestPostgresServer({
-        context: {
-            user: testStateUser(),
-        },
-    })
-
-    const cmsServer = await constructTestPostgresServer({
-        context: {
-            user: testCMSUser(),
-        },
-    })
-
-    const submittedContractA =
-        await createAndSubmitTestContractWithRate(stateServer)
-    const rateAID =
-        submittedContractA.packageSubmissions[0].rateRevisions[0].rateID
-
-    await unlockTestContract(cmsServer, submittedContractA.id, 'unlock 1')
-    await submitTestContract(stateServer, submittedContractA.id, 'submit 2')
-
-    const contractB = await createAndUpdateTestContractWithoutRates(stateServer)
-
-    // link rate contract B
-    must(
-        await stateServer.executeOperation({
-            query: UpdateDraftContractRatesDocument,
-            variables: {
-                input: {
-                    contractID: contractB.id,
-                    lastSeenUpdatedAt: contractB.draftRevision?.updatedAt,
-                    updatedRates: [
-                        {
-                            type: 'LINK',
-                            rateID: rateAID,
-                        },
-                        {
-                            type: 'CREATE',
-                            formData: testRateFormInputData(),
-                        },
-                    ],
-                },
+        const stateServer = await constructTestPostgresServer({
+            context: {
+                user: testStateUser(),
             },
         })
-    )
 
-    await submitTestContract(stateServer, contractB.id)
-
-    let rateARelatedStrippedContracts = must(
-        await findRateRelatedContracts(client, rateAID)
-    )
-
-    // expect parent contract B to be resubmitted
-    expect(rateARelatedStrippedContracts).toEqual(
-        expect.arrayContaining([
-            {
-                id: submittedContractA.id,
-                consolidatedStatus: 'RESUBMITTED',
-            },
-            {
-                id: contractB.id,
-                consolidatedStatus: 'SUBMITTED',
-            },
-        ])
-    )
-
-    await unlockTestContract(
-        cmsServer,
-        submittedContractA.id,
-        'unlocked parent contract'
-    )
-
-    const contractC = await createAndUpdateTestContractWithoutRates(stateServer)
-    // link rate contract C
-    must(
-        await stateServer.executeOperation({
-            query: UpdateDraftContractRatesDocument,
-            variables: {
-                input: {
-                    contractID: contractC.id,
-                    lastSeenUpdatedAt: contractC.draftRevision?.updatedAt,
-                    updatedRates: [
-                        {
-                            type: 'LINK',
-                            rateID: rateAID,
-                        },
-                        {
-                            type: 'CREATE',
-                            formData: testRateFormInputData(),
-                        },
-                    ],
-                },
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: testCMSUser(),
             },
         })
-    )
 
-    await submitTestContract(stateServer, contractC.id)
+        const submittedContractA =
+            await createAndSubmitTestContractWithRate(stateServer)
+        const rateAID =
+            submittedContractA.packageSubmissions[0].rateRevisions[0].rateID
 
-    const unlockedContractB = await unlockTestContract(
-        cmsServer,
-        contractB.id,
-        'unlock to remove rate A'
-    )
-    const rateBID = unlockedContractB.packageSubmissions[0].rateRevisions.find(
-        (rate) => rate.rateID !== rateAID
-    )?.rateID
+        await unlockTestContract(cmsServer, submittedContractA.id, 'unlock 1')
+        await submitTestContract(stateServer, submittedContractA.id, 'submit 2')
 
-    if (!rateBID) {
-        throw new Error('Unexpected error: rateBID should exist, but does not.')
-    }
+        const contractB =
+            await createAndUpdateTestContractWithoutRates(stateServer)
 
-    // Remove rateA from contractB, but keep it unlocked
-    must(
-        await stateServer.executeOperation({
-            query: UpdateDraftContractRatesDocument,
-            variables: {
-                input: {
-                    contractID: unlockedContractB.id,
-                    lastSeenUpdatedAt:
-                        unlockedContractB.draftRevision?.updatedAt,
-                    updatedRates: [
-                        {
-                            type: 'UPDATE',
-                            formData: testRateFormInputData(),
-                            rateID: rateBID,
-                        },
-                    ],
+        // link rate contract B
+        must(
+            await stateServer.executeOperation({
+                query: UpdateDraftContractRatesDocument,
+                variables: {
+                    input: {
+                        contractID: contractB.id,
+                        lastSeenUpdatedAt: contractB.draftRevision?.updatedAt,
+                        updatedRates: [
+                            {
+                                type: 'LINK',
+                                rateID: rateAID,
+                            },
+                            {
+                                type: 'CREATE',
+                                formData: testRateFormInputData(),
+                            },
+                        ],
+                    },
                 },
-            },
-        })
-    )
+            })
+        )
 
-    rateARelatedStrippedContracts = must(
-        await findRateRelatedContracts(client, rateAID)
-    )
+        await submitTestContract(stateServer, contractB.id)
 
-    // expect all contracts to still be related
-    expect(rateARelatedStrippedContracts).toEqual(
-        expect.arrayContaining([
-            {
-                id: submittedContractA.id,
-                consolidatedStatus: 'UNLOCKED',
-            },
-            {
-                id: contractB.id,
-                consolidatedStatus: 'UNLOCKED',
-            },
-            {
-                id: contractC.id,
-                consolidatedStatus: 'SUBMITTED',
-            },
-        ])
-    )
+        let rateARelatedStrippedContracts = must(
+            await findRateRelatedContracts(client, rateAID)
+        )
 
-    // resubmit contract B should remove it from the related contracts
-    await submitTestContract(
-        stateServer,
-        contractB.id,
-        'resubmit contractB without rateA'
-    )
+        // expect parent contract B to be resubmitted
+        expect(rateARelatedStrippedContracts).toEqual(
+            expect.arrayContaining([
+                {
+                    id: submittedContractA.id,
+                    consolidatedStatus: 'RESUBMITTED',
+                },
+                {
+                    id: contractB.id,
+                    consolidatedStatus: 'SUBMITTED',
+                },
+            ])
+        )
 
-    // approve contractC
-    await approveTestContract(cmsServer, contractC.id)
+        await unlockTestContract(
+            cmsServer,
+            submittedContractA.id,
+            'unlocked parent contract'
+        )
 
-    rateARelatedStrippedContracts = must(
-        await findRateRelatedContracts(client, rateAID)
-    )
+        const contractC =
+            await createAndUpdateTestContractWithoutRates(stateServer)
+        // link rate contract C
+        must(
+            await stateServer.executeOperation({
+                query: UpdateDraftContractRatesDocument,
+                variables: {
+                    input: {
+                        contractID: contractC.id,
+                        lastSeenUpdatedAt: contractC.draftRevision?.updatedAt,
+                        updatedRates: [
+                            {
+                                type: 'LINK',
+                                rateID: rateAID,
+                            },
+                            {
+                                type: 'CREATE',
+                                formData: testRateFormInputData(),
+                            },
+                        ],
+                    },
+                },
+            })
+        )
 
-    // expect B to be gone and C to be approved
-    expect(rateARelatedStrippedContracts).toEqual(
-        expect.arrayContaining([
-            {
-                id: submittedContractA.id,
-                consolidatedStatus: 'UNLOCKED',
-            },
-            {
-                id: contractC.id,
-                consolidatedStatus: 'APPROVED',
-            },
-        ])
-    )
-}, 10000)
+        await submitTestContract(stateServer, contractC.id)
+
+        const unlockedContractB = await unlockTestContract(
+            cmsServer,
+            contractB.id,
+            'unlock to remove rate A'
+        )
+        const rateBID =
+            unlockedContractB.packageSubmissions[0].rateRevisions.find(
+                (rate) => rate.rateID !== rateAID
+            )?.rateID
+
+        if (!rateBID) {
+            throw new Error(
+                'Unexpected error: rateBID should exist, but does not.'
+            )
+        }
+
+        // Remove rateA from contractB, but keep it unlocked
+        must(
+            await stateServer.executeOperation({
+                query: UpdateDraftContractRatesDocument,
+                variables: {
+                    input: {
+                        contractID: unlockedContractB.id,
+                        lastSeenUpdatedAt:
+                            unlockedContractB.draftRevision?.updatedAt,
+                        updatedRates: [
+                            {
+                                type: 'UPDATE',
+                                formData: testRateFormInputData(),
+                                rateID: rateBID,
+                            },
+                        ],
+                    },
+                },
+            })
+        )
+
+        rateARelatedStrippedContracts = must(
+            await findRateRelatedContracts(client, rateAID)
+        )
+
+        // expect all contracts to still be related
+        expect(rateARelatedStrippedContracts).toEqual(
+            expect.arrayContaining([
+                {
+                    id: submittedContractA.id,
+                    consolidatedStatus: 'UNLOCKED',
+                },
+                {
+                    id: contractB.id,
+                    consolidatedStatus: 'UNLOCKED',
+                },
+                {
+                    id: contractC.id,
+                    consolidatedStatus: 'SUBMITTED',
+                },
+            ])
+        )
+
+        // resubmit contract B should remove it from the related contracts
+        await submitTestContract(
+            stateServer,
+            contractB.id,
+            'resubmit contractB without rateA'
+        )
+
+        // approve contractC
+        await approveTestContract(cmsServer, contractC.id)
+
+        rateARelatedStrippedContracts = must(
+            await findRateRelatedContracts(client, rateAID)
+        )
+
+        // expect B to be gone and C to be approved
+        expect(rateARelatedStrippedContracts).toEqual(
+            expect.arrayContaining([
+                {
+                    id: submittedContractA.id,
+                    consolidatedStatus: 'UNLOCKED',
+                },
+                {
+                    id: contractC.id,
+                    consolidatedStatus: 'APPROVED',
+                },
+            ])
+        )
+    },
+    EXTENDED_TIMEOUT
+)

--- a/services/app-api/src/postgres/contractAndRates/findRateRelatedContracts.test.ts
+++ b/services/app-api/src/postgres/contractAndRates/findRateRelatedContracts.test.ts
@@ -12,198 +12,188 @@ import { must } from '../../testHelpers'
 import { UpdateDraftContractRatesDocument } from '../../gen/gqlClient'
 import { testRateFormInputData } from '../../testHelpers/gqlRateHelpers'
 import { findRateRelatedContracts } from './findRateRelatedContracts'
-import { EXTENDED_TIMEOUT } from '../../testHelpers/assertionHelpers'
 
-it(
-    'returns related contracts with correct status',
-    async () => {
-        const client = await sharedTestPrismaClient()
+it('returns related contracts with correct status', async () => {
+    const client = await sharedTestPrismaClient()
 
-        const stateServer = await constructTestPostgresServer({
-            context: {
-                user: testStateUser(),
+    const stateServer = await constructTestPostgresServer({
+        context: {
+            user: testStateUser(),
+        },
+    })
+
+    const cmsServer = await constructTestPostgresServer({
+        context: {
+            user: testCMSUser(),
+        },
+    })
+
+    const submittedContractA =
+        await createAndSubmitTestContractWithRate(stateServer)
+    const rateAID =
+        submittedContractA.packageSubmissions[0].rateRevisions[0].rateID
+
+    await unlockTestContract(cmsServer, submittedContractA.id, 'unlock 1')
+    await submitTestContract(stateServer, submittedContractA.id, 'submit 2')
+
+    const contractB = await createAndUpdateTestContractWithoutRates(stateServer)
+
+    // link rate contract B
+    must(
+        await stateServer.executeOperation({
+            query: UpdateDraftContractRatesDocument,
+            variables: {
+                input: {
+                    contractID: contractB.id,
+                    lastSeenUpdatedAt: contractB.draftRevision?.updatedAt,
+                    updatedRates: [
+                        {
+                            type: 'LINK',
+                            rateID: rateAID,
+                        },
+                        {
+                            type: 'CREATE',
+                            formData: testRateFormInputData(),
+                        },
+                    ],
+                },
             },
         })
+    )
 
-        const cmsServer = await constructTestPostgresServer({
-            context: {
-                user: testCMSUser(),
+    await submitTestContract(stateServer, contractB.id)
+
+    let rateARelatedStrippedContracts = must(
+        await findRateRelatedContracts(client, rateAID)
+    )
+
+    // expect parent contract B to be resubmitted
+    expect(rateARelatedStrippedContracts).toEqual(
+        expect.arrayContaining([
+            {
+                id: submittedContractA.id,
+                consolidatedStatus: 'RESUBMITTED',
+            },
+            {
+                id: contractB.id,
+                consolidatedStatus: 'SUBMITTED',
+            },
+        ])
+    )
+
+    await unlockTestContract(
+        cmsServer,
+        submittedContractA.id,
+        'unlocked parent contract'
+    )
+
+    const contractC = await createAndUpdateTestContractWithoutRates(stateServer)
+    // link rate contract C
+    must(
+        await stateServer.executeOperation({
+            query: UpdateDraftContractRatesDocument,
+            variables: {
+                input: {
+                    contractID: contractC.id,
+                    lastSeenUpdatedAt: contractC.draftRevision?.updatedAt,
+                    updatedRates: [
+                        {
+                            type: 'LINK',
+                            rateID: rateAID,
+                        },
+                        {
+                            type: 'CREATE',
+                            formData: testRateFormInputData(),
+                        },
+                    ],
+                },
             },
         })
+    )
 
-        const submittedContractA =
-            await createAndSubmitTestContractWithRate(stateServer)
-        const rateAID =
-            submittedContractA.packageSubmissions[0].rateRevisions[0].rateID
+    await submitTestContract(stateServer, contractC.id)
 
-        await unlockTestContract(cmsServer, submittedContractA.id, 'unlock 1')
-        await submitTestContract(stateServer, submittedContractA.id, 'submit 2')
+    const unlockedContractB = await unlockTestContract(
+        cmsServer,
+        contractB.id,
+        'unlock to remove rate A'
+    )
+    const rateBID = unlockedContractB.packageSubmissions[0].rateRevisions.find(
+        (rate) => rate.rateID !== rateAID
+    )?.rateID
 
-        const contractB =
-            await createAndUpdateTestContractWithoutRates(stateServer)
+    if (!rateBID) {
+        throw new Error('Unexpected error: rateBID should exist, but does not.')
+    }
 
-        // link rate contract B
-        must(
-            await stateServer.executeOperation({
-                query: UpdateDraftContractRatesDocument,
-                variables: {
-                    input: {
-                        contractID: contractB.id,
-                        lastSeenUpdatedAt: contractB.draftRevision?.updatedAt,
-                        updatedRates: [
-                            {
-                                type: 'LINK',
-                                rateID: rateAID,
-                            },
-                            {
-                                type: 'CREATE',
-                                formData: testRateFormInputData(),
-                            },
-                        ],
-                    },
+    // Remove rateA from contractB, but keep it unlocked
+    must(
+        await stateServer.executeOperation({
+            query: UpdateDraftContractRatesDocument,
+            variables: {
+                input: {
+                    contractID: unlockedContractB.id,
+                    lastSeenUpdatedAt:
+                        unlockedContractB.draftRevision?.updatedAt,
+                    updatedRates: [
+                        {
+                            type: 'UPDATE',
+                            formData: testRateFormInputData(),
+                            rateID: rateBID,
+                        },
+                    ],
                 },
-            })
-        )
+            },
+        })
+    )
 
-        await submitTestContract(stateServer, contractB.id)
+    rateARelatedStrippedContracts = must(
+        await findRateRelatedContracts(client, rateAID)
+    )
 
-        let rateARelatedStrippedContracts = must(
-            await findRateRelatedContracts(client, rateAID)
-        )
+    // expect all contracts to still be related
+    expect(rateARelatedStrippedContracts).toEqual(
+        expect.arrayContaining([
+            {
+                id: submittedContractA.id,
+                consolidatedStatus: 'UNLOCKED',
+            },
+            {
+                id: contractB.id,
+                consolidatedStatus: 'UNLOCKED',
+            },
+            {
+                id: contractC.id,
+                consolidatedStatus: 'SUBMITTED',
+            },
+        ])
+    )
 
-        // expect parent contract B to be resubmitted
-        expect(rateARelatedStrippedContracts).toEqual(
-            expect.arrayContaining([
-                {
-                    id: submittedContractA.id,
-                    consolidatedStatus: 'RESUBMITTED',
-                },
-                {
-                    id: contractB.id,
-                    consolidatedStatus: 'SUBMITTED',
-                },
-            ])
-        )
+    // resubmit contract B should remove it from the related contracts
+    await submitTestContract(
+        stateServer,
+        contractB.id,
+        'resubmit contractB without rateA'
+    )
 
-        await unlockTestContract(
-            cmsServer,
-            submittedContractA.id,
-            'unlocked parent contract'
-        )
+    // approve contractC
+    await approveTestContract(cmsServer, contractC.id)
 
-        const contractC =
-            await createAndUpdateTestContractWithoutRates(stateServer)
-        // link rate contract C
-        must(
-            await stateServer.executeOperation({
-                query: UpdateDraftContractRatesDocument,
-                variables: {
-                    input: {
-                        contractID: contractC.id,
-                        lastSeenUpdatedAt: contractC.draftRevision?.updatedAt,
-                        updatedRates: [
-                            {
-                                type: 'LINK',
-                                rateID: rateAID,
-                            },
-                            {
-                                type: 'CREATE',
-                                formData: testRateFormInputData(),
-                            },
-                        ],
-                    },
-                },
-            })
-        )
+    rateARelatedStrippedContracts = must(
+        await findRateRelatedContracts(client, rateAID)
+    )
 
-        await submitTestContract(stateServer, contractC.id)
-
-        const unlockedContractB = await unlockTestContract(
-            cmsServer,
-            contractB.id,
-            'unlock to remove rate A'
-        )
-        const rateBID =
-            unlockedContractB.packageSubmissions[0].rateRevisions.find(
-                (rate) => rate.rateID !== rateAID
-            )?.rateID
-
-        if (!rateBID) {
-            throw new Error(
-                'Unexpected error: rateBID should exist, but does not.'
-            )
-        }
-
-        // Remove rateA from contractB, but keep it unlocked
-        must(
-            await stateServer.executeOperation({
-                query: UpdateDraftContractRatesDocument,
-                variables: {
-                    input: {
-                        contractID: unlockedContractB.id,
-                        lastSeenUpdatedAt:
-                            unlockedContractB.draftRevision?.updatedAt,
-                        updatedRates: [
-                            {
-                                type: 'UPDATE',
-                                formData: testRateFormInputData(),
-                                rateID: rateBID,
-                            },
-                        ],
-                    },
-                },
-            })
-        )
-
-        rateARelatedStrippedContracts = must(
-            await findRateRelatedContracts(client, rateAID)
-        )
-
-        // expect all contracts to still be related
-        expect(rateARelatedStrippedContracts).toEqual(
-            expect.arrayContaining([
-                {
-                    id: submittedContractA.id,
-                    consolidatedStatus: 'UNLOCKED',
-                },
-                {
-                    id: contractB.id,
-                    consolidatedStatus: 'UNLOCKED',
-                },
-                {
-                    id: contractC.id,
-                    consolidatedStatus: 'SUBMITTED',
-                },
-            ])
-        )
-
-        // resubmit contract B should remove it from the related contracts
-        await submitTestContract(
-            stateServer,
-            contractB.id,
-            'resubmit contractB without rateA'
-        )
-
-        // approve contractC
-        await approveTestContract(cmsServer, contractC.id)
-
-        rateARelatedStrippedContracts = must(
-            await findRateRelatedContracts(client, rateAID)
-        )
-
-        // expect B to be gone and C to be approved
-        expect(rateARelatedStrippedContracts).toEqual(
-            expect.arrayContaining([
-                {
-                    id: submittedContractA.id,
-                    consolidatedStatus: 'UNLOCKED',
-                },
-                {
-                    id: contractC.id,
-                    consolidatedStatus: 'APPROVED',
-                },
-            ])
-        )
-    },
-    EXTENDED_TIMEOUT
-)
+    // expect B to be gone and C to be approved
+    expect(rateARelatedStrippedContracts).toEqual(
+        expect.arrayContaining([
+            {
+                id: submittedContractA.id,
+                consolidatedStatus: 'UNLOCKED',
+            },
+            {
+                id: contractC.id,
+                consolidatedStatus: 'APPROVED',
+            },
+        ])
+    )
+})

--- a/services/app-api/src/postgres/contractAndRates/findRateRelatedContracts.ts
+++ b/services/app-api/src/postgres/contractAndRates/findRateRelatedContracts.ts
@@ -13,9 +13,7 @@ async function findRateRelatedContractsInTransaction(
         where: {
             id: rateID,
         },
-        include: {
-            ...includeRateRelatedContracts,
-        },
+        include: includeRateRelatedContracts,
     })
 
     if (!rate) {

--- a/services/app-api/src/postgres/contractAndRates/parseContractWithHistory.ts
+++ b/services/app-api/src/postgres/contractAndRates/parseContractWithHistory.ts
@@ -213,7 +213,7 @@ function contractWithHistoryToDomainModelWithoutRates(
     }
 
     const status = getContractRateStatus(contract.revisions)
-    const reviewStatus = getContractReviewStatus(contract)
+    const reviewStatus = getContractReviewStatus(contract.reviewStatusActions)
     const consolidatedStatus = getConsolidatedContractStatus(
         status,
         reviewStatus

--- a/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
@@ -28,7 +28,7 @@ import type {
     RateRevisionTablePayload,
     RateTableWithoutDraftContractsStrippedPayload,
     RateRevisionTableWithRelatedSubmissionContracts,
-    SelectSubmissionPackageContractRevisionData,
+    SubmissionPackageContractRevisionData,
     RateTableWithRelatedContractsPayload,
 } from './prismaSubmittedRateHelpers'
 import type { ConsolidatedRateStatusType } from '../../domain-models/contractAndRates/statusType'
@@ -90,7 +90,7 @@ function getContractRateStatus(
         | ContractRevisionTableWithFormData[]
         | RateRevisionTableWithFormData[]
         | StrippedRateRevisionTableWithFormData[]
-        | SelectSubmissionPackageContractRevisionData[]
+        | SubmissionPackageContractRevisionData[]
 ): PackageStatusType {
     // need to order revisions from latest to earliest
     const revs = [...revisions].sort(

--- a/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
@@ -238,7 +238,7 @@ const getParentContractID = (
     return latestParentContract.contractID
 }
 
-// Function to loop through a rate revisions related submissions to find a new suitable parent contract.
+// Function to loop through a list of revisions on a rate and find a suitable parent contract. Meant to be used in cases where the original parent contract associated with that rate has been withdrawn but the rate is still linked to other contracts.
 const getNewParentContract = (
     rateRevisions: RateRevisionTableWithRelatedSubmissionContracts[]
 ):

--- a/services/app-api/src/postgres/contractAndRates/prismaSubmittedRateHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaSubmittedRateHelpers.ts
@@ -108,73 +108,71 @@ const includeStrippedRateWithoutDraftContracts = {
     },
 } satisfies Prisma.RateTableInclude
 
-const includeRateRelatedContracts = {
-    revisions: {
+const includeRateRevisionWithRelatedSubmissionContracts = {
+    submitInfo: {
+        select: {
+            id: true,
+            updatedAt: true,
+            updatedReason: true,
+            submittedContracts: {
+                select: {
+                    contractID: true,
+                },
+            },
+        },
+    },
+    unlockInfo: {
+        select: {
+            id: true,
+            updatedAt: true,
+            updatedReason: true,
+        },
+    },
+    relatedSubmissions: {
         orderBy: {
-            createdAt: 'asc',
+            updatedAt: 'desc',
         },
         include: {
-            submitInfo: {
-                select: {
-                    id: true,
-                    updatedAt: true,
-                    updatedReason: true,
-                },
-            },
-            unlockInfo: {
-                select: {
-                    id: true,
-                    updatedAt: true,
-                    updatedReason: true,
-                },
-            },
-            relatedSubmissions: {
-                orderBy: {
-                    updatedAt: 'asc',
-                },
+            submissionPackages: {
                 include: {
-                    submissionPackages: {
-                        include: {
-                            contractRevision: {
+                    contractRevision: {
+                        select: {
+                            createdAt: true,
+                            contract: {
                                 select: {
-                                    createdAt: true,
-                                    contract: {
+                                    id: true,
+                                    revisions: {
+                                        orderBy: {
+                                            updatedAt: 'desc',
+                                        },
+                                        take: 1,
                                         select: {
-                                            id: true,
-                                            revisions: {
-                                                orderBy: {
-                                                    updatedAt: 'desc',
-                                                },
-                                                take: 1,
-                                                select: {
-                                                    unlockInfo: {
-                                                        select: {
-                                                            id: true,
-                                                            updatedAt: true,
-                                                            updatedReason: true,
-                                                        },
-                                                    },
-                                                    submitInfo: {
-                                                        select: {
-                                                            id: true,
-                                                            updatedAt: true,
-                                                            updatedReason: true,
-                                                        },
-                                                    },
-                                                },
-                                            },
-                                            reviewStatusActions: {
-                                                orderBy: {
-                                                    updatedAt: 'desc',
-                                                },
-                                                take: 1,
+                                            unlockInfo: {
                                                 select: {
                                                     id: true,
                                                     updatedAt: true,
                                                     updatedReason: true,
-                                                    actionType: true,
                                                 },
                                             },
+                                            submitInfo: {
+                                                select: {
+                                                    id: true,
+                                                    updatedAt: true,
+                                                    updatedReason: true,
+                                                },
+                                            },
+                                        },
+                                    },
+                                    reviewStatusActions: {
+                                        orderBy: {
+                                            updatedAt: 'desc',
+                                        },
+                                        take: 1,
+                                        select: {
+                                            id: true,
+                                            updatedAt: true,
+                                            updatedReason: true,
+                                            actionType: true,
                                         },
                                     },
                                 },
@@ -184,6 +182,16 @@ const includeRateRelatedContracts = {
                 },
             },
         },
+        take: 1,
+    },
+} satisfies Prisma.RateRevisionTableInclude
+
+const includeRateRelatedContracts = {
+    revisions: {
+        orderBy: {
+            createdAt: 'asc',
+        },
+        include: includeRateRevisionWithRelatedSubmissionContracts,
     },
 } satisfies Prisma.RateTableInclude
 
@@ -205,11 +213,17 @@ type RateRevisionsTableStrippedPayload =
 type RateRevisionTablePayload =
     RateTableWithoutDraftContractsPayload['revisions']
 
+type RateRevisionTableWithRelatedSubmissionContracts =
+    Prisma.RateRevisionTableGetPayload<{
+        include: typeof includeRateRevisionWithRelatedSubmissionContracts
+    }>
+
 export {
     includeRateWithoutDraftContracts,
     includeLatestSubmittedRateRev,
     includeStrippedRateWithoutDraftContracts,
     includeRateRelatedContracts,
+    includeRateRevisionWithRelatedSubmissionContracts,
 }
 
 export type {
@@ -218,4 +232,5 @@ export type {
     RateRevisionsTableStrippedPayload,
     RateRevisionTablePayload,
     RateTableWithRelatedContractsPayload,
+    RateRevisionTableWithRelatedSubmissionContracts,
 }

--- a/services/app-api/src/postgres/contractAndRates/prismaSubmittedRateHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaSubmittedRateHelpers.ts
@@ -72,7 +72,7 @@ const includeRateWithoutDraftContracts = {
     },
 } satisfies Prisma.RateTableInclude
 
-const selectSubmissionPackageContractRevision = {
+const includeSubmissionPackageContractRevision = {
     unlockInfo: {
         select: {
             id: true,
@@ -89,9 +89,9 @@ const selectSubmissionPackageContractRevision = {
     },
 } satisfies Prisma.ContractRevisionTableInclude
 
-type SelectSubmissionPackageContractRevisionData =
+type SubmissionPackageContractRevisionData =
     Prisma.ContractRevisionTableGetPayload<{
-        include: typeof selectSubmissionPackageContractRevision
+        include: typeof includeSubmissionPackageContractRevision
     }>
 
 const includeStrippedRateWithoutDraftContracts = {
@@ -169,7 +169,7 @@ const includeRateRevisionWithRelatedSubmissionContracts = {
                                         },
                                         take: 1,
                                         include:
-                                            selectSubmissionPackageContractRevision,
+                                            includeSubmissionPackageContractRevision,
                                     },
                                     reviewStatusActions: {
                                         orderBy: {
@@ -229,6 +229,7 @@ export {
     includeStrippedRateWithoutDraftContracts,
     includeRateRelatedContracts,
     includeRateRevisionWithRelatedSubmissionContracts,
+    includeSubmissionPackageContractRevision,
 }
 
 export type {
@@ -238,5 +239,5 @@ export type {
     RateRevisionTablePayload,
     RateTableWithRelatedContractsPayload,
     RateRevisionTableWithRelatedSubmissionContracts,
-    SelectSubmissionPackageContractRevisionData,
+    SubmissionPackageContractRevisionData,
 }

--- a/services/app-api/src/postgres/contractAndRates/prismaSubmittedRateHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaSubmittedRateHelpers.ts
@@ -72,6 +72,28 @@ const includeRateWithoutDraftContracts = {
     },
 } satisfies Prisma.RateTableInclude
 
+const selectSubmissionPackageContractRevision = {
+    unlockInfo: {
+        select: {
+            id: true,
+            updatedAt: true,
+            updatedReason: true,
+        },
+    },
+    submitInfo: {
+        select: {
+            id: true,
+            updatedAt: true,
+            updatedReason: true,
+        },
+    },
+} satisfies Prisma.ContractRevisionTableInclude
+
+type SelectSubmissionPackageContractRevisionData =
+    Prisma.ContractRevisionTableGetPayload<{
+        include: typeof selectSubmissionPackageContractRevision
+    }>
+
 const includeStrippedRateWithoutDraftContracts = {
     withdrawInfo: includeUpdateInfo,
     revisions: {
@@ -146,33 +168,16 @@ const includeRateRevisionWithRelatedSubmissionContracts = {
                                             updatedAt: 'desc',
                                         },
                                         take: 1,
-                                        select: {
-                                            unlockInfo: {
-                                                select: {
-                                                    id: true,
-                                                    updatedAt: true,
-                                                    updatedReason: true,
-                                                },
-                                            },
-                                            submitInfo: {
-                                                select: {
-                                                    id: true,
-                                                    updatedAt: true,
-                                                    updatedReason: true,
-                                                },
-                                            },
-                                        },
+                                        include:
+                                            selectSubmissionPackageContractRevision,
                                     },
                                     reviewStatusActions: {
                                         orderBy: {
                                             updatedAt: 'desc',
                                         },
                                         take: 1,
-                                        select: {
-                                            id: true,
-                                            updatedAt: true,
-                                            updatedReason: true,
-                                            actionType: true,
+                                        include: {
+                                            updatedBy: true,
                                         },
                                     },
                                 },
@@ -233,4 +238,5 @@ export type {
     RateRevisionTablePayload,
     RateTableWithRelatedContractsPayload,
     RateRevisionTableWithRelatedSubmissionContracts,
+    SelectSubmissionPackageContractRevisionData,
 }

--- a/services/app-api/src/postgres/contractAndRates/prismaToDomainModel.test.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaToDomainModel.test.ts
@@ -88,6 +88,23 @@ describe('prismaToDomainModel', () => {
                 revision: [
                     {
                         createdAt: new Date(21, 4, 1),
+                        unlockInfo: {
+                            id: uuidv4(),
+                            updatedAt: new Date(),
+                            updatedByID: 'someone',
+                            updatedReason: 'second unlock',
+                            updatedBy: {
+                                id: 'someone',
+                                createdAt: new Date(),
+                                updatedAt: new Date(),
+                                givenName: 'Bob',
+                                familyName: 'Law',
+                                email: 'boblaw@example.com',
+                                role: 'STATE_USER',
+                                divisionAssignment: null,
+                                stateCode: 'OH',
+                            },
+                        },
                     } as ContractRevisionTableWithFormData,
                     {
                         createdAt: new Date(21, 3, 1),
@@ -95,7 +112,24 @@ describe('prismaToDomainModel', () => {
                             id: uuidv4(),
                             updatedAt: new Date(),
                             updatedByID: 'someone',
-                            updatedReason: 'submit',
+                            updatedReason: 'first resubmit',
+                            updatedBy: {
+                                id: 'someone',
+                                createdAt: new Date(),
+                                updatedAt: new Date(),
+                                givenName: 'Bob',
+                                familyName: 'Law',
+                                email: 'boblaw@example.com',
+                                role: 'STATE_USER',
+                                divisionAssignment: null,
+                                stateCode: 'OH',
+                            },
+                        },
+                        unlockInfo: {
+                            id: uuidv4(),
+                            updatedAt: new Date(),
+                            updatedByID: 'someone',
+                            updatedReason: 'first unlock',
                             updatedBy: {
                                 id: 'someone',
                                 createdAt: new Date(),
@@ -115,7 +149,7 @@ describe('prismaToDomainModel', () => {
                             id: uuidv4(),
                             updatedAt: new Date(),
                             updatedByID: 'someone',
-                            updatedReason: 'submit',
+                            updatedReason: 'initial submit',
                             updatedBy: {
                                 id: 'someone',
                                 createdAt: new Date(),
@@ -131,7 +165,7 @@ describe('prismaToDomainModel', () => {
                     } as ContractRevisionTableWithFormData,
                 ],
                 testDescription:
-                    'multiple reivsions and latest revision has not been submitted',
+                    'multiple revisions and latest revision has not been resubmitted',
                 expectedResult: 'UNLOCKED',
             },
             {
@@ -142,7 +176,24 @@ describe('prismaToDomainModel', () => {
                             id: uuidv4(),
                             updatedAt: new Date(),
                             updatedByID: 'someone',
-                            updatedReason: 'submit',
+                            updatedReason: 'resubmit submit',
+                            updatedBy: {
+                                id: 'someone',
+                                createdAt: new Date(),
+                                updatedAt: new Date(),
+                                givenName: 'Bob',
+                                familyName: 'Law',
+                                email: 'boblaw@example.com',
+                                role: 'STATE_USER',
+                                divisionAssignment: null,
+                                stateCode: 'OH',
+                            },
+                        },
+                        unlockInfo: {
+                            id: uuidv4(),
+                            updatedAt: new Date(),
+                            updatedByID: 'someone',
+                            updatedReason: 'first unlock',
                             updatedBy: {
                                 id: 'someone',
                                 createdAt: new Date(),
@@ -162,7 +213,24 @@ describe('prismaToDomainModel', () => {
                             id: uuidv4(),
                             updatedAt: new Date(),
                             updatedByID: 'someone',
-                            updatedReason: 'submit',
+                            updatedReason: 'second resubmit',
+                            updatedBy: {
+                                id: 'someone',
+                                createdAt: new Date(),
+                                updatedAt: new Date(),
+                                givenName: 'Bob',
+                                familyName: 'Law',
+                                email: 'boblaw@example.com',
+                                role: 'STATE_USER',
+                                divisionAssignment: null,
+                                stateCode: 'OH',
+                            },
+                        },
+                        unlockInfo: {
+                            id: uuidv4(),
+                            updatedAt: new Date(),
+                            updatedByID: 'someone',
+                            updatedReason: 'second Unlock',
                             updatedBy: {
                                 id: 'someone',
                                 createdAt: new Date(),
@@ -182,7 +250,7 @@ describe('prismaToDomainModel', () => {
                             id: uuidv4(),
                             updatedAt: new Date(),
                             updatedByID: 'someone',
-                            updatedReason: 'submit',
+                            updatedReason: 'initial submit',
                             updatedBy: {
                                 id: 'someone',
                                 createdAt: new Date(),

--- a/services/app-api/src/postgres/contractAndRates/reassignParentContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/reassignParentContract.ts
@@ -1,0 +1,212 @@
+import type { PrismaTransactionType } from '../prismaTypes'
+import type { ConsolidatedContractStatus } from '../../gen/gqlClient'
+import { includeStrippedRateWithoutDraftContracts } from './prismaSubmittedRateHelpers'
+import { getParentContractID } from './prismaSharedContractRateHelpers'
+import { unlockContractInsideTransaction } from './unlockContract'
+import { submitContractAndOrRates } from './submitContractAndOrRates'
+import type { ProgramType } from '../../domain-models'
+import { packageName } from '@mc-review/hpp'
+
+type RatesToReassign = {
+    rateID: string
+    rateName: string
+}
+
+type ReassignParenContractType = {
+    contractID: string
+    rates: RatesToReassign[]
+    contractStatus: ConsolidatedContractStatus
+    updatedByID: string
+    statePrograms: ProgramType[]
+}
+
+/**
+ * Reassigns rates to a parent contract with appropriate handling based on contract status.
+ *
+ * When reassigning rates to a SUBMITTED or APPROVED contract, we unlock this new parent contract to resubmit it with the rate
+ * , so it becomes its child rate by sharing the same submitInfo.
+ *
+ * When reassigning rates to an UNLOCKED contract, we resubmit this contract with the rate,so it becomes its child rate by sharing
+ * the same submitInfo. Then we unlock the contract again to restore it to its UNLOCKED state like we found it.
+ *
+ * @param tx - The Prisma transaction object used for database operations
+ * @param args - Configuration object containing parameters for reassignment
+ * @param args.contractID - Unique identifier of the parent contract to reassign rates to
+ * @param args.rates - Array of rate objects containing IDs and names to be reassigned
+ * @param args.contractStatus - Current status of the parent contract (UNLOCKED, SUBMITTED, or APPROVED)
+ * @param args.updatedByID - ID of the user performing the reassignment operation
+ * @param args.statePrograms - Array of program types used for contract naming
+ * @param tx
+ * @param args
+ */
+const reassignParentContractInTransaction = async (
+    tx: PrismaTransactionType,
+    args: ReassignParenContractType
+) => {
+    const { contractID, rates, contractStatus, updatedByID, statePrograms } =
+        args
+
+    const rateIDs: string[] = []
+    const rateNames: string[] = []
+
+    rates.forEach((r) => {
+        rateIDs.push(r.rateID)
+        rateNames.push(r.rateName)
+    })
+
+    const errMsgPrefix = `Unable to reassign rates ${rateIDs.join(', ')}`
+    let previousUnlockReason
+    let contractName
+    let draftRates = []
+
+    if (contractStatus === 'UNLOCKED') {
+        // We just want to get the current child rates, so we can submit the reassigned rates with it to become its children.
+        const contractWithDraftRates = await tx.contractTable.findFirst({
+            where: {
+                id: contractID,
+            },
+            select: {
+                stateCode: true,
+                stateNumber: true,
+                revisions: {
+                    orderBy: {
+                        createdAt: 'desc',
+                    },
+                    select: {
+                        unlockInfo: {
+                            select: {
+                                updatedReason: true,
+                            },
+                        },
+                        submitInfo: {
+                            select: {
+                                updatedReason: true,
+                            },
+                        },
+                        programIDs: true,
+                    },
+                    take: 1,
+                },
+                draftRates: {
+                    orderBy: {
+                        ratePosition: 'asc',
+                    },
+                    include: {
+                        rate: {
+                            include: {
+                                ...includeStrippedRateWithoutDraftContracts,
+                                reviewStatusActions: false,
+                                withdrawInfo: false,
+                            },
+                        },
+                    },
+                },
+            },
+        })
+
+        if (!contractWithDraftRates) {
+            throw new Error(
+                `${errMsgPrefix}, contract ${contractID} not found.`
+            )
+        }
+
+        if (!contractWithDraftRates?.draftRates) {
+            throw new Error(
+                `${errMsgPrefix}, contract ${contractID} has no draft rates.`
+            )
+        }
+
+        const latestRevision = contractWithDraftRates.revisions[0]
+        previousUnlockReason = latestRevision?.unlockInfo?.updatedReason
+        contractName = packageName(
+            contractWithDraftRates.stateCode,
+            contractWithDraftRates.stateNumber,
+            latestRevision.programIDs,
+            statePrograms
+        )
+
+        draftRates = contractWithDraftRates.draftRates.map((dr) => ({
+            ...dr.rate,
+            parentContractID: getParentContractID(dr.rate.revisions),
+        }))
+    } else {
+        // Unlock the contract, so we can resubmit it with the reassigned rate to become its child.
+        const unlockedContract = await unlockContractInsideTransaction(tx, {
+            contractID: contractID,
+            unlockedByUserID: updatedByID,
+            // this unlocked reason does not include contract name because new child rates are not sharing this unlockInfo
+            // so no need to point the user to this contract.
+            unlockReason: `CMS to reassign rate(s) ${rateNames.join(', ')} to be editable on this submission.`,
+        })
+
+        if (unlockedContract instanceof Error) {
+            throw new Error(
+                `${errMsgPrefix}, new parent Contract ${contractID} could not be unlocked. ${unlockedContract.message}`
+            )
+        }
+
+        const latestRevision =
+            unlockedContract.packageSubmissions[0].contractRevision
+
+        contractName = packageName(
+            unlockedContract.stateCode,
+            unlockedContract.stateNumber,
+            latestRevision.formData.programIDs,
+            statePrograms
+        )
+
+        draftRates = unlockedContract.draftRates
+    }
+
+    // Collection of rates to submit with the contract. Draft rates includes linked rates that are not being reassigned and should not be submitted with the contract.
+    const ratesToSubmit: string[] = []
+
+    for (const draftRate of draftRates) {
+        // filter out linked rates, except for the linked rates we want to reassign to this contract.
+        if (
+            draftRate.parentContractID === contractID ||
+            rateIDs.includes(draftRate.id)
+        ) {
+            ratesToSubmit.push(draftRate.id)
+        }
+    }
+
+    // resubmit the contract, so we create the submit info for the reassigned rate this will now be our marker in the
+    // DB to identify the parent contract
+    const resubmitContract = await submitContractAndOrRates(
+        tx,
+        contractID,
+        ratesToSubmit,
+        updatedByID,
+        `CMS has reassigned rate(s) ${rateNames.join(', ')} to be editable on submission ${contractName}.`
+    )
+
+    if (resubmitContract instanceof Error) {
+        throw new Error(
+            `Unable to reassign rate(s) ${rateNames.join(', ')}, new parent Contract ${contractID} could not be resubmitted. ${resubmitContract.message}`
+        )
+    }
+
+    // If this contract was originally unlocked, we want to put it back into that status with the new child rates.
+    if (contractStatus === 'UNLOCKED') {
+        const unlockedContract = await unlockContractInsideTransaction(tx, {
+            contractID: contractID,
+            unlockedByUserID: updatedByID,
+            // This unlock includes contract name because the new child rates will share the same unlockInfo.
+            unlockReason: `${previousUnlockReason}. CMS has reassigned rate(s) ${rateNames.join(', ')} to be editable on submission ${contractName}.`,
+            // Adding 50ms to ensure this revision timestamp is later than the rate revision created for the old
+            // parent contract. Needed for reliable sorting in revision history.
+            manualCreatedAt: new Date(new Date().getTime() + 50),
+        })
+
+        if (unlockedContract instanceof Error) {
+            throw new Error(
+                `Unable to reassign rate(s) ${rateNames.join(', ')}, could not return new parent Contract ${contractID} to UNLOCKED status. ${unlockedContract.message}`
+            )
+        }
+    }
+}
+
+export { reassignParentContractInTransaction }
+
+export type { ReassignParenContractType, RatesToReassign }

--- a/services/app-api/src/postgres/contractAndRates/unlockContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/unlockContract.ts
@@ -10,11 +10,11 @@ async function unlockContractInsideTransaction(
     args: UnlockContractArgsType
 ): Promise<UnlockedContractType | Error> {
     const currentDateTime = new Date()
-    const { contractID, unlockedByUserID, unlockReason } = args
+    const { contractID, unlockedByUserID, unlockReason, manualCreatedAt } = args
     // create the unlock info to be shared across all submissions.
     const unlockInfo = await tx.updateInfoTable.create({
         data: {
-            updatedAt: currentDateTime,
+            updatedAt: manualCreatedAt ?? currentDateTime,
             updatedByID: unlockedByUserID,
             updatedReason: unlockReason,
         },
@@ -143,6 +143,7 @@ async function unlockContractInsideTransaction(
 
     await tx.contractRevisionTable.create({
         data: {
+            createdAt: manualCreatedAt ?? currentDateTime,
             contract: {
                 connect: {
                     id: contractID,
@@ -260,6 +261,9 @@ type UnlockContractArgsType = {
     contractID: string
     unlockedByUserID: string
     unlockReason: string
+    // Used to specify a timestamp when calling multiple prisma functions within the same transaction that need
+    // sequential timestamps for revision history
+    manualCreatedAt?: Date
 }
 
 // Unlock the given contract

--- a/services/app-api/src/postgres/contractAndRates/unlockRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/unlockRate.ts
@@ -14,7 +14,7 @@ async function unlockRateInDB(
     tx: PrismaTransactionType,
     rateID: string,
     unlockInfoID: string,
-    // Used to specify a timestamp when calling multiple prisma functions within the same transaction that need
+    // Used to override createdAt timestamp when calling multiple prisma functions within the same transaction that need
     // sequential timestamps for revision history.
     manualCreatedAt?: Date
 ): Promise<string | Error> {

--- a/services/app-api/src/postgres/contractAndRates/unlockRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/unlockRate.ts
@@ -13,8 +13,12 @@ type UnlockRateArgsType = {
 async function unlockRateInDB(
     tx: PrismaTransactionType,
     rateID: string,
-    unlockInfoID: string
+    unlockInfoID: string,
+    // Used to specify a timestamp when calling multiple prisma functions within the same transaction that need
+    // sequential timestamps for revision history.
+    manualCreatedAt?: Date
 ): Promise<string | Error> {
+    const currentDateTime = new Date()
     // find the current rate revision in order to create a new unlocked revision
     const currentRev = await tx.rateRevisionTable.findFirst({
         where: {
@@ -84,6 +88,7 @@ async function unlockRateInDB(
 
     await tx.rateRevisionTable.create({
         data: {
+            createdAt: manualCreatedAt ?? currentDateTime,
             rate: {
                 connect: {
                     id: currentRev.rateID,

--- a/services/app-api/src/postgres/contractAndRates/withdrawContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawContract.ts
@@ -3,10 +3,13 @@ import type { ContractType } from '../../domain-models'
 import { unlockContractInsideTransaction } from './unlockContract'
 import { findStatePrograms } from '../state'
 import { packageName } from '@mc-review/hpp'
-import { submitContractInsideTransaction } from './submitContract'
 import { findContractWithHistory } from './findContractWithHistory'
 import { NotFoundError } from '../postgresErrors'
 import type { ExtendedPrismaClient } from '../prismaClient'
+import type { ConsolidatedContractStatus } from '../../gen/gqlClient'
+import { submitContractAndOrRates } from './submitContractAndOrRates'
+import { includeRateWithoutDraftContracts } from './prismaSubmittedRateHelpers'
+import { getParentContractID } from './prismaSharedContractRateHelpers'
 
 export type WithdrawContractArgsType = {
     contract: ContractType
@@ -18,11 +21,13 @@ export type WithdrawContractArgsType = {
  * Withdraws a contract and its associated eligible rates within a database transaction.
  *
  * This function performs the following operations:
- * 1. Identifies related rates that should be withdrawn with the contract
- * 2. Unlocks the contract and child rates with a withdrawal reason
- * 3. Resubmits the contract and child rates with a withdrawal reason
- * 4. Creates a withdrawal action for the contract
- * 5. Creates withdrawal actions for all eligible associated rates
+ * 1. Identifies child rates that should be withdrawn with the contract
+ * 2. Identifies child rates that cannot be withdrawn should be assigned a new parent contract
+ * 3. Unlocks the contract and child rates with a withdrawal reason
+ * 4. Assign new parent contracts for rates that cannot be withdrawn
+ * 5. Resubmits the contract and child rates with a withdrawal reason
+ * 6. Creates a withdrawal action for the contract
+ * 7. Creates withdrawal actions for all eligible associated rates
  *
  * @async
  * @param {WithdrawContractArgsType} args - Withdrawal arguments
@@ -151,20 +156,35 @@ const withdrawContractInsideTransaction = async (
     })
 
     if (!rates) {
-        throw new NotFoundError('Could not find rates on contract')
+        throw new NotFoundError(
+            'Could not find rates on contract to be withdrawn'
+        )
     }
 
     // Child rates to withdraw with the submission, so it includes the same withdraw reason
     const ratesToWithdraw = []
+    // Child rates that need to be reassigned a new parent contract
+    const ratesToReAssign: {
+        rateID: string
+        rateName?: string
+        reassignToContractID: string
+        contractStatus: ConsolidatedContractStatus
+    }[] = []
 
-    // loop through all rates to determine which ones can be withdrawn.
+    // Loop through all rates to determine which ones can be withdrawn or reassigned parent contract
     for (const rate of rates) {
         // latest rate revision of the current rate on the submission
         const latestRateRevision = rate.revisions[0]
         // find the parent contract of the rate, it is the contract on the rates first submission revision
-        const firstRateRevision = rate.revisions[rate.revisions.length - 1]
+
+        if (!latestRateRevision.submitInfo) {
+            throw new Error(
+                `Child rate ${rate.id} of contract to be withdrawn does is not submitted.`
+            )
+        }
+
         const parentContractID =
-            firstRateRevision.submitInfo?.submittedContracts[0].contractID
+            latestRateRevision.submitInfo?.submittedContracts[0].contractID
 
         // filter out submission packages that do not belong to this rate revision
         const submissionPackages =
@@ -176,42 +196,85 @@ const withdrawContractInsideTransaction = async (
                         a.contractRevision.createdAt.getTime()
                 )
 
-        // get the parent contract data of this rate.
-        const parentContract = submissionPackages?.find(
-            (pkg) => pkg.contractRevision.contract.id === parentContractID
-        )?.contractRevision.contract
-
-        // check if any of the linked submissions are approved or submitted and not withdrawn
-        const hasApprovedOrSubmittedSubs = submissionPackages.some((pkg) => {
-            const reviewStatusAction =
-                pkg.contractRevision.contract.reviewStatusActions[0]?.actionType
-            const isSubmitted =
-                pkg.contractRevision.contract.revisions[0].submitInfo
-
-            // skip if this is the parent contract submission package.
-            if (pkg.contractRevision.contract.id === contract.id) return false
-            // is contract approved
-            if (reviewStatusAction === 'MARK_AS_APPROVED') return true
-            // is contract submitted and review status is not withdrawn
-            if (isSubmitted && reviewStatusAction !== 'WITHDRAW') return true
-            // otherwise does not meet condition
-            return false
-        })
-
         // skipping rate if conditions are met
         if (
             !latestRateRevision.submitInfo || // unlocked rate. linked rates can be in unlocked status
             rate.reviewStatusActions[0]?.actionType === 'WITHDRAW' || // is the rate already withdrawn
-            hasApprovedOrSubmittedSubs || // any of the linked submissions are approved or submitted
-            !parentContract // standalone rate could happen from a bug, old feature, or new feature. We don't want to withdraw these in this fashion.
+            parentContractID !== contract.id // if it is a linked rate
         ) {
             continue
         }
 
-        // TODO: Pending decision if rate can be withdrawn if its linked to a unlocked submission that had this rate in its latest submission package.
-        //  - If we do allow it, then delete this TODO, if we do not allow it we need to add logic to check unlocked
-        //      submissions for rate in its latest submission package.
-        ratesToWithdraw.push(rate)
+        // check if any of the linked submissions are approved or submitted and not withdrawn
+        let reassignToContractID:
+            | {
+                  contractID: string
+                  status: ConsolidatedContractStatus
+              }
+            | undefined = undefined
+
+        // Looping through each rate's latest revision's related submissions to find a valid new parent contract.
+        for (const pkg of submissionPackages) {
+            const contractID = pkg.contractRevision.contract.id
+            const latestRevision = pkg.contractRevision.contract.revisions[0]
+            const isApproved =
+                pkg.contractRevision.contract.reviewStatusActions[0]
+                    ?.actionType === 'MARK_AS_APPROVED'
+            const isWithdrawn =
+                pkg.contractRevision.contract.reviewStatusActions[0]
+                    ?.actionType === 'WITHDRAW'
+
+            // Skip if this was the contract being withdrawn
+            if (contractID === contract.id) {
+                continue
+            }
+
+            // If withdrawn, skip to the next package
+            if (isWithdrawn) {
+                continue
+            }
+            // These next few conditionals are ordered by preferred contract status
+            // Is submitted assigned new value
+            if (latestRevision.submitInfo && !isApproved) {
+                // contract with consolidated status of submitted is our preferred contract, break the loop if we find it.
+                reassignToContractID = {
+                    contractID,
+                    status: 'SUBMITTED',
+                }
+                break
+            }
+            // Is unlocked
+            if (
+                !latestRevision.submitInfo &&
+                latestRevision.unlockInfo &&
+                !isApproved
+            ) {
+                // contract with consolidated status of submitted is our preferred contract, break the loop if we find it.
+                reassignToContractID = {
+                    contractID,
+                    status: 'UNLOCKED',
+                }
+            }
+            // Is approved and no reassigned contract is set, this is the least preferred contract.
+            if (isApproved && !reassignToContractID) {
+                reassignToContractID = {
+                    contractID,
+                    status: 'APPROVED',
+                }
+            }
+        }
+
+        // Reassign if there is a valid contract to reassign to, otherwise we set rate for withdraw
+        if (reassignToContractID) {
+            ratesToReAssign.push({
+                rateID: rate.id,
+                rateName: rate.revisions[0].rateCertificationName ?? undefined,
+                reassignToContractID: reassignToContractID.contractID,
+                contractStatus: reassignToContractID.status,
+            })
+        } else {
+            ratesToWithdraw.push(rate)
+        }
     }
     const statePrograms = findStatePrograms(contract.stateCode)
 
@@ -237,18 +300,141 @@ const withdrawContractInsideTransaction = async (
             : ''
 
     // unlock contract with withdraw default message and withdraw input reason
-    await unlockContractInsideTransaction(tx, {
+    const unlockContract = await unlockContractInsideTransaction(tx, {
         contractID: contract.id,
         unlockedByUserID: updatedByID,
         unlockReason: `CMS withdrawing the submission ${contractName}${rateNamesMessage}. ${updatedReason}`,
     })
 
-    // resubmit contract with the default message and withdraw input reason
-    await submitContractInsideTransaction(tx, {
-        contractID: contract.id,
-        submittedByUserID: updatedByID,
-        submittedReason: `CMS has withdrawn the submission ${contractName}${rateNamesMessage}. ${updatedReason}`,
-    })
+    if (unlockContract instanceof Error) {
+        throw new Error(
+            `Cannot unlock contract to be withdrawn. ${unlockContract.message}`
+        )
+    }
+
+    //NOTE: Consider a separate function to do the reassignment
+
+    // Reassign rate to a new parent contract
+    for (const reassignRate of ratesToReAssign) {
+        const { rateID, reassignToContractID, rateName, contractStatus } =
+            reassignRate
+
+        let draftRates = []
+        if (contractStatus === 'UNLOCKED') {
+            // if this contract is already unlocked, we just want to get the current child rates, so we can submit the
+            // reassigned rate with it ot become its child.
+            const contractWithDraftRates = await tx.contractTable.findFirst({
+                where: {
+                    id: reassignToContractID,
+                },
+                select: {
+                    draftRates: {
+                        orderBy: {
+                            ratePosition: 'asc',
+                        },
+                        include: {
+                            rate: {
+                                include: includeRateWithoutDraftContracts,
+                            },
+                        },
+                    },
+                },
+            })
+
+            if (!contractWithDraftRates) {
+                throw new Error(
+                    `Unable to reassign rate ${rateID}, contract ${reassignToContractID} not found.`
+                )
+            }
+
+            if (!contractWithDraftRates?.draftRates) {
+                throw new Error(
+                    `Unable to reassign rate ${rateID}, contract ${reassignToContractID} has no draft rates.`
+                )
+            }
+
+            draftRates = contractWithDraftRates.draftRates.map((dr) => ({
+                ...dr.rate,
+                parentContractID: getParentContractID(dr.rate.revisions),
+            }))
+        } else {
+            // Unlock the contract, so we can resubmit it with the reassigned rate to become its child.
+            const unlockedContract = await unlockContractInsideTransaction(tx, {
+                contractID: reassignToContractID,
+                unlockedByUserID: updatedByID,
+                unlockReason: `CMS to reassign rate ${rateName} to be editable on this submission`,
+            })
+
+            if (unlockedContract instanceof Error) {
+                throw new Error(
+                    `Unable to reassign rate ${rateID}, new parent Contract ${reassignToContractID} could not be unlocked. ${unlockedContract.message}`
+                )
+            }
+
+            draftRates = unlockedContract.draftRates
+        }
+
+        const ratesToSubmit: string[] = []
+
+        // loop through draft rates as it will also contain linked rates that are also in draft
+        for (const draftRate of draftRates) {
+            // filter out linked rates, except for the one linked rate we want to reassign to this contract.
+            if (
+                draftRate.parentContractID === reassignToContractID ||
+                draftRate.id === reassignRate.rateID // now include this rate we need to reassign
+            ) {
+                ratesToSubmit.push(draftRate.id)
+            }
+        }
+
+        // resubmit the contract, so we create the submit info for the reassigned rate this will now be our marker in the
+        // do to identify the parent contract
+        const resubmitContract = await submitContractAndOrRates(
+            tx,
+            reassignToContractID,
+            ratesToSubmit,
+            updatedByID,
+            `CMS reassigned rate ${rateName} to be editable on this submission`
+        )
+
+        if (resubmitContract instanceof Error) {
+            throw new Error(
+                `Unable to reassign rate ${rateID}, new parent Contract ${reassignToContractID} could not be resubmitted. ${resubmitContract.message}`
+            )
+        }
+
+        // If this contract was originally unlocked, we want to put it back into that status with the new chil rate.
+        if (contractStatus === 'UNLOCKED') {
+            const unlockedContract = await unlockContractInsideTransaction(tx, {
+                contractID: reassignToContractID,
+                unlockedByUserID: updatedByID,
+                unlockReason: `CMS to reassign rate ${rateName} to be editable on this submission`,
+                // Adding 50ms to ensure this revision timestamp is later than the rate revision created for the old
+                // parent contract. Needed for reliable sorting in revision history.
+                manualCreatedAt: new Date(new Date().getTime() + 50),
+            })
+
+            if (unlockedContract instanceof Error) {
+                throw new Error(
+                    `Unable to reassign rate ${rateID}, could not return new parent Contract ${reassignToContractID} to UNLOCKED status. ${unlockedContract.message}`
+                )
+            }
+        }
+    }
+
+    const resubmitWithdrawnContract = await submitContractAndOrRates(
+        tx,
+        contract.id,
+        ratesToWithdraw.map((rate) => rate.id),
+        updatedByID,
+        `CMS has withdrawn the submission ${contractName}${rateNamesMessage}. ${updatedReason}`
+    )
+
+    if (resubmitWithdrawnContract instanceof Error) {
+        throw new Error(
+            `Could not resubmit contract to be withdrawn. ${resubmitWithdrawnContract.message}`
+        )
+    }
 
     // add withdraw action to contract
     await tx.contractTable.update({
@@ -294,7 +480,7 @@ const withdrawContractInsideTransaction = async (
     }
 
     if (withdrawnContract.consolidatedStatus !== 'WITHDRAWN') {
-        throw new Error('contract failed to withdraw')
+        throw new Error('Contract failed to withdraw')
     }
 
     return withdrawnContract
@@ -306,7 +492,10 @@ const withdrawContract = async (
 ): Promise<ContractType | Error> => {
     try {
         return await client.$transaction(
-            async (tx) => await withdrawContractInsideTransaction(tx, args)
+            async (tx) => await withdrawContractInsideTransaction(tx, args),
+            {
+                timeout: 30000,
+            }
         )
     } catch (err) {
         const msg = `PRISMA ERROR: Error withdrawing contract: ${err.message}`

--- a/services/app-api/src/postgres/contractAndRates/withdrawContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawContract.ts
@@ -227,16 +227,15 @@ const withdrawContractInsideTransaction = async (
             }
 
             // These next few conditionals are ordered by preferred contract status
-            // Is submitted assigned new value
             if (latestRevision.submitInfo && !isApproved) {
                 // contract with consolidated status of submitted is our preferred contract, break the loop if we find it.
                 reassignToContractID = {
                     contractID,
-                    status: 'SUBMITTED',
+                    status: 'SUBMITTED', // SUBMITTED includes resubmitted, there is no distinction here.
                 }
                 break
             }
-            // Is unlocked
+            // Is unlocked and not approved
             if (
                 !latestRevision.submitInfo &&
                 latestRevision.unlockInfo &&

--- a/services/app-api/src/postgres/contractAndRates/withdrawContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawContract.ts
@@ -116,10 +116,7 @@ const withdrawContractInsideTransaction = async (
             continue
         }
 
-        const reassignToContractID = getNewParentContract(
-            parentContractID,
-            latestRateRevision
-        )
+        const reassignToContractID = getNewParentContract(rate.revisions)
 
         // Reassign if there is a valid contract to reassign to, otherwise we set rate for withdraw
         if (reassignToContractID) {

--- a/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
@@ -120,7 +120,7 @@ const withdrawRateInsideTransaction = async (
         // Used to track original status of the contract
         const consolidatedStatus = getConsolidatedContractStatus(
             getContractRateStatus(contract.revisions),
-            getContractReviewStatus(contract)
+            getContractReviewStatus(contract.reviewStatusActions)
         )
 
         // Throw error if any contract is approved

--- a/services/app-api/src/resolvers/contract/fetchContract.test.ts
+++ b/services/app-api/src/resolvers/contract/fetchContract.test.ts
@@ -20,7 +20,6 @@ import {
     mockGqlContractDraftRevisionFormDataInput,
     testS3Client,
 } from '../../testHelpers'
-import { EXTENDED_TIMEOUT } from '../../testHelpers/assertionHelpers'
 
 describe('fetchContract', () => {
     const mockS3 = testS3Client()
@@ -77,66 +76,59 @@ describe('fetchContract', () => {
         expect(draftContractRev.contractID).toBe(draftContract.id)
     })
 
-    it(
-        'returns a stable initially submitted at',
-        async () => {
-            const stateServer = await constructTestPostgresServer({
-                s3Client: mockS3,
-            })
-            const cmsServer = await constructTestPostgresServer({
-                context: {
-                    user: testCMSUser(),
-                },
-                s3Client: mockS3,
-            })
+    it('returns a stable initially submitted at', async () => {
+        const stateServer = await constructTestPostgresServer({
+            s3Client: mockS3,
+        })
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: testCMSUser(),
+            },
+            s3Client: mockS3,
+        })
 
-            const draftA0 =
-                await createAndUpdateTestContractWithoutRates(stateServer)
-            const AID = draftA0.id
-            const draftA010 = await addNewRateToTestContract(
-                stateServer,
-                draftA0
-            )
-            await addNewRateToTestContract(stateServer, draftA010)
+        const draftA0 =
+            await createAndUpdateTestContractWithoutRates(stateServer)
+        const AID = draftA0.id
+        const draftA010 = await addNewRateToTestContract(stateServer, draftA0)
+        await addNewRateToTestContract(stateServer, draftA010)
 
-            const unsubmitted = await fetchTestContract(stateServer, AID)
-            expect(unsubmitted.initiallySubmittedAt).toBeNull()
+        const unsubmitted = await fetchTestContract(stateServer, AID)
+        expect(unsubmitted.initiallySubmittedAt).toBeNull()
 
-            const intiallySubmitted = await submitTestContract(stateServer, AID)
+        const intiallySubmitted = await submitTestContract(stateServer, AID)
 
-            await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.0')
-            await submitTestContract(stateServer, AID, 'Submit A.1')
+        await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.0')
+        await submitTestContract(stateServer, AID, 'Submit A.1')
 
-            await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.1')
-            await submitTestContract(stateServer, AID, 'Submit A.2')
+        await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.1')
+        await submitTestContract(stateServer, AID, 'Submit A.2')
 
-            await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.2')
-            await submitTestContract(stateServer, AID, 'Submit A.3')
+        await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.2')
+        await submitTestContract(stateServer, AID, 'Submit A.3')
 
-            await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.3')
-            await submitTestContract(stateServer, AID, 'Submit A.4')
+        await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.3')
+        await submitTestContract(stateServer, AID, 'Submit A.4')
 
-            const submittedMultiply = await fetchTestContract(stateServer, AID)
+        const submittedMultiply = await fetchTestContract(stateServer, AID)
 
-            expect(submittedMultiply.packageSubmissions).toHaveLength(5)
+        expect(submittedMultiply.packageSubmissions).toHaveLength(5)
 
-            expect(submittedMultiply.initiallySubmittedAt).toBeTruthy()
-            expect(submittedMultiply.initiallySubmittedAt).toEqual(
-                intiallySubmitted.initiallySubmittedAt
-            )
+        expect(submittedMultiply.initiallySubmittedAt).toBeTruthy()
+        expect(submittedMultiply.initiallySubmittedAt).toEqual(
+            intiallySubmitted.initiallySubmittedAt
+        )
 
-            await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.4')
+        await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.4')
 
-            const finallyUnlocked = await fetchTestContract(stateServer, AID)
-            expect(finallyUnlocked.packageSubmissions).toHaveLength(5)
+        const finallyUnlocked = await fetchTestContract(stateServer, AID)
+        expect(finallyUnlocked.packageSubmissions).toHaveLength(5)
 
-            expect(finallyUnlocked.initiallySubmittedAt).toBeTruthy()
-            expect(finallyUnlocked.initiallySubmittedAt).toEqual(
-                intiallySubmitted.initiallySubmittedAt
-            )
-        },
-        EXTENDED_TIMEOUT
-    )
+        expect(finallyUnlocked.initiallySubmittedAt).toBeTruthy()
+        expect(finallyUnlocked.initiallySubmittedAt).toEqual(
+            intiallySubmitted.initiallySubmittedAt
+        )
+    })
 
     it('returns lastUpdatedForDisplay', async () => {
         const stateServer = await constructTestPostgresServer({

--- a/services/app-api/src/resolvers/contract/fetchContract.test.ts
+++ b/services/app-api/src/resolvers/contract/fetchContract.test.ts
@@ -20,6 +20,7 @@ import {
     mockGqlContractDraftRevisionFormDataInput,
     testS3Client,
 } from '../../testHelpers'
+import { EXTENDED_TIMEOUT } from '../../testHelpers/assertionHelpers'
 
 describe('fetchContract', () => {
     const mockS3 = testS3Client()
@@ -76,59 +77,66 @@ describe('fetchContract', () => {
         expect(draftContractRev.contractID).toBe(draftContract.id)
     })
 
-    it('returns a stable initially submitted at', async () => {
-        const stateServer = await constructTestPostgresServer({
-            s3Client: mockS3,
-        })
-        const cmsServer = await constructTestPostgresServer({
-            context: {
-                user: testCMSUser(),
-            },
-            s3Client: mockS3,
-        })
+    it(
+        'returns a stable initially submitted at',
+        async () => {
+            const stateServer = await constructTestPostgresServer({
+                s3Client: mockS3,
+            })
+            const cmsServer = await constructTestPostgresServer({
+                context: {
+                    user: testCMSUser(),
+                },
+                s3Client: mockS3,
+            })
 
-        const draftA0 =
-            await createAndUpdateTestContractWithoutRates(stateServer)
-        const AID = draftA0.id
-        const draftA010 = await addNewRateToTestContract(stateServer, draftA0)
-        await addNewRateToTestContract(stateServer, draftA010)
+            const draftA0 =
+                await createAndUpdateTestContractWithoutRates(stateServer)
+            const AID = draftA0.id
+            const draftA010 = await addNewRateToTestContract(
+                stateServer,
+                draftA0
+            )
+            await addNewRateToTestContract(stateServer, draftA010)
 
-        const unsubmitted = await fetchTestContract(stateServer, AID)
-        expect(unsubmitted.initiallySubmittedAt).toBeNull()
+            const unsubmitted = await fetchTestContract(stateServer, AID)
+            expect(unsubmitted.initiallySubmittedAt).toBeNull()
 
-        const intiallySubmitted = await submitTestContract(stateServer, AID)
+            const intiallySubmitted = await submitTestContract(stateServer, AID)
 
-        await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.0')
-        await submitTestContract(stateServer, AID, 'Submit A.1')
+            await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.0')
+            await submitTestContract(stateServer, AID, 'Submit A.1')
 
-        await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.1')
-        await submitTestContract(stateServer, AID, 'Submit A.2')
+            await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.1')
+            await submitTestContract(stateServer, AID, 'Submit A.2')
 
-        await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.2')
-        await submitTestContract(stateServer, AID, 'Submit A.3')
+            await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.2')
+            await submitTestContract(stateServer, AID, 'Submit A.3')
 
-        await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.3')
-        await submitTestContract(stateServer, AID, 'Submit A.4')
+            await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.3')
+            await submitTestContract(stateServer, AID, 'Submit A.4')
 
-        const submittedMultiply = await fetchTestContract(stateServer, AID)
+            const submittedMultiply = await fetchTestContract(stateServer, AID)
 
-        expect(submittedMultiply.packageSubmissions).toHaveLength(5)
+            expect(submittedMultiply.packageSubmissions).toHaveLength(5)
 
-        expect(submittedMultiply.initiallySubmittedAt).toBeTruthy()
-        expect(submittedMultiply.initiallySubmittedAt).toEqual(
-            intiallySubmitted.initiallySubmittedAt
-        )
+            expect(submittedMultiply.initiallySubmittedAt).toBeTruthy()
+            expect(submittedMultiply.initiallySubmittedAt).toEqual(
+                intiallySubmitted.initiallySubmittedAt
+            )
 
-        await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.4')
+            await unlockTestHealthPlanPackage(cmsServer, AID, 'Unlock A.4')
 
-        const finallyUnlocked = await fetchTestContract(stateServer, AID)
-        expect(finallyUnlocked.packageSubmissions).toHaveLength(5)
+            const finallyUnlocked = await fetchTestContract(stateServer, AID)
+            expect(finallyUnlocked.packageSubmissions).toHaveLength(5)
 
-        expect(finallyUnlocked.initiallySubmittedAt).toBeTruthy()
-        expect(finallyUnlocked.initiallySubmittedAt).toEqual(
-            intiallySubmitted.initiallySubmittedAt
-        )
-    }, 10000)
+            expect(finallyUnlocked.initiallySubmittedAt).toBeTruthy()
+            expect(finallyUnlocked.initiallySubmittedAt).toEqual(
+                intiallySubmitted.initiallySubmittedAt
+            )
+        },
+        EXTENDED_TIMEOUT
+    )
 
     it('returns lastUpdatedForDisplay', async () => {
         const stateServer = await constructTestPostgresServer({

--- a/services/app-api/src/resolvers/contract/indexContracts.test.ts
+++ b/services/app-api/src/resolvers/contract/indexContracts.test.ts
@@ -17,7 +17,6 @@ import {
     unlockTestContract,
 } from '../../testHelpers/gqlContractHelpers'
 import { testS3Client } from '../../../../app-api/src/testHelpers/s3Helpers'
-import { EXTENDED_TIMEOUT } from '../../testHelpers/assertionHelpers'
 
 describe(`indexContracts`, () => {
     describe('isStateUser', () => {
@@ -61,84 +60,78 @@ describe(`indexContracts`, () => {
             expect(theseSubmissions[1].status).toBe('SUBMITTED')
         })
 
-        it(
-            'synthesizes the right statuses as a contract is submitted/unlocked/etc',
-            async () => {
-                const stateServer = await constructTestPostgresServer({
-                    s3Client: mockS3,
-                })
+        it('synthesizes the right statuses as a contract is submitted/unlocked/etc', async () => {
+            const stateServer = await constructTestPostgresServer({
+                s3Client: mockS3,
+            })
 
-                const cmsServer = await constructTestPostgresServer({
-                    context: {
-                        user: cmsUser,
-                    },
-                })
+            const cmsServer = await constructTestPostgresServer({
+                context: {
+                    user: cmsUser,
+                },
+            })
 
-                // First, create a new contracts
-                const draftContract =
-                    await createAndUpdateTestContractWithoutRates(stateServer)
-                const submittedContract =
-                    await createAndSubmitTestContractWithRate(stateServer)
-                const unlockedContract =
-                    await createAndSubmitTestContractWithRate(stateServer)
-                const relockedContract =
-                    await createAndSubmitTestContractWithRate(stateServer)
+            // First, create a new contracts
+            const draftContract =
+                await createAndUpdateTestContractWithoutRates(stateServer)
+            const submittedContract =
+                await createAndSubmitTestContractWithRate(stateServer)
+            const unlockedContract =
+                await createAndSubmitTestContractWithRate(stateServer)
+            const relockedContract =
+                await createAndSubmitTestContractWithRate(stateServer)
 
-                // unlock two
-                await unlockTestContract(
-                    cmsServer,
-                    unlockedContract.id,
-                    'Test reason'
-                )
-                await unlockTestContract(
-                    cmsServer,
-                    relockedContract.id,
-                    'Test reason'
-                )
+            // unlock two
+            await unlockTestContract(
+                cmsServer,
+                unlockedContract.id,
+                'Test reason'
+            )
+            await unlockTestContract(
+                cmsServer,
+                relockedContract.id,
+                'Test reason'
+            )
 
-                // resubmit one
-                await submitTestContract(
-                    stateServer,
-                    relockedContract.id,
-                    'Test first resubmission'
-                )
+            // resubmit one
+            await submitTestContract(
+                stateServer,
+                relockedContract.id,
+                'Test first resubmission'
+            )
 
-                // index contracts api request
-                const result = await stateServer.executeOperation({
-                    query: IndexContractsForDashboardDocument,
-                })
-                const submissionsIndex = result.data?.indexContracts
+            // index contracts api request
+            const result = await stateServer.executeOperation({
+                query: IndexContractsForDashboardDocument,
+            })
+            const submissionsIndex = result.data?.indexContracts
 
-                // pull out test related contracts and order them
-                const testSubmissionIDs = [
-                    draftContract.id,
-                    submittedContract.id,
-                    unlockedContract.id,
-                    relockedContract.id,
-                ]
-                const testContracts: Contract[] = submissionsIndex.edges
-                    .map((edge: ContractEdge) => edge.node)
-                    .filter((test: Contract) =>
-                        testSubmissionIDs.includes(test.id)
-                    )
+            // pull out test related contracts and order them
+            const testSubmissionIDs = [
+                draftContract.id,
+                submittedContract.id,
+                unlockedContract.id,
+                relockedContract.id,
+            ]
+            const testContracts: Contract[] = submissionsIndex.edges
+                .map((edge: ContractEdge) => edge.node)
+                .filter((test: Contract) => testSubmissionIDs.includes(test.id))
 
-                expect(testContracts).toHaveLength(4)
+            expect(testContracts).toHaveLength(4)
 
-                // organize test contracts in a predictable order via testContractsIds array
-                testContracts.sort((a, b) => {
-                    if (
-                        testSubmissionIDs.indexOf(a.id) >
-                        testSubmissionIDs.indexOf(b.id)
-                    ) {
-                        return 1
-                    } else {
-                        return -1
-                    }
-                })
-                expect(testContracts[0].status).toBe('DRAFT')
-            },
-            EXTENDED_TIMEOUT
-        )
+            // organize test contracts in a predictable order via testContractsIds array
+            testContracts.sort((a, b) => {
+                if (
+                    testSubmissionIDs.indexOf(a.id) >
+                    testSubmissionIDs.indexOf(b.id)
+                ) {
+                    return 1
+                } else {
+                    return -1
+                }
+            })
+            expect(testContracts[0].status).toBe('DRAFT')
+        })
 
         it('a different user from the same state can index contracts', async () => {
             const server = await constructTestPostgresServer()

--- a/services/app-api/src/resolvers/contract/submitContract.test.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.test.ts
@@ -45,6 +45,7 @@ import {
 } from '../../testHelpers/emailerHelpers'
 import { NewPostgresStore } from '../../postgres'
 import { dayjs } from '@mc-review/dates'
+import { EXTENDED_TIMEOUT } from '../../testHelpers/assertionHelpers'
 
 describe('submitContract', () => {
     const mockS3 = testS3Client()
@@ -328,478 +329,531 @@ describe('submitContract', () => {
         expect(connections).toHaveLength(9)
     })
 
-    it('handles a complex submission', async () => {
-        // this test runs through a scenario from our programming diagrams, maybe best understood next to the visuals
-        const stateServer = await constructTestPostgresServer({
-            s3Client: mockS3,
-        })
+    it(
+        'handles a complex submission',
+        async () => {
+            // this test runs through a scenario from our programming diagrams, maybe best understood next to the visuals
+            const stateServer = await constructTestPostgresServer({
+                s3Client: mockS3,
+            })
 
-        const cmsServer = await constructTestPostgresServer({
-            context: {
-                user: testCMSUser(),
-            },
-            s3Client: mockS3,
-        })
+            const cmsServer = await constructTestPostgresServer({
+                context: {
+                    user: testCMSUser(),
+                },
+                s3Client: mockS3,
+            })
 
-        // 1. Submit A0 with Rate1 and Rate2
-        const draftA0 =
-            await createAndUpdateTestContractWithoutRates(stateServer)
-        const AID = draftA0.id
-        const draftA010 = await addNewRateToTestContract(stateServer, draftA0, {
-            rateDateStart: '2001-01-01',
-        })
+            // 1. Submit A0 with Rate1 and Rate2
+            const draftA0 =
+                await createAndUpdateTestContractWithoutRates(stateServer)
+            const AID = draftA0.id
+            const draftA010 = await addNewRateToTestContract(
+                stateServer,
+                draftA0,
+                {
+                    rateDateStart: '2001-01-01',
+                }
+            )
 
-        await addNewRateToTestContract(stateServer, draftA010, {
-            rateDateStart: '2002-01-01',
-        })
+            await addNewRateToTestContract(stateServer, draftA010, {
+                rateDateStart: '2002-01-01',
+            })
 
-        const contractA0 = await submitTestContract(stateServer, AID)
-        const subA0 = contractA0.packageSubmissions[0]
-        const rate10 = subA0.rateRevisions[0]
-        const OneID = rate10.rateID
-        const rate20 = subA0.rateRevisions[1]
-        const TwoID = rate20.rateID
+            const contractA0 = await submitTestContract(stateServer, AID)
+            const subA0 = contractA0.packageSubmissions[0]
+            const rate10 = subA0.rateRevisions[0]
+            const OneID = rate10.rateID
+            const rate20 = subA0.rateRevisions[1]
+            const TwoID = rate20.rateID
 
-        console.info('ONEID', OneID)
-        console.info('TWOID', TwoID)
+            console.info('ONEID', OneID)
+            console.info('TWOID', TwoID)
 
-        // 2. Submit B0 with Rate1 and Rate3
-        const draftB0 =
-            await createAndUpdateTestContractWithoutRates(stateServer)
-        const BID = draftB0.id
-        const draftB010 = await addNewRateToTestContract(stateServer, draftB0, {
-            rateDateStart: '2003-01-01',
-        })
-        await addLinkedRateToTestContract(stateServer, draftB010, OneID)
+            // 2. Submit B0 with Rate1 and Rate3
+            const draftB0 =
+                await createAndUpdateTestContractWithoutRates(stateServer)
+            const BID = draftB0.id
+            const draftB010 = await addNewRateToTestContract(
+                stateServer,
+                draftB0,
+                {
+                    rateDateStart: '2003-01-01',
+                }
+            )
+            await addLinkedRateToTestContract(stateServer, draftB010, OneID)
 
-        const contractB0 = await submitTestContract(stateServer, draftB0.id)
-        const subB0 = contractB0.packageSubmissions[0]
-        const rate30 = subB0.rateRevisions[0]
-        const ThreeID = rate30.rateID
-        console.info('THREEID', ThreeID)
+            const contractB0 = await submitTestContract(stateServer, draftB0.id)
+            const subB0 = contractB0.packageSubmissions[0]
+            const rate30 = subB0.rateRevisions[0]
+            const ThreeID = rate30.rateID
+            console.info('THREEID', ThreeID)
 
-        expect(subB0.rateRevisions[0].rateID).toBe(ThreeID)
-        expect(subB0.rateRevisions[1].rateID).toBe(OneID)
+            expect(subB0.rateRevisions[0].rateID).toBe(ThreeID)
+            expect(subB0.rateRevisions[1].rateID).toBe(OneID)
 
-        // 3. Submit C0 with Rate20 and Rate40
-        const draftC0 =
-            await createAndUpdateTestContractWithoutRates(stateServer)
-        const CID = draftC0.id
-        const draftC020 = await addLinkedRateToTestContract(
-            stateServer,
-            draftC0,
-            TwoID
-        )
-        await addNewRateToTestContract(stateServer, draftC020, {
-            rateDateStart: '2004-01-01',
-        })
+            // 3. Submit C0 with Rate20 and Rate40
+            const draftC0 =
+                await createAndUpdateTestContractWithoutRates(stateServer)
+            const CID = draftC0.id
+            const draftC020 = await addLinkedRateToTestContract(
+                stateServer,
+                draftC0,
+                TwoID
+            )
+            await addNewRateToTestContract(stateServer, draftC020, {
+                rateDateStart: '2004-01-01',
+            })
 
-        const contractC0 = await submitTestContract(stateServer, draftC0.id)
-        const subC0 = contractC0.packageSubmissions[0]
-        const rate40 = subC0.rateRevisions[1]
-        const FourID = rate40.rateID
-        console.info('FOURID', FourID)
-        expect(subC0.rateRevisions[0].rateID).toBe(TwoID)
+            const contractC0 = await submitTestContract(stateServer, draftC0.id)
+            const subC0 = contractC0.packageSubmissions[0]
+            const rate40 = subC0.rateRevisions[1]
+            const FourID = rate40.rateID
+            console.info('FOURID', FourID)
+            expect(subC0.rateRevisions[0].rateID).toBe(TwoID)
 
-        // 4. Submit D0, contract only
-        const draftD0 = await createAndUpdateTestContractWithoutRates(
-            stateServer,
-            undefined,
-            {
-                submissionType: 'CONTRACT_ONLY',
+            // 4. Submit D0, contract only
+            const draftD0 = await createAndUpdateTestContractWithoutRates(
+                stateServer,
+                undefined,
+                {
+                    submissionType: 'CONTRACT_ONLY',
+                }
+            )
+            const DID = draftD0.id
+            const contractD0 = await submitTestContract(stateServer, draftD0.id)
+
+            console.info(ThreeID, FourID, contractD0)
+
+            // check on initial setup
+            const firstA = await fetchTestContract(stateServer, AID)
+            const firstB = await fetchTestContract(stateServer, BID)
+            const firstC = await fetchTestContract(stateServer, CID)
+            const firstD = await fetchTestContract(stateServer, DID)
+
+            expect(firstA.packageSubmissions).toHaveLength(1)
+            expect(firstB.packageSubmissions).toHaveLength(1)
+            expect(firstC.packageSubmissions).toHaveLength(1)
+            expect(firstD.packageSubmissions).toHaveLength(1)
+
+            // 5. resubmit A, 1, and 2. B and C will get new entries.
+            console.info('---- UNLOCK A.1 ----')
+            const unlockedA0Pkg = await unlockTestHealthPlanPackage(
+                cmsServer,
+                AID,
+                'Unlock A.0'
+            )
+            const a0FormData = latestFormData(unlockedA0Pkg)
+            a0FormData.submissionDescription = 'DESC A1'
+            await updateTestHealthPlanFormData(stateServer, a0FormData)
+            const unlockedA0Contract = await fetchTestContract(stateServer, AID)
+            const a0RatesUpdates =
+                updateRatesInputFromDraftContract(unlockedA0Contract)
+            expect(a0RatesUpdates.updatedRates[0].rateID).toBe(OneID)
+            expect(a0RatesUpdates.updatedRates[1].rateID).toBe(TwoID)
+
+            if (
+                !a0RatesUpdates.updatedRates[0].formData ||
+                !a0RatesUpdates.updatedRates[1].formData
+            ) {
+                throw new Error('missing updates')
             }
-        )
-        const DID = draftD0.id
-        const contractD0 = await submitTestContract(stateServer, draftD0.id)
 
-        console.info(ThreeID, FourID, contractD0)
+            expect(a0RatesUpdates.updatedRates[0].formData.rateDateStart).toBe(
+                '2001-01-01'
+            )
+            expect(a0RatesUpdates.updatedRates[1].formData.rateDateStart).toBe(
+                '2002-01-01'
+            )
 
-        // check on initial setup
-        const firstA = await fetchTestContract(stateServer, AID)
-        const firstB = await fetchTestContract(stateServer, BID)
-        const firstC = await fetchTestContract(stateServer, CID)
-        const firstD = await fetchTestContract(stateServer, DID)
+            a0RatesUpdates.updatedRates[0].formData.rateDateStart = '2001-02-02'
+            a0RatesUpdates.updatedRates[1].formData.rateDateStart = '2002-02-02'
+            await updateTestDraftRatesOnContract(stateServer, a0RatesUpdates)
 
-        expect(firstA.packageSubmissions).toHaveLength(1)
-        expect(firstB.packageSubmissions).toHaveLength(1)
-        expect(firstC.packageSubmissions).toHaveLength(1)
-        expect(firstD.packageSubmissions).toHaveLength(1)
+            console.info('---- SUBMIT A.1 ----')
+            await submitTestContract(stateServer, AID, 'Submit A.1')
 
-        // 5. resubmit A, 1, and 2. B and C will get new entries.
-        console.info('---- UNLOCK A.1 ----')
-        const unlockedA0Pkg = await unlockTestHealthPlanPackage(
-            cmsServer,
-            AID,
-            'Unlock A.0'
-        )
-        const a0FormData = latestFormData(unlockedA0Pkg)
-        a0FormData.submissionDescription = 'DESC A1'
-        await updateTestHealthPlanFormData(stateServer, a0FormData)
-        const unlockedA0Contract = await fetchTestContract(stateServer, AID)
-        const a0RatesUpdates =
-            updateRatesInputFromDraftContract(unlockedA0Contract)
-        expect(a0RatesUpdates.updatedRates[0].rateID).toBe(OneID)
-        expect(a0RatesUpdates.updatedRates[1].rateID).toBe(TwoID)
+            // Check second showing
+            const secondA = await fetchTestContract(stateServer, AID)
+            const secondB = await fetchTestContract(stateServer, BID)
+            const secondC = await fetchTestContract(stateServer, CID)
+            const secondD = await fetchTestContract(stateServer, DID)
 
-        if (
-            !a0RatesUpdates.updatedRates[0].formData ||
-            !a0RatesUpdates.updatedRates[1].formData
-        ) {
-            throw new Error('missing updates')
-        }
+            expect(secondA.packageSubmissions).toHaveLength(2)
+            expect(secondB.packageSubmissions).toHaveLength(2)
+            expect(secondC.packageSubmissions).toHaveLength(2)
+            expect(secondD.packageSubmissions).toHaveLength(1)
 
-        expect(a0RatesUpdates.updatedRates[0].formData.rateDateStart).toBe(
-            '2001-01-01'
-        )
-        expect(a0RatesUpdates.updatedRates[1].formData.rateDateStart).toBe(
-            '2002-01-01'
-        )
+            expect(secondA.packageSubmissions[0].submitInfo.updatedReason).toBe(
+                'Submit A.1'
+            )
+            expect(
+                secondA.packageSubmissions[0].contractRevision.formData
+                    .submissionDescription
+            ).toBe('DESC A1')
+            expect(secondA.packageSubmissions[1].submitInfo.updatedReason).toBe(
+                'Initial submission'
+            )
+            expect(
+                secondA.packageSubmissions[1].contractRevision.formData
+                    .submissionDescription
+            ).toBe('An updated submission')
 
-        a0RatesUpdates.updatedRates[0].formData.rateDateStart = '2001-02-02'
-        a0RatesUpdates.updatedRates[1].formData.rateDateStart = '2002-02-02'
-        await updateTestDraftRatesOnContract(stateServer, a0RatesUpdates)
+            // check B history
+            expect(secondB.packageSubmissions[1].submitInfo.updatedReason).toBe(
+                'Initial submission'
+            )
+            expect(
+                secondB.packageSubmissions[1].contractRevision.formData
+                    .submissionDescription
+            ).toBe('An updated submission')
+            expect(secondB.packageSubmissions[1].rateRevisions).toHaveLength(2)
+            expect(
+                secondB.packageSubmissions[1].rateRevisions[0].formData
+                    .rateDateStart
+            ).toBe('2003-01-01')
+            expect(
+                secondB.packageSubmissions[1].rateRevisions[1].formData
+                    .rateDateStart
+            ).toBe('2001-01-01')
 
-        console.info('---- SUBMIT A.1 ----')
-        await submitTestContract(stateServer, AID, 'Submit A.1')
+            expect(secondB.packageSubmissions[0].submitInfo.updatedReason).toBe(
+                'Submit A.1'
+            )
+            expect(
+                secondB.packageSubmissions[0].contractRevision.formData
+                    .submissionDescription
+            ).toBe('An updated submission')
+            expect(secondB.packageSubmissions[0].rateRevisions).toHaveLength(2)
+            expect(
+                secondB.packageSubmissions[0].rateRevisions[0].formData
+                    .rateDateStart
+            ).toBe('2003-01-01')
+            expect(
+                secondB.packageSubmissions[0].rateRevisions[1].formData
+                    .rateDateStart
+            ).toBe('2001-02-02')
 
-        // Check second showing
-        const secondA = await fetchTestContract(stateServer, AID)
-        const secondB = await fetchTestContract(stateServer, BID)
-        const secondC = await fetchTestContract(stateServer, CID)
-        const secondD = await fetchTestContract(stateServer, DID)
+            // 6. resubmit B, add r4. Only B gets a new entry.
+            console.info('---- UNLOCK B.1 ----')
+            const unlockedB0Pkg = await unlockTestHealthPlanPackage(
+                cmsServer,
+                BID,
+                'Unlock B.0'
+            )
+            const b0FormData = latestFormData(unlockedB0Pkg)
 
-        expect(secondA.packageSubmissions).toHaveLength(2)
-        expect(secondB.packageSubmissions).toHaveLength(2)
-        expect(secondC.packageSubmissions).toHaveLength(2)
-        expect(secondD.packageSubmissions).toHaveLength(1)
+            b0FormData.submissionDescription = 'DESC B1'
+            await updateTestHealthPlanFormData(stateServer, b0FormData)
 
-        expect(secondA.packageSubmissions[0].submitInfo.updatedReason).toBe(
-            'Submit A.1'
-        )
-        expect(
-            secondA.packageSubmissions[0].contractRevision.formData
-                .submissionDescription
-        ).toBe('DESC A1')
-        expect(secondA.packageSubmissions[1].submitInfo.updatedReason).toBe(
-            'Initial submission'
-        )
-        expect(
-            secondA.packageSubmissions[1].contractRevision.formData
-                .submissionDescription
-        ).toBe('An updated submission')
+            const unlockedB0Contract = await fetchTestContract(stateServer, BID)
+            const b0RatesUpdates =
+                updateRatesInputFromDraftContract(unlockedB0Contract)
+            expect(b0RatesUpdates.updatedRates[0].type).toBe('UPDATE')
+            expect(b0RatesUpdates.updatedRates[0].rateID).toBe(ThreeID)
+            expect(b0RatesUpdates.updatedRates[1].type).toBe('LINK')
+            expect(b0RatesUpdates.updatedRates[1].rateID).toBe(OneID)
 
-        // check B history
-        expect(secondB.packageSubmissions[1].submitInfo.updatedReason).toBe(
-            'Initial submission'
-        )
-        expect(
-            secondB.packageSubmissions[1].contractRevision.formData
-                .submissionDescription
-        ).toBe('An updated submission')
-        expect(secondB.packageSubmissions[1].rateRevisions).toHaveLength(2)
-        expect(
-            secondB.packageSubmissions[1].rateRevisions[0].formData
-                .rateDateStart
-        ).toBe('2003-01-01')
-        expect(
-            secondB.packageSubmissions[1].rateRevisions[1].formData
-                .rateDateStart
-        ).toBe('2001-01-01')
+            if (!b0RatesUpdates.updatedRates[0].formData) {
+                throw new Error('missing updates')
+            }
 
-        expect(secondB.packageSubmissions[0].submitInfo.updatedReason).toBe(
-            'Submit A.1'
-        )
-        expect(
-            secondB.packageSubmissions[0].contractRevision.formData
-                .submissionDescription
-        ).toBe('An updated submission')
-        expect(secondB.packageSubmissions[0].rateRevisions).toHaveLength(2)
-        expect(
-            secondB.packageSubmissions[0].rateRevisions[0].formData
-                .rateDateStart
-        ).toBe('2003-01-01')
-        expect(
-            secondB.packageSubmissions[0].rateRevisions[1].formData
-                .rateDateStart
-        ).toBe('2001-02-02')
+            expect(b0RatesUpdates.updatedRates[0].formData.rateDateStart).toBe(
+                '2003-01-01'
+            )
 
-        // 6. resubmit B, add r4. Only B gets a new entry.
-        console.info('---- UNLOCK B.1 ----')
-        const unlockedB0Pkg = await unlockTestHealthPlanPackage(
-            cmsServer,
-            BID,
-            'Unlock B.0'
-        )
-        const b0FormData = latestFormData(unlockedB0Pkg)
+            b0RatesUpdates.updatedRates[0].formData.rateDateStart = '2003-02-02'
 
-        b0FormData.submissionDescription = 'DESC B1'
-        await updateTestHealthPlanFormData(stateServer, b0FormData)
+            const b0RatesUpdatesWith4 = addLinkedRateToRateInput(
+                b0RatesUpdates,
+                FourID
+            )
 
-        const unlockedB0Contract = await fetchTestContract(stateServer, BID)
-        const b0RatesUpdates =
-            updateRatesInputFromDraftContract(unlockedB0Contract)
-        expect(b0RatesUpdates.updatedRates[0].type).toBe('UPDATE')
-        expect(b0RatesUpdates.updatedRates[0].rateID).toBe(ThreeID)
-        expect(b0RatesUpdates.updatedRates[1].type).toBe('LINK')
-        expect(b0RatesUpdates.updatedRates[1].rateID).toBe(OneID)
+            await updateTestDraftRatesOnContract(
+                stateServer,
+                b0RatesUpdatesWith4
+            )
 
-        if (!b0RatesUpdates.updatedRates[0].formData) {
-            throw new Error('missing updates')
-        }
+            console.info('---- SUBMIT B.1 ----')
+            await submitTestContract(stateServer, BID, 'Submit B.1')
 
-        expect(b0RatesUpdates.updatedRates[0].formData.rateDateStart).toBe(
-            '2003-01-01'
-        )
+            // Check third showing
+            const thirdA = await fetchTestContract(stateServer, AID)
+            const thirdB = await fetchTestContract(stateServer, BID)
+            const thirdC = await fetchTestContract(stateServer, CID)
+            const thirdD = await fetchTestContract(stateServer, DID)
 
-        b0RatesUpdates.updatedRates[0].formData.rateDateStart = '2003-02-02'
+            expect(thirdA.packageSubmissions).toHaveLength(2)
+            expect(thirdB.packageSubmissions).toHaveLength(3)
+            expect(thirdC.packageSubmissions).toHaveLength(2)
+            expect(thirdD.packageSubmissions).toHaveLength(1)
 
-        const b0RatesUpdatesWith4 = addLinkedRateToRateInput(
-            b0RatesUpdates,
-            FourID
-        )
+            // 7. Resubmit C, remove rate 2. B should also get an update.
+            const unlockedC0Pkg = await unlockTestHealthPlanPackage(
+                cmsServer,
+                CID,
+                'Unlock C.0'
+            )
+            const c0FormData = latestFormData(unlockedC0Pkg)
+            c0FormData.submissionDescription = 'DESC C1'
+            await updateTestHealthPlanFormData(stateServer, c0FormData)
 
-        await updateTestDraftRatesOnContract(stateServer, b0RatesUpdatesWith4)
+            const unlockedC0Contract = await fetchTestContract(stateServer, CID)
 
-        console.info('---- SUBMIT B.1 ----')
-        await submitTestContract(stateServer, BID, 'Submit B.1')
+            const c0RatesUpdates =
+                updateRatesInputFromDraftContract(unlockedC0Contract)
+            expect(c0RatesUpdates.updatedRates[0].type).toBe('LINK')
+            expect(c0RatesUpdates.updatedRates[0].rateID).toBe(TwoID)
+            expect(c0RatesUpdates.updatedRates[1].type).toBe('UPDATE')
+            expect(c0RatesUpdates.updatedRates[1].rateID).toBe(FourID)
 
-        // Check third showing
-        const thirdA = await fetchTestContract(stateServer, AID)
-        const thirdB = await fetchTestContract(stateServer, BID)
-        const thirdC = await fetchTestContract(stateServer, CID)
-        const thirdD = await fetchTestContract(stateServer, DID)
+            if (!c0RatesUpdates.updatedRates[1].formData) {
+                throw new Error('missing updates')
+            }
 
-        expect(thirdA.packageSubmissions).toHaveLength(2)
-        expect(thirdB.packageSubmissions).toHaveLength(3)
-        expect(thirdC.packageSubmissions).toHaveLength(2)
-        expect(thirdD.packageSubmissions).toHaveLength(1)
+            expect(c0RatesUpdates.updatedRates[1].formData.rateDateStart).toBe(
+                '2004-01-01'
+            )
+            c0RatesUpdates.updatedRates[1].formData.rateDateStart = '2004-02-02'
 
-        // 7. Resubmit C, remove rate 2. B should also get an update.
-        const unlockedC0Pkg = await unlockTestHealthPlanPackage(
-            cmsServer,
-            CID,
-            'Unlock C.0'
-        )
-        const c0FormData = latestFormData(unlockedC0Pkg)
-        c0FormData.submissionDescription = 'DESC C1'
-        await updateTestHealthPlanFormData(stateServer, c0FormData)
+            // remove linked 2.1
+            c0RatesUpdates.updatedRates.splice(0, 1)
 
-        const unlockedC0Contract = await fetchTestContract(stateServer, CID)
+            await updateTestDraftRatesOnContract(stateServer, c0RatesUpdates)
 
-        const c0RatesUpdates =
-            updateRatesInputFromDraftContract(unlockedC0Contract)
-        expect(c0RatesUpdates.updatedRates[0].type).toBe('LINK')
-        expect(c0RatesUpdates.updatedRates[0].rateID).toBe(TwoID)
-        expect(c0RatesUpdates.updatedRates[1].type).toBe('UPDATE')
-        expect(c0RatesUpdates.updatedRates[1].rateID).toBe(FourID)
+            console.info('---- SUBMIT C.1 ----')
+            await submitTestContract(stateServer, CID, 'Submit C.1')
 
-        if (!c0RatesUpdates.updatedRates[1].formData) {
-            throw new Error('missing updates')
-        }
+            // Check fourth showing
+            const fourthA = await fetchTestContract(stateServer, AID)
+            const fourthB = await fetchTestContract(stateServer, BID)
+            const fourthC = await fetchTestContract(stateServer, CID)
+            const fourthD = await fetchTestContract(stateServer, DID)
 
-        expect(c0RatesUpdates.updatedRates[1].formData.rateDateStart).toBe(
-            '2004-01-01'
-        )
-        c0RatesUpdates.updatedRates[1].formData.rateDateStart = '2004-02-02'
+            expect(fourthA.packageSubmissions).toHaveLength(2)
+            expect(fourthB.packageSubmissions).toHaveLength(4)
+            expect(fourthC.packageSubmissions).toHaveLength(3)
+            expect(fourthD.packageSubmissions).toHaveLength(1)
 
-        // remove linked 2.1
-        c0RatesUpdates.updatedRates.splice(0, 1)
+            // check removal happened:
+            const lastCPackage = fourthC.packageSubmissions[0]
+            expect(lastCPackage.rateRevisions).toHaveLength(1)
+            expect(lastCPackage.rateRevisions[0].formData.rateDateStart).toBe(
+                '2004-02-02'
+            )
 
-        await updateTestDraftRatesOnContract(stateServer, c0RatesUpdates)
+            // Now check that all the histories are as expected
+            // Contract A.
+            const as1 = fourthA.packageSubmissions[0]
+            expect(as1.cause).toBe('CONTRACT_SUBMISSION')
+            expect(as1.submittedRevisions).toHaveLength(3)
+            expect(as1.submittedRevisions.map((r) => r.id).sort()).toEqual(
+                [as1.contractRevision.id]
+                    .concat(as1.rateRevisions.map((r) => r.id))
+                    .sort()
+            )
+            expect(as1.contractRevision.formData.submissionDescription).toBe(
+                'DESC A1'
+            )
+            expect(as1.rateRevisions[0].formData.rateDateStart).toBe(
+                '2001-02-02'
+            )
+            expect(as1.rateRevisions[1].formData.rateDateStart).toBe(
+                '2002-02-02'
+            )
 
-        console.info('---- SUBMIT C.1 ----')
-        await submitTestContract(stateServer, CID, 'Submit C.1')
+            const as2 = fourthA.packageSubmissions[1]
+            expect(as2.cause).toBe('CONTRACT_SUBMISSION')
+            expect(as2.submittedRevisions).toHaveLength(3)
+            expect(as2.submittedRevisions.map((r) => r.id).sort()).toEqual(
+                [as2.contractRevision.id]
+                    .concat(as2.rateRevisions.map((r) => r.id))
+                    .sort()
+            )
+            expect(as2.contractRevision.formData.submissionDescription).toBe(
+                'An updated submission'
+            )
+            expect(as2.rateRevisions[0].formData.rateDateStart).toBe(
+                '2001-01-01'
+            )
+            expect(as2.rateRevisions[1].formData.rateDateStart).toBe(
+                '2002-01-01'
+            )
 
-        // Check fourth showing
-        const fourthA = await fetchTestContract(stateServer, AID)
-        const fourthB = await fetchTestContract(stateServer, BID)
-        const fourthC = await fetchTestContract(stateServer, CID)
-        const fourthD = await fetchTestContract(stateServer, DID)
+            // Contract B
+            const bs1 = fourthB.packageSubmissions[0]
+            expect(bs1.submittedRevisions).toHaveLength(2)
+            const bs1submittedContract = bs1
+                .submittedRevisions[0] as ContractRevision
+            const bs1submittedRate = bs1.submittedRevisions[1] as RateRevision
+            expect(bs1submittedContract.formData.submissionDescription).toBe(
+                'DESC C1'
+            )
+            expect(bs1submittedRate.formData.rateDateStart).toBe('2004-02-02')
+            expect(bs1.contractRevision.formData.submissionDescription).toBe(
+                'DESC B1'
+            )
+            expect(bs1.rateRevisions[0].formData.rateDateStart).toBe(
+                '2003-02-02'
+            )
+            expect(bs1.rateRevisions[1].formData.rateDateStart).toBe(
+                '2001-02-02'
+            )
+            expect(bs1.rateRevisions[2].formData.rateDateStart).toBe(
+                '2004-02-02'
+            )
+            expect(bs1.cause).toBe('RATE_SUBMISSION')
 
-        expect(fourthA.packageSubmissions).toHaveLength(2)
-        expect(fourthB.packageSubmissions).toHaveLength(4)
-        expect(fourthC.packageSubmissions).toHaveLength(3)
-        expect(fourthD.packageSubmissions).toHaveLength(1)
+            const bs2 = fourthB.packageSubmissions[1]
+            expect(bs2.submittedRevisions).toHaveLength(2)
+            const bs2submittedContract = bs2
+                .submittedRevisions[0] as ContractRevision
+            const bs2submittedRate = bs2.submittedRevisions[1] as RateRevision
+            expect(bs2submittedContract.formData.submissionDescription).toBe(
+                'DESC B1'
+            )
+            expect(bs2submittedRate.formData.rateDateStart).toBe('2003-02-02')
+            expect(bs2.contractRevision.formData.submissionDescription).toBe(
+                'DESC B1'
+            )
+            expect(bs2.rateRevisions[0].formData.rateDateStart).toBe(
+                '2003-02-02'
+            )
+            expect(bs2.rateRevisions[1].formData.rateDateStart).toBe(
+                '2001-02-02'
+            )
+            expect(bs2.rateRevisions[2].formData.rateDateStart).toBe(
+                '2004-01-01'
+            )
+            expect(bs2.cause).toBe('CONTRACT_SUBMISSION')
 
-        // check removal happened:
-        const lastCPackage = fourthC.packageSubmissions[0]
-        expect(lastCPackage.rateRevisions).toHaveLength(1)
-        expect(lastCPackage.rateRevisions[0].formData.rateDateStart).toBe(
-            '2004-02-02'
-        )
+            const bs3 = fourthB.packageSubmissions[2]
+            expect(bs3.submittedRevisions).toHaveLength(3)
+            const bs3submittedContract = bs3
+                .submittedRevisions[0] as ContractRevision
+            const bs3submittedRate = bs3.submittedRevisions[1] as RateRevision
+            const bs3submittedRate2 = bs3.submittedRevisions[2] as RateRevision
+            expect(bs3submittedContract.formData.submissionDescription).toBe(
+                'DESC A1'
+            )
+            expect(
+                [bs3submittedRate, bs3submittedRate2]
+                    .map((rr) => rr.formData.rateDateStart)
+                    .sort()
+            ).toEqual(['2001-02-02', '2002-02-02'])
+            expect(bs3.contractRevision.formData.submissionDescription).toBe(
+                'An updated submission'
+            )
+            expect(bs3.rateRevisions[0].formData.rateDateStart).toBe(
+                '2003-01-01'
+            )
+            expect(bs3.rateRevisions[1].formData.rateDateStart).toBe(
+                '2001-02-02'
+            )
+            expect(bs3.cause).toBe('RATE_SUBMISSION')
 
-        // Now check that all the histories are as expected
-        // Contract A.
-        const as1 = fourthA.packageSubmissions[0]
-        expect(as1.cause).toBe('CONTRACT_SUBMISSION')
-        expect(as1.submittedRevisions).toHaveLength(3)
-        expect(as1.submittedRevisions.map((r) => r.id).sort()).toEqual(
-            [as1.contractRevision.id]
-                .concat(as1.rateRevisions.map((r) => r.id))
-                .sort()
-        )
-        expect(as1.contractRevision.formData.submissionDescription).toBe(
-            'DESC A1'
-        )
-        expect(as1.rateRevisions[0].formData.rateDateStart).toBe('2001-02-02')
-        expect(as1.rateRevisions[1].formData.rateDateStart).toBe('2002-02-02')
+            const bs4 = fourthB.packageSubmissions[3]
+            expect(bs4.submittedRevisions).toHaveLength(2)
+            const bs4submittedContract = bs4
+                .submittedRevisions[0] as ContractRevision
+            const bs4submittedRate = bs4.submittedRevisions[1] as RateRevision
+            expect(bs4submittedContract.formData.submissionDescription).toBe(
+                'An updated submission'
+            )
+            expect(bs4submittedRate.formData.rateDateStart).toBe('2003-01-01')
+            expect(bs4.contractRevision.formData.submissionDescription).toBe(
+                'An updated submission'
+            )
+            expect(bs4.rateRevisions[0].formData.rateDateStart).toBe(
+                '2003-01-01'
+            )
+            expect(bs4.rateRevisions[1].formData.rateDateStart).toBe(
+                '2001-01-01'
+            )
+            expect(bs4.cause).toBe('CONTRACT_SUBMISSION')
 
-        const as2 = fourthA.packageSubmissions[1]
-        expect(as2.cause).toBe('CONTRACT_SUBMISSION')
-        expect(as2.submittedRevisions).toHaveLength(3)
-        expect(as2.submittedRevisions.map((r) => r.id).sort()).toEqual(
-            [as2.contractRevision.id]
-                .concat(as2.rateRevisions.map((r) => r.id))
-                .sort()
-        )
-        expect(as2.contractRevision.formData.submissionDescription).toBe(
-            'An updated submission'
-        )
-        expect(as2.rateRevisions[0].formData.rateDateStart).toBe('2001-01-01')
-        expect(as2.rateRevisions[1].formData.rateDateStart).toBe('2002-01-01')
+            // C
+            const cs1 = fourthC.packageSubmissions[0]
+            expect(cs1.submittedRevisions).toHaveLength(2)
+            const cs1submittedContract = cs1
+                .submittedRevisions[0] as ContractRevision
+            const cs1submittedRate = cs1.submittedRevisions[1] as RateRevision
+            expect(cs1submittedContract.formData.submissionDescription).toBe(
+                'DESC C1'
+            )
+            expect(cs1submittedRate.formData.rateDateStart).toBe('2004-02-02')
+            expect(cs1.contractRevision.formData.submissionDescription).toBe(
+                'DESC C1'
+            )
+            expect(cs1.rateRevisions[0].formData.rateDateStart).toBe(
+                '2004-02-02'
+            )
+            expect(cs1.rateRevisions).toHaveLength(1)
+            expect(cs1.cause).toBe('CONTRACT_SUBMISSION')
 
-        // Contract B
-        const bs1 = fourthB.packageSubmissions[0]
-        expect(bs1.submittedRevisions).toHaveLength(2)
-        const bs1submittedContract = bs1
-            .submittedRevisions[0] as ContractRevision
-        const bs1submittedRate = bs1.submittedRevisions[1] as RateRevision
-        expect(bs1submittedContract.formData.submissionDescription).toBe(
-            'DESC C1'
-        )
-        expect(bs1submittedRate.formData.rateDateStart).toBe('2004-02-02')
-        expect(bs1.contractRevision.formData.submissionDescription).toBe(
-            'DESC B1'
-        )
-        expect(bs1.rateRevisions[0].formData.rateDateStart).toBe('2003-02-02')
-        expect(bs1.rateRevisions[1].formData.rateDateStart).toBe('2001-02-02')
-        expect(bs1.rateRevisions[2].formData.rateDateStart).toBe('2004-02-02')
-        expect(bs1.cause).toBe('RATE_SUBMISSION')
+            const cs2 = fourthC.packageSubmissions[1]
+            expect(cs2.submittedRevisions).toHaveLength(3)
+            const cs2submittedContract = cs2
+                .submittedRevisions[0] as ContractRevision
+            const cs2submittedRate = cs2.submittedRevisions[1] as RateRevision
+            const cs2submittedRate2 = cs2.submittedRevisions[2] as RateRevision
+            expect(cs2submittedContract.formData.submissionDescription).toBe(
+                'DESC A1'
+            )
+            expect(
+                [cs2submittedRate, cs2submittedRate2]
+                    .map((rr) => rr.formData.rateDateStart)
+                    .sort()
+            ).toEqual(['2001-02-02', '2002-02-02'])
+            expect(cs2.contractRevision.formData.submissionDescription).toBe(
+                'An updated submission'
+            )
+            expect(cs2.rateRevisions[0].formData.rateDateStart).toBe(
+                '2002-02-02'
+            )
+            expect(cs2.rateRevisions[1].formData.rateDateStart).toBe(
+                '2004-01-01'
+            )
+            expect(cs2.rateRevisions).toHaveLength(2)
+            expect(cs2.cause).toBe('RATE_SUBMISSION')
 
-        const bs2 = fourthB.packageSubmissions[1]
-        expect(bs2.submittedRevisions).toHaveLength(2)
-        const bs2submittedContract = bs2
-            .submittedRevisions[0] as ContractRevision
-        const bs2submittedRate = bs2.submittedRevisions[1] as RateRevision
-        expect(bs2submittedContract.formData.submissionDescription).toBe(
-            'DESC B1'
-        )
-        expect(bs2submittedRate.formData.rateDateStart).toBe('2003-02-02')
-        expect(bs2.contractRevision.formData.submissionDescription).toBe(
-            'DESC B1'
-        )
-        expect(bs2.rateRevisions[0].formData.rateDateStart).toBe('2003-02-02')
-        expect(bs2.rateRevisions[1].formData.rateDateStart).toBe('2001-02-02')
-        expect(bs2.rateRevisions[2].formData.rateDateStart).toBe('2004-01-01')
-        expect(bs2.cause).toBe('CONTRACT_SUBMISSION')
+            const cs3 = fourthC.packageSubmissions[2]
+            expect(cs3.submittedRevisions).toHaveLength(2)
+            const cs3submittedContract = cs3
+                .submittedRevisions[0] as ContractRevision
+            const cs3submittedRate = cs3.submittedRevisions[1] as RateRevision
+            expect(cs3submittedContract.formData.submissionDescription).toBe(
+                'An updated submission'
+            )
+            expect(cs3submittedRate.formData.rateDateStart).toBe('2004-01-01')
+            expect(cs3.contractRevision.formData.submissionDescription).toBe(
+                'An updated submission'
+            )
+            expect(cs3.rateRevisions[0].formData.rateDateStart).toBe(
+                '2002-01-01'
+            )
+            expect(cs3.rateRevisions[1].formData.rateDateStart).toBe(
+                '2004-01-01'
+            )
+            expect(cs3.rateRevisions).toHaveLength(2)
+            expect(cs3.cause).toBe('CONTRACT_SUBMISSION')
 
-        const bs3 = fourthB.packageSubmissions[2]
-        expect(bs3.submittedRevisions).toHaveLength(3)
-        const bs3submittedContract = bs3
-            .submittedRevisions[0] as ContractRevision
-        const bs3submittedRate = bs3.submittedRevisions[1] as RateRevision
-        const bs3submittedRate2 = bs3.submittedRevisions[2] as RateRevision
-        expect(bs3submittedContract.formData.submissionDescription).toBe(
-            'DESC A1'
-        )
-        expect(
-            [bs3submittedRate, bs3submittedRate2]
-                .map((rr) => rr.formData.rateDateStart)
-                .sort()
-        ).toEqual(['2001-02-02', '2002-02-02'])
-        expect(bs3.contractRevision.formData.submissionDescription).toBe(
-            'An updated submission'
-        )
-        expect(bs3.rateRevisions[0].formData.rateDateStart).toBe('2003-01-01')
-        expect(bs3.rateRevisions[1].formData.rateDateStart).toBe('2001-02-02')
-        expect(bs3.cause).toBe('RATE_SUBMISSION')
-
-        const bs4 = fourthB.packageSubmissions[3]
-        expect(bs4.submittedRevisions).toHaveLength(2)
-        const bs4submittedContract = bs4
-            .submittedRevisions[0] as ContractRevision
-        const bs4submittedRate = bs4.submittedRevisions[1] as RateRevision
-        expect(bs4submittedContract.formData.submissionDescription).toBe(
-            'An updated submission'
-        )
-        expect(bs4submittedRate.formData.rateDateStart).toBe('2003-01-01')
-        expect(bs4.contractRevision.formData.submissionDescription).toBe(
-            'An updated submission'
-        )
-        expect(bs4.rateRevisions[0].formData.rateDateStart).toBe('2003-01-01')
-        expect(bs4.rateRevisions[1].formData.rateDateStart).toBe('2001-01-01')
-        expect(bs4.cause).toBe('CONTRACT_SUBMISSION')
-
-        // C
-        const cs1 = fourthC.packageSubmissions[0]
-        expect(cs1.submittedRevisions).toHaveLength(2)
-        const cs1submittedContract = cs1
-            .submittedRevisions[0] as ContractRevision
-        const cs1submittedRate = cs1.submittedRevisions[1] as RateRevision
-        expect(cs1submittedContract.formData.submissionDescription).toBe(
-            'DESC C1'
-        )
-        expect(cs1submittedRate.formData.rateDateStart).toBe('2004-02-02')
-        expect(cs1.contractRevision.formData.submissionDescription).toBe(
-            'DESC C1'
-        )
-        expect(cs1.rateRevisions[0].formData.rateDateStart).toBe('2004-02-02')
-        expect(cs1.rateRevisions).toHaveLength(1)
-        expect(cs1.cause).toBe('CONTRACT_SUBMISSION')
-
-        const cs2 = fourthC.packageSubmissions[1]
-        expect(cs2.submittedRevisions).toHaveLength(3)
-        const cs2submittedContract = cs2
-            .submittedRevisions[0] as ContractRevision
-        const cs2submittedRate = cs2.submittedRevisions[1] as RateRevision
-        const cs2submittedRate2 = cs2.submittedRevisions[2] as RateRevision
-        expect(cs2submittedContract.formData.submissionDescription).toBe(
-            'DESC A1'
-        )
-        expect(
-            [cs2submittedRate, cs2submittedRate2]
-                .map((rr) => rr.formData.rateDateStart)
-                .sort()
-        ).toEqual(['2001-02-02', '2002-02-02'])
-        expect(cs2.contractRevision.formData.submissionDescription).toBe(
-            'An updated submission'
-        )
-        expect(cs2.rateRevisions[0].formData.rateDateStart).toBe('2002-02-02')
-        expect(cs2.rateRevisions[1].formData.rateDateStart).toBe('2004-01-01')
-        expect(cs2.rateRevisions).toHaveLength(2)
-        expect(cs2.cause).toBe('RATE_SUBMISSION')
-
-        const cs3 = fourthC.packageSubmissions[2]
-        expect(cs3.submittedRevisions).toHaveLength(2)
-        const cs3submittedContract = cs3
-            .submittedRevisions[0] as ContractRevision
-        const cs3submittedRate = cs3.submittedRevisions[1] as RateRevision
-        expect(cs3submittedContract.formData.submissionDescription).toBe(
-            'An updated submission'
-        )
-        expect(cs3submittedRate.formData.rateDateStart).toBe('2004-01-01')
-        expect(cs3.contractRevision.formData.submissionDescription).toBe(
-            'An updated submission'
-        )
-        expect(cs3.rateRevisions[0].formData.rateDateStart).toBe('2002-01-01')
-        expect(cs3.rateRevisions[1].formData.rateDateStart).toBe('2004-01-01')
-        expect(cs3.rateRevisions).toHaveLength(2)
-        expect(cs3.cause).toBe('CONTRACT_SUBMISSION')
-
-        // D
-        const ds1 = fourthD.packageSubmissions[0]
-        expect(ds1.submittedRevisions).toHaveLength(1)
-        const ds1submittedContract = ds1
-            .submittedRevisions[0] as ContractRevision
-        expect(ds1submittedContract.formData.submissionDescription).toBe(
-            'An updated submission'
-        )
-        expect(ds1.contractRevision.formData.submissionDescription).toBe(
-            'An updated submission'
-        )
-        expect(ds1.rateRevisions).toHaveLength(0)
-        expect(ds1.cause).toBe('CONTRACT_SUBMISSION')
-    }, 15000)
+            // D
+            const ds1 = fourthD.packageSubmissions[0]
+            expect(ds1.submittedRevisions).toHaveLength(1)
+            const ds1submittedContract = ds1
+                .submittedRevisions[0] as ContractRevision
+            expect(ds1submittedContract.formData.submissionDescription).toBe(
+                'An updated submission'
+            )
+            expect(ds1.contractRevision.formData.submissionDescription).toBe(
+                'An updated submission'
+            )
+            expect(ds1.rateRevisions).toHaveLength(0)
+            expect(ds1.cause).toBe('CONTRACT_SUBMISSION')
+        },
+        EXTENDED_TIMEOUT
+    )
 
     it('returns the correct dateAdded for documents', async () => {
         const ldService = testLDService({})

--- a/services/app-api/src/resolvers/contract/submitContract.test.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.test.ts
@@ -1569,7 +1569,9 @@ describe('submitContract', () => {
         })
 
         it('uses email settings from database with remove-parameter-store flag on', async () => {
-            const mockEmailer = await testEmailerFromDatabase()
+            const prismaClient = await sharedTestPrismaClient()
+            const store = NewPostgresStore(prismaClient)
+            const mockEmailer = await testEmailerFromDatabase(store)
             const ldService = testLDService({
                 'remove-parameter-store': true,
             })

--- a/services/app-api/src/resolvers/contract/submitContract.test.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.test.ts
@@ -45,7 +45,6 @@ import {
 } from '../../testHelpers/emailerHelpers'
 import { NewPostgresStore } from '../../postgres'
 import { dayjs } from '@mc-review/dates'
-import { EXTENDED_TIMEOUT } from '../../testHelpers/assertionHelpers'
 
 describe('submitContract', () => {
     const mockS3 = testS3Client()
@@ -329,531 +328,478 @@ describe('submitContract', () => {
         expect(connections).toHaveLength(9)
     })
 
-    it(
-        'handles a complex submission',
-        async () => {
-            // this test runs through a scenario from our programming diagrams, maybe best understood next to the visuals
-            const stateServer = await constructTestPostgresServer({
-                s3Client: mockS3,
-            })
+    it('handles a complex submission', async () => {
+        // this test runs through a scenario from our programming diagrams, maybe best understood next to the visuals
+        const stateServer = await constructTestPostgresServer({
+            s3Client: mockS3,
+        })
 
-            const cmsServer = await constructTestPostgresServer({
-                context: {
-                    user: testCMSUser(),
-                },
-                s3Client: mockS3,
-            })
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: testCMSUser(),
+            },
+            s3Client: mockS3,
+        })
 
-            // 1. Submit A0 with Rate1 and Rate2
-            const draftA0 =
-                await createAndUpdateTestContractWithoutRates(stateServer)
-            const AID = draftA0.id
-            const draftA010 = await addNewRateToTestContract(
-                stateServer,
-                draftA0,
-                {
-                    rateDateStart: '2001-01-01',
-                }
-            )
+        // 1. Submit A0 with Rate1 and Rate2
+        const draftA0 =
+            await createAndUpdateTestContractWithoutRates(stateServer)
+        const AID = draftA0.id
+        const draftA010 = await addNewRateToTestContract(stateServer, draftA0, {
+            rateDateStart: '2001-01-01',
+        })
 
-            await addNewRateToTestContract(stateServer, draftA010, {
-                rateDateStart: '2002-01-01',
-            })
+        await addNewRateToTestContract(stateServer, draftA010, {
+            rateDateStart: '2002-01-01',
+        })
 
-            const contractA0 = await submitTestContract(stateServer, AID)
-            const subA0 = contractA0.packageSubmissions[0]
-            const rate10 = subA0.rateRevisions[0]
-            const OneID = rate10.rateID
-            const rate20 = subA0.rateRevisions[1]
-            const TwoID = rate20.rateID
+        const contractA0 = await submitTestContract(stateServer, AID)
+        const subA0 = contractA0.packageSubmissions[0]
+        const rate10 = subA0.rateRevisions[0]
+        const OneID = rate10.rateID
+        const rate20 = subA0.rateRevisions[1]
+        const TwoID = rate20.rateID
 
-            console.info('ONEID', OneID)
-            console.info('TWOID', TwoID)
+        console.info('ONEID', OneID)
+        console.info('TWOID', TwoID)
 
-            // 2. Submit B0 with Rate1 and Rate3
-            const draftB0 =
-                await createAndUpdateTestContractWithoutRates(stateServer)
-            const BID = draftB0.id
-            const draftB010 = await addNewRateToTestContract(
-                stateServer,
-                draftB0,
-                {
-                    rateDateStart: '2003-01-01',
-                }
-            )
-            await addLinkedRateToTestContract(stateServer, draftB010, OneID)
+        // 2. Submit B0 with Rate1 and Rate3
+        const draftB0 =
+            await createAndUpdateTestContractWithoutRates(stateServer)
+        const BID = draftB0.id
+        const draftB010 = await addNewRateToTestContract(stateServer, draftB0, {
+            rateDateStart: '2003-01-01',
+        })
+        await addLinkedRateToTestContract(stateServer, draftB010, OneID)
 
-            const contractB0 = await submitTestContract(stateServer, draftB0.id)
-            const subB0 = contractB0.packageSubmissions[0]
-            const rate30 = subB0.rateRevisions[0]
-            const ThreeID = rate30.rateID
-            console.info('THREEID', ThreeID)
+        const contractB0 = await submitTestContract(stateServer, draftB0.id)
+        const subB0 = contractB0.packageSubmissions[0]
+        const rate30 = subB0.rateRevisions[0]
+        const ThreeID = rate30.rateID
+        console.info('THREEID', ThreeID)
 
-            expect(subB0.rateRevisions[0].rateID).toBe(ThreeID)
-            expect(subB0.rateRevisions[1].rateID).toBe(OneID)
+        expect(subB0.rateRevisions[0].rateID).toBe(ThreeID)
+        expect(subB0.rateRevisions[1].rateID).toBe(OneID)
 
-            // 3. Submit C0 with Rate20 and Rate40
-            const draftC0 =
-                await createAndUpdateTestContractWithoutRates(stateServer)
-            const CID = draftC0.id
-            const draftC020 = await addLinkedRateToTestContract(
-                stateServer,
-                draftC0,
-                TwoID
-            )
-            await addNewRateToTestContract(stateServer, draftC020, {
-                rateDateStart: '2004-01-01',
-            })
+        // 3. Submit C0 with Rate20 and Rate40
+        const draftC0 =
+            await createAndUpdateTestContractWithoutRates(stateServer)
+        const CID = draftC0.id
+        const draftC020 = await addLinkedRateToTestContract(
+            stateServer,
+            draftC0,
+            TwoID
+        )
+        await addNewRateToTestContract(stateServer, draftC020, {
+            rateDateStart: '2004-01-01',
+        })
 
-            const contractC0 = await submitTestContract(stateServer, draftC0.id)
-            const subC0 = contractC0.packageSubmissions[0]
-            const rate40 = subC0.rateRevisions[1]
-            const FourID = rate40.rateID
-            console.info('FOURID', FourID)
-            expect(subC0.rateRevisions[0].rateID).toBe(TwoID)
+        const contractC0 = await submitTestContract(stateServer, draftC0.id)
+        const subC0 = contractC0.packageSubmissions[0]
+        const rate40 = subC0.rateRevisions[1]
+        const FourID = rate40.rateID
+        console.info('FOURID', FourID)
+        expect(subC0.rateRevisions[0].rateID).toBe(TwoID)
 
-            // 4. Submit D0, contract only
-            const draftD0 = await createAndUpdateTestContractWithoutRates(
-                stateServer,
-                undefined,
-                {
-                    submissionType: 'CONTRACT_ONLY',
-                }
-            )
-            const DID = draftD0.id
-            const contractD0 = await submitTestContract(stateServer, draftD0.id)
-
-            console.info(ThreeID, FourID, contractD0)
-
-            // check on initial setup
-            const firstA = await fetchTestContract(stateServer, AID)
-            const firstB = await fetchTestContract(stateServer, BID)
-            const firstC = await fetchTestContract(stateServer, CID)
-            const firstD = await fetchTestContract(stateServer, DID)
-
-            expect(firstA.packageSubmissions).toHaveLength(1)
-            expect(firstB.packageSubmissions).toHaveLength(1)
-            expect(firstC.packageSubmissions).toHaveLength(1)
-            expect(firstD.packageSubmissions).toHaveLength(1)
-
-            // 5. resubmit A, 1, and 2. B and C will get new entries.
-            console.info('---- UNLOCK A.1 ----')
-            const unlockedA0Pkg = await unlockTestHealthPlanPackage(
-                cmsServer,
-                AID,
-                'Unlock A.0'
-            )
-            const a0FormData = latestFormData(unlockedA0Pkg)
-            a0FormData.submissionDescription = 'DESC A1'
-            await updateTestHealthPlanFormData(stateServer, a0FormData)
-            const unlockedA0Contract = await fetchTestContract(stateServer, AID)
-            const a0RatesUpdates =
-                updateRatesInputFromDraftContract(unlockedA0Contract)
-            expect(a0RatesUpdates.updatedRates[0].rateID).toBe(OneID)
-            expect(a0RatesUpdates.updatedRates[1].rateID).toBe(TwoID)
-
-            if (
-                !a0RatesUpdates.updatedRates[0].formData ||
-                !a0RatesUpdates.updatedRates[1].formData
-            ) {
-                throw new Error('missing updates')
+        // 4. Submit D0, contract only
+        const draftD0 = await createAndUpdateTestContractWithoutRates(
+            stateServer,
+            undefined,
+            {
+                submissionType: 'CONTRACT_ONLY',
             }
+        )
+        const DID = draftD0.id
+        const contractD0 = await submitTestContract(stateServer, draftD0.id)
 
-            expect(a0RatesUpdates.updatedRates[0].formData.rateDateStart).toBe(
-                '2001-01-01'
-            )
-            expect(a0RatesUpdates.updatedRates[1].formData.rateDateStart).toBe(
-                '2002-01-01'
-            )
+        console.info(ThreeID, FourID, contractD0)
 
-            a0RatesUpdates.updatedRates[0].formData.rateDateStart = '2001-02-02'
-            a0RatesUpdates.updatedRates[1].formData.rateDateStart = '2002-02-02'
-            await updateTestDraftRatesOnContract(stateServer, a0RatesUpdates)
+        // check on initial setup
+        const firstA = await fetchTestContract(stateServer, AID)
+        const firstB = await fetchTestContract(stateServer, BID)
+        const firstC = await fetchTestContract(stateServer, CID)
+        const firstD = await fetchTestContract(stateServer, DID)
 
-            console.info('---- SUBMIT A.1 ----')
-            await submitTestContract(stateServer, AID, 'Submit A.1')
+        expect(firstA.packageSubmissions).toHaveLength(1)
+        expect(firstB.packageSubmissions).toHaveLength(1)
+        expect(firstC.packageSubmissions).toHaveLength(1)
+        expect(firstD.packageSubmissions).toHaveLength(1)
 
-            // Check second showing
-            const secondA = await fetchTestContract(stateServer, AID)
-            const secondB = await fetchTestContract(stateServer, BID)
-            const secondC = await fetchTestContract(stateServer, CID)
-            const secondD = await fetchTestContract(stateServer, DID)
+        // 5. resubmit A, 1, and 2. B and C will get new entries.
+        console.info('---- UNLOCK A.1 ----')
+        const unlockedA0Pkg = await unlockTestHealthPlanPackage(
+            cmsServer,
+            AID,
+            'Unlock A.0'
+        )
+        const a0FormData = latestFormData(unlockedA0Pkg)
+        a0FormData.submissionDescription = 'DESC A1'
+        await updateTestHealthPlanFormData(stateServer, a0FormData)
+        const unlockedA0Contract = await fetchTestContract(stateServer, AID)
+        const a0RatesUpdates =
+            updateRatesInputFromDraftContract(unlockedA0Contract)
+        expect(a0RatesUpdates.updatedRates[0].rateID).toBe(OneID)
+        expect(a0RatesUpdates.updatedRates[1].rateID).toBe(TwoID)
 
-            expect(secondA.packageSubmissions).toHaveLength(2)
-            expect(secondB.packageSubmissions).toHaveLength(2)
-            expect(secondC.packageSubmissions).toHaveLength(2)
-            expect(secondD.packageSubmissions).toHaveLength(1)
+        if (
+            !a0RatesUpdates.updatedRates[0].formData ||
+            !a0RatesUpdates.updatedRates[1].formData
+        ) {
+            throw new Error('missing updates')
+        }
 
-            expect(secondA.packageSubmissions[0].submitInfo.updatedReason).toBe(
-                'Submit A.1'
-            )
-            expect(
-                secondA.packageSubmissions[0].contractRevision.formData
-                    .submissionDescription
-            ).toBe('DESC A1')
-            expect(secondA.packageSubmissions[1].submitInfo.updatedReason).toBe(
-                'Initial submission'
-            )
-            expect(
-                secondA.packageSubmissions[1].contractRevision.formData
-                    .submissionDescription
-            ).toBe('An updated submission')
+        expect(a0RatesUpdates.updatedRates[0].formData.rateDateStart).toBe(
+            '2001-01-01'
+        )
+        expect(a0RatesUpdates.updatedRates[1].formData.rateDateStart).toBe(
+            '2002-01-01'
+        )
 
-            // check B history
-            expect(secondB.packageSubmissions[1].submitInfo.updatedReason).toBe(
-                'Initial submission'
-            )
-            expect(
-                secondB.packageSubmissions[1].contractRevision.formData
-                    .submissionDescription
-            ).toBe('An updated submission')
-            expect(secondB.packageSubmissions[1].rateRevisions).toHaveLength(2)
-            expect(
-                secondB.packageSubmissions[1].rateRevisions[0].formData
-                    .rateDateStart
-            ).toBe('2003-01-01')
-            expect(
-                secondB.packageSubmissions[1].rateRevisions[1].formData
-                    .rateDateStart
-            ).toBe('2001-01-01')
+        a0RatesUpdates.updatedRates[0].formData.rateDateStart = '2001-02-02'
+        a0RatesUpdates.updatedRates[1].formData.rateDateStart = '2002-02-02'
+        await updateTestDraftRatesOnContract(stateServer, a0RatesUpdates)
 
-            expect(secondB.packageSubmissions[0].submitInfo.updatedReason).toBe(
-                'Submit A.1'
-            )
-            expect(
-                secondB.packageSubmissions[0].contractRevision.formData
-                    .submissionDescription
-            ).toBe('An updated submission')
-            expect(secondB.packageSubmissions[0].rateRevisions).toHaveLength(2)
-            expect(
-                secondB.packageSubmissions[0].rateRevisions[0].formData
-                    .rateDateStart
-            ).toBe('2003-01-01')
-            expect(
-                secondB.packageSubmissions[0].rateRevisions[1].formData
-                    .rateDateStart
-            ).toBe('2001-02-02')
+        console.info('---- SUBMIT A.1 ----')
+        await submitTestContract(stateServer, AID, 'Submit A.1')
 
-            // 6. resubmit B, add r4. Only B gets a new entry.
-            console.info('---- UNLOCK B.1 ----')
-            const unlockedB0Pkg = await unlockTestHealthPlanPackage(
-                cmsServer,
-                BID,
-                'Unlock B.0'
-            )
-            const b0FormData = latestFormData(unlockedB0Pkg)
+        // Check second showing
+        const secondA = await fetchTestContract(stateServer, AID)
+        const secondB = await fetchTestContract(stateServer, BID)
+        const secondC = await fetchTestContract(stateServer, CID)
+        const secondD = await fetchTestContract(stateServer, DID)
 
-            b0FormData.submissionDescription = 'DESC B1'
-            await updateTestHealthPlanFormData(stateServer, b0FormData)
+        expect(secondA.packageSubmissions).toHaveLength(2)
+        expect(secondB.packageSubmissions).toHaveLength(2)
+        expect(secondC.packageSubmissions).toHaveLength(2)
+        expect(secondD.packageSubmissions).toHaveLength(1)
 
-            const unlockedB0Contract = await fetchTestContract(stateServer, BID)
-            const b0RatesUpdates =
-                updateRatesInputFromDraftContract(unlockedB0Contract)
-            expect(b0RatesUpdates.updatedRates[0].type).toBe('UPDATE')
-            expect(b0RatesUpdates.updatedRates[0].rateID).toBe(ThreeID)
-            expect(b0RatesUpdates.updatedRates[1].type).toBe('LINK')
-            expect(b0RatesUpdates.updatedRates[1].rateID).toBe(OneID)
+        expect(secondA.packageSubmissions[0].submitInfo.updatedReason).toBe(
+            'Submit A.1'
+        )
+        expect(
+            secondA.packageSubmissions[0].contractRevision.formData
+                .submissionDescription
+        ).toBe('DESC A1')
+        expect(secondA.packageSubmissions[1].submitInfo.updatedReason).toBe(
+            'Initial submission'
+        )
+        expect(
+            secondA.packageSubmissions[1].contractRevision.formData
+                .submissionDescription
+        ).toBe('An updated submission')
 
-            if (!b0RatesUpdates.updatedRates[0].formData) {
-                throw new Error('missing updates')
-            }
+        // check B history
+        expect(secondB.packageSubmissions[1].submitInfo.updatedReason).toBe(
+            'Initial submission'
+        )
+        expect(
+            secondB.packageSubmissions[1].contractRevision.formData
+                .submissionDescription
+        ).toBe('An updated submission')
+        expect(secondB.packageSubmissions[1].rateRevisions).toHaveLength(2)
+        expect(
+            secondB.packageSubmissions[1].rateRevisions[0].formData
+                .rateDateStart
+        ).toBe('2003-01-01')
+        expect(
+            secondB.packageSubmissions[1].rateRevisions[1].formData
+                .rateDateStart
+        ).toBe('2001-01-01')
 
-            expect(b0RatesUpdates.updatedRates[0].formData.rateDateStart).toBe(
-                '2003-01-01'
-            )
+        expect(secondB.packageSubmissions[0].submitInfo.updatedReason).toBe(
+            'Submit A.1'
+        )
+        expect(
+            secondB.packageSubmissions[0].contractRevision.formData
+                .submissionDescription
+        ).toBe('An updated submission')
+        expect(secondB.packageSubmissions[0].rateRevisions).toHaveLength(2)
+        expect(
+            secondB.packageSubmissions[0].rateRevisions[0].formData
+                .rateDateStart
+        ).toBe('2003-01-01')
+        expect(
+            secondB.packageSubmissions[0].rateRevisions[1].formData
+                .rateDateStart
+        ).toBe('2001-02-02')
 
-            b0RatesUpdates.updatedRates[0].formData.rateDateStart = '2003-02-02'
+        // 6. resubmit B, add r4. Only B gets a new entry.
+        console.info('---- UNLOCK B.1 ----')
+        const unlockedB0Pkg = await unlockTestHealthPlanPackage(
+            cmsServer,
+            BID,
+            'Unlock B.0'
+        )
+        const b0FormData = latestFormData(unlockedB0Pkg)
 
-            const b0RatesUpdatesWith4 = addLinkedRateToRateInput(
-                b0RatesUpdates,
-                FourID
-            )
+        b0FormData.submissionDescription = 'DESC B1'
+        await updateTestHealthPlanFormData(stateServer, b0FormData)
 
-            await updateTestDraftRatesOnContract(
-                stateServer,
-                b0RatesUpdatesWith4
-            )
+        const unlockedB0Contract = await fetchTestContract(stateServer, BID)
+        const b0RatesUpdates =
+            updateRatesInputFromDraftContract(unlockedB0Contract)
+        expect(b0RatesUpdates.updatedRates[0].type).toBe('UPDATE')
+        expect(b0RatesUpdates.updatedRates[0].rateID).toBe(ThreeID)
+        expect(b0RatesUpdates.updatedRates[1].type).toBe('LINK')
+        expect(b0RatesUpdates.updatedRates[1].rateID).toBe(OneID)
 
-            console.info('---- SUBMIT B.1 ----')
-            await submitTestContract(stateServer, BID, 'Submit B.1')
+        if (!b0RatesUpdates.updatedRates[0].formData) {
+            throw new Error('missing updates')
+        }
 
-            // Check third showing
-            const thirdA = await fetchTestContract(stateServer, AID)
-            const thirdB = await fetchTestContract(stateServer, BID)
-            const thirdC = await fetchTestContract(stateServer, CID)
-            const thirdD = await fetchTestContract(stateServer, DID)
+        expect(b0RatesUpdates.updatedRates[0].formData.rateDateStart).toBe(
+            '2003-01-01'
+        )
 
-            expect(thirdA.packageSubmissions).toHaveLength(2)
-            expect(thirdB.packageSubmissions).toHaveLength(3)
-            expect(thirdC.packageSubmissions).toHaveLength(2)
-            expect(thirdD.packageSubmissions).toHaveLength(1)
+        b0RatesUpdates.updatedRates[0].formData.rateDateStart = '2003-02-02'
 
-            // 7. Resubmit C, remove rate 2. B should also get an update.
-            const unlockedC0Pkg = await unlockTestHealthPlanPackage(
-                cmsServer,
-                CID,
-                'Unlock C.0'
-            )
-            const c0FormData = latestFormData(unlockedC0Pkg)
-            c0FormData.submissionDescription = 'DESC C1'
-            await updateTestHealthPlanFormData(stateServer, c0FormData)
+        const b0RatesUpdatesWith4 = addLinkedRateToRateInput(
+            b0RatesUpdates,
+            FourID
+        )
 
-            const unlockedC0Contract = await fetchTestContract(stateServer, CID)
+        await updateTestDraftRatesOnContract(stateServer, b0RatesUpdatesWith4)
 
-            const c0RatesUpdates =
-                updateRatesInputFromDraftContract(unlockedC0Contract)
-            expect(c0RatesUpdates.updatedRates[0].type).toBe('LINK')
-            expect(c0RatesUpdates.updatedRates[0].rateID).toBe(TwoID)
-            expect(c0RatesUpdates.updatedRates[1].type).toBe('UPDATE')
-            expect(c0RatesUpdates.updatedRates[1].rateID).toBe(FourID)
+        console.info('---- SUBMIT B.1 ----')
+        await submitTestContract(stateServer, BID, 'Submit B.1')
 
-            if (!c0RatesUpdates.updatedRates[1].formData) {
-                throw new Error('missing updates')
-            }
+        // Check third showing
+        const thirdA = await fetchTestContract(stateServer, AID)
+        const thirdB = await fetchTestContract(stateServer, BID)
+        const thirdC = await fetchTestContract(stateServer, CID)
+        const thirdD = await fetchTestContract(stateServer, DID)
 
-            expect(c0RatesUpdates.updatedRates[1].formData.rateDateStart).toBe(
-                '2004-01-01'
-            )
-            c0RatesUpdates.updatedRates[1].formData.rateDateStart = '2004-02-02'
+        expect(thirdA.packageSubmissions).toHaveLength(2)
+        expect(thirdB.packageSubmissions).toHaveLength(3)
+        expect(thirdC.packageSubmissions).toHaveLength(2)
+        expect(thirdD.packageSubmissions).toHaveLength(1)
 
-            // remove linked 2.1
-            c0RatesUpdates.updatedRates.splice(0, 1)
+        // 7. Resubmit C, remove rate 2. B should also get an update.
+        const unlockedC0Pkg = await unlockTestHealthPlanPackage(
+            cmsServer,
+            CID,
+            'Unlock C.0'
+        )
+        const c0FormData = latestFormData(unlockedC0Pkg)
+        c0FormData.submissionDescription = 'DESC C1'
+        await updateTestHealthPlanFormData(stateServer, c0FormData)
 
-            await updateTestDraftRatesOnContract(stateServer, c0RatesUpdates)
+        const unlockedC0Contract = await fetchTestContract(stateServer, CID)
 
-            console.info('---- SUBMIT C.1 ----')
-            await submitTestContract(stateServer, CID, 'Submit C.1')
+        const c0RatesUpdates =
+            updateRatesInputFromDraftContract(unlockedC0Contract)
+        expect(c0RatesUpdates.updatedRates[0].type).toBe('LINK')
+        expect(c0RatesUpdates.updatedRates[0].rateID).toBe(TwoID)
+        expect(c0RatesUpdates.updatedRates[1].type).toBe('UPDATE')
+        expect(c0RatesUpdates.updatedRates[1].rateID).toBe(FourID)
 
-            // Check fourth showing
-            const fourthA = await fetchTestContract(stateServer, AID)
-            const fourthB = await fetchTestContract(stateServer, BID)
-            const fourthC = await fetchTestContract(stateServer, CID)
-            const fourthD = await fetchTestContract(stateServer, DID)
+        if (!c0RatesUpdates.updatedRates[1].formData) {
+            throw new Error('missing updates')
+        }
 
-            expect(fourthA.packageSubmissions).toHaveLength(2)
-            expect(fourthB.packageSubmissions).toHaveLength(4)
-            expect(fourthC.packageSubmissions).toHaveLength(3)
-            expect(fourthD.packageSubmissions).toHaveLength(1)
+        expect(c0RatesUpdates.updatedRates[1].formData.rateDateStart).toBe(
+            '2004-01-01'
+        )
+        c0RatesUpdates.updatedRates[1].formData.rateDateStart = '2004-02-02'
 
-            // check removal happened:
-            const lastCPackage = fourthC.packageSubmissions[0]
-            expect(lastCPackage.rateRevisions).toHaveLength(1)
-            expect(lastCPackage.rateRevisions[0].formData.rateDateStart).toBe(
-                '2004-02-02'
-            )
+        // remove linked 2.1
+        c0RatesUpdates.updatedRates.splice(0, 1)
 
-            // Now check that all the histories are as expected
-            // Contract A.
-            const as1 = fourthA.packageSubmissions[0]
-            expect(as1.cause).toBe('CONTRACT_SUBMISSION')
-            expect(as1.submittedRevisions).toHaveLength(3)
-            expect(as1.submittedRevisions.map((r) => r.id).sort()).toEqual(
-                [as1.contractRevision.id]
-                    .concat(as1.rateRevisions.map((r) => r.id))
-                    .sort()
-            )
-            expect(as1.contractRevision.formData.submissionDescription).toBe(
-                'DESC A1'
-            )
-            expect(as1.rateRevisions[0].formData.rateDateStart).toBe(
-                '2001-02-02'
-            )
-            expect(as1.rateRevisions[1].formData.rateDateStart).toBe(
-                '2002-02-02'
-            )
+        await updateTestDraftRatesOnContract(stateServer, c0RatesUpdates)
 
-            const as2 = fourthA.packageSubmissions[1]
-            expect(as2.cause).toBe('CONTRACT_SUBMISSION')
-            expect(as2.submittedRevisions).toHaveLength(3)
-            expect(as2.submittedRevisions.map((r) => r.id).sort()).toEqual(
-                [as2.contractRevision.id]
-                    .concat(as2.rateRevisions.map((r) => r.id))
-                    .sort()
-            )
-            expect(as2.contractRevision.formData.submissionDescription).toBe(
-                'An updated submission'
-            )
-            expect(as2.rateRevisions[0].formData.rateDateStart).toBe(
-                '2001-01-01'
-            )
-            expect(as2.rateRevisions[1].formData.rateDateStart).toBe(
-                '2002-01-01'
-            )
+        console.info('---- SUBMIT C.1 ----')
+        await submitTestContract(stateServer, CID, 'Submit C.1')
 
-            // Contract B
-            const bs1 = fourthB.packageSubmissions[0]
-            expect(bs1.submittedRevisions).toHaveLength(2)
-            const bs1submittedContract = bs1
-                .submittedRevisions[0] as ContractRevision
-            const bs1submittedRate = bs1.submittedRevisions[1] as RateRevision
-            expect(bs1submittedContract.formData.submissionDescription).toBe(
-                'DESC C1'
-            )
-            expect(bs1submittedRate.formData.rateDateStart).toBe('2004-02-02')
-            expect(bs1.contractRevision.formData.submissionDescription).toBe(
-                'DESC B1'
-            )
-            expect(bs1.rateRevisions[0].formData.rateDateStart).toBe(
-                '2003-02-02'
-            )
-            expect(bs1.rateRevisions[1].formData.rateDateStart).toBe(
-                '2001-02-02'
-            )
-            expect(bs1.rateRevisions[2].formData.rateDateStart).toBe(
-                '2004-02-02'
-            )
-            expect(bs1.cause).toBe('RATE_SUBMISSION')
+        // Check fourth showing
+        const fourthA = await fetchTestContract(stateServer, AID)
+        const fourthB = await fetchTestContract(stateServer, BID)
+        const fourthC = await fetchTestContract(stateServer, CID)
+        const fourthD = await fetchTestContract(stateServer, DID)
 
-            const bs2 = fourthB.packageSubmissions[1]
-            expect(bs2.submittedRevisions).toHaveLength(2)
-            const bs2submittedContract = bs2
-                .submittedRevisions[0] as ContractRevision
-            const bs2submittedRate = bs2.submittedRevisions[1] as RateRevision
-            expect(bs2submittedContract.formData.submissionDescription).toBe(
-                'DESC B1'
-            )
-            expect(bs2submittedRate.formData.rateDateStart).toBe('2003-02-02')
-            expect(bs2.contractRevision.formData.submissionDescription).toBe(
-                'DESC B1'
-            )
-            expect(bs2.rateRevisions[0].formData.rateDateStart).toBe(
-                '2003-02-02'
-            )
-            expect(bs2.rateRevisions[1].formData.rateDateStart).toBe(
-                '2001-02-02'
-            )
-            expect(bs2.rateRevisions[2].formData.rateDateStart).toBe(
-                '2004-01-01'
-            )
-            expect(bs2.cause).toBe('CONTRACT_SUBMISSION')
+        expect(fourthA.packageSubmissions).toHaveLength(2)
+        expect(fourthB.packageSubmissions).toHaveLength(4)
+        expect(fourthC.packageSubmissions).toHaveLength(3)
+        expect(fourthD.packageSubmissions).toHaveLength(1)
 
-            const bs3 = fourthB.packageSubmissions[2]
-            expect(bs3.submittedRevisions).toHaveLength(3)
-            const bs3submittedContract = bs3
-                .submittedRevisions[0] as ContractRevision
-            const bs3submittedRate = bs3.submittedRevisions[1] as RateRevision
-            const bs3submittedRate2 = bs3.submittedRevisions[2] as RateRevision
-            expect(bs3submittedContract.formData.submissionDescription).toBe(
-                'DESC A1'
-            )
-            expect(
-                [bs3submittedRate, bs3submittedRate2]
-                    .map((rr) => rr.formData.rateDateStart)
-                    .sort()
-            ).toEqual(['2001-02-02', '2002-02-02'])
-            expect(bs3.contractRevision.formData.submissionDescription).toBe(
-                'An updated submission'
-            )
-            expect(bs3.rateRevisions[0].formData.rateDateStart).toBe(
-                '2003-01-01'
-            )
-            expect(bs3.rateRevisions[1].formData.rateDateStart).toBe(
-                '2001-02-02'
-            )
-            expect(bs3.cause).toBe('RATE_SUBMISSION')
+        // check removal happened:
+        const lastCPackage = fourthC.packageSubmissions[0]
+        expect(lastCPackage.rateRevisions).toHaveLength(1)
+        expect(lastCPackage.rateRevisions[0].formData.rateDateStart).toBe(
+            '2004-02-02'
+        )
 
-            const bs4 = fourthB.packageSubmissions[3]
-            expect(bs4.submittedRevisions).toHaveLength(2)
-            const bs4submittedContract = bs4
-                .submittedRevisions[0] as ContractRevision
-            const bs4submittedRate = bs4.submittedRevisions[1] as RateRevision
-            expect(bs4submittedContract.formData.submissionDescription).toBe(
-                'An updated submission'
-            )
-            expect(bs4submittedRate.formData.rateDateStart).toBe('2003-01-01')
-            expect(bs4.contractRevision.formData.submissionDescription).toBe(
-                'An updated submission'
-            )
-            expect(bs4.rateRevisions[0].formData.rateDateStart).toBe(
-                '2003-01-01'
-            )
-            expect(bs4.rateRevisions[1].formData.rateDateStart).toBe(
-                '2001-01-01'
-            )
-            expect(bs4.cause).toBe('CONTRACT_SUBMISSION')
+        // Now check that all the histories are as expected
+        // Contract A.
+        const as1 = fourthA.packageSubmissions[0]
+        expect(as1.cause).toBe('CONTRACT_SUBMISSION')
+        expect(as1.submittedRevisions).toHaveLength(3)
+        expect(as1.submittedRevisions.map((r) => r.id).sort()).toEqual(
+            [as1.contractRevision.id]
+                .concat(as1.rateRevisions.map((r) => r.id))
+                .sort()
+        )
+        expect(as1.contractRevision.formData.submissionDescription).toBe(
+            'DESC A1'
+        )
+        expect(as1.rateRevisions[0].formData.rateDateStart).toBe('2001-02-02')
+        expect(as1.rateRevisions[1].formData.rateDateStart).toBe('2002-02-02')
 
-            // C
-            const cs1 = fourthC.packageSubmissions[0]
-            expect(cs1.submittedRevisions).toHaveLength(2)
-            const cs1submittedContract = cs1
-                .submittedRevisions[0] as ContractRevision
-            const cs1submittedRate = cs1.submittedRevisions[1] as RateRevision
-            expect(cs1submittedContract.formData.submissionDescription).toBe(
-                'DESC C1'
-            )
-            expect(cs1submittedRate.formData.rateDateStart).toBe('2004-02-02')
-            expect(cs1.contractRevision.formData.submissionDescription).toBe(
-                'DESC C1'
-            )
-            expect(cs1.rateRevisions[0].formData.rateDateStart).toBe(
-                '2004-02-02'
-            )
-            expect(cs1.rateRevisions).toHaveLength(1)
-            expect(cs1.cause).toBe('CONTRACT_SUBMISSION')
+        const as2 = fourthA.packageSubmissions[1]
+        expect(as2.cause).toBe('CONTRACT_SUBMISSION')
+        expect(as2.submittedRevisions).toHaveLength(3)
+        expect(as2.submittedRevisions.map((r) => r.id).sort()).toEqual(
+            [as2.contractRevision.id]
+                .concat(as2.rateRevisions.map((r) => r.id))
+                .sort()
+        )
+        expect(as2.contractRevision.formData.submissionDescription).toBe(
+            'An updated submission'
+        )
+        expect(as2.rateRevisions[0].formData.rateDateStart).toBe('2001-01-01')
+        expect(as2.rateRevisions[1].formData.rateDateStart).toBe('2002-01-01')
 
-            const cs2 = fourthC.packageSubmissions[1]
-            expect(cs2.submittedRevisions).toHaveLength(3)
-            const cs2submittedContract = cs2
-                .submittedRevisions[0] as ContractRevision
-            const cs2submittedRate = cs2.submittedRevisions[1] as RateRevision
-            const cs2submittedRate2 = cs2.submittedRevisions[2] as RateRevision
-            expect(cs2submittedContract.formData.submissionDescription).toBe(
-                'DESC A1'
-            )
-            expect(
-                [cs2submittedRate, cs2submittedRate2]
-                    .map((rr) => rr.formData.rateDateStart)
-                    .sort()
-            ).toEqual(['2001-02-02', '2002-02-02'])
-            expect(cs2.contractRevision.formData.submissionDescription).toBe(
-                'An updated submission'
-            )
-            expect(cs2.rateRevisions[0].formData.rateDateStart).toBe(
-                '2002-02-02'
-            )
-            expect(cs2.rateRevisions[1].formData.rateDateStart).toBe(
-                '2004-01-01'
-            )
-            expect(cs2.rateRevisions).toHaveLength(2)
-            expect(cs2.cause).toBe('RATE_SUBMISSION')
+        // Contract B
+        const bs1 = fourthB.packageSubmissions[0]
+        expect(bs1.submittedRevisions).toHaveLength(2)
+        const bs1submittedContract = bs1
+            .submittedRevisions[0] as ContractRevision
+        const bs1submittedRate = bs1.submittedRevisions[1] as RateRevision
+        expect(bs1submittedContract.formData.submissionDescription).toBe(
+            'DESC C1'
+        )
+        expect(bs1submittedRate.formData.rateDateStart).toBe('2004-02-02')
+        expect(bs1.contractRevision.formData.submissionDescription).toBe(
+            'DESC B1'
+        )
+        expect(bs1.rateRevisions[0].formData.rateDateStart).toBe('2003-02-02')
+        expect(bs1.rateRevisions[1].formData.rateDateStart).toBe('2001-02-02')
+        expect(bs1.rateRevisions[2].formData.rateDateStart).toBe('2004-02-02')
+        expect(bs1.cause).toBe('RATE_SUBMISSION')
 
-            const cs3 = fourthC.packageSubmissions[2]
-            expect(cs3.submittedRevisions).toHaveLength(2)
-            const cs3submittedContract = cs3
-                .submittedRevisions[0] as ContractRevision
-            const cs3submittedRate = cs3.submittedRevisions[1] as RateRevision
-            expect(cs3submittedContract.formData.submissionDescription).toBe(
-                'An updated submission'
-            )
-            expect(cs3submittedRate.formData.rateDateStart).toBe('2004-01-01')
-            expect(cs3.contractRevision.formData.submissionDescription).toBe(
-                'An updated submission'
-            )
-            expect(cs3.rateRevisions[0].formData.rateDateStart).toBe(
-                '2002-01-01'
-            )
-            expect(cs3.rateRevisions[1].formData.rateDateStart).toBe(
-                '2004-01-01'
-            )
-            expect(cs3.rateRevisions).toHaveLength(2)
-            expect(cs3.cause).toBe('CONTRACT_SUBMISSION')
+        const bs2 = fourthB.packageSubmissions[1]
+        expect(bs2.submittedRevisions).toHaveLength(2)
+        const bs2submittedContract = bs2
+            .submittedRevisions[0] as ContractRevision
+        const bs2submittedRate = bs2.submittedRevisions[1] as RateRevision
+        expect(bs2submittedContract.formData.submissionDescription).toBe(
+            'DESC B1'
+        )
+        expect(bs2submittedRate.formData.rateDateStart).toBe('2003-02-02')
+        expect(bs2.contractRevision.formData.submissionDescription).toBe(
+            'DESC B1'
+        )
+        expect(bs2.rateRevisions[0].formData.rateDateStart).toBe('2003-02-02')
+        expect(bs2.rateRevisions[1].formData.rateDateStart).toBe('2001-02-02')
+        expect(bs2.rateRevisions[2].formData.rateDateStart).toBe('2004-01-01')
+        expect(bs2.cause).toBe('CONTRACT_SUBMISSION')
 
-            // D
-            const ds1 = fourthD.packageSubmissions[0]
-            expect(ds1.submittedRevisions).toHaveLength(1)
-            const ds1submittedContract = ds1
-                .submittedRevisions[0] as ContractRevision
-            expect(ds1submittedContract.formData.submissionDescription).toBe(
-                'An updated submission'
-            )
-            expect(ds1.contractRevision.formData.submissionDescription).toBe(
-                'An updated submission'
-            )
-            expect(ds1.rateRevisions).toHaveLength(0)
-            expect(ds1.cause).toBe('CONTRACT_SUBMISSION')
-        },
-        EXTENDED_TIMEOUT
-    )
+        const bs3 = fourthB.packageSubmissions[2]
+        expect(bs3.submittedRevisions).toHaveLength(3)
+        const bs3submittedContract = bs3
+            .submittedRevisions[0] as ContractRevision
+        const bs3submittedRate = bs3.submittedRevisions[1] as RateRevision
+        const bs3submittedRate2 = bs3.submittedRevisions[2] as RateRevision
+        expect(bs3submittedContract.formData.submissionDescription).toBe(
+            'DESC A1'
+        )
+        expect(
+            [bs3submittedRate, bs3submittedRate2]
+                .map((rr) => rr.formData.rateDateStart)
+                .sort()
+        ).toEqual(['2001-02-02', '2002-02-02'])
+        expect(bs3.contractRevision.formData.submissionDescription).toBe(
+            'An updated submission'
+        )
+        expect(bs3.rateRevisions[0].formData.rateDateStart).toBe('2003-01-01')
+        expect(bs3.rateRevisions[1].formData.rateDateStart).toBe('2001-02-02')
+        expect(bs3.cause).toBe('RATE_SUBMISSION')
+
+        const bs4 = fourthB.packageSubmissions[3]
+        expect(bs4.submittedRevisions).toHaveLength(2)
+        const bs4submittedContract = bs4
+            .submittedRevisions[0] as ContractRevision
+        const bs4submittedRate = bs4.submittedRevisions[1] as RateRevision
+        expect(bs4submittedContract.formData.submissionDescription).toBe(
+            'An updated submission'
+        )
+        expect(bs4submittedRate.formData.rateDateStart).toBe('2003-01-01')
+        expect(bs4.contractRevision.formData.submissionDescription).toBe(
+            'An updated submission'
+        )
+        expect(bs4.rateRevisions[0].formData.rateDateStart).toBe('2003-01-01')
+        expect(bs4.rateRevisions[1].formData.rateDateStart).toBe('2001-01-01')
+        expect(bs4.cause).toBe('CONTRACT_SUBMISSION')
+
+        // C
+        const cs1 = fourthC.packageSubmissions[0]
+        expect(cs1.submittedRevisions).toHaveLength(2)
+        const cs1submittedContract = cs1
+            .submittedRevisions[0] as ContractRevision
+        const cs1submittedRate = cs1.submittedRevisions[1] as RateRevision
+        expect(cs1submittedContract.formData.submissionDescription).toBe(
+            'DESC C1'
+        )
+        expect(cs1submittedRate.formData.rateDateStart).toBe('2004-02-02')
+        expect(cs1.contractRevision.formData.submissionDescription).toBe(
+            'DESC C1'
+        )
+        expect(cs1.rateRevisions[0].formData.rateDateStart).toBe('2004-02-02')
+        expect(cs1.rateRevisions).toHaveLength(1)
+        expect(cs1.cause).toBe('CONTRACT_SUBMISSION')
+
+        const cs2 = fourthC.packageSubmissions[1]
+        expect(cs2.submittedRevisions).toHaveLength(3)
+        const cs2submittedContract = cs2
+            .submittedRevisions[0] as ContractRevision
+        const cs2submittedRate = cs2.submittedRevisions[1] as RateRevision
+        const cs2submittedRate2 = cs2.submittedRevisions[2] as RateRevision
+        expect(cs2submittedContract.formData.submissionDescription).toBe(
+            'DESC A1'
+        )
+        expect(
+            [cs2submittedRate, cs2submittedRate2]
+                .map((rr) => rr.formData.rateDateStart)
+                .sort()
+        ).toEqual(['2001-02-02', '2002-02-02'])
+        expect(cs2.contractRevision.formData.submissionDescription).toBe(
+            'An updated submission'
+        )
+        expect(cs2.rateRevisions[0].formData.rateDateStart).toBe('2002-02-02')
+        expect(cs2.rateRevisions[1].formData.rateDateStart).toBe('2004-01-01')
+        expect(cs2.rateRevisions).toHaveLength(2)
+        expect(cs2.cause).toBe('RATE_SUBMISSION')
+
+        const cs3 = fourthC.packageSubmissions[2]
+        expect(cs3.submittedRevisions).toHaveLength(2)
+        const cs3submittedContract = cs3
+            .submittedRevisions[0] as ContractRevision
+        const cs3submittedRate = cs3.submittedRevisions[1] as RateRevision
+        expect(cs3submittedContract.formData.submissionDescription).toBe(
+            'An updated submission'
+        )
+        expect(cs3submittedRate.formData.rateDateStart).toBe('2004-01-01')
+        expect(cs3.contractRevision.formData.submissionDescription).toBe(
+            'An updated submission'
+        )
+        expect(cs3.rateRevisions[0].formData.rateDateStart).toBe('2002-01-01')
+        expect(cs3.rateRevisions[1].formData.rateDateStart).toBe('2004-01-01')
+        expect(cs3.rateRevisions).toHaveLength(2)
+        expect(cs3.cause).toBe('CONTRACT_SUBMISSION')
+
+        // D
+        const ds1 = fourthD.packageSubmissions[0]
+        expect(ds1.submittedRevisions).toHaveLength(1)
+        const ds1submittedContract = ds1
+            .submittedRevisions[0] as ContractRevision
+        expect(ds1submittedContract.formData.submissionDescription).toBe(
+            'An updated submission'
+        )
+        expect(ds1.contractRevision.formData.submissionDescription).toBe(
+            'An updated submission'
+        )
+        expect(ds1.rateRevisions).toHaveLength(0)
+        expect(ds1.cause).toBe('CONTRACT_SUBMISSION')
+    })
 
     it('returns the correct dateAdded for documents', async () => {
         const ldService = testLDService({})

--- a/services/app-api/src/resolvers/contract/withdrawContract.test.ts
+++ b/services/app-api/src/resolvers/contract/withdrawContract.test.ts
@@ -655,7 +655,7 @@ describe('withdrawContract', () => {
         expect(rateA.parentContractID).toBe(draftContractB.id)
     }, 10000)
 
-    it('withdraws rate with reassgined parent', async () => {
+    it('withdraws rate with reassigned parent', async () => {
         const stateServer = await constructTestPostgresServer({
             context: {
                 user: stateUser,

--- a/services/app-api/src/resolvers/rate/submitRate.test.ts
+++ b/services/app-api/src/resolvers/rate/submitRate.test.ts
@@ -36,6 +36,7 @@ import {
 import { testS3Client } from '../../../../app-api/src/testHelpers/s3Helpers'
 import { submitRate } from '../../postgres/contractAndRates'
 import { sharedTestPrismaClient } from '../../testHelpers/storeHelpers'
+import { EXTENDED_TIMEOUT } from '../../testHelpers/assertionHelpers'
 
 describe('submitRate', () => {
     const ldService = testLDService({
@@ -258,124 +259,137 @@ describe('submitRate', () => {
         )
     })
 
-    it('returns the latest linked contracts', async () => {
-        const stateServer = await constructTestPostgresServer({
-            ldService,
-            s3Client: mockS3,
-        })
-        const cmsServer = await constructTestPostgresServer({
-            ldService,
-            context: {
-                user: testCMSUser(),
-            },
-            s3Client: mockS3,
-        })
+    it(
+        'returns the latest linked contracts',
+        async () => {
+            const stateServer = await constructTestPostgresServer({
+                ldService,
+                s3Client: mockS3,
+            })
+            const cmsServer = await constructTestPostgresServer({
+                ldService,
+                context: {
+                    user: testCMSUser(),
+                },
+                s3Client: mockS3,
+            })
 
-        // 1. Submit A0 with Rate1 and Rate2
-        const draftA0 =
-            await createAndUpdateTestContractWithoutRates(stateServer)
-        const AID = draftA0.id
-        await addNewRateToTestContract(stateServer, draftA0, {
-            rateDateStart: '2001-01-01',
-        })
+            // 1. Submit A0 with Rate1 and Rate2
+            const draftA0 =
+                await createAndUpdateTestContractWithoutRates(stateServer)
+            const AID = draftA0.id
+            await addNewRateToTestContract(stateServer, draftA0, {
+                rateDateStart: '2001-01-01',
+            })
 
-        const contractA0 = await submitTestContract(stateServer, AID)
-        const subA0 = contractA0.packageSubmissions[0]
-        const rate10 = subA0.rateRevisions[0]
-        const OneID = rate10.rateID
+            const contractA0 = await submitTestContract(stateServer, AID)
+            const subA0 = contractA0.packageSubmissions[0]
+            const rate10 = subA0.rateRevisions[0]
+            const OneID = rate10.rateID
 
-        console.info('ONEID', OneID)
+            console.info('ONEID', OneID)
 
-        // 2. Submit B0 with Rate2
-        const draftB0 =
-            await createAndUpdateTestContractWithoutRates(stateServer)
-        await addNewRateToTestContract(stateServer, draftB0, {
-            rateDateStart: '2003-01-01',
-        })
+            // 2. Submit B0 with Rate2
+            const draftB0 =
+                await createAndUpdateTestContractWithoutRates(stateServer)
+            await addNewRateToTestContract(stateServer, draftB0, {
+                rateDateStart: '2003-01-01',
+            })
 
-        const contractB0 = await submitTestContract(stateServer, draftB0.id)
-        const subB0 = contractB0.packageSubmissions[0]
-        const rate30 = subB0.rateRevisions[0]
-        const TwoID = rate30.rateID
-        console.info('TWOID', TwoID)
+            const contractB0 = await submitTestContract(stateServer, draftB0.id)
+            const subB0 = contractB0.packageSubmissions[0]
+            const rate30 = subB0.rateRevisions[0]
+            const TwoID = rate30.rateID
+            console.info('TWOID', TwoID)
 
-        expect(subB0.rateRevisions[0].rateID).toBe(TwoID)
+            expect(subB0.rateRevisions[0].rateID).toBe(TwoID)
 
-        // 3. Submit C0 with Rate10 and Rate20
-        const draftC0 =
-            await createAndUpdateTestContractWithoutRates(stateServer)
-        const draftC020 = await addLinkedRateToTestContract(
-            stateServer,
-            draftC0,
-            OneID
-        )
-        await addLinkedRateToTestContract(stateServer, draftC020, TwoID)
+            // 3. Submit C0 with Rate10 and Rate20
+            const draftC0 =
+                await createAndUpdateTestContractWithoutRates(stateServer)
+            const draftC020 = await addLinkedRateToTestContract(
+                stateServer,
+                draftC0,
+                OneID
+            )
+            await addLinkedRateToTestContract(stateServer, draftC020, TwoID)
 
-        const contractC0 = await submitTestContract(stateServer, draftC0.id)
+            const contractC0 = await submitTestContract(stateServer, draftC0.id)
 
-        // 4. make sure both rates return contract C in their list of revisions
-        const rateOne = await fetchTestRateById(stateServer, OneID)
+            // 4. make sure both rates return contract C in their list of revisions
+            const rateOne = await fetchTestRateById(stateServer, OneID)
 
-        expect(rateOne.packageSubmissions).toHaveLength(2)
-        expect(rateOne.packageSubmissions?.[0].contractRevisions).toHaveLength(
-            2
-        )
-        expect(rateOne.packageSubmissions?.[1].contractRevisions).toHaveLength(
-            1
-        )
+            expect(rateOne.packageSubmissions).toHaveLength(2)
+            expect(
+                rateOne.packageSubmissions?.[0].contractRevisions
+            ).toHaveLength(2)
+            expect(
+                rateOne.packageSubmissions?.[1].contractRevisions
+            ).toHaveLength(1)
 
-        const rateTwo = await fetchTestRateById(stateServer, TwoID)
+            const rateTwo = await fetchTestRateById(stateServer, TwoID)
 
-        expect(rateTwo.packageSubmissions).toHaveLength(2)
-        expect(rateTwo.packageSubmissions?.[0].contractRevisions).toHaveLength(
-            2
-        )
-        expect(rateTwo.packageSubmissions?.[1].contractRevisions).toHaveLength(
-            1
-        )
+            expect(rateTwo.packageSubmissions).toHaveLength(2)
+            expect(
+                rateTwo.packageSubmissions?.[0].contractRevisions
+            ).toHaveLength(2)
+            expect(
+                rateTwo.packageSubmissions?.[1].contractRevisions
+            ).toHaveLength(1)
 
-        // 5. unlock and resubmit A
-        await unlockTestHealthPlanPackage(
-            cmsServer,
-            contractA0.id,
-            'does this mess history'
-        )
+            // 5. unlock and resubmit A
+            await unlockTestHealthPlanPackage(
+                cmsServer,
+                contractA0.id,
+                'does this mess history'
+            )
 
-        const unlockedRateOne = await fetchTestRateById(stateServer, OneID)
+            const unlockedRateOne = await fetchTestRateById(stateServer, OneID)
 
-        expect(unlockedRateOne.packageSubmissions).toHaveLength(2)
-        expect(
-            unlockedRateOne.packageSubmissions?.[0].contractRevisions
-        ).toHaveLength(2)
-        expect(
-            unlockedRateOne.packageSubmissions?.[1].contractRevisions
-        ).toHaveLength(1)
+            expect(unlockedRateOne.packageSubmissions).toHaveLength(2)
+            expect(
+                unlockedRateOne.packageSubmissions?.[0].contractRevisions
+            ).toHaveLength(2)
+            expect(
+                unlockedRateOne.packageSubmissions?.[1].contractRevisions
+            ).toHaveLength(1)
 
-        await submitTestContract(
-            stateServer,
-            contractA0.id,
-            'but what about this'
-        )
+            await submitTestContract(
+                stateServer,
+                contractA0.id,
+                'but what about this'
+            )
 
-        // everything should have the latest
-        const resubmittedRateOne = await fetchTestRateById(stateServer, OneID)
+            // everything should have the latest
+            const resubmittedRateOne = await fetchTestRateById(
+                stateServer,
+                OneID
+            )
 
-        expect(resubmittedRateOne.packageSubmissions).toHaveLength(3)
-        expect(
-            resubmittedRateOne.packageSubmissions?.[0].contractRevisions
-        ).toHaveLength(2)
+            expect(resubmittedRateOne.packageSubmissions).toHaveLength(3)
+            expect(
+                resubmittedRateOne.packageSubmissions?.[0].contractRevisions
+            ).toHaveLength(2)
 
-        const postResubmitRateTwo = await fetchTestRateById(stateServer, TwoID)
+            const postResubmitRateTwo = await fetchTestRateById(
+                stateServer,
+                TwoID
+            )
 
-        expect(postResubmitRateTwo.packageSubmissions).toHaveLength(2)
-        expect(
-            postResubmitRateTwo.packageSubmissions?.[0].contractRevisions
-        ).toHaveLength(2)
+            expect(postResubmitRateTwo.packageSubmissions).toHaveLength(2)
+            expect(
+                postResubmitRateTwo.packageSubmissions?.[0].contractRevisions
+            ).toHaveLength(2)
 
-        const postSubmitC = await fetchTestContract(stateServer, contractC0.id)
+            const postSubmitC = await fetchTestContract(
+                stateServer,
+                contractC0.id
+            )
 
-        expect(postSubmitC.packageSubmissions).toHaveLength(2)
-    }, 10000)
+            expect(postSubmitC.packageSubmissions).toHaveLength(2)
+        },
+        EXTENDED_TIMEOUT
+    )
 
     // TODO: this test needs to be updated to remove references to healthplanpackage
     it('can unlock and submit rate independent of contract status', async () => {

--- a/services/app-api/src/resolvers/rate/undoWithdrawRate.test.ts
+++ b/services/app-api/src/resolvers/rate/undoWithdrawRate.test.ts
@@ -27,6 +27,7 @@ import {
 import { describe } from 'vitest'
 import { mockStoreThatErrors } from '../../testHelpers/storeHelpers'
 import { testEmailConfig, testEmailer } from '../../testHelpers/emailerHelpers'
+import { EXTENDED_TIMEOUT } from '../../testHelpers/assertionHelpers'
 
 const testRateFormInputData = (): RateFormDataInput => ({
     rateType: 'AMENDMENT',
@@ -59,327 +60,345 @@ const testRateFormInputData = (): RateFormDataInput => ({
 })
 
 describe('undoWithdrawRate', () => {
-    it('can undo withdraw a rate without errors', async () => {
-        const stateUser = testStateUser()
-        const cmsUser = testCMSUser()
-        const stateServer = await constructTestPostgresServer({
-            context: {
-                user: stateUser,
-            },
-        })
-
-        const cmsServer = await constructTestPostgresServer({
-            context: {
-                user: cmsUser,
-            },
-        })
-
-        //We need to include an extra rate in order to be able to submit
-        const draftA = await createAndUpdateTestContractWithRate(stateServer)
-        const draftAWithExtraRate = await addNewRateToTestContract(
-            stateServer,
-            draftA
-        )
-        const contractA = await submitTestContract(
-            stateServer,
-            draftAWithExtraRate.id
-        )
-
-        const rateID = contractA.packageSubmissions[0].rateRevisions[0].rateID
-        const formData =
-            contractA.packageSubmissions[0].rateRevisions[0].formData
-
-        const contractB =
-            await createAndUpdateTestContractWithoutRates(stateServer)
-
-        // link rate contract B
-        must(
-            await stateServer.executeOperation({
-                query: UpdateDraftContractRatesDocument,
-                variables: {
-                    input: {
-                        contractID: contractB.id,
-                        lastSeenUpdatedAt: contractB.draftRevision?.updatedAt,
-                        updatedRates: [
-                            {
-                                type: 'LINK',
-                                rateID: rateID,
-                            },
-                            {
-                                type: 'CREATE',
-                                formData: testRateFormInputData(),
-                            },
-                        ],
-                    },
+    it(
+        'can undo withdraw a rate without errors',
+        async () => {
+            const stateUser = testStateUser()
+            const cmsUser = testCMSUser()
+            const stateServer = await constructTestPostgresServer({
+                context: {
+                    user: stateUser,
                 },
             })
-        )
 
-        await submitTestContract(stateServer, contractB.id)
-
-        await unlockTestContract(
-            cmsServer,
-            contractB.id,
-            'unlock to prep for withdraw rate'
-        )
-
-        await withdrawTestRate(cmsServer, rateID, 'Withdraw invalid rate')
-
-        await unlockTestContract(
-            cmsServer,
-            contractA.id,
-            'Unlock after withdraw'
-        )
-
-        await submitTestContract(
-            stateServer,
-            contractB.id,
-            'resubmit after withdrawing rate'
-        )
-
-        await submitTestContract(
-            stateServer,
-            contractA.id,
-            'Submit before undo withdraw'
-        )
-
-        const unwithdrawnRate = await undoWithdrawTestRate(
-            cmsServer,
-            rateID,
-            'Undo withdraw rate'
-        )
-
-        const submittedContractA = await fetchTestContract(
-            cmsServer,
-            contractA.id
-        )
-        const submittedContractB = await fetchTestContract(
-            cmsServer,
-            contractB.id
-        )
-
-        // Expect un-withdrawn rate formData to equal formData before it was withdrawn
-        expect(
-            unwithdrawnRate.packageSubmissions[0].rateRevision.formData
-        ).toEqual(formData)
-        expect(unwithdrawnRate.withdrawnFromContracts).toHaveLength(0)
-        expect(unwithdrawnRate.consolidatedStatus).toBe('RESUBMITTED')
-        expect(unwithdrawnRate.parentContractID).toBe(contractA.id)
-
-        //expect contract A to have rate back
-        expect(submittedContractA.withdrawnRates).toHaveLength(0)
-        expect(submittedContractA.packageSubmissions[0].rateRevisions).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    rateID,
-                }),
-            ])
-        )
-
-        //expect contract B to have rate back
-        expect(submittedContractB.withdrawnRates).toHaveLength(0)
-        expect(submittedContractB.packageSubmissions[0].rateRevisions).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    rateID,
-                }),
-            ])
-        )
-
-        // Check history
-        const contractAHistory =
-            contractHistoryToDescriptions(submittedContractA)
-        const contractBHistory =
-            contractHistoryToDescriptions(submittedContractB)
-
-        // Expect contract A history to be in order
-        expect(contractAHistory).toStrictEqual(
-            expect.arrayContaining([
-                'Initial submission',
-                `CMS withdrawing rate ${formData.rateCertificationName} from this submission. Withdraw invalid rate`,
-                `CMS has withdrawn rate ${formData.rateCertificationName} from this submission. Withdraw invalid rate`,
-                'Unlock after withdraw',
-                'Submit before undo withdraw',
-                `Undo withdrawal of rate ${formData.rateCertificationName} from this submission. Undo withdraw rate`,
-                `CMS has changed the status of rate ${formData.rateCertificationName} to submitted. Undo withdraw rate`,
-            ])
-        )
-
-        // Expect contract B to be in order
-        expect(contractBHistory).toStrictEqual(
-            expect.arrayContaining([
-                'Initial submission',
-                'unlock to prep for withdraw rate',
-                'resubmit after withdrawing rate',
-                `Undo withdrawal of rate ${formData.rateCertificationName} from this submission. Undo withdraw rate`,
-                `CMS has changed the status of rate ${formData.rateCertificationName} to submitted. Undo withdraw rate`,
-            ])
-        )
-    }, 10000)
-
-    it('sends emails to CMS and state contacts when a rate is unwithdrawn', async () => {
-        const emailConfig = testEmailConfig()
-        const mockEmailer = testEmailer(emailConfig)
-        const stateUser = testStateUser()
-        const cmsUser = testCMSUser()
-        const stateServer = await constructTestPostgresServer({
-            context: {
-                user: stateUser,
-            },
-        })
-
-        const cmsServer = await constructTestPostgresServer({
-            context: {
-                user: cmsUser,
-            },
-            emailer: mockEmailer,
-        })
-
-        const draftA = await createAndUpdateTestContractWithRate(stateServer)
-        const draftAWithExtraRate = await addNewRateToTestContract(
-            stateServer,
-            draftA
-        )
-        const contractA = await submitTestContract(
-            stateServer,
-            draftAWithExtraRate.id
-        )
-
-        const rateID = contractA.packageSubmissions[0].rateRevisions[0].rateID
-
-        const contractB =
-            await createAndUpdateTestContractWithoutRates(stateServer)
-
-        // link rate contract B
-        must(
-            await stateServer.executeOperation({
-                query: UpdateDraftContractRatesDocument,
-                variables: {
-                    input: {
-                        contractID: contractB.id,
-                        lastSeenUpdatedAt: contractB.draftRevision?.updatedAt,
-                        updatedRates: [
-                            {
-                                type: 'LINK',
-                                rateID: rateID,
-                            },
-                            {
-                                type: 'CREATE',
-                                formData: testRateFormInputData(),
-                            },
-                        ],
-                    },
+            const cmsServer = await constructTestPostgresServer({
+                context: {
+                    user: cmsUser,
                 },
             })
-        )
 
-        await submitTestContract(stateServer, contractB.id)
-
-        await unlockTestContract(
-            cmsServer,
-            contractB.id,
-            'unlock to prep for withdraw rate'
-        )
-
-        await withdrawTestRate(cmsServer, rateID, 'Withdraw invalid rate')
-
-        await unlockTestContract(
-            cmsServer,
-            contractA.id,
-            'Unlock after withdraw'
-        )
-
-        const submittedContractB = await submitTestContract(
-            stateServer,
-            contractB.id,
-            'resubmit after withdrawing rate'
-        )
-
-        const submittedContractA = await submitTestContract(
-            stateServer,
-            contractA.id,
-            'Submit before undo withdraw'
-        )
-
-        const contractAName =
-            submittedContractA.packageSubmissions[0].contractRevision
-                .contractName
-        const contractBName =
-            submittedContractB.packageSubmissions[0].contractRevision
-                .contractName
-
-        const stateReceiverEmails =
-            contractA.packageSubmissions[0].contractRevision.formData.stateContacts.map(
-                (contact) => contact.email
+            //We need to include an extra rate in order to be able to submit
+            const draftA =
+                await createAndUpdateTestContractWithRate(stateServer)
+            const draftAWithExtraRate = await addNewRateToTestContract(
+                stateServer,
+                draftA
+            )
+            const contractA = await submitTestContract(
+                stateServer,
+                draftAWithExtraRate.id
             )
 
-        const unwithdrawnRate = await undoWithdrawTestRate(
-            cmsServer,
-            rateID,
-            'Undo withdraw rate'
-        )
+            const rateID =
+                contractA.packageSubmissions[0].rateRevisions[0].rateID
+            const formData =
+                contractA.packageSubmissions[0].rateRevisions[0].formData
 
-        const unwithdrawnRateName =
-            unwithdrawnRate.packageSubmissions[0].rateRevision.formData
-                .rateCertificationName!
+            const contractB =
+                await createAndUpdateTestContractWithoutRates(stateServer)
 
-        //Check state email for proper info
-        expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
-            7,
-            expect.objectContaining({
-                subject: expect.stringContaining(
-                    `${unwithdrawnRateName} status update`
-                ),
-                sourceEmail: emailConfig.emailSource,
-                toAddresses: expect.arrayContaining(stateReceiverEmails),
-                bodyHTML: expect.stringContaining(unwithdrawnRateName),
-            })
-        )
+            // link rate contract B
+            must(
+                await stateServer.executeOperation({
+                    query: UpdateDraftContractRatesDocument,
+                    variables: {
+                        input: {
+                            contractID: contractB.id,
+                            lastSeenUpdatedAt:
+                                contractB.draftRevision?.updatedAt,
+                            updatedRates: [
+                                {
+                                    type: 'LINK',
+                                    rateID: rateID,
+                                },
+                                {
+                                    type: 'CREATE',
+                                    formData: testRateFormInputData(),
+                                },
+                            ],
+                        },
+                    },
+                })
+            )
 
-        //Check that all submissions related to the rate were included in the state email
-        expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
-            7,
-            expect.objectContaining({
-                bodyHTML: expect.stringContaining(contractAName),
-            })
-        )
-        expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
-            7,
-            expect.objectContaining({
-                bodyHTML: expect.stringContaining(contractBName),
-            })
-        )
+            await submitTestContract(stateServer, contractB.id)
 
-        //Check CMS email for proper info
-        expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
-            8,
-            expect.objectContaining({
-                subject: expect.stringContaining(
-                    `${unwithdrawnRateName} status update`
-                ),
-                sourceEmail: emailConfig.emailSource,
-                toAddresses: expect.arrayContaining([
-                    ...testEmailConfig().dmcpSubmissionEmails,
-                    ...testEmailConfig().oactEmails,
-                ]),
-                bodyHTML: expect.stringContaining(unwithdrawnRateName),
-            })
-        )
+            await unlockTestContract(
+                cmsServer,
+                contractB.id,
+                'unlock to prep for withdraw rate'
+            )
 
-        //Check that all submissions related to the rate were included in the CMS email
-        expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
-            8,
-            expect.objectContaining({
-                bodyHTML: expect.stringContaining(contractAName),
+            await withdrawTestRate(cmsServer, rateID, 'Withdraw invalid rate')
+
+            await unlockTestContract(
+                cmsServer,
+                contractA.id,
+                'Unlock after withdraw'
+            )
+
+            await submitTestContract(
+                stateServer,
+                contractB.id,
+                'resubmit after withdrawing rate'
+            )
+
+            await submitTestContract(
+                stateServer,
+                contractA.id,
+                'Submit before undo withdraw'
+            )
+
+            const unwithdrawnRate = await undoWithdrawTestRate(
+                cmsServer,
+                rateID,
+                'Undo withdraw rate'
+            )
+
+            const submittedContractA = await fetchTestContract(
+                cmsServer,
+                contractA.id
+            )
+            const submittedContractB = await fetchTestContract(
+                cmsServer,
+                contractB.id
+            )
+
+            // Expect un-withdrawn rate formData to equal formData before it was withdrawn
+            expect(
+                unwithdrawnRate.packageSubmissions[0].rateRevision.formData
+            ).toEqual(formData)
+            expect(unwithdrawnRate.withdrawnFromContracts).toHaveLength(0)
+            expect(unwithdrawnRate.consolidatedStatus).toBe('RESUBMITTED')
+            expect(unwithdrawnRate.parentContractID).toBe(contractA.id)
+
+            //expect contract A to have rate back
+            expect(submittedContractA.withdrawnRates).toHaveLength(0)
+            expect(
+                submittedContractA.packageSubmissions[0].rateRevisions
+            ).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        rateID,
+                    }),
+                ])
+            )
+
+            //expect contract B to have rate back
+            expect(submittedContractB.withdrawnRates).toHaveLength(0)
+            expect(
+                submittedContractB.packageSubmissions[0].rateRevisions
+            ).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        rateID,
+                    }),
+                ])
+            )
+
+            // Check history
+            const contractAHistory =
+                contractHistoryToDescriptions(submittedContractA)
+            const contractBHistory =
+                contractHistoryToDescriptions(submittedContractB)
+
+            // Expect contract A history to be in order
+            expect(contractAHistory).toStrictEqual(
+                expect.arrayContaining([
+                    'Initial submission',
+                    `CMS withdrawing rate ${formData.rateCertificationName} from this submission. Withdraw invalid rate`,
+                    `CMS has withdrawn rate ${formData.rateCertificationName} from this submission. Withdraw invalid rate`,
+                    'Unlock after withdraw',
+                    'Submit before undo withdraw',
+                    `Undo withdrawal of rate ${formData.rateCertificationName} from this submission. Undo withdraw rate`,
+                    `CMS has changed the status of rate ${formData.rateCertificationName} to submitted. Undo withdraw rate`,
+                ])
+            )
+
+            // Expect contract B to be in order
+            expect(contractBHistory).toStrictEqual(
+                expect.arrayContaining([
+                    'Initial submission',
+                    'unlock to prep for withdraw rate',
+                    'resubmit after withdrawing rate',
+                    `Undo withdrawal of rate ${formData.rateCertificationName} from this submission. Undo withdraw rate`,
+                    `CMS has changed the status of rate ${formData.rateCertificationName} to submitted. Undo withdraw rate`,
+                ])
+            )
+        },
+        EXTENDED_TIMEOUT
+    )
+
+    it(
+        'sends emails to CMS and state contacts when a rate is unwithdrawn',
+        async () => {
+            const emailConfig = testEmailConfig()
+            const mockEmailer = testEmailer(emailConfig)
+            const stateUser = testStateUser()
+            const cmsUser = testCMSUser()
+            const stateServer = await constructTestPostgresServer({
+                context: {
+                    user: stateUser,
+                },
             })
-        )
-        expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
-            8,
-            expect.objectContaining({
-                bodyHTML: expect.stringContaining(contractBName),
+
+            const cmsServer = await constructTestPostgresServer({
+                context: {
+                    user: cmsUser,
+                },
+                emailer: mockEmailer,
             })
-        )
-    }, 15000)
+
+            const draftA =
+                await createAndUpdateTestContractWithRate(stateServer)
+            const draftAWithExtraRate = await addNewRateToTestContract(
+                stateServer,
+                draftA
+            )
+            const contractA = await submitTestContract(
+                stateServer,
+                draftAWithExtraRate.id
+            )
+
+            const rateID =
+                contractA.packageSubmissions[0].rateRevisions[0].rateID
+
+            const contractB =
+                await createAndUpdateTestContractWithoutRates(stateServer)
+
+            // link rate contract B
+            must(
+                await stateServer.executeOperation({
+                    query: UpdateDraftContractRatesDocument,
+                    variables: {
+                        input: {
+                            contractID: contractB.id,
+                            lastSeenUpdatedAt:
+                                contractB.draftRevision?.updatedAt,
+                            updatedRates: [
+                                {
+                                    type: 'LINK',
+                                    rateID: rateID,
+                                },
+                                {
+                                    type: 'CREATE',
+                                    formData: testRateFormInputData(),
+                                },
+                            ],
+                        },
+                    },
+                })
+            )
+
+            await submitTestContract(stateServer, contractB.id)
+
+            await unlockTestContract(
+                cmsServer,
+                contractB.id,
+                'unlock to prep for withdraw rate'
+            )
+
+            await withdrawTestRate(cmsServer, rateID, 'Withdraw invalid rate')
+
+            await unlockTestContract(
+                cmsServer,
+                contractA.id,
+                'Unlock after withdraw'
+            )
+
+            const submittedContractB = await submitTestContract(
+                stateServer,
+                contractB.id,
+                'resubmit after withdrawing rate'
+            )
+
+            const submittedContractA = await submitTestContract(
+                stateServer,
+                contractA.id,
+                'Submit before undo withdraw'
+            )
+
+            const contractAName =
+                submittedContractA.packageSubmissions[0].contractRevision
+                    .contractName
+            const contractBName =
+                submittedContractB.packageSubmissions[0].contractRevision
+                    .contractName
+
+            const stateReceiverEmails =
+                contractA.packageSubmissions[0].contractRevision.formData.stateContacts.map(
+                    (contact) => contact.email
+                )
+
+            const unwithdrawnRate = await undoWithdrawTestRate(
+                cmsServer,
+                rateID,
+                'Undo withdraw rate'
+            )
+
+            const unwithdrawnRateName =
+                unwithdrawnRate.packageSubmissions[0].rateRevision.formData
+                    .rateCertificationName!
+
+            //Check state email for proper info
+            expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
+                7,
+                expect.objectContaining({
+                    subject: expect.stringContaining(
+                        `${unwithdrawnRateName} status update`
+                    ),
+                    sourceEmail: emailConfig.emailSource,
+                    toAddresses: expect.arrayContaining(stateReceiverEmails),
+                    bodyHTML: expect.stringContaining(unwithdrawnRateName),
+                })
+            )
+
+            //Check that all submissions related to the rate were included in the state email
+            expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
+                7,
+                expect.objectContaining({
+                    bodyHTML: expect.stringContaining(contractAName),
+                })
+            )
+            expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
+                7,
+                expect.objectContaining({
+                    bodyHTML: expect.stringContaining(contractBName),
+                })
+            )
+
+            //Check CMS email for proper info
+            expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
+                8,
+                expect.objectContaining({
+                    subject: expect.stringContaining(
+                        `${unwithdrawnRateName} status update`
+                    ),
+                    sourceEmail: emailConfig.emailSource,
+                    toAddresses: expect.arrayContaining([
+                        ...testEmailConfig().dmcpSubmissionEmails,
+                        ...testEmailConfig().oactEmails,
+                    ]),
+                    bodyHTML: expect.stringContaining(unwithdrawnRateName),
+                })
+            )
+
+            //Check that all submissions related to the rate were included in the CMS email
+            expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
+                8,
+                expect.objectContaining({
+                    bodyHTML: expect.stringContaining(contractAName),
+                })
+            )
+            expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
+                8,
+                expect.objectContaining({
+                    bodyHTML: expect.stringContaining(contractBName),
+                })
+            )
+        },
+        EXTENDED_TIMEOUT
+    )
 })
 
 describe('undo withdraw rate error handling', async () => {

--- a/services/app-api/src/resolvers/rate/undoWithdrawRate.test.ts
+++ b/services/app-api/src/resolvers/rate/undoWithdrawRate.test.ts
@@ -379,7 +379,7 @@ describe('undoWithdrawRate', () => {
                 bodyHTML: expect.stringContaining(contractBName),
             })
         )
-    }, 10000)
+    }, 15000)
 })
 
 describe('undo withdraw rate error handling', async () => {

--- a/services/app-api/src/resolvers/rate/withdrawRate.test.ts
+++ b/services/app-api/src/resolvers/rate/withdrawRate.test.ts
@@ -31,6 +31,7 @@ import { expect } from 'vitest'
 import { testEmailConfig, testEmailer } from '../../testHelpers/emailerHelpers'
 import { packageName } from '@mc-review/hpp/build/healthPlanFormDataType/healthPlanFormData'
 import { must } from '../../testHelpers'
+import { EXTENDED_TIMEOUT } from '../../testHelpers/assertionHelpers'
 
 const testRateFormInputData = (): RateFormDataInput => ({
     rateType: 'AMENDMENT',
@@ -404,416 +405,429 @@ describe('withdrawRate', () => {
         )
     })
 
-    it('withdraws rate when linked to other multi-rate contracts', async () => {
-        const stateUser = testStateUser()
-        const cmsUser = testCMSUser()
-        const stateServer = await constructTestPostgresServer({
-            context: {
-                user: stateUser,
-            },
-        })
-
-        const cmsServer = await constructTestPostgresServer({
-            context: {
-                user: cmsUser,
-            },
-        })
-
-        const contractA = await createAndSubmitTestContractWithRate(stateServer)
-        const rateID = contractA.packageSubmissions[0].rateRevisions[0].rateID
-
-        const contractB =
-            await createAndUpdateTestContractWithoutRates(stateServer)
-
-        // link rate to contract B
-        must(
-            await stateServer.executeOperation({
-                query: UpdateDraftContractRatesDocument,
-                variables: {
-                    input: {
-                        contractID: contractB.id,
-                        lastSeenUpdatedAt: contractB.draftRevision?.updatedAt,
-                        updatedRates: [
-                            {
-                                type: 'LINK',
-                                rateID: rateID,
-                            },
-                            {
-                                type: 'CREATE',
-                                formData: testRateFormInputData(),
-                            },
-                        ],
-                    },
+    it(
+        'withdraws rate when linked to other multi-rate contracts',
+        async () => {
+            const stateUser = testStateUser()
+            const cmsUser = testCMSUser()
+            const stateServer = await constructTestPostgresServer({
+                context: {
+                    user: stateUser,
                 },
             })
-        )
 
-        const submittedContractB = await submitTestContract(
-            stateServer,
-            contractB.id
-        )
-
-        // expect contract B to be submitted before we withdraw rate
-        expect(submittedContractB.status).toBe('SUBMITTED')
-
-        const withdrawnRate = await withdrawTestRate(
-            cmsServer,
-            rateID,
-            'Withdraw invalid rate'
-        )
-
-        // expect rate to contain both contracts in withdrawn join table
-        expect(withdrawnRate.withdrawnFromContracts).toHaveLength(2)
-        expect(withdrawnRate.withdrawnFromContracts).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    id: contractB.id,
-                }),
-                expect.objectContaining({
-                    id: contractA.id,
-                }),
-            ])
-        )
-
-        // expect review status action to be WITHDRAW
-        expect(withdrawnRate.reviewStatusActions).toHaveLength(1)
-        expect(withdrawnRate.reviewStatusActions).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    updatedAt: expect.any(Date),
-                    updatedBy: expect.objectContaining({
-                        role: cmsUser.role,
-                        email: cmsUser.email,
-                        givenName: cmsUser.givenName,
-                        familyName: cmsUser.familyName,
-                    }),
-                    updatedReason: 'Withdraw invalid rate',
-                    actionType: 'WITHDRAW',
-                    rateID,
-                }),
-            ])
-        )
-
-        const contractAWithWithdrawnRate = await fetchTestContractWithQuestions(
-            stateServer,
-            contractA.id
-        )
-        expect(contractAWithWithdrawnRate.withdrawnRates).toBeDefined()
-
-        // expect contract A to contain the withdrawn rate
-        expect(contractAWithWithdrawnRate?.withdrawnRates).toHaveLength(1)
-        expect(contractAWithWithdrawnRate?.withdrawnRates).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    id: rateID,
-                }),
-            ])
-        )
-
-        const contractBWithWithdrawnRate = await fetchTestContractWithQuestions(
-            stateServer,
-            contractB.id
-        )
-        expect(contractBWithWithdrawnRate.withdrawnRates).toBeDefined()
-
-        // expect contract B to contain the withdrawn rate
-        expect(contractBWithWithdrawnRate?.withdrawnRates).toHaveLength(1)
-        expect(contractBWithWithdrawnRate?.withdrawnRates).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    id: rateID,
-                }),
-            ])
-        )
-    }, 10000)
-
-    it('removes rate from DRAFT and UNLOCKED contracts linked to rate', async () => {
-        const stateUser = testStateUser()
-        const cmsUser = testCMSUser()
-        const stateServer = await constructTestPostgresServer({
-            context: {
-                user: stateUser,
-            },
-        })
-
-        const cmsServer = await constructTestPostgresServer({
-            context: {
-                user: cmsUser,
-            },
-        })
-
-        // contractA is parent contract and submitted
-        const contractA = await createAndSubmitTestContractWithRate(stateServer)
-        const rateID = contractA.packageSubmissions[0].rateRevisions[0].rateID
-
-        // contract B is linked and in draft
-        const contractB =
-            await createAndUpdateTestContractWithoutRates(stateServer)
-
-        // contract C is linked, submitted, then unlocked
-        const contractC =
-            await createAndUpdateTestContractWithoutRates(stateServer)
-
-        // contract D is submitted, unlocked, then linked
-        const contractD = await createAndSubmitTestContractWithRate(stateServer)
-
-        // link rate to contract B
-        must(
-            await stateServer.executeOperation({
-                query: UpdateDraftContractRatesDocument,
-                variables: {
-                    input: {
-                        contractID: contractB.id,
-                        lastSeenUpdatedAt: contractB.draftRevision?.updatedAt,
-                        updatedRates: [
-                            {
-                                type: 'LINK',
-                                rateID: rateID,
-                            },
-                        ],
-                    },
+            const cmsServer = await constructTestPostgresServer({
+                context: {
+                    user: cmsUser,
                 },
             })
-        )
 
-        // link rate to contract C, submit, unlock, then update child rate
-        must(
-            await stateServer.executeOperation({
-                query: UpdateDraftContractRatesDocument,
-                variables: {
-                    input: {
-                        contractID: contractC.id,
-                        lastSeenUpdatedAt: contractC.draftRevision?.updatedAt,
-                        updatedRates: [
-                            {
-                                type: 'LINK',
-                                rateID: rateID,
-                            },
-                            {
-                                type: 'CREATE',
-                                formData: testRateFormInputData(),
-                            },
-                        ],
-                    },
-                },
-            })
-        )
+            const contractA =
+                await createAndSubmitTestContractWithRate(stateServer)
+            const rateID =
+                contractA.packageSubmissions[0].rateRevisions[0].rateID
 
-        const submittedContractC = await submitTestContract(
-            stateServer,
-            contractC.id
-        )
-        const newContractCRate =
-            submittedContractC.packageSubmissions[0].rateRevisions.find(
-                (rev) => rev.rateID !== rateID
-            )
-        if (!newContractCRate) {
-            throw new Error('Expected contract C child rate to be defined')
-        }
+            const contractB =
+                await createAndUpdateTestContractWithoutRates(stateServer)
 
-        const unlockContractC = await unlockTestContract(
-            cmsServer,
-            contractC.id,
-            'unlock to make updates'
-        )
-
-        // update contract C child rate to assert it wasn't modified
-        must(
-            await stateServer.executeOperation({
-                query: UpdateDraftContractRatesDocument,
-                variables: {
-                    input: {
-                        contractID: contractC.id,
-                        lastSeenUpdatedAt:
-                            unlockContractC.draftRevision.updatedAt,
-                        updatedRates: [
-                            {
-                                type: 'LINK',
-                                rateID: rateID,
-                            },
-                            {
-                                type: 'UPDATE',
-                                rateID: newContractCRate.rateID,
-                                formData: {
-                                    rateType: 'AMENDMENT',
-                                    rateDocuments: [],
-                                    supportingDocuments: [],
-                                    certifyingActuaryContacts: [],
-                                    deprecatedRateProgramIDs: [],
-                                    rateProgramIDs: [],
+            // link rate to contract B
+            must(
+                await stateServer.executeOperation({
+                    query: UpdateDraftContractRatesDocument,
+                    variables: {
+                        input: {
+                            contractID: contractB.id,
+                            lastSeenUpdatedAt:
+                                contractB.draftRevision?.updatedAt,
+                            updatedRates: [
+                                {
+                                    type: 'LINK',
+                                    rateID: rateID,
                                 },
-                            },
-                        ],
+                                {
+                                    type: 'CREATE',
+                                    formData: testRateFormInputData(),
+                                },
+                            ],
+                        },
                     },
-                },
-            })
-        )
+                })
+            )
 
-        // submit unlock contractD, then link rate
-        await unlockTestContract(
-            cmsServer,
-            contractD.id,
-            'unlock to make updates'
-        )
-        must(
-            await stateServer.executeOperation({
-                query: UpdateDraftContractRatesDocument,
-                variables: {
-                    input: {
-                        contractID: contractD.id,
-                        lastSeenUpdatedAt: contractD.draftRevision?.updatedAt,
-                        updatedRates: [
-                            {
-                                type: 'LINK',
-                                rateID: rateID,
-                            },
-                        ],
-                    },
-                },
-            })
-        )
+            const submittedContractB = await submitTestContract(
+                stateServer,
+                contractB.id
+            )
 
-        const withdrawnRate = await withdrawTestRate(
-            cmsServer,
-            rateID,
-            'Withdraw invalid rate'
-        )
+            // expect contract B to be submitted before we withdraw rate
+            expect(submittedContractB.status).toBe('SUBMITTED')
 
-        // expect withdrawn rate to contain contractA and contractC in withdrawn join table
-        expect(withdrawnRate.withdrawnFromContracts).toHaveLength(2)
-        expect(withdrawnRate.withdrawnFromContracts).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    id: contractA.id,
-                }),
-                expect.objectContaining({
-                    id: contractC.id,
-                }),
-            ])
-        )
+            const withdrawnRate = await withdrawTestRate(
+                cmsServer,
+                rateID,
+                'Withdraw invalid rate'
+            )
 
-        // expect withdrawn rate to not contain DRAFT contractB and Unlocked contractD.
-        // Both contracts were never submitted with the rate before it was withdrawn.
-        expect(withdrawnRate.withdrawnFromContracts).not.toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    id: contractB.id,
-                }),
-                expect.objectContaining({
-                    id: contractD.id,
-                }),
-            ])
-        )
-
-        // expect withdrawn status
-        expect(withdrawnRate).toEqual(
-            expect.objectContaining({
-                reviewStatus: 'WITHDRAWN',
-                consolidatedStatus: 'WITHDRAWN',
-            })
-        )
-
-        // expect correct actions
-        expect(withdrawnRate.reviewStatusActions).toHaveLength(1)
-        expect(withdrawnRate.reviewStatusActions).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    updatedAt: expect.any(Date),
-                    updatedBy: expect.objectContaining({
-                        role: cmsUser.role,
-                        email: cmsUser.email,
-                        givenName: cmsUser.givenName,
-                        familyName: cmsUser.familyName,
+            // expect rate to contain both contracts in withdrawn join table
+            expect(withdrawnRate.withdrawnFromContracts).toHaveLength(2)
+            expect(withdrawnRate.withdrawnFromContracts).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: contractB.id,
                     }),
-                    updatedReason: 'Withdraw invalid rate',
-                    actionType: 'WITHDRAW',
-                    rateID,
-                }),
-            ])
-        )
+                    expect.objectContaining({
+                        id: contractA.id,
+                    }),
+                ])
+            )
 
-        const contractBResult = await fetchTestContractWithQuestions(
-            stateServer,
-            contractB.id
-        )
+            // expect review status action to be WITHDRAW
+            expect(withdrawnRate.reviewStatusActions).toHaveLength(1)
+            expect(withdrawnRate.reviewStatusActions).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        updatedAt: expect.any(Date),
+                        updatedBy: expect.objectContaining({
+                            role: cmsUser.role,
+                            email: cmsUser.email,
+                            givenName: cmsUser.givenName,
+                            familyName: cmsUser.familyName,
+                        }),
+                        updatedReason: 'Withdraw invalid rate',
+                        actionType: 'WITHDRAW',
+                        rateID,
+                    }),
+                ])
+            )
 
-        // expect no withdrawn rates, since rate was never submitted with this contract before the withdraw
-        expect(contractBResult.withdrawnRates).toHaveLength(0)
+            const contractAWithWithdrawnRate =
+                await fetchTestContractWithQuestions(stateServer, contractA.id)
+            expect(contractAWithWithdrawnRate.withdrawnRates).toBeDefined()
 
-        // expect contract B to still be DRAFT
-        expect(contractBResult.consolidatedStatus).toEqual('DRAFT')
+            // expect contract A to contain the withdrawn rate
+            expect(contractAWithWithdrawnRate?.withdrawnRates).toHaveLength(1)
+            expect(contractAWithWithdrawnRate?.withdrawnRates).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: rateID,
+                    }),
+                ])
+            )
 
-        // expect contract B to not contain withdrawn rate in DraftRates
-        expect(contractBResult.draftRates).not.toEqual(
-            expect.arrayContaining([
+            const contractBWithWithdrawnRate =
+                await fetchTestContractWithQuestions(stateServer, contractB.id)
+            expect(contractBWithWithdrawnRate.withdrawnRates).toBeDefined()
+
+            // expect contract B to contain the withdrawn rate
+            expect(contractBWithWithdrawnRate?.withdrawnRates).toHaveLength(1)
+            expect(contractBWithWithdrawnRate?.withdrawnRates).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: rateID,
+                    }),
+                ])
+            )
+        },
+        EXTENDED_TIMEOUT
+    )
+
+    it(
+        'removes rate from DRAFT and UNLOCKED contracts linked to rate',
+        async () => {
+            const stateUser = testStateUser()
+            const cmsUser = testCMSUser()
+            const stateServer = await constructTestPostgresServer({
+                context: {
+                    user: stateUser,
+                },
+            })
+
+            const cmsServer = await constructTestPostgresServer({
+                context: {
+                    user: cmsUser,
+                },
+            })
+
+            // contractA is parent contract and submitted
+            const contractA =
+                await createAndSubmitTestContractWithRate(stateServer)
+            const rateID =
+                contractA.packageSubmissions[0].rateRevisions[0].rateID
+
+            // contract B is linked and in draft
+            const contractB =
+                await createAndUpdateTestContractWithoutRates(stateServer)
+
+            // contract C is linked, submitted, then unlocked
+            const contractC =
+                await createAndUpdateTestContractWithoutRates(stateServer)
+
+            // contract D is submitted, unlocked, then linked
+            const contractD =
+                await createAndSubmitTestContractWithRate(stateServer)
+
+            // link rate to contract B
+            must(
+                await stateServer.executeOperation({
+                    query: UpdateDraftContractRatesDocument,
+                    variables: {
+                        input: {
+                            contractID: contractB.id,
+                            lastSeenUpdatedAt:
+                                contractB.draftRevision?.updatedAt,
+                            updatedRates: [
+                                {
+                                    type: 'LINK',
+                                    rateID: rateID,
+                                },
+                            ],
+                        },
+                    },
+                })
+            )
+
+            // link rate to contract C, submit, unlock, then update child rate
+            must(
+                await stateServer.executeOperation({
+                    query: UpdateDraftContractRatesDocument,
+                    variables: {
+                        input: {
+                            contractID: contractC.id,
+                            lastSeenUpdatedAt:
+                                contractC.draftRevision?.updatedAt,
+                            updatedRates: [
+                                {
+                                    type: 'LINK',
+                                    rateID: rateID,
+                                },
+                                {
+                                    type: 'CREATE',
+                                    formData: testRateFormInputData(),
+                                },
+                            ],
+                        },
+                    },
+                })
+            )
+
+            const submittedContractC = await submitTestContract(
+                stateServer,
+                contractC.id
+            )
+            const newContractCRate =
+                submittedContractC.packageSubmissions[0].rateRevisions.find(
+                    (rev) => rev.rateID !== rateID
+                )
+            if (!newContractCRate) {
+                throw new Error('Expected contract C child rate to be defined')
+            }
+
+            const unlockContractC = await unlockTestContract(
+                cmsServer,
+                contractC.id,
+                'unlock to make updates'
+            )
+
+            // update contract C child rate to assert it wasn't modified
+            must(
+                await stateServer.executeOperation({
+                    query: UpdateDraftContractRatesDocument,
+                    variables: {
+                        input: {
+                            contractID: contractC.id,
+                            lastSeenUpdatedAt:
+                                unlockContractC.draftRevision.updatedAt,
+                            updatedRates: [
+                                {
+                                    type: 'LINK',
+                                    rateID: rateID,
+                                },
+                                {
+                                    type: 'UPDATE',
+                                    rateID: newContractCRate.rateID,
+                                    formData: {
+                                        rateType: 'AMENDMENT',
+                                        rateDocuments: [],
+                                        supportingDocuments: [],
+                                        certifyingActuaryContacts: [],
+                                        deprecatedRateProgramIDs: [],
+                                        rateProgramIDs: [],
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                })
+            )
+
+            // submit unlock contractD, then link rate
+            await unlockTestContract(
+                cmsServer,
+                contractD.id,
+                'unlock to make updates'
+            )
+            must(
+                await stateServer.executeOperation({
+                    query: UpdateDraftContractRatesDocument,
+                    variables: {
+                        input: {
+                            contractID: contractD.id,
+                            lastSeenUpdatedAt:
+                                contractD.draftRevision?.updatedAt,
+                            updatedRates: [
+                                {
+                                    type: 'LINK',
+                                    rateID: rateID,
+                                },
+                            ],
+                        },
+                    },
+                })
+            )
+
+            const withdrawnRate = await withdrawTestRate(
+                cmsServer,
+                rateID,
+                'Withdraw invalid rate'
+            )
+
+            // expect withdrawn rate to contain contractA and contractC in withdrawn join table
+            expect(withdrawnRate.withdrawnFromContracts).toHaveLength(2)
+            expect(withdrawnRate.withdrawnFromContracts).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: contractA.id,
+                    }),
+                    expect.objectContaining({
+                        id: contractC.id,
+                    }),
+                ])
+            )
+
+            // expect withdrawn rate to not contain DRAFT contractB and Unlocked contractD.
+            // Both contracts were never submitted with the rate before it was withdrawn.
+            expect(withdrawnRate.withdrawnFromContracts).not.toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: contractB.id,
+                    }),
+                    expect.objectContaining({
+                        id: contractD.id,
+                    }),
+                ])
+            )
+
+            // expect withdrawn status
+            expect(withdrawnRate).toEqual(
                 expect.objectContaining({
-                    id: rateID,
+                    reviewStatus: 'WITHDRAWN',
                     consolidatedStatus: 'WITHDRAWN',
-                }),
-            ])
-        )
+                })
+            )
 
-        const contractCResult = await fetchTestContractWithQuestions(
-            stateServer,
-            contractC.id
-        )
+            // expect correct actions
+            expect(withdrawnRate.reviewStatusActions).toHaveLength(1)
+            expect(withdrawnRate.reviewStatusActions).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        updatedAt: expect.any(Date),
+                        updatedBy: expect.objectContaining({
+                            role: cmsUser.role,
+                            email: cmsUser.email,
+                            givenName: cmsUser.givenName,
+                            familyName: cmsUser.familyName,
+                        }),
+                        updatedReason: 'Withdraw invalid rate',
+                        actionType: 'WITHDRAW',
+                        rateID,
+                    }),
+                ])
+            )
 
-        // expect contract C to contain the withdrawn rate, since it had been submitted with this
-        expect(contractCResult.withdrawnRates).toHaveLength(1)
+            const contractBResult = await fetchTestContractWithQuestions(
+                stateServer,
+                contractB.id
+            )
 
-        expect(contractCResult.withdrawnRates).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    id: rateID,
-                    consolidatedStatus: 'WITHDRAWN',
-                }),
-            ])
-        )
+            // expect no withdrawn rates, since rate was never submitted with this contract before the withdraw
+            expect(contractBResult.withdrawnRates).toHaveLength(0)
 
-        // expect contract C to still be UNLOCKED
-        expect(contractCResult.consolidatedStatus).toEqual('UNLOCKED')
+            // expect contract B to still be DRAFT
+            expect(contractBResult.consolidatedStatus).toEqual('DRAFT')
 
-        //expect contract C to not contain withdrawn rate in DraftRates
-        expect(contractCResult.draftRates).not.toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    id: rateID,
-                    consolidatedStatus: 'WITHDRAWN',
-                }),
-            ])
-        )
+            // expect contract B to not contain withdrawn rate in DraftRates
+            expect(contractBResult.draftRates).not.toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: rateID,
+                        consolidatedStatus: 'WITHDRAWN',
+                    }),
+                ])
+            )
 
-        // expect contractC draft child rate to not be modified
-        const contractCdraftRateFormData =
-            contractCResult.draftRates?.[0].draftRevision?.formData
+            const contractCResult = await fetchTestContractWithQuestions(
+                stateServer,
+                contractC.id
+            )
 
-        if (!contractCdraftRateFormData) {
-            throw new Error('Contract C child rate not found')
-        }
+            // expect contract C to contain the withdrawn rate, since it had been submitted with this
+            expect(contractCResult.withdrawnRates).toHaveLength(1)
 
-        expect(contractCdraftRateFormData.rateType).toBe('AMENDMENT')
+            expect(contractCResult.withdrawnRates).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: rateID,
+                        consolidatedStatus: 'WITHDRAWN',
+                    }),
+                ])
+            )
 
-        const contractDResult = await fetchTestContractWithQuestions(
-            stateServer,
-            contractD.id
-        )
+            // expect contract C to still be UNLOCKED
+            expect(contractCResult.consolidatedStatus).toEqual('UNLOCKED')
 
-        // expect no withdrawn rates, since rate was never submitted with this contract before the withdraw
-        expect(contractDResult.withdrawnRates).toHaveLength(0)
+            //expect contract C to not contain withdrawn rate in DraftRates
+            expect(contractCResult.draftRates).not.toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: rateID,
+                        consolidatedStatus: 'WITHDRAWN',
+                    }),
+                ])
+            )
 
-        // expect contract D to still be UNLOCKED
-        expect(contractDResult.consolidatedStatus).toEqual('UNLOCKED')
+            // expect contractC draft child rate to not be modified
+            const contractCdraftRateFormData =
+                contractCResult.draftRates?.[0].draftRevision?.formData
 
-        // expect contract D to not contain withdrawn rate in DraftRates
-        expect(contractDResult.draftRates).not.toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    id: rateID,
-                    consolidatedStatus: 'WITHDRAWN',
-                }),
-            ])
-        )
-    }, 10000)
+            if (!contractCdraftRateFormData) {
+                throw new Error('Contract C child rate not found')
+            }
+
+            expect(contractCdraftRateFormData.rateType).toBe('AMENDMENT')
+
+            const contractDResult = await fetchTestContractWithQuestions(
+                stateServer,
+                contractD.id
+            )
+
+            // expect no withdrawn rates, since rate was never submitted with this contract before the withdraw
+            expect(contractDResult.withdrawnRates).toHaveLength(0)
+
+            // expect contract D to still be UNLOCKED
+            expect(contractDResult.consolidatedStatus).toEqual('UNLOCKED')
+
+            // expect contract D to not contain withdrawn rate in DraftRates
+            expect(contractDResult.draftRates).not.toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: rateID,
+                        consolidatedStatus: 'WITHDRAWN',
+                    }),
+                ])
+            )
+        },
+        EXTENDED_TIMEOUT
+    )
 
     it('sends emails to state and CMS when a rate is withdrawn', async () => {
         const emailConfig = testEmailConfig()

--- a/services/app-api/src/testHelpers/assertionHelpers.ts
+++ b/services/app-api/src/testHelpers/assertionHelpers.ts
@@ -14,6 +14,4 @@ function expectToBeDefined<T>(arg: T): asserts arg is NonNullable<T> {
     expect(arg).toBeDefined()
 }
 
-const EXTENDED_TIMEOUT = 20000
-
-export { must, expectToBeDefined, EXTENDED_TIMEOUT }
+export { must, expectToBeDefined }

--- a/services/app-api/src/testHelpers/assertionHelpers.ts
+++ b/services/app-api/src/testHelpers/assertionHelpers.ts
@@ -14,4 +14,6 @@ function expectToBeDefined<T>(arg: T): asserts arg is NonNullable<T> {
     expect(arg).toBeDefined()
 }
 
-export { must, expectToBeDefined }
+const EXTENDED_TIMEOUT = 20000
+
+export { must, expectToBeDefined, EXTENDED_TIMEOUT }

--- a/services/app-api/vitest.config.ts
+++ b/services/app-api/vitest.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
         alias: {
             uuid: 'uuid',
         },
+        testTimeout: 20000,
     },
     define: {
         global: 'globalThis',


### PR DESCRIPTION
## Summary
[MCR-5207](https://jiraent.cms.gov/browse/MCR-5207)

- Refactor `withdrawContract` postgres function to reassign child rates that cannot be withdrawn to new parent contracts.
   - Child rates linked to other contracts that are `SUBMITTED`, `UNLOCKED` (but had been submitted with this linked rate), and `APPROVED` cannot be withdrawn.
   - These rates will be reassigned a new parent contract. The contract will chosen from the contracts linked to this rate.
   - The priority of the selected of the new parent contract is based on the status. From highest to lowest priority `SUBMITTED` -> `UNLOCKED` -> `APPROVED`.
      - The `UNLOCKED` contract must have been submitted with this rate previously as a linked rate.
      - `SUBMITTED` includes `RESUBMITTED`, but in the code we are just checking if the latest revision has a `submitInfo`. Knowing the difference between `SUBMITTED` and `RESUBMITTED` is irrelevant here.
   - When reassigning rate to a `SUBMITTED` or `APPROVED` contract we unlock this new parent contract to resubmit it with the rate so it becomes its child rate **by sharing the same submitInfo**
   - When reassigning rate to a `UNLOCKED` contract, we resubmit this contract with the rate so it becomes its child rate **by sharing the same submitInfo**. Then we unlock the contract again to restore it to its `UNLOCKED` state like we found it.
- Refactor `getContractID` function to use the latest submitted revision to find the current parent contract.
   - Before we used the initial submitted revision, but now that we can reassign the parent contract we have to look at the latest submitted revision
- Add `getNewParentContract` function to get new parent contracts for a rate.
- Add `reassignParentContractInTransaction` function.
- Set a global test timeout for API tests. This should also help local testing as you hit the timeout often.

AC:
- When a submission is withdrawn, a child rate linked to another submission is not withdrawn but assigned a new parent submission from one of its linked submissions.
- After submission withdrawal, the linked rate on the rate summary page still can be unlocked (now from a new parent submission)

#### Related issues

#### Screenshots

#### Test cases covered

`withdrawContract.test.ts` - resolver test
- (UPDATE) `cant withdraw contract and rates submissions without withdrawing linked rates` -> `can withdraw contract and reassigns parent contract to rates that cannot be withdrawn`
- (NEW) `prioritizes submitted contracts for rate parent contract reassignment`
- (NEW) `prioritizes unlocked contracts for rate parent contract reassignment when there are no submitted contracts`
- (UPDATE) `withdraws rate if when withdrawing linked contract and parent contract is already withdrawn` -> `withdraws rate with reassigned parent`
- (UPDATE) `withdraws rate with contract when rate is linked to unlocked contract` -> `withdraws rate with parent when linked contract is unlocked without previously submitting with linked rate`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

- Test complex linked rates still get reassigned a new parent contract
   - Unlock and resubmits with links, delinks and removals of rates before testing withdraws
- Test the status of the rate on the dashboard and in rate summary match its new parent submission.

<!---These are developer instructions on how to test or validate the work -->
