### PR TITLE
[MCR-5273] State cannot remove a rate that has already been submitted

### DIFF
--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -20,7 +20,6 @@ import {
     indexRatesMockSuccess,
     mockWithdrawnRates,
     mockContractPackageUnlockedWithUnlockedType,
-    mockMNState,
 } from '@mc-review/mocks'
 import { Route, Routes, Location } from 'react-router-dom'
 import { RoutesRecord } from '@mc-review/constants'
@@ -563,7 +562,65 @@ describe('RateDetails', () => {
             })
         }, 15000)
 
-        it('does not render remove certification button for UNLOCKED rates', async () => {
+        it('does not render remove certification button for non-draft rates', async () => {
+            renderWithProviders(
+                <Routes>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_RATE_DETAILS}
+                        element={<RateDetails type="MULTI" />}
+                    />
+                </Routes>,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({ statusCode: 200 }),
+                            fetchContractMockSuccess({
+                                contract: {
+                                    ...mockContractPackageDraft({
+                                        draftRates: [
+                                            draftRateDataMock({
+                                                parentContractID:
+                                                    'test-abc-123',
+                                                status: 'SUBMITTED',
+                                                consolidatedStatus: 'SUBMITTED',
+                                            }),
+                                            draftRateDataMock({
+                                                parentContractID:
+                                                    'test-abc-123',
+                                                status: 'SUBMITTED',
+                                                consolidatedStatus: 'SUBMITTED',
+                                            }),
+                                        ],
+                                    }),
+                                    id: 'test-abc-123',
+                                },
+                            }),
+                            updateDraftContractRatesMockSuccess({
+                                contract: {
+                                    id: 'test-abc-123',
+                                },
+                            }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: `/submissions/test-abc-123/edit/rate-details`,
+                    },
+                    featureFlags: {
+                        'rate-edit-unlock': false,
+                    },
+                }
+            )
+            await screen.findByText('Rate Details')
+            const rateCertsOnLoad = rateCertifications(screen)
+            expect(rateCertsOnLoad).toHaveLength(2)
+            expect(
+                screen.queryByRole('button', {
+                    name: /Remove rate certification/,
+                })
+            ).not.toBeInTheDocument()
+        })
+
+        it('does render the remove certification button for a linked rate regardless of status', async () => {
             renderWithProviders(
                 <Routes>
                     <Route
@@ -580,236 +637,22 @@ describe('RateDetails', () => {
                                     ...mockContractPackageUnlockedWithUnlockedType(
                                         {
                                             draftRates: [
-                                                {
-                                                    __typename: 'Rate',
-                                                    id: 'unlocked-rate-123',
-                                                    webURL: 'https://testmcreview.example/rates/unlocked-rate-123',
-                                                    createdAt: new Date(),
-                                                    updatedAt: new Date(),
-                                                    status: 'UNLOCKED',
-                                                    reviewStatus:
-                                                        'UNDER_REVIEW',
-                                                    consolidatedStatus:
-                                                        'UNLOCKED',
-                                                    reviewStatusActions: [],
-                                                    stateCode: 'MN',
-                                                    revisions: [],
-                                                    state: mockMNState(),
-                                                    stateNumber: 5,
+                                                draftRateDataMock({
                                                     parentContractID:
                                                         'test-abc-123',
-                                                    draftRevision: {
-                                                        __typename:
-                                                            'RateRevision',
-                                                        id: 'unlocked-rr-123',
-                                                        rateID: '456',
-                                                        createdAt: new Date(),
-                                                        updatedAt: new Date(),
-                                                        unlockInfo: {
-                                                            __typename:
-                                                                'UpdateInformation',
-                                                            updatedAt:
-                                                                new Date(),
-                                                            updatedBy: {
-                                                                email: 'cms@example.com',
-                                                                role: 'STATE_USER',
-                                                                givenName:
-                                                                    'John',
-                                                                familyName:
-                                                                    'Vila',
-                                                            },
-                                                            updatedReason:
-                                                                'unlocked for a test',
-                                                        },
-                                                        formData: {
-                                                            __typename:
-                                                                'RateFormData',
-                                                            rateType:
-                                                                'AMENDMENT',
-                                                            rateCapitationType:
-                                                                'RATE_CELL',
-                                                            rateDocuments: [
-                                                                {
-                                                                    s3URL: 's3://bucketname/key/rate',
-                                                                    sha256: 'fakesha',
-                                                                    name: 'rate',
-                                                                    dateAdded:
-                                                                        new Date(
-                                                                            '03/02/2023'
-                                                                        ),
-                                                                },
-                                                            ],
-                                                            supportingDocuments:
-                                                                [],
-                                                            rateDateStart:
-                                                                new Date(
-                                                                    '2020-02-02'
-                                                                ),
-                                                            rateDateEnd:
-                                                                new Date(
-                                                                    '2021-02-02'
-                                                                ),
-                                                            rateDateCertified:
-                                                                new Date(),
-                                                            amendmentEffectiveDateStart:
-                                                                new Date(),
-                                                            amendmentEffectiveDateEnd:
-                                                                new Date(),
-                                                            rateProgramIDs: [
-                                                                'abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce',
-                                                            ],
-                                                            consolidatedRateProgramIDs:
-                                                                [
-                                                                    'abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce',
-                                                                ],
-                                                            deprecatedRateProgramIDs:
-                                                                [
-                                                                    'd95394e5-44d1-45df-8151-1cc1ee66f10',
-                                                                ],
-                                                            certifyingActuaryContacts:
-                                                                [
-                                                                    {
-                                                                        actuarialFirm:
-                                                                            'DELOITTE',
-                                                                        name: 'Actuary Contact 1',
-                                                                        titleRole:
-                                                                            'Test Actuary Contact 1',
-                                                                        email: 'actuarycontact1@test.com',
-                                                                    },
-                                                                ],
-                                                            addtlActuaryContacts:
-                                                                [
-                                                                    {
-                                                                        actuarialFirm:
-                                                                            'DELOITTE',
-                                                                        name: 'Actuary Contact 1',
-                                                                        titleRole:
-                                                                            'Test Actuary Contact 1',
-                                                                        email: 'additionalactuarycontact1@test.com',
-                                                                    },
-                                                                ],
-                                                            actuaryCommunicationPreference:
-                                                                'OACT_TO_ACTUARY',
-                                                            packagesWithSharedRateCerts:
-                                                                [],
-                                                        },
-                                                    },
-                                                },
-                                                {
-                                                    __typename: 'Rate',
-                                                    id: 'unlocked-rate-1234',
-                                                    webURL: 'https://testmcreview.example/rates/unlocked-rate-123',
-                                                    createdAt: new Date(),
-                                                    updatedAt: new Date(),
-                                                    status: 'UNLOCKED',
-                                                    reviewStatus:
-                                                        'UNDER_REVIEW',
+                                                    status: 'SUBMITTED',
                                                     consolidatedStatus:
-                                                        'UNLOCKED',
-                                                    reviewStatusActions: [],
-                                                    stateCode: 'MN',
-                                                    revisions: [],
-                                                    state: mockMNState(),
-                                                    stateNumber: 5,
+                                                        'SUBMITTED',
+                                                }),
+                                                //This will be considered a linked rate due to the mismatching parentContractID
+                                                //Expect the remove button to render eventhough this rate is a non-draft state
+                                                draftRateDataMock({
                                                     parentContractID:
-                                                        'test-abc-123',
-                                                    draftRevision: {
-                                                        __typename:
-                                                            'RateRevision',
-                                                        id: 'unlocked-rr-1234',
-                                                        rateID: '456',
-                                                        createdAt: new Date(),
-                                                        updatedAt: new Date(),
-                                                        unlockInfo: {
-                                                            __typename:
-                                                                'UpdateInformation',
-                                                            updatedAt:
-                                                                new Date(),
-                                                            updatedBy: {
-                                                                email: 'cms@example.com',
-                                                                role: 'STATE_USER',
-                                                                givenName:
-                                                                    'John',
-                                                                familyName:
-                                                                    'Vila',
-                                                            },
-                                                            updatedReason:
-                                                                'unlocked for a test',
-                                                        },
-                                                        formData: {
-                                                            __typename:
-                                                                'RateFormData',
-                                                            rateType:
-                                                                'AMENDMENT',
-                                                            rateCapitationType:
-                                                                'RATE_CELL',
-                                                            rateDocuments: [
-                                                                {
-                                                                    s3URL: 's3://bucketname/key/rate',
-                                                                    sha256: 'fakesha',
-                                                                    name: 'rate',
-                                                                    dateAdded:
-                                                                        new Date(
-                                                                            '03/02/2023'
-                                                                        ),
-                                                                },
-                                                            ],
-                                                            supportingDocuments:
-                                                                [],
-                                                            rateDateStart:
-                                                                new Date(
-                                                                    '2020-02-02'
-                                                                ),
-                                                            rateDateEnd:
-                                                                new Date(
-                                                                    '2021-02-02'
-                                                                ),
-                                                            rateDateCertified:
-                                                                new Date(),
-                                                            amendmentEffectiveDateStart:
-                                                                new Date(),
-                                                            amendmentEffectiveDateEnd:
-                                                                new Date(),
-                                                            rateProgramIDs: [
-                                                                'abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce',
-                                                            ],
-                                                            consolidatedRateProgramIDs:
-                                                                [
-                                                                    'abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce',
-                                                                ],
-                                                            deprecatedRateProgramIDs:
-                                                                [
-                                                                    'd95394e5-44d1-45df-8151-1cc1ee66f10',
-                                                                ],
-                                                            certifyingActuaryContacts:
-                                                                [
-                                                                    {
-                                                                        actuarialFirm:
-                                                                            'DELOITTE',
-                                                                        name: 'Actuary Contact 1',
-                                                                        titleRole:
-                                                                            'Test Actuary Contact 1',
-                                                                        email: 'actuarycontact1@test.com',
-                                                                    },
-                                                                ],
-                                                            addtlActuaryContacts:
-                                                                [
-                                                                    {
-                                                                        actuarialFirm:
-                                                                            'DELOITTE',
-                                                                        name: 'Actuary Contact 1',
-                                                                        titleRole:
-                                                                            'Test Actuary Contact 1',
-                                                                        email: 'additionalactuarycontact1@test.com',
-                                                                    },
-                                                                ],
-                                                            actuaryCommunicationPreference:
-                                                                'OACT_TO_ACTUARY',
-                                                            packagesWithSharedRateCerts:
-                                                                [],
-                                                        },
-                                                    },
-                                                },
+                                                        'mismatched-id',
+                                                    status: 'SUBMITTED',
+                                                    consolidatedStatus:
+                                                        'SUBMITTED',
+                                                }),
                                             ],
                                         }
                                     ),
@@ -838,7 +681,7 @@ describe('RateDetails', () => {
                 screen.queryByRole('button', {
                     name: /Remove rate certification/,
                 })
-            ).not.toBeInTheDocument()
+            ).toBeInTheDocument()
         })
 
         it('accepts documents on second rate', async () => {

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -388,10 +388,11 @@ const RateDetails = ({
 
     const displayRemoveRateBtn = (index: number, rateForm: FormikRateForm) => {
         if (index >= 1 && !displayAsStandaloneRate) {
-            //We expect to display the button regardless of status if the rate is a linked rate
+            //We expect to display the button regardless of status if the rate is a linked rate otherwise only display the button if it is a draft rate
             if (
                 rateForm.ratePreviouslySubmitted === 'YES' ||
-                rateForm.status !== 'UNLOCKED'
+                rateForm.status === 'DRAFT' ||
+                rateForm.status === undefined
             ) {
                 return true
             }


### PR DESCRIPTION
## Summary
This PR removes the `Remove rate certification` for multiple unlocked rates
#### Related issues
[MCR-5273](https://jiraent.cms.gov/browse/MCR-5273)
#### Screenshots

#### Test cases covered
Added a test to ensure the button doesn't render for multiple unlocked rates
<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

- Submit a contract with 2 or more rates
- Unlock it as a cms user
- Visit the rate details page as a state user
- Expect the remove button to not render at the bottom of the rate
- However if you add a new rate on that same page expect the button to render for that specific rate

<!---These are developer instructions on how to test or validate the work -->
