### PR TITLE
MCR-4752: Migrate rate withdrawInfo into rate reviewStatusAction WITHDRAW

### DIFF
--- a/services/app-api/prisma/migrations/20250418212330_migrate_redundant_rate_to_withdrawn_rate/migration.sql
+++ b/services/app-api/prisma/migrations/20250418212330_migrate_redundant_rate_to_withdrawn_rate/migration.sql
@@ -1,0 +1,91 @@
+BEGIN;
+
+-- Create submitInfo records and reviewStatusActions for each withdrawInfo
+DO $$
+DECLARE
+  rate_record RECORD;
+  latest_revision RECORD;
+  withdraw_info RECORD;
+  submit_info_id UUID;
+  withdraw_info_ids TEXT[] := '{}';
+BEGIN
+  -- Loop through each rate with a withdrawInfoID
+  FOR rate_record IN
+    SELECT r.id, r."withdrawInfoID"
+    FROM "RateTable" r
+    WHERE r."withdrawInfoID" IS NOT NULL
+  LOOP
+    -- Get the withdraw info
+    SELECT * INTO withdraw_info
+    FROM "UpdateInfoTable"
+    WHERE id = rate_record."withdrawInfoID";
+
+    -- Find the latest revision for this rate
+    SELECT * INTO latest_revision
+    FROM "RateRevisionTable"
+    WHERE "rateID" = rate_record.id
+    ORDER BY "createdAt" DESC
+    LIMIT 1;
+
+    IF NOT FOUND THEN
+      RAISE WARNING 'No revisions found for rate with ID: %', rate_record.id;
+      CONTINUE;
+    END IF;
+
+    -- Create a new submitInfo record
+    submit_info_id := uuid_generate_v4();
+    INSERT INTO "UpdateInfoTable" (
+      id,
+      "updatedAt",
+      "updatedByID",
+      "updatedReason"
+    ) VALUES (
+      submit_info_id,
+      -- Add 50ms to updateAt timestamp so it will be after the unlockInfo timestamp.
+      withdraw_info."updatedAt" + INTERVAL '50 milliseconds',
+      withdraw_info."updatedByID",
+      withdraw_info."updatedReason"
+    );
+
+    -- Update the latest revision with the new submitInfo
+    UPDATE "RateRevisionTable"
+    SET "submitInfoID" = submit_info_id
+    WHERE id = latest_revision.id;
+
+    -- Create a reviewStatusActions record of type WITHDRAW
+    INSERT INTO "RateActionTable" (
+      id,
+      "updatedAt",
+      "updatedByID",
+      "updatedReason",
+      "actionType",
+      "rateID"
+    ) VALUES (
+      uuid_generate_v4(),
+      -- Match timestamp of the submitInfo.
+      withdraw_info."updatedAt" + INTERVAL '50 milliseconds',
+      withdraw_info."updatedByID",
+      withdraw_info."updatedReason",
+      'WITHDRAW',
+      rate_record.id
+    );
+
+    -- Store the withdrawInfoID to delete later
+    withdraw_info_ids := array_append(withdraw_info_ids, rate_record."withdrawInfoID");
+
+    -- Remove the withdrawInfo relationship from the rate
+    UPDATE "RateTable"
+    SET "withdrawInfoID" = NULL
+    WHERE id = rate_record.id;
+
+    RAISE NOTICE 'Processed rate ID: % - Created submitInfo and reviewStatusAction', rate_record.id;
+  END LOOP;
+
+  -- Delete all the withdrawInfo records from UpdateInfoTable
+  DELETE FROM "UpdateInfoTable"
+  WHERE id = ANY(withdraw_info_ids);
+
+  RAISE NOTICE 'Deleted % withdrawInfo records from UpdateInfoTable', array_length(withdraw_info_ids, 1);
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## Summary
**NOTE**: After approval I will NOT be merging this until after prod/design review of the `csv` files. I do not want to apply the migration until the submission migrations looks correct.

We are deprecating the replace redundant rate feature now that we have a withdraw rate feature that accomplishes the same thing. Before we deprecate the code for replace redundant rate, we need to migrate all the rates that had been replaced using this feature into a withdrawn rate.

