### PR TITLE
Bump TLS version in CloudFront distro

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -143,7 +143,7 @@ resources:
             Fn::If:
               - CreateCustomCloudFrontDomain
               - AcmCertificateArn: ${self:custom.cloudfrontCertificateArn}
-                MinimumProtocolVersion: TLSv1
+                MinimumProtocolVersion: TLSv1.2_2021
                 SslSupportMethod: sni-only
               - CloudFrontDefaultCertificate: true
           CustomErrorResponses:


### PR DESCRIPTION
## Summary

This updates the minimum TLS version in our CloudFront distribution to match more modern versions. The quickstart we branched off of had an old setting here.

### Related Issues
https://jiraent.cms.gov/browse/MCR-5303
