### PR TITLE
[MCR-4915] CMS sees undo withdraw button on submission summary

### DIFF
--- a/packages/constants/src/routes.ts
+++ b/packages/constants/src/routes.ts
@@ -104,7 +104,7 @@ const RoutesRecord: Record<RouteT, string> = {
         '/submissions/:id/rates/:rateID/question-and-answers/:division/:questionID/upload-response',
     SUBMISSIONS_RELEASED_TO_STATE: '/submissions/:id/released-to-state',
     SUBMISSION_WITHDRAW: '/submission-reviews/:id/withdraw-submission',
-    UNDO_SUBMISSION_WITHDRAW: '/submission-reviews/:id/undo-withdraw',
+    UNDO_SUBMISSION_WITHDRAW: '/submission-reviews/:id/undo-withdraw-submission',
 }
 
 // Constants for releated descendant routes
@@ -217,7 +217,7 @@ const PageTitlesRecord: Record<RouteT | 'UNKNOWN_ROUTE', string> = {
     SUBMISSIONS_RELEASED_TO_STATE: 'Released to state',
     UNKNOWN_ROUTE: 'Not found',
     SUBMISSION_WITHDRAW: 'Withdraw submission',
-    UNDO_SUBMISSION_WITHDRAW: 'Undo withdraw'
+    UNDO_SUBMISSION_WITHDRAW: 'Undo submission withdraw'
 }
 
 /*

--- a/packages/constants/src/routes.ts
+++ b/packages/constants/src/routes.ts
@@ -44,7 +44,8 @@ const ROUTES = [
     'SUBMISSIONS_UPLOAD_CONTRACT_RESPONSE',
     'SUBMISSIONS_UPLOAD_RATE_RESPONSE',
     'SUBMISSIONS_RELEASED_TO_STATE',
-    'SUBMISSION_WITHDRAW'
+    'SUBMISSION_WITHDRAW',
+    'UNDO_SUBMISSION_WITHDRAW'
 ] as const // iterable union type
 type RouteT = (typeof ROUTES)[number]
 type RouteTWithUnknown = RouteT | 'UNKNOWN_ROUTE'
@@ -102,7 +103,8 @@ const RoutesRecord: Record<RouteT, string> = {
     SUBMISSIONS_UPLOAD_RATE_RESPONSE:
         '/submissions/:id/rates/:rateID/question-and-answers/:division/:questionID/upload-response',
     SUBMISSIONS_RELEASED_TO_STATE: '/submissions/:id/released-to-state',
-    SUBMISSION_WITHDRAW: '/submission-reviews/:id/withdraw-submission'
+    SUBMISSION_WITHDRAW: '/submission-reviews/:id/withdraw-submission',
+    UNDO_SUBMISSION_WITHDRAW: '/submission-reviews/:id/undo-withdraw',
 }
 
 // Constants for releated descendant routes
@@ -160,7 +162,8 @@ const CMS_WORKFLOW_FORM_ROUTES: RouteTWithUnknown[]  = [
     'RATE_WITHDRAW',
     'UNDO_RATE_WITHDRAW',
     'SUBMISSIONS_RELEASED_TO_STATE',
-    'SUBMISSION_WITHDRAW'
+    'SUBMISSION_WITHDRAW',
+    'UNDO_SUBMISSION_WITHDRAW'
 ]
 
 const SETTINGS_HIDE_SIDEBAR_ROUTES: RouteTWithUnknown[] = [
@@ -213,7 +216,8 @@ const PageTitlesRecord: Record<RouteT | 'UNKNOWN_ROUTE', string> = {
     SUBMISSIONS_UPLOAD_RATE_RESPONSE: 'Add rate response',
     SUBMISSIONS_RELEASED_TO_STATE: 'Released to state',
     UNKNOWN_ROUTE: 'Not found',
-    SUBMISSION_WITHDRAW: 'Withdraw submission'
+    SUBMISSION_WITHDRAW: 'Withdraw submission',
+    UNDO_SUBMISSION_WITHDRAW: 'Undo withdraw'
 }
 
 /*

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -200,6 +200,10 @@ const CMSUserRoutes = ({
         featureFlags.WITHDRAW_SUBMISSION.flag,
         featureFlags.WITHDRAW_SUBMISSION.defaultValue
     )
+    const showUndoWithdrawSubmission: boolean = ldClient?.variation(
+        featureFlags.UNDO_WITHDRAW_SUBMISSION.flag,
+        featureFlags.UNDO_WITHDRAW_SUBMISSION.defaultValue
+    )
 
     return (
         <AuthenticatedRouteWrapper>
@@ -279,6 +283,13 @@ const CMSUserRoutes = ({
                     <Route
                         path={RoutesRecord.SUBMISSION_WITHDRAW}
                         element={<SubmissionWithdraw />}
+                    />
+                )}
+
+                {showUndoWithdrawSubmission && (
+                    <Route
+                        path={RoutesRecord.UNDO_SUBMISSION_WITHDRAW}
+                        element={<h1>UNDO_SUBMISSION_WITHDRAW</h1>}
                     />
                 )}
 

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -569,7 +569,9 @@ describe('SubmissionSummary', () => {
                             routerProvider: {
                                 route: '/submissions/test-abc-123',
                             },
-                            featureFlags: {},
+                            featureFlags: {
+                                'undo-withdraw-submission': true,
+                            },
                         }
                     )
 
@@ -625,6 +627,9 @@ describe('SubmissionSummary', () => {
                             routerProvider: {
                                 route: '/submissions/test-abc-123',
                             },
+                            featureFlags: {
+                                'undo-withdraw-submission': true,
+                            },
                         }
                     )
 
@@ -664,7 +669,9 @@ describe('SubmissionSummary', () => {
                             routerProvider: {
                                 route: '/submissions/test-abc-123',
                             },
-                            featureFlags: {},
+                            featureFlags: {
+                                'undo-withdraw-submission': true,
+                            },
                         }
                     )
                     await waitFor(() => {
@@ -737,7 +744,9 @@ describe('SubmissionSummary', () => {
                             routerProvider: {
                                 route: '/submissions/test-abc-123',
                             },
-                            featureFlags: {},
+                            featureFlags: {
+                                'undo-withdraw-submission': true,
+                            },
                         }
                     )
 
@@ -783,6 +792,9 @@ describe('SubmissionSummary', () => {
                             },
                             routerProvider: {
                                 route: '/submissions/15',
+                            },
+                            featureFlags: {
+                                'undo-withdraw-submission': true,
                             },
                         }
                     )
@@ -842,7 +854,9 @@ describe('SubmissionSummary', () => {
                             routerProvider: {
                                 route: '/submissions/test-abc-123',
                             },
-                            featureFlags: {},
+                            featureFlags: {
+                                'undo-withdraw-submission': true,
+                            },
                         }
                     )
 
@@ -916,6 +930,9 @@ describe('SubmissionSummary', () => {
                             routerProvider: {
                                 route: '/submissions/test-abc-123',
                             },
+                            featureFlags: {
+                                'undo-withdraw-submission': true,
+                            },
                         }
                     )
 
@@ -973,6 +990,9 @@ describe('SubmissionSummary', () => {
                             },
                             routerProvider: {
                                 route: '/submissions/test-abc-123',
+                            },
+                            featureFlags: {
+                                'undo-withdraw-submission': true,
                             },
                         }
                     )
@@ -1039,6 +1059,9 @@ describe('SubmissionSummary', () => {
                             },
                             routerProvider: {
                                 route: '/submissions/test-abc-123',
+                            },
+                            featureFlags: {
+                                'undo-withdraw-submission': true,
                             },
                         }
                     )
@@ -1119,6 +1142,9 @@ describe('SubmissionSummary', () => {
                             routerProvider: {
                                 route: '/submissions/test-abc-123',
                             },
+                            featureFlags: {
+                                'undo-withdraw-submission': true,
+                            },
                         }
                     )
 
@@ -1164,6 +1190,9 @@ describe('SubmissionSummary', () => {
                             },
                             routerProvider: {
                                 route: '/submissions/test-abc-123',
+                            },
+                            featureFlags: {
+                                'undo-withdraw-submission': true,
                             },
                         }
                     )
@@ -1225,6 +1254,7 @@ describe('SubmissionSummary', () => {
                             },
                             featureFlags: {
                                 'withdraw-submission': true,
+                                'undo-withdraw-submission': true,
                             },
                         }
                     )
@@ -1253,7 +1283,7 @@ describe('SubmissionSummary', () => {
                     ).toHaveClass('usa-button')
                 })
 
-                it('does not render withdraw submission button for an withdrawn submission', async () => {
+                it('render undo withdraw button for a withdrawn submission', async () => {
                     const contract =
                         mockContractPackageSubmittedWithQuestions(
                             'test-abc-123'
@@ -1287,6 +1317,9 @@ describe('SubmissionSummary', () => {
                             routerProvider: {
                                 route: '/submissions/test-abc-123',
                             },
+                            featureFlags: {
+                                'undo-withdraw-submission': true,
+                            },
                         }
                     )
                     await waitFor(() => {
@@ -1310,9 +1343,16 @@ describe('SubmissionSummary', () => {
                     ).not.toBeInTheDocument()
 
                     expect(
-                        screen.getByText(
+                        screen.queryByText(
                             'No action can be taken on this submission in its current status.'
                         )
+                    ).not.toBeInTheDocument()
+
+                    //Expect undo withdraw button to render
+                    expect(
+                        screen.queryByRole('button', {
+                            name: 'Undo submission withdraw',
+                        })
                     ).toBeInTheDocument()
                 })
             })

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -300,9 +300,7 @@ export const SubmissionSummary = (): React.ReactElement => {
                                 current status.
                             </Grid>
                         ) : (
-                            <MultiColumnGrid
-                                columns={showUndoWithdrawBtn ? 2 : 3}
-                            >
+                            <MultiColumnGrid columns={3}>
                                 {showUnlockBtn && (
                                     <ModalOpenButton
                                         modalRef={modalRef}
@@ -349,10 +347,11 @@ export const SubmissionSummary = (): React.ReactElement => {
                                         outline
                                         onClick={() =>
                                             navigate(
-                                                `/submission-reviews/${contract.id}/undo-withdraw`
+                                                `/submission-reviews/${contract.id}/undo-withdraw-submission`
                                             )
                                         }
-                                        link_url={`/submission-reviews/${contract.id}/undo-withdraw`}
+                                        link_url={`/submission-reviews/${contract.id}/undo-withdraw-submission`}
+                                        style={{ width: '16rem' }}
                                     >
                                         Undo submission withdraw
                                     </ButtonWithLogging>

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -65,6 +65,11 @@ export const SubmissionSummary = (): React.ReactElement => {
         featureFlags.WITHDRAW_SUBMISSION.defaultValue
     )
 
+    const undoWithdrawSubmissionFlag = ldClient?.variation(
+        featureFlags.UNDO_WITHDRAW_SUBMISSION.flag,
+        featureFlags.UNDO_WITHDRAW_SUBMISSION.defaultValue
+    )
+
     // API requests
     const { data, loading, error } = useFetchContractWithQuestionsQuery({
         variables: {
@@ -189,9 +194,15 @@ export const SubmissionSummary = (): React.ReactElement => {
         hasCMSPermissions &&
         withdrawSubmissionFlag &&
         ['SUBMITTED', 'RESUBMITTED'].includes(consolidatedStatus)
+    const showUndoWithdrawBtn =
+        hasCMSPermissions &&
+        undoWithdrawSubmissionFlag &&
+        consolidatedStatus === 'WITHDRAWN'
     const showNoActionsMsg =
-        !showApprovalBtn && !showUnlockBtn && !showWithdrawBtn
-
+        !showApprovalBtn &&
+        !showUnlockBtn &&
+        !showWithdrawBtn &&
+        !showUndoWithdrawBtn
     const showApprovalBanner =
         consolidatedStatus === 'APPROVED' && latestContractAction
     const showWithdrawnBanner =
@@ -289,7 +300,9 @@ export const SubmissionSummary = (): React.ReactElement => {
                                 current status.
                             </Grid>
                         ) : (
-                            <MultiColumnGrid columns={3}>
+                            <MultiColumnGrid
+                                columns={showUndoWithdrawBtn ? 2 : 3}
+                            >
                                 {showUnlockBtn && (
                                     <ModalOpenButton
                                         modalRef={modalRef}
@@ -327,6 +340,21 @@ export const SubmissionSummary = (): React.ReactElement => {
                                         link_url={`/submission-reviews/${contract.id}/withdraw-submission`}
                                     >
                                         Withdraw submission
+                                    </ButtonWithLogging>
+                                )}
+                                {showUndoWithdrawBtn && (
+                                    <ButtonWithLogging
+                                        className="usa-button usa-button--outline"
+                                        type="button"
+                                        outline
+                                        onClick={() =>
+                                            navigate(
+                                                `/submission-reviews/${contract.id}/undo-withdraw`
+                                            )
+                                        }
+                                        link_url={`/submission-reviews/${contract.id}/undo-withdraw`}
+                                    >
+                                        Undo submission withdraw
                                     </ButtonWithLogging>
                                 )}
                             </MultiColumnGrid>

--- a/services/app-web/src/tealium/constants.ts
+++ b/services/app-web/src/tealium/constants.ts
@@ -42,6 +42,7 @@ const TEALIUM_CONTENT_TYPE_BY_ROUTE: Record<RouteT | 'UNKNOWN_ROUTE', string> =
         SUBMISSIONS_UPLOAD_RATE_RESPONSE: 'form',
         SUBMISSIONS_RELEASED_TO_STATE: 'form',
         SUBMISSION_WITHDRAW: 'form',
+        UNDO_SUBMISSION_WITHDRAW: 'form',
         UNKNOWN_ROUTE: '404',
     }
 


### PR DESCRIPTION
## Summary
CMS sees an undo withdrawal button on submission summary

AC: 

1. If I am logged in as a CMS user and I go to a submission summary page for a withdrawn submission then I see an "Undo withdraw" button in the actions section
2. If I am logged in as a CMS user and I go to a submission summary page for a submission that is submitted then I do not see "Undo Withdraw" button included but I see "Unlock submission, Withdraw submission, Released to state"
3. If I am logged in as a CMS user and I go to a submission summary page for a submission that is approved or unlocked then I do not see "Undo Withdraw" button included but I see No actions available empty state message

#### Related issues
[MCR-4915](https://jiraent.cms.gov/browse/MCR-4915)
#### Screenshots
![image](https://github.com/user-attachments/assets/fe8ad486-e170-4386-bc59-d2d9be0c59cd)

#### Test cases covered

1. Edited an old test case to check for the undo button

## QA guidance
1. Withdraw a submission
2. Expect the undo button to render on the submission summary page
<!---These are developer instructions on how to test or validate the work -->
