### PR TITLE
Fix destroy action environment variable

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: serverless reconcile
         env:
-          SERVERLESS_ACCESS_KEY: ${{ secrets.serverless_license_key }}
+          SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_V4_LICENSE }}
         run: |
           pnpm add -g serverless
           echo "serverlessAccessKey: $SERVERLESS_ACCESS_KEY" > ~/.serverlessrc


### PR DESCRIPTION
## Summary

There was a copy/paste error in the license key environment variable name from the last PR for the `destroy` action. This just fixes that.
