### PR TITLE
MCR-5149: complete undo withdraw api

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/undoWithdrawContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/undoWithdrawContract.ts
@@ -1,0 +1,179 @@
+import type { ContractType } from '../../domain-models'
+import type { RateForDisplay } from './withdrawContract'
+import type { PrismaTransactionType } from '../prismaTypes'
+import type { ExtendedPrismaClient } from '../prismaClient'
+import { unlockContractInsideTransaction } from './unlockContract'
+import { submitContractInsideTransaction } from './submitContract'
+import { findContractWithHistory } from './findContractWithHistory'
+
+export type UndoWithdrawContractArgsType = {
+    contract: ContractType
+    updatedByID: string
+    updatedReason: string
+}
+
+export type UndoWithdrawContractReturnType = {
+    contract: ContractType
+    ratesForDisplay: RateForDisplay[]
+}
+
+/**
+ * Undo a withdrawn contract and rates withdrawn along with it.
+ *
+ * This function performs the following operations:
+ * 1. Validates the contract is currently withdrawn
+ * 2. Unlock contract with child rates with default undo withdrawal reason and append inputted withdraw reason
+ * 3. Resubmits contract with child rate with default undo withdrawal reason and append inputted withdraw reason
+ * 4. Creates a new UNDER_REVIEW action for contract and child rates
+ * 5. Resubmits the contract and child rates with a withdrawal reason
+ *
+ * @param tx - The Prisma transaction object used for database operations
+ * @param {UndoWithdrawContractArgsType} args - Undo withdrawal arguments
+ * @param {ContractType} args.contract - The contract to undo withdrawal
+ * @param {string} args.updatedReason - The reason for undoing withdrawal
+ * @param {string} args.updatedByID - ID of the user performing undo withdrawal
+ *
+ */
+const undoWithdrawContractInsideTransaction = async (
+    tx: PrismaTransactionType,
+    args: UndoWithdrawContractArgsType
+): Promise<UndoWithdrawContractReturnType> => {
+    const { contract, updatedReason, updatedByID } = args
+
+    // Check contract review status again
+    const contractReviewStatus = await tx.contractTable.findUnique({
+        where: {
+            id: contract.id,
+        },
+        select: {
+            reviewStatusActions: {
+                orderBy: {
+                    updatedAt: 'desc',
+                },
+                take: 1,
+                select: {
+                    actionType: true,
+                },
+            },
+        },
+    })
+
+    if (!contractReviewStatus) {
+        throw new Error(
+            'Could not find contract to validate review status is WITHDRAW.'
+        )
+    }
+
+    if (contractReviewStatus.reviewStatusActions[0].actionType !== 'WITHDRAW') {
+        throw new Error(
+            'Contract to undo withdrawal is not currently withdrawn.'
+        )
+    }
+
+    // Unlock contract and child rates
+    const unlockedContract = await unlockContractInsideTransaction(tx, {
+        contractID: contract.id,
+        unlockedByUserID: updatedByID,
+        unlockReason: `CMS undoing submission submission withdrawal. ${updatedReason}`,
+    })
+
+    if (unlockedContract instanceof Error) {
+        throw new Error(
+            `Cannot unlock contract to undo a submission withdrawal. ${unlockedContract.message}`
+        )
+    }
+
+    // Go through all the draft rates and find the child rate ID's and rate cert names
+    const ratesForDisplay: RateForDisplay[] = []
+    unlockedContract.draftRates.forEach((dr) => {
+        if (dr.parentContractID === contract.id) {
+            const rateCertificationName =
+                dr.draftRevision?.formData.rateCertificationName
+            ratesForDisplay.push({
+                id: dr.id,
+                rateCertificationName: rateCertificationName ?? 'Unknown Rate',
+            })
+        }
+    })
+
+    // Resubmit contact and child rates
+    const resubmitContract = await submitContractInsideTransaction(tx, {
+        contractID: contract.id,
+        submittedByUserID: updatedByID,
+        submittedReason: `CMS undid submission withdrawal. ${updatedReason}`,
+    })
+
+    if (resubmitContract instanceof Error) {
+        throw new Error(
+            `Cannot resubmit contract tot undo a submission withdrawal`
+        )
+    }
+
+    // Add UNDER_REVIEW action to contract
+    await tx.contractTable.update({
+        where: {
+            id: contract.id,
+        },
+        data: {
+            reviewStatusActions: {
+                create: {
+                    updatedByID,
+                    updatedReason,
+                    actionType: 'UNDER_REVIEW',
+                },
+            },
+        },
+    })
+
+    for (const rate of ratesForDisplay) {
+        // Add UNDER_REVIEW action to all rates that are withdrawn with this submission
+        await tx.rateActionTable.create({
+            data: {
+                updatedReason,
+                updatedBy: {
+                    connect: {
+                        id: updatedByID,
+                    },
+                },
+                actionType: 'UNDER_REVIEW',
+                rate: {
+                    connect: {
+                        id: rate.id,
+                    },
+                },
+            },
+        })
+    }
+
+    const undoWithdrawnContract = await findContractWithHistory(tx, contract.id)
+
+    if (undoWithdrawnContract instanceof Error) {
+        throw new Error(undoWithdrawnContract.message)
+    }
+
+    if (undoWithdrawnContract.consolidatedStatus !== 'RESUBMITTED') {
+        throw new Error('Contract failed to withdraw')
+    }
+
+    return {
+        contract: undoWithdrawnContract,
+        ratesForDisplay: ratesForDisplay,
+    }
+}
+
+const undoWithdrawContract = async (
+    client: ExtendedPrismaClient,
+    args: UndoWithdrawContractArgsType
+): Promise<UndoWithdrawContractReturnType | Error> => {
+    try {
+        return await client.$transaction(
+            async (tx) => await undoWithdrawContractInsideTransaction(tx, args)
+        )
+    } catch (err) {
+        const msg = `PRISMA ERROR: Error undo withdraw contract: ${err.message}`
+        console.error(msg)
+        return err
+    }
+}
+
+export { undoWithdrawContract }

