### PR TITLE
MCR-5293: cms sees orphan rates label on rate summary page

### DIFF
--- a/packages/mocks/src/apollo/contractPackageDataMock.ts
+++ b/packages/mocks/src/apollo/contractPackageDataMock.ts
@@ -1119,10 +1119,12 @@ function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
         status: 'SUBMITTED',
         reviewStatus: 'UNDER_REVIEW',
         consolidatedStatus: 'SUBMITTED',
+        reviewStatusActions: [],
         __typename: 'Contract',
         createdAt: new Date(),
         updatedAt: new Date(),
         lastUpdatedForDisplay: new Date(),
+        dateContractDocsExecuted: new Date(),
         webURL: 'https://testmcreview.example/submissions/test-abc-123',
         initiallySubmittedAt: new Date('2024-11-27'),
         id: contractID,
@@ -1236,6 +1238,18 @@ function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
                         rateID: '123',
                         createdAt: new Date('01/01/2023'),
                         updatedAt: new Date('01/01/2023'),
+                        submitInfo: {
+                            __typename: 'UpdateInformation',
+                            updatedAt: new Date(),
+                            updatedBy: {
+                                email: 'example@state.com',
+                                role: 'STATE_USER',
+                                givenName: 'John',
+                                familyName: 'Vila',
+                            },
+                            updatedReason: 'contract submit',
+                        },
+                        unlockInfo: null,
                         rate: null,
                         formData: {
                             __typename: 'RateFormData',
@@ -1281,18 +1295,22 @@ function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
                             deprecatedRateProgramIDs: [],
                             certifyingActuaryContacts: [
                                 {
+                                    id: 'certifyingActuaryContacts1',
                                     actuarialFirm: 'DELOITTE',
                                     name: 'Actuary Contact 1',
                                     titleRole: 'Test Actuary Contact 1',
                                     email: 'actuarycontact1@test.com',
+                                    actuarialFirmOther: null
                                 },
                             ],
                             addtlActuaryContacts: [
                                 {
+                                    id: 'addtlActuaryContacts1',
                                     actuarialFirm: 'DELOITTE',
                                     name: 'Actuary Contact 1',
                                     titleRole: 'Test Actuary Contact 1',
                                     email: 'actuarycontact1@test.com',
+                                    actuarialFirmOther: null
                                 },
                             ],
                             actuaryCommunicationPreference: 'OACT_TO_ACTUARY',

--- a/services/app-web/src/components/DataDetail/DataDetail.module.scss
+++ b/services/app-web/src/components/DataDetail/DataDetail.module.scss
@@ -23,4 +23,9 @@
     color: custom.$mcr-error-base;
     font-weight: 700;
     display: flex;
+    margin-top: 5px;
+}
+
+.missingInfoIcon {
+    margin-right: 3px;
 }