The migration file will find all rates that have a `withdrawInfo`, this field signifies it was a redundant rate, and use the data in that to create a `reviewStatusActions` of `WITHDRAW` for the rate. Then delete the `withdrawInfo` relationship between `RateTable` and `UpdateInfoTable` on `withdrawInfo`.

There are 12 redundant rates in `PROD`. I was able to copy prod data and run this migration locally successfully.

Here are the results of the relevant data needed to confirm the migration in `csv` format

Redundant rates before migration.
```csv
rateID,rateCertificationName,replaceRateUpdateReason,consolidatedStatus
13cd3be6-226c-4008-96a9-7a8cac1b2031,MCR-AZ-0011-ACCRBHA-RATE-20221001-20230930-AMENDMENT-20230323,"Rate MCR-AZ-0011-ACCRBHA-RATE-20221001-20230930-AMENDMENT-20230323 is redundant of and has been consolidated with Rate Name MCR-AZ-0012-ACC-RATE-20221001-20230930-AMENDMENT-20230323 by Administrator. The review and approval of the associated rate certification will be on MCR-AZ-0012-ACC-RATE-20221001-20230930-AMENDMENT-20230323 going forward",UNLOCKED
33a0a3e8-a645-4729-bab3-39e6764d2f0a,MCR-RI-0010-CORE-RATE-20230701-20240630-CERTIFICATION-20230623,"Rate MCR-RI-0010-CORE-RATE-20230701-20240630-CERTIFICATION-20230623 is redundant of and has been consolidated with Rate Name MCR-RI-0008-CORE-RATE-20230701-20240630-CERTIFICATION-20230623 by Administrator. The review and approval of the associated rate certification will be on MCR-RI-0008-CORE-RATE-20230701-20240630-CERTIFICATION-20230623 going forward",UNLOCKED
3f467b37-7fc6-45fa-9ccd-b29141fd48c1,MCR-AZ-0022-ACC-ACCRBHA-RATE-20231001-20240930-AMENDMENT-20240131,"Rate MCR-AZ-0022-ACC-ACCRBHA-RATE-20231001-20240930-AMENDMENT-20240131 is redundant of and has been consolidated with Rate Name MCR-AZ-0021-ACC-ACCRBHA-RATE-20231001-20240930-AMENDMENT-20240131 by Administrator. The review and approval of the associated rate certifcation will be on MCR-AZ-0021-ACC-ACCRBHA-RATE-20231001-20240930-AMENDMENT-20240131 going forward. ",UNLOCKED
53bd1a93-6397-458d-8ed0-08faa1e4fef6,MCR-KY-0003-MCO-RATE-20240101-20241231-CERTIFICATION-20231215,"Rate MCR-KY-0003-MCO-RATE-20240101-20241231-CERTIFICATION-20231215 is redundant of and has been consolidated with Rate Name MCR-KY-0001-MCO-RATE-20240101-20241231-CERTIFICATION-20231215 by Administrator. The review and approval of the associated rate certification will be on MCR-KY-0001-MCO-RATE-20240101-20241231-CERTIFICATION-20231215 going forward",UNLOCKED
6116527e-77ff-4cbe-b1f0-8ff6bc3d9513,MCR-AZ-0013-ACC-ACCRBHA-RATE-20231001-20240930-CERTIFICATION-20230811,"Rate MCR-AZ-0013-ACC-ACCRBHA-RATE-20231001-20240930-CERTIFICATION-20230811 is redundant of and has been consolidated with Rate Name MCR-AZ-0014-ACC-ACCRBHA-RATE-20231001-20240930-CERTIFICATION-20230811 by Administrator. The review and approval of the associated rate certification will be on MCR-AZ-0014-ACC-ACCRBHA-RATE-20231001-20240930-CERTIFICATION-20230811 going forward. ",UNLOCKED
64e08f3d-af53-46fc-8d5e-fe3bc63eb4fa,MCR-AZ-0018-ACC-ACCRBHA-RATE-20221001-20230930-AMENDMENT-20231031,"Rate MCR-AZ-0018-ACC-ACCRBHA-RATE-20221001-20230930-AMENDMENT-20231031 is redundant of and has been consolidated with Rate Name MCR-AZ-0017-ACC-ACCRBHA-RATE-20221001-20230930-AMENDMENT-20231031 by Administrator. The review and approval of the associated rate certification will be on MCR-AZ-0017-ACC-ACCRBHA-RATE-20221001-20230930-AMENDMENT-20231031 going forward.",UNLOCKED
87d07e4c-bd27-4e4c-8bf4-b6836295f6f7,MCR-TX-0008-STAR+PLUS-RATE-20220901-20230831-AMENDMENT-20230929,"Rate MCR-TX-0008-STAR+PLUS-RATE-20220901-20230831-AMENDMENT-20230929 is redundant of and has been consolidated with Rate Name MCR-TX-0007-STAR+PLUS-RATE-20220901-20230831-AMENDMENT-20230929 by Administrator. The review and approval of the associated rate certification will be on MCR-TX-0007-STAR+PLUS-RATE-20220901-20230831-AMENDMENT-20230929 going forward. ",UNLOCKED
880d460b-8564-4674-be48-dcc2836be059,MCR-RI-0009-CORE-RATE-20230701-20240630-CERTIFICATION-20230623,"Rate MCR-RI-0009-CORE-RATE-20230701-20240630-CERTIFICATION-20230623 is redundant of and has been consolidated with Rate Name MCR-RI-0008-CORE-RATE-20230701-20240630-CERTIFICATION-20230623 by Administrator. The review and approval of the associated rate certification will be on MCR-RI-0008-CORE-RATE-20230701-20240630-CERTIFICATION-20230623 going forward",UNLOCKED
8d0f51f6-1d2c-4b9d-b01a-68112c3ba4df,MCR-KY-0002-MCO-RATE-20240101-20241231-CERTIFICATION-20231215,"Rate MCR-KY-0002-MCO-RATE-20240101-20241231-CERTIFICATION-20231215 is redundant of and has been consolidated with Rate Name MCR-KY-0001-MCO-RATE-20240101-20241231-CERTIFICATION-20231215 by Administrator. The review and approval of the associated rate certification will be on MCR-KY-0001-MCO-RATE-20240101-20241231-CERTIFICATION-20231215 going forward.",UNLOCKED
a8c4f89a-a24d-40cb-9007-888809704c2a,MCR-TX-0011-STAR+PLUS-RATE-20230901-20240831-AMENDMENT-20240115,"This rate is a duplicate of and is being consolidated with rate name MCR-TX-0016-STAR+PLUS-RATE-20230901-20240831-AMENDMENT-20240115 by a CMS Administrator. The review and approval of this rate will be captured going forward on MCR-TX-0016-STAR+PLUS-RATE-20230901-20240831-AMENDMENT-20240115. ",UNLOCKED
b0c60b5e-95c3-4c8a-bafa-15a2cb3a5c20,MCR-TX-0017-STAR+PLUS-RATE-20230901-20240831-AMENDMENT-20240115,"Rate MCR-TX-0017-STAR+PLUS-RATE-20230901-20240831-AMENDMENT-20240115 is redundant of and has been consolidated with rate MCR-TX-0016-STAR+PLUS-RATE-20230901-20240831-AMENDMENT-20240115 by Administrator. The review and approval of rate MCR-TX-0017-STAR+PLUS-RATE-20230901-20240831-AMENDMENT-20240115 will be on MCR-TX-0016-STAR+PLUS-RATE-20230901-20240831-AMENDMENT-20240115 going forward. ",UNLOCKED
e276ba27-fee9-425e-88a9-438f51b7a016,MCR-TX-0009-STAR+PLUS-RATE-20220901-20230831-AMENDMENT-20230929,"Rate MCR-TX-0009-STAR+PLUS-RATE-20220901-20230831-AMENDMENT-20230929 is redundant of and has been consolidated with Rate Name MCR-TX-0007-STAR+PLUS-RATE-20220901-20230831-AMENDMENT-20230929 by Administrator. The review and approval of the associated rate certification will be on MCR-TX-0007-STAR+PLUS-RATE-20220901-20230831-AMENDMENT-20230929 going forward. ",UNLOCKED
```

