### PR TITLE
MCR-5259: withdraw contract system error

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
@@ -24,8 +24,6 @@ import type {
 } from '../../gen/gqlServer'
 import type {
     RateTableWithoutDraftContractsPayload,
-    RateRevisionsTableStrippedPayload,
-    RateRevisionTablePayload,
     RateTableWithoutDraftContractsStrippedPayload,
     RateRevisionTableWithRelatedSubmissionContracts,
     SubmissionPackageContractRevisionData,
@@ -187,11 +185,22 @@ function getConsolidatedRateStatus(
     }
 }
 
+// Minimum required structure of a rate revision that contains parent contract relationship information.
+interface RateRevisionWithSubmittedContracts {
+    createdAt: Date
+    submitInfo?: {
+        submittedContracts: Array<{
+            contractID: string
+        }>
+    } | null
+    relatedSubmissions: Array<unknown>
+}
+
 // Find this rate's parent contract. It'll be the contract it was initially submitted with
 // or the contract it is associated with as an initial draft.
 const getParentContractID = (
-    rateRevisions: RateRevisionsTableStrippedPayload | RateRevisionTablePayload
-) => {
+    rateRevisions: RateRevisionWithSubmittedContracts[]
+): string | Error => {
     // sort in descending order
     const revisions = [...rateRevisions].sort(
         (revA, revB) => revB.createdAt.getTime() - revA.createdAt.getTime()


### PR DESCRIPTION
## Summary

Withdrawing a submission linked to an unlocked rate results in a system error. The fix was to to move checking for an unlocked child rate further in the code were we know this is a child rate. I also updated `getContractID` function to be more versatile by narrowing the parameter type to only the data we need.

#### Related issues
[MCR-5259](https://jiraent.cms.gov/browse/MCR-5259)

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

Steps to validate fix: 
- Create a contract and rate submission and submit it
- Create a second contract and rate submission, linking to the rate from the first submission and submit it.
- As a CMS user unlock the first submission.
- As a CMS user try to withdraw the second submission that is linked to the rate that is the child of the first submission.
- The second submission should successfully withdraw

<!---These are developer instructions on how to test or validate the work -->