--- a/services/app-web/src/components/DataDetail/DataDetail.tsx
+++ b/services/app-web/src/components/DataDetail/DataDetail.tsx
@@ -7,6 +7,7 @@ export type DataDetailProps = {
     label: string
     children?: React.ReactNode | string[]
     explainMissingData?: boolean // Display fallback text when data is undefined or null. Should be true on review-and-submit
+    explainMissingDataMsg?: string
 }
 
 /*
@@ -30,6 +31,7 @@ export const DataDetail = ({
     label,
     children,
     explainMissingData = false,
+    explainMissingDataMsg,
 }: DataDetailProps): React.ReactElement | null => {
     const handleArray = Array.isArray(children)
     const noData =
@@ -40,7 +42,9 @@ export const DataDetail = ({
             <dt id={id}>{label}</dt>
             <dd role="definition" aria-labelledby={id}>
                 {explainMissingData && noData ? (
-                    <DataDetailMissingField />
+                    <DataDetailMissingField
+                        requiredText={explainMissingDataMsg}
+                    />
                 ) : handleArray ? (
                     children.join(', ').toUpperCase()
                 ) : (

--- a/services/app-web/src/components/DataDetail/DataDetailMissingField/DataDetailMissingField.tsx
+++ b/services/app-web/src/components/DataDetail/DataDetailMissingField/DataDetailMissingField.tsx
@@ -16,7 +16,7 @@ export const DataDetailMissingField = ({
 
     return (
         <span className={classnames(styles.missingInfo, classname)}>
-            <span>
+            <span className={styles.missingInfoIcon}>
                 <Icon.Error aria-label="An error icon" size={3} />
             </span>
             <span>{requiredFieldMissingText}</span>

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummarySection.tsx
@@ -68,7 +68,10 @@ const rateCertificationType = (formData: RateFormData) => {
 
 const relatedSubmissions = (
     contractRevisions: ContractRevision[]
-): React.ReactElement => {
+): React.ReactElement | null => {
+    if (contractRevisions.length === 0) {
+        return null
+    }
     return (
         <ul className={styles.commaList}>
             {contractRevisions.map((contractRev) => (
@@ -351,6 +354,8 @@ export const SingleRateSummarySection = ({
                         <DataDetail
                             id="submittedWithContract"
                             label="Contract actions"
+                            explainMissingData
+                            explainMissingDataMsg="Missing contract action"
                             children={relatedSubmissions(contractActions)}
                         />
                     </Grid>

--- a/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
@@ -52,7 +52,6 @@ describe('RateSummary', () => {
                                     parentContractID: contract.id,
                                 },
                             }),
-                            fetchContractMockSuccess({ contract }),
                         ],
                     },
                     routerProvider: {
@@ -380,7 +379,6 @@ describe('RateSummary', () => {
                             fetchRateWithQuestionsMockSuccess({
                                 rate,
                             }),
-                            fetchContractMockSuccess({ contract }),
                         ],
                     },
                     routerProvider: {
@@ -441,7 +439,6 @@ describe('RateSummary', () => {
                             fetchRateWithQuestionsMockSuccess({
                                 rate,
                             }),
-                            fetchContractMockSuccess({ contract }),
                         ],
                     },
                     routerProvider: {
@@ -501,7 +498,6 @@ describe('RateSummary', () => {
                                     ],
                                 },
                             }),
-                            fetchContractMockSuccess({ contract }),
                         ],
                     },
                     routerProvider: {
@@ -754,7 +750,7 @@ describe('RateSummary', () => {
                 ).toBeInTheDocument()
                 expect(
                     screen.queryByRole('button', { name: 'Undo withdraw' })
-                ).toBeNull()
+                ).not.toBeInTheDocument()
                 expect(
                     screen.queryByRole('button', { name: 'Unlock rate' })
                 ).toBeInTheDocument()

--- a/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
@@ -352,6 +352,176 @@ describe('RateSummary', () => {
                     ).not.toBeInTheDocument()
                 })
             })
+
+            it('renders missing contract action text on orphaned rate', async () => {
+                const rate = rateWithHistoryMock()
+                const latestPkgSub = rate.packageSubmissions?.[0]
+                if (!latestPkgSub)
+                    throw new Error(
+                        'Unexpected error: Expected rate to have a package submission.'
+                    )
+                rate.id = '7a'
+                rate.parentContractID = contract.id
+                rate.withdrawnFromContracts = []
+                rate.packageSubmissions = [
+                    {
+                        ...latestPkgSub,
+                        contractRevisions: [],
+                    },
+                ]
+                renderWithProviders(wrapInRoutes(<RateSummary />), {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                user: mockUser(),
+                                statusCode: 200,
+                            }),
+                            fetchContractMockSuccess({ contract }),
+                            fetchRateWithQuestionsMockSuccess({
+                                rate,
+                            }),
+                            fetchContractMockSuccess({ contract }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: '/rates/7a',
+                    },
+                })
+
+                await waitFor(() => {
+                    expect(
+                        screen.getByTestId('error-alert')
+                    ).toBeInTheDocument()
+                    expect(
+                        screen.getByText('Missing contract action')
+                    ).toBeInTheDocument()
+                })
+            })
+
+            it('renders missing contract action text on withdrawn orphaned rate', async () => {
+                const rate = rateWithHistoryMock()
+                const latestPkgSub = rate.packageSubmissions?.[0]
+                if (!latestPkgSub)
+                    throw new Error(
+                        'Unexpected error: Expected rate to have a package submission.'
+                    )
+
+                rate.id = '7a'
+                rate.parentContractID = contract.id
+                rate.withdrawnFromContracts = []
+                rate.consolidatedStatus = 'WITHDRAWN'
+                rate.packageSubmissions = [
+                    {
+                        ...latestPkgSub,
+                        contractRevisions: [],
+                    },
+                ]
+                rate.reviewStatusActions = [
+                    {
+                        rateID: '7a',
+                        actionType: 'WITHDRAW',
+                        updatedAt: new Date('2024-01-01'),
+                        updatedReason: 'Withdraw only the rate',
+                        updatedBy: {
+                            email: 'someone@example.com',
+                            familyName: 'one',
+                            givenName: 'some',
+                            role: 'CMS_USER',
+                        },
+                    },
+                ]
+                renderWithProviders(wrapInRoutes(<RateSummary />), {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                user: mockUser(),
+                                statusCode: 200,
+                            }),
+                            fetchContractMockSuccess({ contract }),
+                            fetchRateWithQuestionsMockSuccess({
+                                rate,
+                            }),
+                            fetchContractMockSuccess({ contract }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: '/rates/7a',
+                    },
+                })
+
+                await waitFor(() => {
+                    expect(
+                        screen.getByTestId('error-alert')
+                    ).toBeInTheDocument()
+                    expect(
+                        screen.getByTestId('rateWithdrawBanner')
+                    ).toBeInTheDocument()
+                    expect(
+                        screen.getByText('Missing contract action')
+                    ).toBeInTheDocument()
+                })
+            })
+
+            it('does not render missing contract action text on withdrawn rate', async () => {
+                const rate = rateWithHistoryMock()
+                const latestPkgSub = rate.packageSubmissions?.[0]
+                if (!latestPkgSub)
+                    throw new Error(
+                        'Unexpected error: Expected rate to have a package submission.'
+                    )
+                renderWithProviders(wrapInRoutes(<RateSummary />), {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                user: mockUser(),
+                                statusCode: 200,
+                            }),
+                            fetchContractMockSuccess({ contract }),
+                            fetchRateWithQuestionsMockSuccess({
+                                rate: {
+                                    id: '7a',
+                                    status: 'SUBMITTED',
+                                    consolidatedStatus: 'WITHDRAWN',
+                                    parentContractID: contract.id,
+                                    withdrawnFromContracts: [contract],
+                                    reviewStatusActions: [
+                                        {
+                                            rateID: '1337',
+                                            actionType: 'WITHDRAW',
+                                            updatedAt: new Date('2024-01-01'),
+                                            updatedReason:
+                                                'Withdraw only the rate',
+                                            updatedBy: {
+                                                email: 'someone@example.com',
+                                                familyName: 'one',
+                                                givenName: 'some',
+                                                role: 'CMS_USER',
+                                            },
+                                        },
+                                    ],
+                                },
+                            }),
+                            fetchContractMockSuccess({ contract }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: '/rates/7a',
+                    },
+                })
+
+                await waitFor(() => {
+                    expect(
+                        screen.getByTestId('rateWithdrawBanner')
+                    ).toBeInTheDocument()
+                })
+
+                expect(
+                    screen.queryByTestId('error-alert')
+                ).not.toBeInTheDocument()
+                expect(
+                    screen.queryByText('Missing contract action')
+                ).not.toBeInTheDocument()
+            })
         }
     )
 

--- a/services/app-web/src/pages/RateSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.tsx
@@ -21,7 +21,10 @@ import { SingleRateSummarySection } from '../../components/SubmissionSummarySect
 import { useAuth } from '../../contexts/AuthContext'
 import { ErrorForbiddenPage } from '../Errors/ErrorForbiddenPage'
 import { Error404 } from '../Errors/Error404Page'
-import { RateWithdrawBanner } from '../../components/Banner'
+import {
+    IncompleteSubmissionBanner,
+    RateWithdrawBanner,
+} from '../../components/Banner'
 import { hasCMSUserPermissions } from '@mc-review/helpers'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { featureFlags } from '@mc-review/common-code'
@@ -299,6 +302,9 @@ export const RateSummary = (): React.ReactElement => {
                 data-testid="rate-summary"
                 className={styles.container}
             >
+                {isOrphanedRate && (
+                    <IncompleteSubmissionBanner message="This rate is missing a contract action" />
+                )}
                 {showWithdrawBanner && (
                     <RateWithdrawBanner
                         updatedAt={latestRateAction.updatedAt}

--- a/services/app-web/src/pages/RateSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.tsx
@@ -232,6 +232,7 @@ export const RateSummary = (): React.ReactElement => {
     ) {
         rateActions.push(
             <UnlockRateButton
+                key="unlock-rate-button"
                 disabled={unlockLoading}
                 onClick={handleUnlockRate}
             >
@@ -242,6 +243,7 @@ export const RateSummary = (): React.ReactElement => {
         rateActions.push(
             /* This second option is an interim state for unlock rate button (when linked rates is turned on but unlock and edit rate is not available yet). Remove when rate unlock is permanently on. */
             <UnlockRateButton
