### PR TITLE
[MCR-4918] cms must enter reason for undoing withdrawal

### DIFF
--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -57,6 +57,7 @@ import { ReleasedToState } from '../SubmissionReleasedToState/ReleasedToState'
 import { RateWithdraw } from '../RateWithdraw/RateWithdraw'
 import { UndoRateWithdraw } from '../UndoRateWithdraw/UndoRateWithdraw'
 import { SubmissionWithdraw } from '../SubmissionWithdraw/SubmissionWithdraw'
+import { UndoSubmissionWithdraw } from '../UndoSubmissionWithdraw/UndoSubmissionWithdraw'
 
 function componentForAuthMode(
     authMode: AuthModeType
@@ -289,7 +290,7 @@ const CMSUserRoutes = ({
                 {showUndoWithdrawSubmission && (
                     <Route
                         path={RoutesRecord.UNDO_SUBMISSION_WITHDRAW}
-                        element={<h1>UNDO_SUBMISSION_WITHDRAW</h1>}
+                        element={<UndoSubmissionWithdraw />}
                     />
                 )}
 

--- a/services/app-web/src/pages/UndoSubmissionWithdraw/UndoSubmissionWithdraw.module.scss
+++ b/services/app-web/src/pages/UndoSubmissionWithdraw/UndoSubmissionWithdraw.module.scss
@@ -1,0 +1,16 @@
+@use '../../styles/custom.scss' as custom;
+@use '../../styles/uswdsImports.scss' as uswds;
+
+.undoSubmissionWithdrawContainer {
+    max-width: custom.$mcr-container-standard-width-fixed;
+    background-color: none;
+    @include uswds.at-media('tablet') {
+        min-width: 20rem;
+        max-width: 40rem;
+        margin: 0 auto;
+    }
+}
+
+.formContainer {
+    @include custom.form-fields;
+}

--- a/services/app-web/src/pages/UndoSubmissionWithdraw/UndoSubmissionWithdraw.test.tsx
+++ b/services/app-web/src/pages/UndoSubmissionWithdraw/UndoSubmissionWithdraw.test.tsx
@@ -1,0 +1,309 @@
+import { Route, Routes } from 'react-router'
+import {
+    fetchContractMockSuccess,
+    fetchContractWithQuestionsMockSuccess,
+    fetchCurrentUserMock,
+    mockContractPackageSubmitted,
+    mockValidCMSUser,
+    undoWithdrawContractMockFailure,
+    undoWithdrawContractMockSuccess,
+} from '@mc-review/mocks'
+import { renderWithProviders } from '../../testHelpers'
+import { SubmissionSideNav } from '../SubmissionSideNav'
+import { RoutesRecord } from '@mc-review/constants'
+import { SubmissionSummary } from '../SubmissionSummary'
+import { UndoSubmissionWithdraw } from './UndoSubmissionWithdraw'
+import { waitFor, screen } from '@testing-library/react'
+import { Contract } from '../../gen/gqlClient'
+import { Location } from 'react-router-dom'
+
+describe('UndoSubmissionWithdraw', () => {
+    it('renders without errors', async () => {
+        const contract = mockContractPackageSubmitted({
+            id: 'test-abc-123',
+        })
+        renderWithProviders(
+            <Routes>
+                <Route element={<SubmissionSideNav />}>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_SUMMARY}
+                        element={<SubmissionSummary />}
+                    />
+                    <Route
+                        path={RoutesRecord.UNDO_SUBMISSION_WITHDRAW}
+                        element={<UndoSubmissionWithdraw />}
+                    />
+                </Route>
+            </Routes>,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchContractWithQuestionsMockSuccess({
+                            contract,
+                        }),
+                        fetchContractMockSuccess({ contract }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/submission-reviews/test-abc-123/undo-withdraw-submission',
+                },
+                featureFlags: {
+                    'undo-withdraw-submission': true,
+                },
+            }
+        )
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('heading', {
+                    name: 'Undo submission withdraw',
+                    level: 2,
+                })
+            ).toBeInTheDocument()
+            expect(
+                screen.getByText('Reason for undoing the submission withdraw.')
+            ).toBeInTheDocument()
+            expect(
+                screen.getByRole('button', { name: 'Undo withdraw' })
+            ).toBeInTheDocument()
+        })
+    })
+
+    it('renders generic API banner error on failed undo submission withdraw', async () => {
+        const contract = mockContractPackageSubmitted({
+            id: 'test-abc-123',
+        })
+        const { user } = renderWithProviders(
+            <Routes>
+                <Route element={<SubmissionSideNav />}>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_SUMMARY}
+                        element={<SubmissionSummary />}
+                    />
+                    <Route
+                        path={RoutesRecord.UNDO_SUBMISSION_WITHDRAW}
+                        element={<UndoSubmissionWithdraw />}
+                    />
+                </Route>
+            </Routes>,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchContractWithQuestionsMockSuccess({
+                            contract,
+                        }),
+                        fetchContractMockSuccess({ contract }),
+                        undoWithdrawContractMockFailure(),
+                    ],
+                },
+                routerProvider: {
+                    route: '/submission-reviews/test-abc-123/undo-withdraw-submission',
+                },
+                featureFlags: {
+                    'undo-withdraw-submission': true,
+                },
+            }
+        )
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('button', { name: 'Undo withdraw' })
+            ).toBeInTheDocument()
+        })
+
+        const undoWithdrawReasonInput = screen.getByTestId(
+            'undoSubmissionWithdrawReason'
+        )
+        const undoWithdrawBtn = screen.getByRole('button', {
+            name: 'Undo withdraw',
+        })
+
+        await user.type(undoWithdrawReasonInput, 'Undo submission withdraw')
+        await user.click(undoWithdrawBtn)
+
+        await waitFor(() => {
+            expect(screen.getByTestId('error-alert')).toBeInTheDocument()
+        })
+    })
+
+    it('validates reason input field', async () => {
+        const contract = mockContractPackageSubmitted({
+            id: 'test-abc-123',
+        })
+        const { user } = renderWithProviders(
+            <Routes>
+                <Route element={<SubmissionSideNav />}>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_SUMMARY}
+                        element={<SubmissionSummary />}
+                    />
+                    <Route
+                        path={RoutesRecord.UNDO_SUBMISSION_WITHDRAW}
+                        element={<UndoSubmissionWithdraw />}
+                    />
+                </Route>
+            </Routes>,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchContractWithQuestionsMockSuccess({
+                            contract,
+                        }),
+                        fetchContractMockSuccess({ contract }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/submission-reviews/test-abc-123/undo-withdraw-submission',
+                },
+                featureFlags: {
+                    'undo-withdraw-submission': true,
+                },
+            }
+        )
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('button', { name: 'Undo withdraw' })
+            ).toBeInTheDocument()
+        })
+
+        const undoWithdrawBtn = screen.getByRole('button', {
+            name: 'Undo withdraw',
+        })
+
+        await user.click(undoWithdrawBtn)
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('You must provide a reason for this change.')
+            ).toBeInTheDocument()
+        })
+    })
+
+    it('can undo submission withdraw', async () => {
+        let testLocation: Location
+        const contract = mockContractPackageSubmitted({
+            id: 'test-abc-123',
+        })
+        const withdrawnContract: Contract = {
+            ...contract,
+            reviewStatus: 'WITHDRAWN',
+            consolidatedStatus: 'WITHDRAWN',
+            status: 'RESUBMITTED',
+            reviewStatusActions: [
+                {
+                    contractID: contract.id,
+                    updatedAt: new Date(),
+                    updatedBy: {
+                        role: 'CMS_USER',
+                        givenName: 'bob',
+                        familyName: 'ddmas',
+                        email: 'bob@dmas.mn.gov',
+                    },
+                    actionType: 'WITHDRAW',
+                    updatedReason: 'a valid note',
+                },
+            ],
+        }
+        const { user } = renderWithProviders(
+            <Routes>
+                <Route element={<SubmissionSideNav />}>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_SUMMARY}
+                        element={<SubmissionSummary />}
+                    />
+                    <Route
+                        path={RoutesRecord.UNDO_SUBMISSION_WITHDRAW}
+                        element={<UndoSubmissionWithdraw />}
+                    />
+                </Route>
+            </Routes>,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchContractWithQuestionsMockSuccess({
+                            contract: withdrawnContract,
+                        }),
+                        fetchContractMockSuccess({
+                            contract: withdrawnContract,
+                        }),
+                        undoWithdrawContractMockSuccess({
+                            contractData: contract,
+                        }),
+                        fetchContractWithQuestionsMockSuccess({
+                            contract,
+                        }),
+                        fetchContractWithQuestionsMockSuccess({
+                            contract,
+                        }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/submission-reviews/test-abc-123/undo-withdraw-submission',
+                },
+                featureFlags: {
+                    'withdraw-submission': true,
+                    'undo-withdraw-submission': true,
+                },
+                location: (location) => (testLocation = location),
+            }
+        )
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('button', { name: 'Undo withdraw' })
+            ).toBeInTheDocument()
+        })
+
+        const undoWithdrawReasonInput = screen.getByTestId(
+            'undoSubmissionWithdrawReason'
+        )
+        const undoWithdrawBtn = screen.getByRole('button', {
+            name: 'Undo withdraw',
+        })
+
+        await user.type(undoWithdrawReasonInput, 'Undo submission withdraw')
+        await user.click(undoWithdrawBtn)
+
+        await waitFor(() => {
+            //Expect redirect
+            expect(testLocation.pathname).toBe(`/submissions/${contract.id}`)
+            //Expect success banner
+            expect(
+                screen.getByTestId('statusUpdatedBanner')
+            ).toBeInTheDocument()
+            //Expect action buttons
+            expect(
+                screen.getByRole('button', {
+                    name: 'Unlock submission',
+                })
+            ).toBeInTheDocument()
+            expect(
+                screen.getByRole('link', {
+                    name: 'Released to state',
+                })
+            ).toBeInTheDocument()
+            expect(
+                screen.getByRole('button', {
+                    name: 'Withdraw submission',
+                })
+            ).toBeInTheDocument()
+        })
+    })
+})

