### PR TITLE
Add response size logging

### DIFF
--- a/services/app-api/src/handlers/apollo_gql.ts
+++ b/services/app-api/src/handlers/apollo_gql.ts
@@ -364,7 +364,18 @@ const gqlHandler: Handler = async (event, context, completion) => {
     // Once initialized, future awaits will return immediately
     const initializedHandler = await handlerPromise
 
-    return await initializedHandler(event, context, completion)
+    const response = await initializedHandler(event, context, completion)
+
+    // Log response size metrics without modifying the response
+    if (response && response.body) {
+        const bodySize = Buffer.from(response.body).length
+        console.info(`Response size: ${bodySize} bytes`)
+        if (bodySize > 4 * 1024 * 1024) {
+            console.warn(`Large response detected: ${bodySize} bytes`)
+        }
+    }
+
+    return response
 }
 
 module.exports = { gqlHandler }


### PR DESCRIPTION
## Summary

I was looking at the response sizes locally for the bug we have on a CA submission, but the sizes are actually under the Lambda/API Gateway size limit. I want to see what it actually looks like in prod, so this is just a minimal log for the time being.
