### PR TITLE
[MCR-5274] State cannot change answer from "no" to "yes" on "was this rate included on any other submissions"

### DIFF
--- a/services/app-web/src/pages/LinkYourRates/LinkYourRates.stories.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkYourRates.stories.tsx
@@ -20,6 +20,7 @@ export const LinkRates = (): React.ReactElement => {
                     autofill={() => {
                         console.info('autofill rate')
                     }}
+                    disableRadioBtns={false}
                 />
             </form>
         </Formik>

--- a/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
@@ -18,6 +18,7 @@ export type LinkYourRatesProps = {
     index: number
     shouldValidate: boolean
     autofill: (rateForm: FormikRateForm) => void // used for multi-rates, when called will FieldArray replace the existing form fields with new data
+    disableRadioBtns: boolean
 }
 
 export const LinkYourRates = ({
@@ -25,6 +26,7 @@ export const LinkYourRates = ({
     index,
     autofill,
     shouldValidate,
+    disableRadioBtns,
 }: LinkYourRatesProps): React.ReactElement | null => {
     const { values, errors } = useFormikContext<RateDetailFormConfig>()
     const { getKey } = useS3()
@@ -63,8 +65,14 @@ export const LinkYourRates = ({
                 legend={
                     'Was this rate certification included with another submission?'
                 }
+                data-testid="linkRateRadioGroup"
+                disabled={disableRadioBtns}
             >
-                <span className={styles.requiredOptionalText}>Required</span>
+                {!disableRadioBtns && (
+                    <span className={styles.requiredOptionalText}>
+                        Required
+                    </span>
+                )}
                 <PoliteErrorMessage formFieldLabel="Was this rate certification included with another submission?">
                     {showFieldErrors('ratePreviouslySubmitted')}
                 </PoliteErrorMessage>
@@ -102,6 +110,14 @@ export const LinkYourRates = ({
                     radio_button_title="Yes, this rate certification is part of another submission"
                     parent_component_heading="Was this rate certification included with another submission?"
                 />
+                {disableRadioBtns && (
+                    <span
+                        className={styles.requiredOptionalText}
+                        style={{ marginTop: '3%' }}
+                    >
+                        If you need to change your response, contact CMS.
+                    </span>
+                )}
             </Fieldset>
             {getIn(values, `${fieldNamePrefix}.ratePreviouslySubmitted`) ===
                 'YES' && (

--- a/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/V2/RateDetailsV2.tsx
@@ -401,6 +401,20 @@ const RateDetails = ({
         return false
     }
 
+    const disableRateLinkRadios = (rateForm: FormikRateForm) => {
+        //Expect the `Was this rate certification included with another submission?`
+        //radio buttons to be disabled for any rate that is not a linked rate or in a draft state
+        if (
+            rateForm.ratePreviouslySubmitted === 'YES' ||
+            rateForm.status === 'DRAFT' ||
+            rateForm.status === undefined
+        ) {
+            return false
+        }
+
+        return true
+    }
+
     return (
         <>
             <FormNotificationContainer>
@@ -516,6 +530,9 @@ const RateDetails = ({
                                                                         shouldValidate={
                                                                             shouldValidate
                                                                         }
+                                                                        disableRadioBtns={disableRateLinkRadios(
+                                                                            rateForm
+                                                                        )}
                                                                     />
                                                                 )}
                                                                 {!displayAsStandaloneRate &&


### PR DESCRIPTION
## Summary
As a state user, 
I want to be prevented from removing a submitted rate from a submission. 
so that I do not inadvertently close out a rate review that CMS is in the middle of reviewing. 

AC: 

- If I am a state user on an unlocked submission contains a submitted rate and "was this rate included on any other submissions" was answered as "no", Then I do NOT see the "was this rate included on any other submissions" form field as an editable form field (suggest that the question not appear at all). 

- If I am a state user on submission contains a draft, unsubmitted rate where "was this rate included on any other submissions" = "no", Then I continue to see the "was this rate included on any other submissions" form field and I can edit it. 

- If I am a state user on a submission contains an unlocked submitted rate and "was this rate included on any other submissions" was answered as"yes", Then I DO see the "was this rate included on any other submissions" question and I can change my response to unlink the rate. 

#### Related issues
[MCR-5274](https://jiraent.cms.gov/browse/MCR-5274)

[Design](https://www.figma.com/design/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?node-id=19968-21121&t=UVlPH93azeDY09UZ-0)
#### Screenshots
![image](https://github.com/user-attachments/assets/35c6ca2f-0874-4ba4-ade6-a2c5acc543ff)

#### Test cases covered
Added a test to ensure the radio group is dis/enabled under three different conditions and the expected message is rendered beneath the radio group
<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

1. Access a submission (as a state user) that has been unlocked and contains at least one child rate and one linked rate
2. Expect the child rate to be disabled
3. Expect the `Required` label to disappear and expect `If you need to change your response, contact CMS.` to render below the radio group [per design](https://www.figma.com/design/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?node-id=19968-21121&t=UVlPH93azeDY09UZ-0)
4. Expect the linked rate to be enabled

<!---These are developer instructions on how to test or validate the work -->
