### PR TITLE
Change compression size on zip lambda

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -58,6 +58,9 @@ custom:
   lambdaMemory:
     prod: 4096
     default: 1024
+  lambdaTmp:
+    prod: 2048
+    default: 512
   instanceId: ${sls:instanceId}
 
 provider:
@@ -223,6 +226,7 @@ functions:
           authorizer: aws_iam
     timeout: 60
     memorySize: ${self:custom.lambdaMemory.${sls:stage}, self:custom.lambdaMemory.default}
+    ephemeralStorageSize: ${self:custom.lambdaTmp.${sls:stage}, self:custom.lambdaTmp.default}
 
   cleanup:
     handler: src/handlers/cleanup.main

--- a/services/app-api/src/handlers/bulk_download.ts
+++ b/services/app-api/src/handlers/bulk_download.ts
@@ -202,7 +202,7 @@ const main: APIGatewayProxyHandler = async (event) => {
         // Create zip file
         const zipPath = path.join(TEMP_DIR, 'output.zip')
         const zipStream = fs.createWriteStream(zipPath)
-        const archive = Archiver('zip', { zlib: { level: 5 } })
+        const archive = Archiver('zip', { zlib: { level: 2 } })
 
         archive.pipe(zipStream)
 

--- a/services/app-api/src/handlers/bulk_download.ts
+++ b/services/app-api/src/handlers/bulk_download.ts
@@ -15,7 +15,7 @@ import { pipeline } from 'stream/promises'
 const s3 = new S3Client({ region: 'us-east-1' })
 
 // Configuration constants
-const BATCH_SIZE = 20 // Increased batch size for parallel downloads
+const BATCH_SIZE = 50 // Increased batch size for parallel downloads
 const BASE_TIMEOUT = 120000
 const TIMEOUT_PER_MB = 1000
 const MAX_TOTAL_SIZE = 1024 * 1024 * 1024 // 1GB limit
@@ -202,7 +202,7 @@ const main: APIGatewayProxyHandler = async (event) => {
         // Create zip file
         const zipPath = path.join(TEMP_DIR, 'output.zip')
         const zipStream = fs.createWriteStream(zipPath)
-        const archive = Archiver('zip', { zlib: { level: 2 } })
+        const archive = Archiver('zip', { zlib: { level: 0 } })
 
         archive.pipe(zipStream)
 


### PR DESCRIPTION
## Summary
We have a user that has a lot of medium sized pdf files in their submission. This is bumping into the max lambda timeout for a lambda attached to an API gateway (29s), which is causing the zip lambda to fail. This changes the compression level to 0 for the `zlib` library, which essentially is no compression at all. We also increase the batch size for downloading the files.

This has allowed the zip file to be created (~615MB) just shy of the 29s limit, but we'll need to refactor the way we're handling zips sometime soon (we've talked about this a couple times already). Zip file sizes are going to be larger for batch file downloads until this changes and we can put the zlib compression back up.

#### Related issues
https://jiraent.cms.gov/browse/MCR-5195