Migrated withdrawn redundant rates
```csv
rateID,rateCertificationName,withdrawReason,consolidatedStatus
13cd3be6-226c-4008-96a9-7a8cac1b2031,MCR-AZ-0011-ACCRBHA-RATE-20221001-20230930-AMENDMENT-20230323,"Rate MCR-AZ-0011-ACCRBHA-RATE-20221001-20230930-AMENDMENT-20230323 is redundant of and has been consolidated with Rate Name MCR-AZ-0012-ACC-RATE-20221001-20230930-AMENDMENT-20230323 by Administrator. The review and approval of the associated rate certification will be on MCR-AZ-0012-ACC-RATE-20221001-20230930-AMENDMENT-20230323 going forward",WITHDRAW
33a0a3e8-a645-4729-bab3-39e6764d2f0a,MCR-RI-0010-CORE-RATE-20230701-20240630-CERTIFICATION-20230623,"Rate MCR-RI-0010-CORE-RATE-20230701-20240630-CERTIFICATION-20230623 is redundant of and has been consolidated with Rate Name MCR-RI-0008-CORE-RATE-20230701-20240630-CERTIFICATION-20230623 by Administrator. The review and approval of the associated rate certification will be on MCR-RI-0008-CORE-RATE-20230701-20240630-CERTIFICATION-20230623 going forward",WITHDRAW
3f467b37-7fc6-45fa-9ccd-b29141fd48c1,MCR-AZ-0022-ACC-ACCRBHA-RATE-20231001-20240930-AMENDMENT-20240131,"Rate MCR-AZ-0022-ACC-ACCRBHA-RATE-20231001-20240930-AMENDMENT-20240131 is redundant of and has been consolidated with Rate Name MCR-AZ-0021-ACC-ACCRBHA-RATE-20231001-20240930-AMENDMENT-20240131 by Administrator. The review and approval of the associated rate certifcation will be on MCR-AZ-0021-ACC-ACCRBHA-RATE-20231001-20240930-AMENDMENT-20240131 going forward. ",WITHDRAW
53bd1a93-6397-458d-8ed0-08faa1e4fef6,MCR-KY-0003-MCO-RATE-20240101-20241231-CERTIFICATION-20231215,"Rate MCR-KY-0003-MCO-RATE-20240101-20241231-CERTIFICATION-20231215 is redundant of and has been consolidated with Rate Name MCR-KY-0001-MCO-RATE-20240101-20241231-CERTIFICATION-20231215 by Administrator. The review and approval of the associated rate certification will be on MCR-KY-0001-MCO-RATE-20240101-20241231-CERTIFICATION-20231215 going forward",WITHDRAW
6116527e-77ff-4cbe-b1f0-8ff6bc3d9513,MCR-AZ-0013-ACC-ACCRBHA-RATE-20231001-20240930-CERTIFICATION-20230811,"Rate MCR-AZ-0013-ACC-ACCRBHA-RATE-20231001-20240930-CERTIFICATION-20230811 is redundant of and has been consolidated with Rate Name MCR-AZ-0014-ACC-ACCRBHA-RATE-20231001-20240930-CERTIFICATION-20230811 by Administrator. The review and approval of the associated rate certification will be on MCR-AZ-0014-ACC-ACCRBHA-RATE-20231001-20240930-CERTIFICATION-20230811 going forward. ",WITHDRAW
64e08f3d-af53-46fc-8d5e-fe3bc63eb4fa,MCR-AZ-0018-ACC-ACCRBHA-RATE-20221001-20230930-AMENDMENT-20231031,"Rate MCR-AZ-0018-ACC-ACCRBHA-RATE-20221001-20230930-AMENDMENT-20231031 is redundant of and has been consolidated with Rate Name MCR-AZ-0017-ACC-ACCRBHA-RATE-20221001-20230930-AMENDMENT-20231031 by Administrator. The review and approval of the associated rate certification will be on MCR-AZ-0017-ACC-ACCRBHA-RATE-20221001-20230930-AMENDMENT-20231031 going forward.",WITHDRAW
87d07e4c-bd27-4e4c-8bf4-b6836295f6f7,MCR-TX-0008-STAR+PLUS-RATE-20220901-20230831-AMENDMENT-20230929,"Rate MCR-TX-0008-STAR+PLUS-RATE-20220901-20230831-AMENDMENT-20230929 is redundant of and has been consolidated with Rate Name MCR-TX-0007-STAR+PLUS-RATE-20220901-20230831-AMENDMENT-20230929 by Administrator. The review and approval of the associated rate certification will be on MCR-TX-0007-STAR+PLUS-RATE-20220901-20230831-AMENDMENT-20230929 going forward. ",WITHDRAW
880d460b-8564-4674-be48-dcc2836be059,MCR-RI-0009-CORE-RATE-20230701-20240630-CERTIFICATION-20230623,"Rate MCR-RI-0009-CORE-RATE-20230701-20240630-CERTIFICATION-20230623 is redundant of and has been consolidated with Rate Name MCR-RI-0008-CORE-RATE-20230701-20240630-CERTIFICATION-20230623 by Administrator. The review and approval of the associated rate certification will be on MCR-RI-0008-CORE-RATE-20230701-20240630-CERTIFICATION-20230623 going forward",WITHDRAW
8d0f51f6-1d2c-4b9d-b01a-68112c3ba4df,MCR-KY-0002-MCO-RATE-20240101-20241231-CERTIFICATION-20231215,"Rate MCR-KY-0002-MCO-RATE-20240101-20241231-CERTIFICATION-20231215 is redundant of and has been consolidated with Rate Name MCR-KY-0001-MCO-RATE-20240101-20241231-CERTIFICATION-20231215 by Administrator. The review and approval of the associated rate certification will be on MCR-KY-0001-MCO-RATE-20240101-20241231-CERTIFICATION-20231215 going forward.",WITHDRAW
a8c4f89a-a24d-40cb-9007-888809704c2a,MCR-TX-0011-STAR+PLUS-RATE-20230901-20240831-AMENDMENT-20240115,"This rate is a duplicate of and is being consolidated with rate name MCR-TX-0016-STAR+PLUS-RATE-20230901-20240831-AMENDMENT-20240115 by a CMS Administrator. The review and approval of this rate will be captured going forward on MCR-TX-0016-STAR+PLUS-RATE-20230901-20240831-AMENDMENT-20240115. ",WITHDRAW
b0c60b5e-95c3-4c8a-bafa-15a2cb3a5c20,MCR-TX-0017-STAR+PLUS-RATE-20230901-20240831-AMENDMENT-20240115,"Rate MCR-TX-0017-STAR+PLUS-RATE-20230901-20240831-AMENDMENT-20240115 is redundant of and has been consolidated with rate MCR-TX-0016-STAR+PLUS-RATE-20230901-20240831-AMENDMENT-20240115 by Administrator. The review and approval of rate MCR-TX-0017-STAR+PLUS-RATE-20230901-20240831-AMENDMENT-20240115 will be on MCR-TX-0016-STAR+PLUS-RATE-20230901-20240831-AMENDMENT-20240115 going forward. ",WITHDRAW
e276ba27-fee9-425e-88a9-438f51b7a016,MCR-TX-0009-STAR+PLUS-RATE-20220901-20230831-AMENDMENT-20230929,"Rate MCR-TX-0009-STAR+PLUS-RATE-20220901-20230831-AMENDMENT-20230929 is redundant of and has been consolidated with Rate Name MCR-TX-0007-STAR+PLUS-RATE-20220901-20230831-AMENDMENT-20230929 by Administrator. The review and approval of the associated rate certification will be on MCR-TX-0007-STAR+PLUS-RATE-20220901-20230831-AMENDMENT-20230929 going forward. ",WITHDRAW
```

#### Related issues
[MCR-4752](https://jiraent.cms.gov/browse/MCR-4752)

#### Screenshots

#### Test cases covered

No test cases. Please review the CSV I have added in the description above to make sure:
- All the rates were migrated
- The `withdrawReason` matches the `replaceRateUpdateReason`
- `consolidatedStatus` after migration is now `WITHDRAWN`

Also the migration file could use a deep look to make sure there are no errors.

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