+                key="unlock-rate-button"
                 onClick={() => {
                     navigate(`/submissions/${parentContractSubmissionID}`)
                 }}
@@ -262,6 +264,7 @@ export const RateSummary = (): React.ReactElement => {
     ) {
         rateActions.push(
             <ButtonWithLogging
+                key="withdraw-rate-button"
                 className="usa-button usa-button--outline"
                 type="button"
                 onClick={() =>
@@ -283,6 +286,7 @@ export const RateSummary = (): React.ReactElement => {
     ) {
         rateActions.push(
             <ButtonWithLogging
+                key="undo-withdraw-rate-button"
                 className="usa-button usa-button--outline"
                 type="button"
                 onClick={() =>


### PR DESCRIPTION
## Summary
[MCR-5293](https://jiraent.cms.gov/browse/MCR-5293)
[design](https://www.figma.com/design/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?node-id=20073-49379&t=hNsx53PRC20wAWJ4-4)

AC:
- The Contract Actions section on the rate summary page clearly labels the orphaned rate
- The contract action section matches this [design](https://www.figma.com/design/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?node-id=20073-49379&t=hNsx53PRC20wAWJ4-4)
- The value for the contract actions label displays a red error icon and error text that reads: Missing contract action
- There is an error alert at the top of the page that reads: Incomplete submission This rate certification is missing a contract action.
- Withdrawn orphaned rates will also show both banner and missing contract actions text.

Other work:
- Adding spacing to the error icon in `DataDetailMissingField` component.

#### Related issues

#### Screenshots
<img src="https://github.com/user-attachments/assets/037f0b1e-59e7-45b2-9a8c-f26ac4ebb7b9" />

#### Test cases covered

- `RateSummary.test.tsx`
   - `'renders missing contract action text on orphaned rate'`
   - `'renders missing contract action text on withdrawn orphaned rate'`
   - `'does not render missing contract action text on withdrawn rate'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

In order to get a rate into a orphaned state you must use the GraphQL explorer tool.

Steps
- Create contract and rate submission and submit it.
- As a CMS user, Unlock the submission
- As a State user, In GraphQL Explorer tool:
   - Execute a `fetchContract` query for the unlocked submission
   - copy the `formData` for the `draftRevision` of the contract
   - copy the `updatedAt` for the `draftRevision`
   - Configure a `UpdateContractDraftRevision` mutation
   - The input `formData` should be the one copied from fetch contract, modify `submissionType` to `CONTRACT_ONLY`.
   - The input `lastSeenUpdatedAt` should be the `updatedAt` from the `draftRevision you copied.
   - Execute the `UpdateContractDraftRevision` mutation.
   - Make sure there are no errors from the response.
- Log in as a CMS user and view the rate of the contract we just orphaned you should see the missing contract action text and banner.
- Withdraw the orphaned rate, you should still see the missing contract action text and banner along with the Updated banner.

<!---These are developer instructions on how to test or validate the work -->