--- a/services/app-web/src/pages/UndoSubmissionWithdraw/UndoSubmissionWithdraw.tsx
+++ b/services/app-web/src/pages/UndoSubmissionWithdraw/UndoSubmissionWithdraw.tsx
@@ -1,0 +1,228 @@
+import React, { useEffect, useState } from 'react'
+import styles from './UndoSubmissionWithdraw.module.scss'
+import * as Yup from 'yup'
+import { Formik, FormikErrors } from 'formik'
+import { useNavigate, useParams } from 'react-router'
+import { usePage } from '../../contexts/PageContext'
+import { useTealium } from '../../hooks'
+import {
+    useFetchContractQuery,
+    useUndoWithdrawContractMutation,
+} from '../../gen/gqlClient'
+import {
+    ActionButton,
+    Breadcrumbs,
+    GenericApiErrorBanner,
+    PoliteErrorMessage,
+} from '../../components'
+import { RoutesRecord } from '@mc-review/constants'
+import { ErrorOrLoadingPage } from '../StateSubmission'
+import { handleAndReturnErrorState } from '../StateSubmission/ErrorOrLoadingPage'
+import { GenericErrorPage } from '../Errors/GenericErrorPage'
+import {
+    ButtonGroup,
+    Form,
+    FormGroup,
+    Label,
+    Textarea,
+} from '@trussworks/react-uswds'
+import { PageActionsContainer } from '../StateSubmission/PageActions'
+import { recordJSException } from '@mc-review/otel'
+
+type UndoSubmissionWithdrawValues = {
+    undoSubmissionWithdrawReason: string
+}
+
+type FormError =
+    FormikErrors<UndoSubmissionWithdrawValues>[keyof FormikErrors<UndoSubmissionWithdrawValues>]
+
+const UndoSubmissionWithdrawSchema = Yup.object().shape({
+    undoSubmissionWithdrawReason: Yup.string().required(
+        'You must provide a reason for this change.'
+    ),
+})
+
+export const UndoSubmissionWithdraw = (): React.ReactElement => {
+    const { id } = useParams() as { id: string }
+    const { updateHeading } = usePage()
+    const { logFormSubmitEvent } = useTealium()
+    const navigate = useNavigate()
+    const [shouldValidate, setShouldValidate] = useState(false)
+    const showFieldErrors = (error?: FormError): boolean | undefined =>
+        shouldValidate && Boolean(error)
+    const [
+        undoWithdrawSubmission,
+        { error: undoWithdrawError, loading: undoWithdrawLoading },
+    ] = useUndoWithdrawContractMutation()
+
+    const formInitialValues: UndoSubmissionWithdrawValues = {
+        undoSubmissionWithdrawReason: '',
+    }
+
+    const { data, loading, error } = useFetchContractQuery({
+        variables: {
+            input: {
+                contractID: id,
+            },
+        },
+        fetchPolicy: 'cache-and-network',
+    })
+
+    const contract = data?.fetchContract.contract
+    const contractName =
+        contract?.packageSubmissions[0].contractRevision.contractName
+
+    useEffect(() => {
+        updateHeading({ customHeading: contractName })
+    }, [contractName, updateHeading])
+
+    if (loading) {
+        return <ErrorOrLoadingPage state="LOADING" />
+    } else if (error) {
+        return <ErrorOrLoadingPage state={handleAndReturnErrorState(error!)} />
+    } else if (!contract) {
+        return <GenericErrorPage />
+    }
+
+    const undoWithdrawSubmissionAction = async (
+        values: UndoSubmissionWithdrawValues
+    ) => {
+        logFormSubmitEvent({
+            heading: 'Undo withdraw',
+            form_name: 'Undo Withdraw',
+            event_name: 'form_field_submit',
+            link_type: 'link_other',
+        })
+        try {
+            await undoWithdrawSubmission({
+                variables: {
+                    input: {
+                        contractID: id,
+                        updatedReason: values.undoSubmissionWithdrawReason,
+                    },
+                },
+            })
+            navigate(`/submissions/${id}?showUndoWithdrawBanner=true`)
+        } catch (err) {
+            recordJSException(
+                `undoWithdrawSubmission: Apollo error reported. Error message: ${err}`
+            )
+        }
+    }
+
+    return (
+        <div className={styles.undoSubmissionWithdrawContainer}>
+            <Breadcrumbs
+                className="usa-breadcrumb--wrap"
+                items={[
+                    {
+                        link: RoutesRecord.DASHBOARD_SUBMISSIONS,
+                        text: 'Dashboard',
+                    },
+                    {
+                        link: `/submissions/${id}`,
+                        text: contractName || '',
+                    },
+                    {
+                        link: '',
+                        text: 'Undo submission withdraw',
+                    },
+                ]}
+            />
+            <Formik
+                initialValues={formInitialValues}
+                onSubmit={(values) => undoWithdrawSubmissionAction(values)}
+                validationSchema={UndoSubmissionWithdrawSchema}
+            >
+                {({ handleSubmit, handleChange, errors, values }) => (
+                    <Form
+                        id="undoSubmissionWithdrawForm"
+                        className={styles.formContainer}
+                        aria-label="Undo submission withdraw"
+                        aria-describedby="form-guidance"
+                        onSubmit={(e) => {
+                            setShouldValidate(true)
+                            return handleSubmit(e)
+                        }}
+                    >
+                        {undoWithdrawError && <GenericApiErrorBanner />}
+                        <fieldset className="usa-fieldset">
+                            <h2>Undo submission withdraw</h2>
+                            <FormGroup
+                                error={showFieldErrors(
+                                    errors.undoSubmissionWithdrawReason
+                                )}
+                                className="margin-top-0"
+                            >
+                                <Label
+                                    htmlFor="undoSubmissionWithdrawReason"
+                                    className="margin-bottom-0 text-bold"
+                                >
+                                    Reason for undoing the submission withdraw.
+                                </Label>
+                                <p className="margin-bottom-0 margin-top-05 usa-hint">
+                                    Required
+                                </p>
+                                <p className="margin-bottom-0 margin-top-05 usa-hint">
+                                    This will move the submission back to the
+                                    submitted status.
+                                </p>
+                                {showFieldErrors(
+                                    errors.undoSubmissionWithdrawReason
+                                ) && (
+                                    <PoliteErrorMessage formFieldLabel="Reason for undoing withdraw">
+                                        {errors.undoSubmissionWithdrawReason}
+                                    </PoliteErrorMessage>
+                                )}
+                                <Textarea
+                                    name="undoSubmissionWithdrawReason"
+                                    id="undoSubmissionWithdrawReason"
+                                    data-testid="undoSubmissionWithdrawReason"
+                                    aria-labelledby="undoSubmissionWithdrawReason"
+                                    aria-required
+                                    defaultValue={
+                                        values.undoSubmissionWithdrawReason
+                                    }
+                                    onChange={handleChange}
+                                    error={showFieldErrors(
+                                        errors.undoSubmissionWithdrawReason
+                                    )}
+                                />
+                            </FormGroup>
+                        </fieldset>
+                        <PageActionsContainer>
+                            <ButtonGroup type="default">
+                                <ActionButton
+                                    type="button"
+                                    variant="outline"
+                                    data-testid="page-actions-left-secondary"
+                                    parent_component_type="page body"
+                                    link_url={`/submissions/${id}`}
+                                    onClick={() =>
+                                        navigate(`/submissions/${id}`)
+                                    }
+                                >
+                                    Cancel
+                                </ActionButton>
+                                <ActionButton
+                                    type="submit"
+                                    variant="default"
+                                    data-testid="page-actions-right-primary"
+                                    parent_component_heading="page body"
+                                    link_url={`/submissions/${id}`}
+                                    animationTimeout={1000}
+                                    disabled={showFieldErrors(
+                                        errors.undoSubmissionWithdrawReason
+                                    )}
+                                    loading={undoWithdrawLoading}
+                                >
+                                    Undo withdraw
+                                </ActionButton>
+                            </ButtonGroup>
+                        </PageActionsContainer>
+                    </Form>
+                )}
+            </Formik>
+        </div>
+    )
+}


