### PR TITLE
Bump bulk download to 1GB

### DIFF
--- a/services/app-api/src/handlers/bulk_download.ts
+++ b/services/app-api/src/handlers/bulk_download.ts
@@ -18,7 +18,7 @@ const s3 = new S3Client({ region: 'us-east-1' })
 const BATCH_SIZE = 20 // Increased batch size for parallel downloads
 const BASE_TIMEOUT = 120000
 const TIMEOUT_PER_MB = 1000
-const MAX_TOTAL_SIZE = 600 * 1024 * 1024 // 600MB limit
+const MAX_TOTAL_SIZE = 1024 * 1024 * 1024 // 1GB limit
 const MEMORY_LOG_INTERVAL = 5000
 const TEMP_DIR = '/tmp/downloads' // Lambda temp directory
 


### PR DESCRIPTION
## Summary

I just merged a PR (#3300)  to bump the max file size for a zip to 600MB, as we were getting an error with one of our users that has a submission with > 500MB in files (the previous limit). Looks like error in our logs of attempting to zip 515MB was just the first value over the limit which caused the lambda to exit -- we're now getting one around the 600MB limit. 

This bumps us up to a full gig. I looked at the bulk dl request and it doesn't look like it'll exceed that.

#### Related issues
https://jiraent.cms.gov/browse/MCR-5195