### PR TITLE
MCR-5146: update withdraw and undo withdraw rate api for submission withdraw

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/findContractWithHistory.test.ts
+++ b/services/app-api/src/postgres/contractAndRates/findContractWithHistory.test.ts
@@ -911,8 +911,14 @@ describe('findContractWithHistory with full contract and rate history', () => {
 })
 
 describe('findContractWithHistory with only contract history', () => {
+    // Test for independent rate unlocks/submits (not currently supported).
+    // Skip reason: Recent withdraw/undo features introduced rate parent contract reassignment,
+    // changing how parent contracts are determined (now using latest revision's submitInfo
+    // instead of initial revision). This breaks the test's expectations about parent calculation.
+    // Keeping for future implementation of independent rate actions.
+    //
     // eslint-disable-next-line jest/no-disabled-tests
-    it('matches correct rate revisions to contract revision with independent rate unlocks and submits', async () => {
+    it.skip('matches correct rate revisions to contract revision with independent rate unlocks and submits', async () => {
         const client = await sharedTestPrismaClient()
 
         const stateUser = await client.user.create({

--- a/services/app-api/src/postgres/contractAndRates/unlockContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/unlockContract.ts
@@ -115,7 +115,7 @@ async function unlockContractInsideTransaction(
                     },
                     unlockInfo: true,
                 },
-                //take: 2 // Only two revision states are possible: mutually unlocked or submitted
+                take: 2, // Only two revision states are possible: mutually unlocked or submitted
             },
             reviewStatusActions: {
                 orderBy: {

--- a/services/app-api/src/postgres/contractAndRates/unlockContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/unlockContract.ts
@@ -79,11 +79,9 @@ async function unlockContractInsideTransaction(
     }
 
     const childRateIDs: string[] = []
-    // This finds the child rates for this submission.
-    // A child rate is a rate that shares a submit info with this contract.
-    // technically only a rate that is _initially_ submitted with a contract
-    // is a child rate, but we should never allow re-submission so this simpler
-    // query that doesn't try to filter to initial revisions works.
+    // This find rates that where submitted with this contract at least once.
+    // The result could be a child or a previous child of the rate.
+    // A rate can become a previous child if the contract was withdrawn and the rate is reassigned a new parent contract.
     const childRates = await tx.rateTable.findMany({
         where: {
             revisions: {
@@ -98,7 +96,27 @@ async function unlockContractInsideTransaction(
                 },
             },
         },
-        include: {
+        // return data only queries data we need.
+        select: {
+            id: true,
+            revisions: {
+                orderBy: {
+                    createdAt: 'desc',
+                },
+                select: {
+                    submitInfo: {
+                        select: {
+                            submittedContracts: {
+                                select: {
+                                    contractID: true,
+                                },
+                            },
+                        },
+                    },
+                    unlockInfo: true,
+                },
+                //take: 2 // Only two revision states are possible: mutually unlocked or submitted
+            },
             reviewStatusActions: {
                 orderBy: {
                     updatedAt: 'desc',
@@ -107,16 +125,21 @@ async function unlockContractInsideTransaction(
         },
     })
 
-    // only unlock children that were submitted in the latest submission
+    // Only unlock child rates if the rate latest parent contract is still this one.
+    // Withdrawing a contract will reassign parent contracts.
     const submissionPackageEntries =
         currentRev.relatedSubmisions[0].submissionPackages
 
     for (const childRate of childRates) {
+        const latestSubmittedRev = childRate.revisions.find((r) => r.submitInfo)
+        const latestSubmissionParentContract =
+            latestSubmittedRev?.submitInfo?.submittedContracts[0]?.contractID
+
         if (
             submissionPackageEntries.some(
                 (p) => p.rateRevision.rateID === childRate.id
             ) &&
-            childRate.reviewStatusActions[0]?.actionType !== 'WITHDRAW'
+            latestSubmissionParentContract === contractID
         ) {
             childRateIDs.push(childRate.id)
         }

--- a/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
@@ -138,7 +138,11 @@ const withdrawRateInsideTransaction = async (
         let previousRates = []
 
         // If the contract is locked, unlock it and set previousRates.
-        if (['SUBMITTED', 'RESUBMITTED'].includes(consolidatedStatus)) {
+        if (
+            ['SUBMITTED', 'RESUBMITTED', 'WITHDRAWN'].includes(
+                consolidatedStatus
+            )
+        ) {
             const unlockedContract = await unlockContractInsideTransaction(tx, {
                 contractID: contract.id,
                 unlockedByUserID: updatedByID,
@@ -256,7 +260,11 @@ const withdrawRateInsideTransaction = async (
         }
 
         // Resubmit contract if it was unlocked in this loop. We know because of original consolidatedStatus
-        if (['SUBMITTED', 'RESUBMITTED'].includes(consolidatedStatus)) {
+        if (
+            ['SUBMITTED', 'RESUBMITTED', 'WITHDRAWN'].includes(
+                consolidatedStatus
+            )
+        ) {
             const resubmitContractArgs: SubmitContractArgsType = {
                 contractID: contract.id,
                 submittedByUserID: updatedByID,

--- a/services/app-api/src/resolvers/rate/undoWithdrawRate.test.ts
+++ b/services/app-api/src/resolvers/rate/undoWithdrawRate.test.ts
@@ -4,7 +4,6 @@ import {
     defaultFloridaProgram,
 } from '../../testHelpers/gqlHelpers'
 import {
-    approveTestContract,
     createAndSubmitTestContractWithRate,
     createAndUpdateTestContractWithoutRates,
     createAndUpdateTestContractWithRate,
@@ -12,6 +11,7 @@ import {
     submitTestContract,
     unlockTestContract,
     contractHistoryToDescriptions,
+    withdrawTestContract,
 } from '../../testHelpers/gqlContractHelpers'
 import {
     withdrawTestRate,
@@ -61,6 +61,7 @@ const testRateFormInputData = (): RateFormDataInput => ({
 describe('undoWithdrawRate', () => {
     it('can undo withdraw a rate without errors', async () => {
         const stateUser = testStateUser()
+
         const cmsUser = testCMSUser()
         const stateServer = await constructTestPostgresServer({
             context: {
@@ -211,6 +212,161 @@ describe('undoWithdrawRate', () => {
                 'Initial submission',
                 'unlock to prep for withdraw rate',
                 'resubmit after withdrawing rate',
+                `Undo withdrawal of rate ${formData.rateCertificationName} from this submission. Undo withdraw rate`,
+                `CMS has changed the status of rate ${formData.rateCertificationName} to submitted. Undo withdraw rate`,
+            ])
+        )
+    })
+
+    it('can undo withdraw a rate previously linked to withdrawn contract', async () => {
+        const stateUser = testStateUser()
+
+        const cmsUser = testCMSUser()
+        const stateServer = await constructTestPostgresServer({
+            context: {
+                user: stateUser,
+            },
+        })
+
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+        })
+
+        //We need to include an extra rate in order to be able to submit
+        const draftA = await createAndUpdateTestContractWithRate(stateServer)
+        const draftAWithExtraRate = await addNewRateToTestContract(
+            stateServer,
+            draftA
+        )
+        const contractA = await submitTestContract(
+            stateServer,
+            draftAWithExtraRate.id
+        )
+
+        const rateID = contractA.packageSubmissions[0].rateRevisions[0].rateID
+        const formData =
+            contractA.packageSubmissions[0].rateRevisions[0].formData
+
+        const contractB =
+            await createAndUpdateTestContractWithoutRates(stateServer)
+
+        // link rate contract B
+        must(
+            await stateServer.executeOperation({
+                query: UpdateDraftContractRatesDocument,
+                variables: {
+                    input: {
+                        contractID: contractB.id,
+                        lastSeenUpdatedAt: contractB.draftRevision?.updatedAt,
+                        updatedRates: [
+                            {
+                                type: 'LINK',
+                                rateID: rateID,
+                            },
+                            {
+                                type: 'CREATE',
+                                formData: testRateFormInputData(),
+                            },
+                        ],
+                    },
+                },
+            })
+        )
+
+        await submitTestContract(stateServer, contractB.id)
+
+        await withdrawTestRate(cmsServer, rateID, 'Withdraw invalid rate')
+
+        await unlockTestContract(
+            cmsServer,
+            contractA.id,
+            'Unlock after withdraw'
+        )
+
+        await submitTestContract(
+            stateServer,
+            contractA.id,
+            'Submit before undo withdraw'
+        )
+
+        await withdrawTestContract(
+            cmsServer,
+            contractB.id,
+            'withdraw contractB'
+        )
+
+        const unwithdrawnRate = await undoWithdrawTestRate(
+            cmsServer,
+            rateID,
+            'Undo withdraw rate'
+        )
+
+        const submittedContractA = await fetchTestContract(
+            cmsServer,
+            contractA.id
+        )
+        const submittedContractB = await fetchTestContract(
+            cmsServer,
+            contractB.id
+        )
+
+        // Expect un-withdrawn rate formData to equal formData before it was withdrawn
+        expect(
+            unwithdrawnRate.packageSubmissions[0].rateRevision.formData
+        ).toEqual(formData)
+        expect(unwithdrawnRate.withdrawnFromContracts).toHaveLength(0)
+        expect(unwithdrawnRate.consolidatedStatus).toBe('RESUBMITTED')
+        expect(unwithdrawnRate.parentContractID).toBe(contractA.id)
+
+        //expect contract A to have rate back
+        expect(submittedContractA.withdrawnRates).toHaveLength(0)
+        expect(submittedContractA.packageSubmissions[0].rateRevisions).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    rateID,
+                }),
+            ])
+        )
+
+        //expect contract B to have rate back
+        expect(submittedContractB.withdrawnRates).toHaveLength(0)
+        expect(submittedContractB.packageSubmissions[0].rateRevisions).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    rateID,
+                }),
+            ])
+        )
+
+        // Check history
+        const contractAHistory =
+            contractHistoryToDescriptions(submittedContractA)
+        const contractBHistory =
+            contractHistoryToDescriptions(submittedContractB)
+
+        // Expect contract A history to be in order
+        expect(contractAHistory).toStrictEqual(
+            expect.arrayContaining([
+                'Initial submission',
+                `CMS withdrawing rate ${formData.rateCertificationName} from this submission. Withdraw invalid rate`,
+                `CMS has withdrawn rate ${formData.rateCertificationName} from this submission. Withdraw invalid rate`,
+                'Unlock after withdraw',
+                'Submit before undo withdraw',
+                `Undo withdrawal of rate ${formData.rateCertificationName} from this submission. Undo withdraw rate`,
+                `CMS has changed the status of rate ${formData.rateCertificationName} to submitted. Undo withdraw rate`,
+            ])
+        )
+
+        // Expect contract B to be in order
+        expect(contractBHistory).toStrictEqual(
+            expect.arrayContaining([
+                'Initial submission',
+                `CMS withdrawing rate ${formData.rateCertificationName} from this submission. Withdraw invalid rate`,
+                `CMS has withdrawn rate ${formData.rateCertificationName} from this submission. Withdraw invalid rate`,
+                `Withdraw submission. withdraw contractB`,
+                `CMS withdrew the submission from review. withdraw contractB`,
                 `Undo withdrawal of rate ${formData.rateCertificationName} from this submission. Undo withdraw rate`,
                 `CMS has changed the status of rate ${formData.rateCertificationName} to submitted. Undo withdraw rate`,
             ])
@@ -437,7 +593,11 @@ describe('undo withdraw rate error handling', async () => {
 
         await withdrawTestRate(cmsServer, rateID, 'Withdraw invalid rate')
 
-        await approveTestContract(cmsServer, contractA.id)
+        await withdrawTestContract(
+            cmsServer,
+            contractA.id,
+            'Withdraw contractA'
+        )
 
         const unwithdrawnRate = await cmsServer.executeOperation({
             query: UndoWithdrawnRateDocument,
@@ -451,7 +611,7 @@ describe('undo withdraw rate error handling', async () => {
 
         expect(unwithdrawnRate.errors).toBeDefined()
         expect(unwithdrawnRate.errors?.[0].message).toContain(
-            `Attempted to undo rate withdrawal with contract(s) that are in an invalid state. Invalid contract IDs: ${[contractA.id, contractB.id]}`
+            `Attempted to undo rate withdrawal with parent contract in an invalid state: APPROVED`
         )
     })
 

--- a/services/app-api/src/resolvers/rate/withdrawRate.ts
+++ b/services/app-api/src/resolvers/rate/withdrawRate.ts
@@ -92,6 +92,7 @@ export function withdrawRate(
         const allowedParentContractStatus = [
             'SUBMITTED',
             'RESUBMITTED',
+            'WITHDRAWN',
         ].includes(parentContract.consolidatedStatus)
 
         if (!allowedRateStatus || !allowedParentContractStatus) {

--- a/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
@@ -871,7 +871,7 @@ describe('RateSummary', () => {
         })
         it('renders undo withdraw button when withdrawn independently', async () => {
             const contract = mockContractPackageSubmitted({
-                consolidatedStatus: 'WITHDRAWN',
+                consolidatedStatus: 'SUBMITTED',
             })
             const rateData = rateWithHistoryMock()
             rateData.parentContractID = contract.id
@@ -929,7 +929,7 @@ describe('RateSummary', () => {
                 screen.getByRole('button', { name: 'Undo withdraw' })
             ).toBeInTheDocument()
         })
-        it('does not render withdraw button when withdrawn independently', async () => {
+        it('does not render undo withdraw button when parent submission is withdrawn', async () => {
             const contract = mockContractPackageSubmitted({
                 consolidatedStatus: 'WITHDRAWN',
             })
@@ -986,8 +986,8 @@ describe('RateSummary', () => {
             })
 
             expect(
-                screen.getByRole('button', { name: 'Undo withdraw' })
-            ).toBeInTheDocument()
+                screen.queryByRole('button', { name: 'Undo withdraw' })
+            ).not.toBeInTheDocument()
         })
     })
 })

--- a/services/app-web/src/pages/RateSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.tsx
@@ -220,6 +220,7 @@ export const RateSummary = (): React.ReactElement => {
     const showNoActionsMessage =
         parentContractIsApproved ||
         parentContractIsUnlocked ||
+        parentContractIsWithdrawn ||
         isWithdrawnWithContract ||
         (!showUndoWithdrawRate && isWithdrawn) ||
         isUnlocked


### PR DESCRIPTION
## Summary

This work updates our `withdrawRate` and `undoWithdrawRate` for the submission withdraw feature which adds a new contract status of `WITHDRAWN` and parent contract reassignment.

**Notes**
- `unlockContract` postgres functions
   - This one needed updated for rate withdraw/un-withdrawal feature because of parent contract reassignment. We still query the rate the same, but now we need to look at the latest 2 rate revisions to find the contract it was submitted with.
   - We only want to unlock this child rate if the latest rate submission was submitted with this contract. If it wasn't then we know this rate was reassigned or withdrawn from this contract.
   - `findContractWithHistory.test.ts`
      - Skipping `matches correct rate revisions to contract revision with independent rate unlocks and submits`
      - See the comments above the test:
         ```
            // Test for independent rate unlocks/submits (not currently supported).
            // Skip reason: Recent withdraw/undo features introduced rate parent contract reassignment,
            // changing how parent contracts are determined (now using latest revision's submitInfo
            // instead of initial revision). This breaks the test's expectations about parent calculation.
            // Keeping for future implementation of independent rate actions.
        ```
   - Update the rate summary page so that `Undo withdraw` does not appear if the parent contract is `WITHDRAWN`.
      - This is so that actions users cannot take because of the API should also not be shown.
  
AC:
 - `withdrawRate` API allows a rate to be withdrawn if its parent contract is withdrawn
    - withdrawn rates will be unlock and resubmitted to move the rate relationship to the WithdrawnRateJoinTable
    - **TESTING NOTE**: This AC will be hard to test because now are reassigning linked rates when the parent contract is withdrawn there should never be a rate in this state from the submission withdraw process. I do think we include this AC and the unit test incase a bug or we figure out that there is an edge case.
 - `undoWithdrawRate` API will not allow a rate to be un-withdrawn if the parent contract is withdrawn.
 - `undoWithdrawRate` API allows rate to be un-withdrawn if linked contracts are withdrawn.
 - There are unit test for APU updates. It can be included in an existing test as an assertion.

#### Related issues
[MCR-5146](https://jiraent.cms.gov/browse/MCR-5146)

#### Screenshots

#### Test cases covered

`withdrawRate.test.ts`
- `'can withdraw a rate when parent contract is withdrawn'`
- `'withdraws rate when linked to withdrawn contract'`

`undoWithdrawRate.test.ts`
- `'can undo withdraw a rate previously linked to withdrawn contract'`
- `'returns an error if parent contract is in an invalid state'`

`RateSummary.test.tsx`
- `'does not render undo withdraw button when parent submission is withdrawn'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->

- A withdrawn rate, using the withdraw rate feature, should not be able to be un-withdrawn using the undo withdraw feature if the parent contract is now withdrawn
   - Create a contract and rates submission and submit it
   - Withdraw the rate using the withdraw rate feature
   - Withdraw the contract using the submission withdraw feature
   - Attempting to undo withdraw the rate should result in an error
- Allows a rate to be withdrawn, using the rate withdraw feature, if the parent contract is WITHDRAWN
   - This AC will be hard to test because now are reassigning linked rates when the parent contract is withdrawn there should never be a rate in this state from the submission withdraw process. I do think we include this AC incase a bug or we figure out that there is an edge case.
   - The unit test can cover the validation for this small piece of work.