### PR DESCRIPTION
## Summary
As a CMS user, 
I want to enter a reason for undoing a submission withdrawal 
so I can add context to myself and other users about why I undid the withdrawal. 

AC: 

If click the `Undo withdraw` button on the submission summary page
I am on the undo submission withdrawal page
then I see a single step form field with the label "Undo withdraw" and an open text form field with the label "Reason for change."
If I do not enter a reason and I try to undo 
then I receive an inline error message "You must provide a reason for this change" 
If I enter a reason and click undo withdraw
Then I'm taken back to the submission summary page, and the status is changed to SUBMITTED and I see that on the submission and on the main dashboard for all submissions.
#### Related issues
[MCR-4918](https://jiraent.cms.gov/browse/MCR-4918)
#### Screenshots
![image](https://github.com/user-attachments/assets/34be2a23-1019-4265-9bcf-301398063084)
![image](https://github.com/user-attachments/assets/8fcea0f6-7295-4835-a6c2-4a3d57439084)

#### Test cases covered

1. renders without errors
2. renders generic banner on failure
3. input validation
4. able to undo submission withdraw

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

1. Access a withdrawn submission
2. click undo withdraw button 
3. expect undo withdraw page
4. fill in input
5. click undo button
6. expect to land on summary page and see success banner

<!---These are developer instructions on how to test or validate the work -->
