### PR TITLE
MCR-5276: Fix - Add text when CHIP-only is disabled and update test

### DIFF
--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.test.tsx
@@ -511,10 +511,10 @@ describe('SubmissionType', () => {
                 screen.getByRole('radio', { name: 'CHIP-only' })
             ).toBeDisabled()
             expect(
-                screen.queryByText(
+                screen.queryAllByText(
                     'If you need to change your response, contact CMS.'
                 )
-            ).toBeInTheDocument()
+            ).toHaveLength(2)
         })
     })
 

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
@@ -548,6 +548,17 @@ export const SubmissionType = ({
                                                         ]
                                                     }
                                                 />
+                                                {hasPreviouslySubmittedRates && (
+                                                    <div
+                                                        role="note"
+                                                        aria-labelledby="populationCovered"
+                                                        className="usa-hint padding-top-2"
+                                                    >
+                                                        If you need to change
+                                                        your response, contact
+                                                        CMS.
+                                                    </div>
+                                                )}
                                             </Fieldset>
                                         </FormGroup>
 


### PR DESCRIPTION
## Summary
[MCR-5276](https://jiraent.cms.gov/browse/MCR-5276)

- Add `If you need to change your response, contact CMS.` text below population question when CHIP-only radio is disabled.
- Updated unit test.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