--- a/services/app-api/src/postgres/contractAndRates/withdrawContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawContract.ts
@@ -53,7 +53,7 @@ export type WithdrawContractReturnType = {
 const withdrawContractInsideTransaction = async (
     tx: PrismaTransactionType,
     args: WithdrawContractArgsType
-): Promise<WithdrawContractReturnType | Error> => {
+): Promise<WithdrawContractReturnType> => {
     const { contract, updatedReason, updatedByID } = args
 
     const latestSubmission = contract.packageSubmissions[0]

--- a/services/app-api/src/postgres/postgresStore.ts
+++ b/services/app-api/src/postgres/postgresStore.ts
@@ -21,7 +21,7 @@ import type {
     AuditDocument,
     EmailSettingsType,
 } from '../domain-models'
-import { findPrograms, findStatePrograms } from '../postgres'
+import { findPrograms, findStatePrograms } from './'
 import type { InsertUserArgsType } from './user'
 import {
     findUser,
@@ -97,37 +97,40 @@ import type {
 import { withdrawContract } from './contractAndRates/withdrawContract'
 import { findRateRelatedContracts } from './contractAndRates/findRateRelatedContracts'
 import type { RelatedContractStripped } from '../gen/gqlClient'
+import {
+    undoWithdrawContract,
+    type UndoWithdrawContractArgsType,
+    type UndoWithdrawContractReturnType,
+} from './contractAndRates/undoWithdrawContract'
 
 type Store = {
+    /** Settings functions **/
+    findEmailSettings: () => Promise<EmailSettingsType | Error>
+    updateEmailSettings: (
+        emailSettings: EmailSettingsType
+    ) => Promise<EmailSettingsType | Error>
     findPrograms: (
         stateCode: string,
         programIDs: Array<string>
     ) => ProgramType[] | Error
-
     findStatePrograms: (stateCode: string) => ProgramType[] | Error
-
     findAllSupportedStates: () => Promise<StateType[] | Error>
 
-    findAllUsers: () => Promise<UserType[] | Error>
-
-    findUser: (id: string) => Promise<UserType | undefined | Error>
-
-    findStateAssignedUsers: (
-        stateCode: StateCodeType
-    ) => Promise<UserType[] | Error>
-
+    /** User functions **/
     insertUser: (user: InsertUserArgsType) => Promise<UserType | Error>
-
     insertManyUsers: (
         users: InsertUserArgsType[]
     ) => Promise<UserType[] | Error>
-
+    findAllUsers: () => Promise<UserType[] | Error>
+    findUser: (id: string) => Promise<UserType | undefined | Error>
+    findStateAssignedUsers: (
+        stateCode: StateCodeType
+    ) => Promise<UserType[] | Error>
     updateStateAssignedUsers: (
         idOfUserPerformingUpdate: string,
         stateCode: StateCodeType,
         assignedUserIDs: string[]
     ) => Promise<UserType[] | Error>
-
     updateCmsUserProperties: (
         userID: string,
         idOfUserPerformingUpdate: string,
@@ -136,128 +139,128 @@ type Store = {
         description?: string | null
     ) => Promise<CMSUsersUnionType | Error>
 
-    insertContractQuestion: (
-        questionInput: CreateContractQuestionInput,
-        user: CMSUsersUnionType
-    ) => Promise<ContractQuestionType | Error>
-
-    findAllQuestionsByContract: (
-        pkgID: string
-    ) => Promise<ContractQuestionType[] | Error>
-
-    insertContractQuestionResponse: (
-        questionInput: InsertQuestionResponseArgs,
-        user: StateUserType
-    ) => Promise<ContractQuestionType | Error>
-
-    insertRateQuestionResponse: (
-        questionInput: InsertQuestionResponseArgs,
-        user: StateUserType
-    ) => Promise<RateQuestionType | Error>
-
-    insertRateQuestion: (
-        questionInput: CreateRateQuestionInputType,
-        user: CMSUsersUnionType
-    ) => Promise<RateQuestionType | Error>
-
-    findAllQuestionsByRate: (
-        rateID: string
-    ) => Promise<RateQuestionType[] | Error>
-
+    /** Contract functions **/
     insertDraftContract: (
         args: InsertContractArgsType
     ) => Promise<ContractType | Error>
-
-    approveContract: (
-        args: ApproveContractArgsType
-    ) => Promise<ContractType | Error>
-
-    withdrawContract: (
-        args: WithdrawContractArgsType
-    ) => Promise<WithdrawContractReturnType | Error>
-
-    withdrawRate: (args: WithdrawRateArgsType) => Promise<RateType | Error>
-
-    undoWithdrawRate: (
-        args: UndoWithdrawRateArgsType
-    ) => Promise<RateType | Error>
-
     findContractWithHistory: (
         contractID: string
     ) => Promise<ContractType | Error>
-
-    findRateWithHistory: (rateID: string) => Promise<RateType | Error>
-    findRateRelatedContracts: (
-        rateID: string
-    ) => Promise<RelatedContractStripped[] | Error>
-
-    updateContract: (
-        args: UpdateMCCRSIDFormArgsType
-    ) => Promise<ContractType | Error>
-
-    updateDraftContract: (
-        args: UpdateContractArgsType
-    ) => Promise<ContractType | Error>
-
-    updateDraftContractWithRates: (
-        args: UpdateContractArgsType
-    ) => Promise<ContractType | Error>
-
-    updateDraftContractRates: (
-        args: UpdateDraftContractRatesArgsType
-    ) => Promise<ContractType | Error>
-
     findAllContractsWithHistoryByState: (
         stateCode: string
     ) => Promise<ContractOrErrorArrayType | Error>
-
     findAllContractsWithHistoryBySubmitInfo: (
         useZod?: boolean
     ) => Promise<ContractOrErrorArrayType | Error>
-
-    findAllRatesWithHistoryBySubmitInfo: (
-        args?: FindAllRatesWithHistoryBySubmitType
-    ) => Promise<RateOrErrorArrayType | Error>
-
-    findAllRatesStripped: (
-        args?: FindAllRatesStrippedType
-    ) => Promise<StrippedRateOrErrorArrayType | Error>
-
+    findContractRevision: (
+        contractRevID: string
+    ) => Promise<ContractRevisionTable | Error>
+    updateContract: (
+        args: UpdateMCCRSIDFormArgsType
+    ) => Promise<ContractType | Error>
+    updateDraftContract: (
+        args: UpdateContractArgsType
+    ) => Promise<ContractType | Error>
+    updateDraftContractWithRates: (
+        args: UpdateContractArgsType
+    ) => Promise<ContractType | Error>
+    updateDraftContractRates: (
+        args: UpdateDraftContractRatesArgsType
+    ) => Promise<ContractType | Error>
     submitContract: (
         args: SubmitContractArgsType
     ) => Promise<ContractType | Error>
-
-    submitRate: (args: SubmitRateArgsType) => Promise<RateType | Error>
-
     unlockContract: (
         args: UnlockContractArgsType,
         linkRatesFF?: boolean
     ) => Promise<UnlockedContractType | Error>
+    approveContract: (
+        args: ApproveContractArgsType
+    ) => Promise<ContractType | Error>
+    withdrawContract: (
+        args: WithdrawContractArgsType
+    ) => Promise<WithdrawContractReturnType | Error>
+    undoWithdrawContract: (
+        args: UndoWithdrawContractArgsType
+    ) => Promise<UndoWithdrawContractReturnType | Error>
 
-    unlockRate: (args: UnlockRateArgsType) => Promise<RateType | Error>
-
-    findAllDocuments: () => Promise<AuditDocument[] | Error>
-
-    findContractRevision: (
-        contractRevID: string
-    ) => Promise<ContractRevisionTable | Error>
-
+    /** Rate functions **/
+    findRateWithHistory: (rateID: string) => Promise<RateType | Error>
     findRateRevision: (
         rateRevisionID: string
     ) => Promise<RateRevisionTable | Error>
+    findRateRelatedContracts: (
+        rateID: string
+    ) => Promise<RelatedContractStripped[] | Error>
+    findAllRatesWithHistoryBySubmitInfo: (
+        args?: FindAllRatesWithHistoryBySubmitType
+    ) => Promise<RateOrErrorArrayType | Error>
+    findAllRatesStripped: (
+        args?: FindAllRatesStrippedType
+    ) => Promise<StrippedRateOrErrorArrayType | Error>
+    submitRate: (args: SubmitRateArgsType) => Promise<RateType | Error>
+    unlockRate: (args: UnlockRateArgsType) => Promise<RateType | Error>
+    withdrawRate: (args: WithdrawRateArgsType) => Promise<RateType | Error>
+    undoWithdrawRate: (
+        args: UndoWithdrawRateArgsType
+    ) => Promise<RateType | Error>
 
-    findEmailSettings: () => Promise<EmailSettingsType | Error>
-    updateEmailSettings: (
-        emailSettings: EmailSettingsType
-    ) => Promise<EmailSettingsType | Error>
+    /** Q&A functions **/
+    insertContractQuestion: (
+        questionInput: CreateContractQuestionInput,
+        user: CMSUsersUnionType
+    ) => Promise<ContractQuestionType | Error>
+    insertContractQuestionResponse: (
+        questionInput: InsertQuestionResponseArgs,
+        user: StateUserType
+    ) => Promise<ContractQuestionType | Error>
+    findAllQuestionsByContract: (
+        pkgID: string
+    ) => Promise<ContractQuestionType[] | Error>
+    insertRateQuestion: (
+        questionInput: CreateRateQuestionInputType,
+        user: CMSUsersUnionType
+    ) => Promise<RateQuestionType | Error>
+    insertRateQuestionResponse: (
+        questionInput: InsertQuestionResponseArgs,
+        user: StateUserType
+    ) => Promise<RateQuestionType | Error>
+    findAllQuestionsByRate: (
+        rateID: string
+    ) => Promise<RateQuestionType[] | Error>
+
+    /** Other **/
+    findAllDocuments: () => Promise<AuditDocument[] | Error>
 }
 
 function NewPostgresStore(client: ExtendedPrismaClient): Store {
     return {
+        /** Settings functions **/
+        findEmailSettings: () => findEmailSettings(client),
+        updateEmailSettings: (emailSettings) =>
+            updateEmailSettings(client, emailSettings),
         findPrograms: findPrograms,
-        findUser: (id) => findUser(client, id),
+        findStatePrograms: findStatePrograms,
+        findAllSupportedStates: () => findAllSupportedStates(client),
+
+        /** User functions **/
         insertUser: (args) => insertUser(client, args),
         insertManyUsers: (args) => insertManyUsers(client, args),
+        findAllUsers: () => findAllUsers(client),
+        findUser: (id) => findUser(client, id),
+        findStateAssignedUsers: (stateCode) =>
+            findStateAssignedUsers(client, stateCode),
+        updateStateAssignedUsers: (
+            idOfUserPerformingUpdate,
+            stateCode,
+            assignedUserIDs
+        ) =>
+            updateStateAssignedUsers(
+                client,
+                idOfUserPerformingUpdate,
+                stateCode,
+                assignedUserIDs
+            ),
         updateCmsUserProperties: (
             userID,
             stateCodes,
@@ -273,29 +276,48 @@ function NewPostgresStore(client: ExtendedPrismaClient): Store {
                 divisionAssignment,
                 description
             ),
-        updateStateAssignedUsers: (
-            idOfUserPerformingUpdate,
-            stateCode,
-            assignedUserIDs
-        ) =>
-            updateStateAssignedUsers(
-                client,
-                idOfUserPerformingUpdate,
-                stateCode,
-                assignedUserIDs
-            ),
-        findStatePrograms: findStatePrograms,
-        findAllSupportedStates: () => findAllSupportedStates(client),
-        findAllUsers: () => findAllUsers(client),
-        findStateAssignedUsers: (stateCode) =>
-            findStateAssignedUsers(client, stateCode),
 
+        /** Contract functions **/
+        insertDraftContract: (args) => insertDraftContract(client, args),
+        findContractWithHistory: (args) =>
+            findContractWithHistory(client, args),
+        findAllContractsWithHistoryByState: (args) =>
+            findAllContractsWithHistoryByState(client, args),
+        findAllContractsWithHistoryBySubmitInfo: (args) =>
+            findAllContractsWithHistoryBySubmitInfo(client, args),
+        findContractRevision: (args) => findContractRevision(client, args),
+        updateContract: (args) => updateMCCRSID(client, args),
+        updateDraftContract: (args) => updateDraftContract(client, args),
+        updateDraftContractWithRates: (args) =>
+            updateDraftContractWithRates(client, args),
+        updateDraftContractRates: (args) =>
+            updateDraftContractRates(client, args),
+        submitContract: (args) => submitContract(client, args),
+        unlockContract: (args) => unlockContract(client, args),
+        approveContract: (args) => approveContract(client, args),
+        withdrawContract: (args) => withdrawContract(client, args),
+        undoWithdrawContract: (args) => undoWithdrawContract(client, args),
+
+        /** Rate functions **/
+        findRateWithHistory: (args) => findRateWithHistory(client, args),
+        findRateRevision: (args) => findRateRevision(client, args),
+        findRateRelatedContracts: (args) =>
+            findRateRelatedContracts(client, args),
+        findAllRatesWithHistoryBySubmitInfo: (args) =>
+            findAllRatesWithHistoryBySubmitInfo(client, args),
+        findAllRatesStripped: (args) => findAllRatesStripped(client, args),
+        submitRate: (args) => submitRate(client, args),
+        unlockRate: (args) => unlockRate(client, args),
+        withdrawRate: (args) => withdrawRate(client, args),
+        undoWithdrawRate: (args) => undoWithdrawRate(client, args),
+
+        /** Q&A functions **/
         insertContractQuestion: (questionInput, user) =>
             insertContractQuestion(client, questionInput, user),
-        findAllQuestionsByContract: (pkgID) =>
-            findAllQuestionsByContract(client, pkgID),
         insertContractQuestionResponse: (questionInput, user) =>
             insertContractQuestionResponse(client, questionInput, user),
+        findAllQuestionsByContract: (pkgID) =>
+            findAllQuestionsByContract(client, pkgID),
         insertRateQuestion: (questionInput, user) =>
             insertRateQuestion(client, questionInput, user),
         insertRateQuestionResponse: (questionInput, user) =>
@@ -303,41 +325,8 @@ function NewPostgresStore(client: ExtendedPrismaClient): Store {
         findAllQuestionsByRate: (rateID) =>
             findAllQuestionsByRate(client, rateID),
 
-        insertDraftContract: (args) => insertDraftContract(client, args),
-        approveContract: (args) => approveContract(client, args),
-        withdrawContract: (args) => withdrawContract(client, args),
-        withdrawRate: (args) => withdrawRate(client, args),
-        undoWithdrawRate: (args) => undoWithdrawRate(client, args),
-        findContractWithHistory: (args) =>
-            findContractWithHistory(client, args),
-        findRateWithHistory: (args) => findRateWithHistory(client, args),
-        findRateRelatedContracts: (args) =>
-            findRateRelatedContracts(client, args),
-        updateDraftContractWithRates: (args) =>
-            updateDraftContractWithRates(client, args),
-        updateContract: (args) => updateMCCRSID(client, args),
-        updateDraftContract: (args) => updateDraftContract(client, args),
-        updateDraftContractRates: (args) =>
-            updateDraftContractRates(client, args),
-        findAllContractsWithHistoryByState: (args) =>
-            findAllContractsWithHistoryByState(client, args),
-        findAllContractsWithHistoryBySubmitInfo: (args) =>
-            findAllContractsWithHistoryBySubmitInfo(client, args),
-        findAllRatesWithHistoryBySubmitInfo: (args) =>
-            findAllRatesWithHistoryBySubmitInfo(client, args),
-        findAllRatesStripped: (args) => findAllRatesStripped(client, args),
-        submitContract: (args) => submitContract(client, args),
-        submitRate: (args) => submitRate(client, args),
-        unlockContract: (args) => unlockContract(client, args),
-        unlockRate: (args) => unlockRate(client, args),
-
+        /** Other **/
         findAllDocuments: () => findAllDocuments(client),
-        findContractRevision: (args) => findContractRevision(client, args),
-        findRateRevision: (args) => findRateRevision(client, args),
-
-        findEmailSettings: () => findEmailSettings(client),
-        updateEmailSettings: (emailSettings) =>
-            updateEmailSettings(client, emailSettings),
     }
 }
 

--- a/services/app-api/src/resolvers/configureResolvers.ts
+++ b/services/app-api/src/resolvers/configureResolvers.ts
@@ -62,6 +62,7 @@ import { undoWithdrawRate } from './rate/undoWithdrawRate'
 import { rateStrippedResolver } from './rate/rateResolver'
 import { indexRatesStripped } from './rate/indexRatesStripped'
 import { withdrawContract } from './contract/withdrawContract'
+import { undoWithdrawContract } from './contract/undoWithdrawContract'
 
 export function configureResolvers(
     store: Store,
@@ -112,6 +113,7 @@ export function configureResolvers(
             updateDraftContractRates: updateDraftContractRates(store),
             approveContract: approveContract(store),
             withdrawContract: withdrawContract(store, emailer),
+            undoWithdrawContract: undoWithdrawContract(store),
             withdrawRate: withdrawRate(store, emailer),
             undoWithdrawRate: undoWithdrawRate(store, emailer),
             updateDivisionAssignment: updateDivisionAssignment(store),

--- a/services/app-api/src/resolvers/contract/undoWithdrawContract.test.ts
+++ b/services/app-api/src/resolvers/contract/undoWithdrawContract.test.ts
@@ -1,0 +1,517 @@
+import { testCMSUser, testStateUser } from '../../testHelpers/userHelpers'
+import {
+    constructTestPostgresServer,
+    defaultFloridaProgram,
+} from '../../testHelpers/gqlHelpers'
+import {
+    createAndUpdateTestContractWithoutRates,
+    submitTestContract,
+    withdrawTestContract,
+    undoWithdrawTestContract,
+    createAndUpdateTestContractWithRate,
+    createAndSubmitTestContract,
+    approveTestContract,
+    contractHistoryToDescriptions,
+} from '../../testHelpers/gqlContractHelpers'
+import { fetchTestRateById, must } from '../../testHelpers'
+import {
+    addNewRateToTestContract,
+    fetchTestIndexRatesStripped,
+} from '../../testHelpers/gqlRateHelpers'
+import {
+    type RateFormDataInput,
+    UpdateDraftContractRatesDocument,
+} from '../../gen/gqlClient'
+import { expect } from 'vitest'
+
+const testRateFormInputData = (): RateFormDataInput => ({
+    rateType: 'AMENDMENT',
+    rateCapitationType: 'RATE_RANGE',
+    rateDateStart: '2024-01-01',
+    rateDateEnd: '2025-01-01',
+    rateDateCertified: '2024-01-01',
+    amendmentEffectiveDateStart: '2024-02-01',
+    amendmentEffectiveDateEnd: '2025-02-01',
+    rateProgramIDs: [defaultFloridaProgram().id],
+    deprecatedRateProgramIDs: [],
+    rateDocuments: [
+        {
+            s3URL: 's3://bucketname/key/test1',
+            name: 'updatedratedoc1.doc',
+            sha256: 'foobar',
+        },
+    ],
+    supportingDocuments: [],
+    certifyingActuaryContacts: [
+        {
+            name: 'Foo Person',
+            titleRole: 'Bar Job',
+            email: 'foo@example.com',
+            actuarialFirm: 'GUIDEHOUSE',
+        },
+    ],
+    addtlActuaryContacts: [],
+    actuaryCommunicationPreference: 'OACT_TO_ACTUARY',
+})
+
+describe('undoWithdrawContract', () => {
+    const stateUser = testStateUser()
+    const cmsUser = testCMSUser()
+    it('can undo a contract-only submission withdrawal', async () => {
+        const stateServer = await constructTestPostgresServer({
+            context: {
+                user: stateUser,
+            },
+        })
+
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+        })
+
+        const contract = await createAndSubmitTestContract(
+            stateServer,
+            undefined,
+            {
+                submissionType: 'CONTRACT_ONLY',
+            }
+        )
+
+        const withdrawnContract = await withdrawTestContract(
+            cmsServer,
+            contract.id,
+            'withdraw submission'
+        )
+
+        expect(withdrawnContract.consolidatedStatus).toBe('WITHDRAWN')
+
+        const undoWithdrawnContract = await undoWithdrawTestContract(
+            cmsServer,
+            contract.id,
+            'Undo submission withdraw done in error.'
+        )
+
+        const contractHistory = contractHistoryToDescriptions(
+            undoWithdrawnContract
+        )
+        expect(undoWithdrawnContract.consolidatedStatus).toBe('RESUBMITTED')
+        expect(contractHistory).toStrictEqual(
+            expect.arrayContaining([
+                'Initial submission',
+                'CMS undoing submission submission withdrawal. Undo submission withdraw done in error.',
+                'CMS undid submission withdrawal. Undo submission withdraw done in error.',
+            ])
+        )
+    })
+
+    it('can undo a contract and rate submission withdrawal', async () => {
+        const stateServer = await constructTestPostgresServer({
+            context: {
+                user: stateUser,
+            },
+        })
+
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+        })
+
+        const draftContract =
+            await createAndUpdateTestContractWithRate(stateServer)
+
+        await addNewRateToTestContract(stateServer, draftContract)
+
+        const contract = await submitTestContract(stateServer, draftContract.id)
+
+        const rateAID = contract.packageSubmissions[0].rateRevisions[0].rateID
+        const rateBID = contract.packageSubmissions[0].rateRevisions[1].rateID
+
+        if (!rateAID || !rateBID) {
+            throw new Error(
+                'Unexpected error: Rate not found on contract and rate draft submission.'
+            )
+        }
+
+        const withdrawnContract = await withdrawTestContract(
+            cmsServer,
+            contract.id,
+            'withdraw submission'
+        )
+
+        const withdrawnARate = await fetchTestRateById(cmsServer, rateAID)
+        const withdrawnBRate = await fetchTestRateById(cmsServer, rateBID)
+
+        // Expect contract and rates to be withdrawn
+        expect(withdrawnContract.consolidatedStatus).toBe('WITHDRAWN')
+        expect(withdrawnARate.consolidatedStatus).toBe('WITHDRAWN')
+        expect(withdrawnBRate.consolidatedStatus).toBe('WITHDRAWN')
+
+        const undoWithdrawnContract = await undoWithdrawTestContract(
+            cmsServer,
+            contract.id,
+            'undo submission withdraw'
+        )
+
+        const undoWithdrawnARate = await fetchTestRateById(cmsServer, rateAID)
+        const undoWithdrawnBRate = await fetchTestRateById(cmsServer, rateBID)
+
+        expect(undoWithdrawnContract.consolidatedStatus).toBe('RESUBMITTED')
+        expect(undoWithdrawnARate.consolidatedStatus).toBe('RESUBMITTED')
+        expect(undoWithdrawnBRate.consolidatedStatus).toBe('RESUBMITTED')
+    })
+
+    it('can undo a submission withdrawal that had linked child rates', async () => {
+        const stateServer = await constructTestPostgresServer({
+            context: {
+                user: stateUser,
+            },
+        })
+
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+        })
+
+        const draftContract =
+            await createAndUpdateTestContractWithoutRates(stateServer)
+
+        if (!draftContract.draftRevision) {
+            throw new Error(
+                'Unexpected error, no draft revision on draft contract'
+            )
+        }
+
+        must(
+            await stateServer.executeOperation({
+                query: UpdateDraftContractRatesDocument,
+                variables: {
+                    input: {
+                        contractID: draftContract.id,
+                        lastSeenUpdatedAt:
+                            draftContract.draftRevision.updatedAt,
+                        updatedRates: [
+                            {
+                                type: 'CREATE',
+                                formData: testRateFormInputData(),
+                            },
+                            {
+                                type: 'CREATE',
+                                formData: testRateFormInputData(),
+                            },
+                            {
+                                type: 'CREATE',
+                                formData: testRateFormInputData(),
+                            },
+                        ],
+                    },
+                },
+            })
+        )
+
+        const contractA = await submitTestContract(
+            stateServer,
+            draftContract.id
+        )
+
+        const rateAID = contractA.packageSubmissions[0].rateRevisions[0].rateID
+        const rateBID = contractA.packageSubmissions[0].rateRevisions[1].rateID
+        const rateCID = contractA.packageSubmissions[0].rateRevisions[2].rateID
+
+        if (!rateAID) {
+            throw new Error('Unexpected error, expecting rate to exist')
+        }
+
+        if (!rateBID) {
+            throw new Error('Unexpected error, expecting rate to exist')
+        }
+
+        if (!rateCID) {
+            throw new Error('Unexpected error, expecting rate to exist')
+        }
+
+        const draftContractB =
+            await createAndUpdateTestContractWithoutRates(stateServer)
+
+        if (!draftContractB.draftRevision) {
+            throw new Error(
+                'Unexpected error, no draft revision on draft contract'
+            )
+        }
+
+        // Link rate B to contract B
+        must(
+            await stateServer.executeOperation({
+                query: UpdateDraftContractRatesDocument,
+                variables: {
+                    input: {
+                        contractID: draftContractB.id,
+                        lastSeenUpdatedAt:
+                            draftContractB.draftRevision.updatedAt,
+                        updatedRates: [
+                            {
+                                type: 'LINK',
+                                rateID: rateBID,
+                            },
+                        ],
+                    },
+                },
+            })
+        )
+
+        // Submit contract B with linked rate B, now rate B will not be withdrawn
+        await submitTestContract(stateServer, draftContractB.id)
+
+        const draftContractC =
+            await createAndUpdateTestContractWithoutRates(stateServer)
+
+        if (!draftContractC.draftRevision) {
+            throw new Error(
+                'Unexpected error, no draft revision on draft contract'
+            )
+        }
+
+        // Link rate C to contract C
+        must(
+            await stateServer.executeOperation({
+                query: UpdateDraftContractRatesDocument,
+                variables: {
+                    input: {
+                        contractID: draftContractC.id,
+                        lastSeenUpdatedAt:
+                            draftContractC.draftRevision.updatedAt,
+                        updatedRates: [
+                            {
+                                type: 'LINK',
+                                rateID: rateCID,
+                            },
+                        ],
+                    },
+                },
+            })
+        )
+
+        // // contract C is approved, which should not allow rate C to be withdrawn
+        await submitTestContract(stateServer, draftContractC.id)
+        await approveTestContract(cmsServer, draftContractC.id)
+
+        const withdrawnContractA = await withdrawTestContract(
+            cmsServer,
+            contractA.id,
+            'withdraw submission'
+        )
+
+        let ratesStripped = await fetchTestIndexRatesStripped(
+            cmsServer,
+            contractA.stateCode,
+            [rateAID, rateBID, rateCID]
+        )
+
+        let rateA = ratesStripped.edges.find(
+            ({ node }) => node.id === rateAID
+        )?.node
+        let rateB = ratesStripped.edges.find(
+            ({ node }) => node.id === rateBID
+        )?.node
+        let rateC = ratesStripped.edges.find(
+            ({ node }) => node.id === rateCID
+        )?.node
+
+        if (!rateA) {
+            throw new Error(
+                `Unexpected error: Rate A was not found after withdrawing contract.`
+            )
+        }
+        if (!rateB) {
+            throw new Error(
+                `Unexpected error: Rate B was not found after withdrawing contract.`
+            )
+        }
+        if (!rateC) {
+            throw new Error(
+                `Unexpected error: Rate C was not found after withdrawing contract.`
+            )
+        }
+
+        // Expect Contract A to be withdrawn
+        expect(withdrawnContractA.consolidatedStatus).toBe('WITHDRAWN')
+
+        // Expect Rate A to be withdrawn with Contract A
+        expect(rateA.consolidatedStatus).toBe('WITHDRAWN')
+        expect(rateA.parentContractID).toBe(withdrawnContractA.id)
+
+        // Expect Rate B to be resubmitted with Contract B
+        expect(rateB.consolidatedStatus).toBe('RESUBMITTED')
+        expect(rateB.parentContractID).toBe(draftContractB.id)
+
+        // Expect Rate C to be resubmitted with Contract C
+        expect(rateC.consolidatedStatus).toBe('RESUBMITTED')
+        expect(rateC.parentContractID).toBe(draftContractC.id)
+
+        // Undo submission withdrawal
+        const undoWithdrawnContractA = await undoWithdrawTestContract(
+            cmsServer,
+            contractA.id,
+            'undo submission withdraw'
+        )
+
+        ratesStripped = await fetchTestIndexRatesStripped(
+            cmsServer,
+            contractA.stateCode,
+            [rateAID, rateBID, rateCID]
+        )
+
+        rateA = ratesStripped.edges.find(
+            ({ node }) => node.id === rateAID
+        )?.node
+        rateB = ratesStripped.edges.find(
+            ({ node }) => node.id === rateBID
+        )?.node
+        rateC = ratesStripped.edges.find(
+            ({ node }) => node.id === rateCID
+        )?.node
+
+        if (!rateA) {
+            throw new Error(
+                `Unexpected error: Rate A was not found after undo withdrawal.`
+            )
+        }
+        if (!rateB) {
+            throw new Error(
+                `Unexpected error: Rate B was not found after undo withdrawal.`
+            )
+        }
+        if (!rateC) {
+            throw new Error(
+                `Unexpected error: Rate C was not found after undo withdrawal.`
+            )
+        }
+
+        // Expect contract A to be un-withdrawn
+        expect(undoWithdrawnContractA.consolidatedStatus).toBe('RESUBMITTED')
+
+        // Expect Rate A to be un-withdrawn with Contract A
+        expect(rateA.consolidatedStatus).toBe('RESUBMITTED')
+        expect(rateA.parentContractID).toBe(withdrawnContractA.id)
+
+        // Expect Rate B to still be resubmitted with Contract B
+        expect(rateB.consolidatedStatus).toBe('RESUBMITTED')
+        expect(rateB.parentContractID).toBe(draftContractB.id)
+
+        // Expect Rate C to still be resubmitted with Contract C
+        expect(rateC.consolidatedStatus).toBe('RESUBMITTED')
+        expect(rateC.parentContractID).toBe(draftContractC.id)
+    })
+    it('can undo a submission withdrawal that has linked rates', async () => {
+        const stateServer = await constructTestPostgresServer({
+            context: {
+                user: stateUser,
+            },
+        })
+
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+        })
+
+        const draftContractB =
+            await createAndUpdateTestContractWithoutRates(stateServer)
+
+        if (!draftContractB.draftRevision) {
+            throw new Error(
+                'Unexpected error, no draft revision on draft contract'
+            )
+        }
+
+        await addNewRateToTestContract(stateServer, draftContractB)
+
+        const contractB = await submitTestContract(
+            stateServer,
+            draftContractB.id
+        )
+        const rateBID = contractB.packageSubmissions[0].rateRevisions[0].rateID
+
+        if (!rateBID) {
+            throw new Error('Unexpected error, expecting rate B to exist')
+        }
+
+        const draftContractA =
+            await createAndUpdateTestContractWithoutRates(stateServer)
+
+        if (!draftContractA.draftRevision) {
+            throw new Error(
+                'Unexpected error, no draft revision on draft contract'
+            )
+        }
+
+        must(
+            await stateServer.executeOperation({
+                query: UpdateDraftContractRatesDocument,
+                variables: {
+                    input: {
+                        contractID: draftContractA.id,
+                        lastSeenUpdatedAt:
+                            draftContractA.draftRevision.updatedAt,
+                        updatedRates: [
+                            {
+                                type: 'LINK',
+                                rateID: rateBID,
+                            },
+                        ],
+                    },
+                },
+            })
+        )
+
+        const contractA = await submitTestContract(
+            stateServer,
+            draftContractA.id
+        )
+
+        const withdrawnContractA = await withdrawTestContract(
+            cmsServer,
+            contractA.id,
+            'withdraw submission'
+        )
+
+        let rateB = await fetchTestRateById(cmsServer, rateBID)
+
+        if (!rateB) {
+            throw new Error(
+                `Unexpected error: Rate B was not found after withdrawing contract.`
+            )
+        }
+
+        // Expect Contract A to be withdrawn
+        expect(withdrawnContractA.consolidatedStatus).toBe('WITHDRAWN')
+
+        // Expect Rate B to be submitted with Contract B
+        expect(rateB.consolidatedStatus).toBe('SUBMITTED')
+        expect(rateB.parentContractID).toBe(draftContractB.id)
+
+        // Undo submission withdrawal
+        const undoWithdrawnContractA = await undoWithdrawTestContract(
+            cmsServer,
+            contractA.id,
+            'undo submission withdraw'
+        )
+
+        rateB = await fetchTestRateById(cmsServer, rateBID)
+
+        if (!rateB) {
+            throw new Error(
+                `Unexpected error: Rate B was not found after undo withdrawal.`
+            )
+        }
+
+        // Expect contract A to be un-withdrawn
+        expect(undoWithdrawnContractA.consolidatedStatus).toBe('RESUBMITTED')
+
+        // Expect Rate B to still be submitted with Contract B
+        expect(rateB.consolidatedStatus).toBe('SUBMITTED')
+        expect(rateB.parentContractID).toBe(draftContractB.id)
+    })
+})

--- a/services/app-api/src/resolvers/contract/undoWithdrawContract.ts
+++ b/services/app-api/src/resolvers/contract/undoWithdrawContract.ts
@@ -1,0 +1,103 @@
+import type { Store } from '../../postgres'
+import type { MutationResolvers } from '../../gen/gqlServer'
+import {
+    setErrorAttributesOnActiveSpan,
+    setResolverDetailsOnActiveSpan,
+    setSuccessAttributesOnActiveSpan,
+} from '../attributeHelper'
+import { NotFoundError } from '../../postgres'
+import { logError, logSuccess } from '../../logger'
+import { ForbiddenError, UserInputError } from 'apollo-server-lambda'
+import { GraphQLError } from 'graphql/index'
+import { hasCMSPermissions } from '../../domain-models'
+
+export function undoWithdrawContract(
+    store: Store
+): MutationResolvers['undoWithdrawContract'] {
+    return async (_parent, { input }, context) => {
+        const { user, ctx, tracer } = context
+        const span = tracer?.startSpan('undoWithdrawContract', {}, ctx)
+        setResolverDetailsOnActiveSpan('undoWithdrawContract', user, span)
+
+        const { contractID, updatedReason } = input
+        span?.setAttribute('mcreview.package_id', contractID)
+
+        if (!hasCMSPermissions(user)) {
+            const message =
+                'user not authorized to undo a submission withdrawal'
+            logError('undoWithdrawContract', message)
+            setErrorAttributesOnActiveSpan(message, span)
+            throw new ForbiddenError(message)
+        }
+
+        const contractWithHistory =
+            await store.findContractWithHistory(contractID)
+
+        if (contractWithHistory instanceof Error) {
+            if (contractWithHistory instanceof NotFoundError) {
+                const errMessage = `A contract must exist to undo a submission withdrawal: ${contractID}`
+                logError('undoWithdrawContract', errMessage)
+                setErrorAttributesOnActiveSpan(errMessage, span)
+                throw new UserInputError(errMessage, {
+                    argumentName: 'contractID',
+                })
+            }
+
+            const errMessage = `Issue finding a contract. Message: ${contractWithHistory.message}`
+            logError('undoWithdrawContract', errMessage)
+            setErrorAttributesOnActiveSpan(errMessage, span)
+            throw new GraphQLError(errMessage, {
+                extensions: {
+                    code: 'INTERNAL_SERVER_ERROR',
+                    cause: 'DB_ERROR',
+                },
+            })
+        }
+
+        if (contractWithHistory.consolidatedStatus !== 'WITHDRAWN') {
+            const errMessage = `Attempted to undo a submission withdrawal with invalid contract status of ${contractWithHistory.consolidatedStatus}`
+            logError('undoWithdrawContract', errMessage)
+            setErrorAttributesOnActiveSpan(errMessage, span)
+            throw new UserInputError(errMessage, {
+                argumentName: 'contractID',
+                cause: 'INVALID_PACKAGE_STATUS',
+            })
+        }
+
+        const undoWithdrawResult = await store.undoWithdrawContract({
+            contract: contractWithHistory,
+            updatedByID: user.id,
+            updatedReason,
+        })
+
+        if (undoWithdrawResult instanceof Error) {
+            const errMessage = `Failed to undo a submission withdrawal. ${undoWithdrawResult.message}`
+            logError('undoWithdrawContract', errMessage)
+
+            if (undoWithdrawResult instanceof NotFoundError) {
+                throw new GraphQLError(errMessage, {
+                    extensions: {
+                        code: 'NOT_FOUND',
+                        cause: 'DB_ERROR',
+                    },
+                })
+            }
+
+            throw new GraphQLError(errMessage, {
+                extensions: {
+                    code: 'INTERNAL_SERVER_ERROR',
+                    cause: 'DB_ERROR',
+                },
+            })
+        }
+
+        const { contract } = undoWithdrawResult
+
+        logSuccess('undoWithdrawContract')
+        setSuccessAttributesOnActiveSpan(span)
+
+        return {
+            contract: contract,
+        }
+    }
+}

--- a/services/app-api/src/resolvers/contract/withdrawContract.test.ts
+++ b/services/app-api/src/resolvers/contract/withdrawContract.test.ts
@@ -332,7 +332,7 @@ describe('withdrawContract', () => {
         expect(rateC.parentContractID).toBe(draftContractC.id)
 
         const contractAHistory =
-            await contractHistoryToDescriptions(withdrawnContract)
+            contractHistoryToDescriptions(withdrawnContract)
 
         expect(contractAHistory).toStrictEqual(
             expect.arrayContaining([
@@ -659,7 +659,7 @@ describe('withdrawContract', () => {
 
         const rateA = await fetchTestRateById(cmsServer, rateARevision.rateID)
 
-        // expect rateA to be withdrawn with the original parent contract
+        // expect contract A to be withdrawn
         expect(withdrawnContract.consolidatedStatus).toBe('WITHDRAWN')
 
         // expect rate A to be resubmitted and its new parent contract is B.

--- a/services/app-api/src/resolvers/contract/withdrawContract.ts
+++ b/services/app-api/src/resolvers/contract/withdrawContract.ts
@@ -36,8 +36,8 @@ export function withdrawContract(
 
         if (contractWithHistory instanceof Error) {
             if (contractWithHistory instanceof NotFoundError) {
-                const errMessage = `A contract must exist to be unlocked: ${contractID}`
-                logError('unlockContract', errMessage)
+                const errMessage = `A contract must exist to be withdrawn: ${contractID}`
+                logError('withdrawContract', errMessage)
                 setErrorAttributesOnActiveSpan(errMessage, span)
                 throw new UserInputError(errMessage, {
                     argumentName: 'contractID',
@@ -45,7 +45,7 @@ export function withdrawContract(
             }
 
             const errMessage = `Issue finding a contract. Message: ${contractWithHistory.message}`
-            logError('unlockContract', errMessage)
+            logError('withdrawContract', errMessage)
             setErrorAttributesOnActiveSpan(errMessage, span)
             throw new GraphQLError(errMessage, {
                 extensions: {

--- a/services/app-api/src/testHelpers/gqlContractHelpers.ts
+++ b/services/app-api/src/testHelpers/gqlContractHelpers.ts
@@ -34,6 +34,7 @@ import { addNewRateToTestContract } from './gqlRateHelpers'
 import type { ContractFormDataType } from '../domain-models'
 import type { CreateHealthPlanPackageInput } from '../gen/gqlServer'
 import { mockGqlContractDraftRevisionFormDataInput } from './gqlContractInputMocks'
+import type { GraphQLFormattedError } from 'graphql/index'
 
 const createAndSubmitTestContract = async (
     server: ApolloServer,
@@ -518,6 +519,30 @@ const undoWithdrawTestContract = async (
     return undoWithdrawResult.data.undoWithdrawContract.contract
 }
 
+const errorUndoWithdrawTestContract = async (
+    server: ApolloServer,
+    contractID: string,
+    updatedReason: string
+): Promise<ReadonlyArray<GraphQLFormattedError>> => {
+    const undoWithdrawResult = await server.executeOperation({
+        query: UndoWithdrawContractDocument,
+        variables: {
+            input: {
+                contractID,
+                updatedReason,
+            },
+        },
+    })
+
+    if (!undoWithdrawResult.errors) {
+        throw new Error(
+            'errorUndoWithdrawTestContract: expected errors to return'
+        )
+    }
+
+    return undoWithdrawResult.errors
+}
+
 const contractHistoryToDescriptions = (contract: Contract): string[] => {
     return contract.packageSubmissions.reduce((history: string[], pkgSub) => {
         const updatedHistory = history
@@ -560,4 +585,5 @@ export {
     withdrawTestContract,
     undoWithdrawTestContract,
     contractHistoryToDescriptions,
+    errorUndoWithdrawTestContract,
 }

--- a/services/app-api/src/testHelpers/gqlRateHelpers.ts
+++ b/services/app-api/src/testHelpers/gqlRateHelpers.ts
@@ -520,13 +520,15 @@ const undoWithdrawTestRate = async (
 
 const fetchTestIndexRatesStripped = async (
     server: ApolloServer,
-    stateCode?: string
+    stateCode?: string,
+    rateIDs?: string[]
 ): Promise<IndexRatesStrippedPayload> => {
     const indexRatesStrippedResult = await server.executeOperation({
         query: IndexRatesStrippedDocument,
         variables: {
             input: {
-                stateCode: stateCode,
+                stateCode,
+                rateIDs,
             },
         },
     })

--- a/services/app-api/src/testHelpers/storeHelpers.ts
+++ b/services/app-api/src/testHelpers/storeHelpers.ts
@@ -139,9 +139,6 @@ function mockStoreThatErrors(): Store {
         unlockRate: async (_ID) => {
             return genericError
         },
-        replaceRateOnContract: async (_ID) => {
-            return genericError
-        },
         findAllDocuments: async () => {
             return genericError
         },
@@ -155,6 +152,9 @@ function mockStoreThatErrors(): Store {
             return genericError
         },
         withdrawContract: async (_ID) => {
+            return genericError
+        },
+        undoWithdrawContract: async (_ID) => {
             return genericError
         },
         withdrawRate: async (_ID) => {

--- a/services/app-graphql/src/mutations/undoWithdrawContract.graphql
+++ b/services/app-graphql/src/mutations/undoWithdrawContract.graphql
@@ -1,0 +1,37 @@
+mutation undoWithdrawContract($input: UndoWithdrawContractInput!) {
+    undoWithdrawContract(input: $input) {
+        contract {
+            ...contractFieldsFragment
+
+            draftRevision {
+                ...contractRevisionFragment
+            }
+
+            draftRates {
+                ...rateFieldsFragment
+
+                draftRevision {
+                    ...rateRevisionFragment
+                }
+
+                revisions {
+                    ...rateRevisionFragment
+                }
+            }
+
+            withdrawnRates {
+                ...rateFieldsFragment,
+                revisions {
+                    ...rateRevisionFragment
+                }
+                packageSubmissions {
+                    ...ratePackageSubmissionsFragment
+                }
+            }
+
+            packageSubmissions {
+                ...packageSubmissionsFragment
+            }
+        }
+    }
+}

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -584,7 +584,14 @@ type Mutation {
     """
     withdrawContract(
         input: WithdrawContractInput!
-    ): WithdrawContractPayload
+    ): WithdrawContractPayload!
+
+    """
+    unoWithdrawSubmission is a CMS user only action to undo a submission widthdrawal, which includes contract and and child rates withdrawn together.
+    """
+    undoWithdrawContract(
+        input: UndoWithdrawContractInput!
+    ): UndoWithdrawContractPayload!
 }
 
 input CreateHealthPlanPackageInput {
@@ -667,6 +674,10 @@ type WithdrawContractPayload {
     contract: Contract!
 }
 
+type UndoWithdrawContractPayload {
+    contract: Contract!
+}
+
 input WithdrawRateInput {
     rateID: ID!
     updatedReason: String!
@@ -678,6 +689,11 @@ input UndoWithdrawRateInput {
 }
 
 input WithdrawContractInput {
+    contractID: ID!
+    updatedReason: String!
+}
+
+input UndoWithdrawContractInput {
     contractID: ID!
     updatedReason: String!
 }
@@ -1370,6 +1386,31 @@ type GenericDocument {
     "The first date this document was added to submitted package - if still an initial draft, this date is last updated, otherwise it is the submitInfo lastUpdated"
     dateAdded: DateTime
 }
+
+input GenericDocumentInput {
+    "The user created name of the document"
+    name: String!
+    "The S3 URL of the document, generated on the FE currently in the FileUpload component"
+    s3URL: String!
+    "The sha256 is a unique string representing the file, generated on the FE currently in the FileUpload component"
+    sha256: String!
+    "The first date this document was added to submitted package - if still an initial draft, this date is last updated, otherwise it is the submitInfo lastUpdated"
+    dateAdded: DateTime
+}
+
+type GenericDocumentReturnData {
+    "The user created name of the document"
+    name: String!
+    "The S3 URL of the document, generated on the FE currently in the FileUpload component"
+    s3URL: String!
+    "The sha256 is a unique string representing the file, generated on the FE currently in the FileUpload component"
+    sha256: String!
+    "URL received from S3 for downloading the document"
+    downloadURL: String
+    "The first date this document was added to submitted package - if still an initial draft, this date is last updated, otherwise it is the submitInfo lastUpdated"
+    dateAdded: DateTime
+}
+
 
 """
 GenericDocument
@@ -2272,7 +2313,7 @@ input FetchRateInput {
 
 type FetchContractPayload {
     """
-    A rate that include contract and rate revisions
+    A contract that include contract and rate revisions
     """
     contract: Contract!
 }

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -1387,31 +1387,6 @@ type GenericDocument {
     dateAdded: DateTime
 }
 
-input GenericDocumentInput {
-    "The user created name of the document"
-    name: String!
-    "The S3 URL of the document, generated on the FE currently in the FileUpload component"
-    s3URL: String!
-    "The sha256 is a unique string representing the file, generated on the FE currently in the FileUpload component"
-    sha256: String!
-    "The first date this document was added to submitted package - if still an initial draft, this date is last updated, otherwise it is the submitInfo lastUpdated"
-    dateAdded: DateTime
-}
-
-type GenericDocumentReturnData {
-    "The user created name of the document"
-    name: String!
-    "The S3 URL of the document, generated on the FE currently in the FileUpload component"
-    s3URL: String!
-    "The sha256 is a unique string representing the file, generated on the FE currently in the FileUpload component"
-    sha256: String!
-    "URL received from S3 for downloading the document"
-    downloadURL: String
-    "The first date this document was added to submitted package - if still an initial draft, this date is last updated, otherwise it is the submitInfo lastUpdated"
-    dateAdded: DateTime
-}
-
-
 """
 GenericDocument
 


### PR DESCRIPTION
## Summary
[MCR-5149](https://jiraent.cms.gov/browse/MCR-5149)

Adds `undoWithdrawContract` API. This will allow a `WITHDRAWN` submission (contract and child rates) to be un-withdrawn.

- The Postgres function here is pretty simple
   - Validate contract is withdrawn by querying the contract's review status to check if latest action was `WITHDRAW`
      - The resolver also checks for `WITHDRAWN` status, but since this is a transaction function that could be use elsewhere we want to validate the status again.
   - Unlocked the contract with default withdraw text and append inputted reason.
   - Gather all draft rates with this contracts ID as the `parentContractID`
      - During a submission withdraw, linked child rates (child rate that is linked to another submission) are NOT withdrawn with the contract and are reassigned a new parent contract. 
      - At this point any rate that is still a child rate, was withdrawn with this contract. Our unlock Postgres function will automatically unlock them because of the parent child relationship.
   - Submit contract with default withdraw text and append inputted reason.
   - Add action type of `UNDER_REVIEW` for the contract
   - Loop through the rates we gathered after unlocking and add an action type of `UNDER_REVIEW`.
   - Returns the un-withdrawn contract along with the rates for the emails.
- The resolver work 
 - Performs user auth
 - contract status validations
 - OUT OF SCOPE: emails.
 
 AC:
When a submission is un-withdrawn
- The contract adds a new review action of action type UNDER_REVIEW
   - Revision unlock and submit info should contain a default message about it being withdrawn and include the inputted unwithdraw reason.
   - The default message should probably include rates unwithdrawn with this submission.
      - **NOTE**: We did NOT do this with submission withdraw, so following that pattern here
- Child rates also adds a new review action of action type UNDER_REVIEW
   - Revision unlock and submit info should contain a default message about it being withdrawn and include the inputted unwithdraw reason.
   - The default message should probably include contract unwithdrawn with this submission.
      - **NOTE**: We did NOT do this with submission withdraw, so following that pattern here.
      - Also the pattern we use for unlocking a submission is sharing the unlock and resubmit reason across the contract and child rates. Having a separate message while taking an action on an entire submission greatly deviates with the pattern.
 
#### Related issues

#### Screenshots

#### Test cases covered

`undoWithdrawContract.test.ts` - resolver
- `'can undo a contract-only submission withdrawal'`
- `'can undo a contract and rate submission withdrawal'`
- `'can undo a submission withdrawal that had linked child rates'`
- `'can undo a submission withdrawal that has linked rates'`
- `'returns an error if contract is in incorrect status'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

You can manually call this API using the GraphQL explorer tool.

<!---These are developer instructions on how to test or validate the work -->
