### PR TITLE
MCR-5264: Submission withdrawal reason appears incorrect

### DIFF
--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -1216,7 +1216,7 @@ type ContractReviewStatusActions {
     "the user who performed the update"
     updatedBy: UpdatedBy!
     "the reason provided by the user when performing the update"
-    updatedReason: String
+    updatedReason: String!
     "the type of review action performed on the contract: APPROVED, WITHDRAWN"
     actionType: ContractActionType!
     "Manual time entered by CMS to represent when an approval released to state"

--- a/services/app-web/src/components/Banner/SubmissionWithdrawnBanner/SubmissionWithdrawnBanner.test.tsx
+++ b/services/app-web/src/components/Banner/SubmissionWithdrawnBanner/SubmissionWithdrawnBanner.test.tsx
@@ -14,7 +14,7 @@ const updateInfo = {
 }
 
 test('renders submission withdraw success banner without errors', () => {
-    renderWithProviders(<SubmissionWithdrawnBanner updateInfo={updateInfo} />)
+    renderWithProviders(<SubmissionWithdrawnBanner withdrawInfo={updateInfo} />)
 
     expect(screen.getByTestId('withdrawnSubmissionBanner')).toBeInTheDocument()
     expect(screen.getByText('Status Updated')).toBeInTheDocument()

--- a/services/app-web/src/components/Banner/SubmissionWithdrawnBanner/SubmissionWithdrawnBanner.tsx
+++ b/services/app-web/src/components/Banner/SubmissionWithdrawnBanner/SubmissionWithdrawnBanner.tsx
@@ -1,18 +1,23 @@
+import React from 'react'
 import { Alert } from '@trussworks/react-uswds'
 import styles from '../Banner.module.scss'
 import { getUpdatedByDisplayName } from '@mc-review/helpers'
 import { formatBannerDate } from '@mc-review/dates'
 import { ExpandableText } from '../../ExpandableText'
-import { UpdateInformation } from '../../../gen/gqlClient'
+import { UpdatedBy } from '../../../gen/gqlClient'
 
 interface SubmissionWithdrawnBannerProps
     extends React.HTMLAttributes<HTMLDivElement> {
-    updateInfo: UpdateInformation
+    withdrawInfo: {
+        updatedBy: UpdatedBy
+        updatedAt: Date
+        updatedReason: string
+    }
 }
 
 export const SubmissionWithdrawnBanner = ({
     className,
-    updateInfo,
+    withdrawInfo,
 }: SubmissionWithdrawnBannerProps): React.ReactElement => {
     return (
         <Alert
@@ -30,15 +35,15 @@ export const SubmissionWithdrawnBanner = ({
                 </p>
                 <p className="usa-alert__text">
                     <b>Updated by:&nbsp;</b>
-                    {getUpdatedByDisplayName(updateInfo.updatedBy)}
+                    {getUpdatedByDisplayName(withdrawInfo.updatedBy)}
                 </p>
                 <p className="usa-alert__text">
                     <b>Updated on:&nbsp;</b>
-                    {formatBannerDate(updateInfo.updatedAt)}
+                    {formatBannerDate(withdrawInfo.updatedAt)}
                 </p>
                 <ExpandableText>
                     <b>Reason for withdrawing the submission:&nbsp;</b>
-                    {updateInfo.updatedReason}
+                    {withdrawInfo.updatedReason}
                 </ExpandableText>
             </div>
         </Alert>

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -184,26 +184,28 @@ export const SubmissionSummary = (): React.ReactElement => {
 
     const latestContractAction = contract.reviewStatusActions?.[0]
 
-    // Only show for CMS_USER or CMS_APPROVER_USER users
-    // and if the submission isn't approved
     const showApprovalBtn =
         submissionApprovalFlag &&
         hasCMSPermissions &&
-        ['SUBMITTED', 'RESUBMITTED'].includes(contract.consolidatedStatus)
-    const showApprovalBanner =
-        submissionApprovalFlag &&
-        contract.reviewStatus === 'APPROVED' &&
-        latestContractAction
+        ['SUBMITTED', 'RESUBMITTED'].includes(consolidatedStatus)
     const showUnlockBtn =
         hasCMSPermissions &&
-        ['SUBMITTED', 'RESUBMITTED'].includes(contract.consolidatedStatus)
+        ['SUBMITTED', 'RESUBMITTED'].includes(consolidatedStatus)
     const showWithdrawBtn =
         hasCMSPermissions &&
         withdrawSubmissionFlag &&
-        ['SUBMITTED', 'RESUBMITTED'].includes(contract.consolidatedStatus)
-
+        ['SUBMITTED', 'RESUBMITTED'].includes(consolidatedStatus)
     const showNoActionsMsg =
         !showApprovalBtn && !showUnlockBtn && !showWithdrawBtn
+
+    const showApprovalBanner =
+        submissionApprovalFlag &&
+        consolidatedStatus === 'APPROVED' &&
+        latestContractAction
+    const showWithdrawnBanner =
+        withdrawSubmissionFlag &&
+        consolidatedStatus === 'WITHDRAWN' &&
+        latestContractAction
 
     const renderStatusAlerts = () => {
         if (showApprovalBanner) {
@@ -214,6 +216,15 @@ export const SubmissionSummary = (): React.ReactElement => {
                     dateReleasedToState={
                         latestContractAction.dateApprovalReleasedToState
                     }
+                />
+            )
+        }
+
+        if (showWithdrawnBanner) {
+            return (
+                <SubmissionWithdrawnBanner
+                    className={styles.banner}
+                    withdrawInfo={latestContractAction}
                 />
             )
         }
@@ -235,19 +246,6 @@ export const SubmissionSummary = (): React.ReactElement => {
         ) {
             return (
                 <SubmissionUpdatedBanner
-                    className={styles.banner}
-                    updateInfo={updateInfo}
-                />
-            )
-        }
-
-        if (
-            submissionStatus === 'RESUBMITTED' &&
-            consolidatedStatus === 'WITHDRAWN' &&
-            updateInfo
-        ) {
-            return (
-                <SubmissionWithdrawnBanner
                     className={styles.banner}
                     updateInfo={updateInfo}
                 />

--- a/services/app-web/src/pages/SubmissionWithdraw/SubmissionWithdraw.test.tsx
+++ b/services/app-web/src/pages/SubmissionWithdraw/SubmissionWithdraw.test.tsx
@@ -87,6 +87,20 @@ describe('SubmissionWithdraw', () => {
             reviewStatus: 'WITHDRAWN',
             consolidatedStatus: 'WITHDRAWN',
             status: 'RESUBMITTED',
+            reviewStatusActions: [
+                {
+                    contractID: contract.id,
+                    updatedAt: new Date(),
+                    updatedBy: {
+                        role: 'CMS_USER',
+                        givenName: 'bob',
+                        familyName: 'ddmas',
+                        email: 'bob@dmas.mn.gov',
+                    },
+                    actionType: 'WITHDRAW',
+                    updatedReason: 'a valid note',
+                },
+            ],
         }
 
         const { user } = renderWithProviders(


### PR DESCRIPTION
## Summary

The withdraw banner for a submission is displaying the default text `CMS withdraw the submission` prepended to the actual withdraw reason. This is incorrect, it should only display the withdraw reason.

The issue is the `SubmissionWithdrawBanner` component is using the the `submitInfo` data instead of the contract action data in `contract.reviewStatusActions`

The fix here fixes the banner and the data used for it.
 
#### Related issues
[MCR-5462](https://jiraent.cms.gov/browse/MCR-5264)

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
