### PR TITLE
MCR-5332: date added field not showing for some submissions

### DIFF
--- a/packages/mocks/src/apollo/contractPackageDataMock.ts
+++ b/packages/mocks/src/apollo/contractPackageDataMock.ts
@@ -257,6 +257,7 @@ function mockContractRevision(
             submissionDescription: `Submission ${name}`,
             supportingDocuments: [
                 {
+                    id: `contractSupporting${name}1`,
                     s3URL: `s3://bucketname/key/contractsupporting${name}1`,
                     sha256: 'fakesha',
                     name: `contractSupporting${name}1`,
@@ -264,6 +265,7 @@ function mockContractRevision(
                     downloadURL: s3DlUrl,
                 },
                 {
+                    id: `s3://bucketname/key/contractsupporting${name}2`,
                     s3URL: `s3://bucketname/key/contractsupporting${name}2`,
                     sha256: 'fakesha',
                     name: `contractSupporting${name}2`,
@@ -276,6 +278,7 @@ function mockContractRevision(
             contractExecutionStatus: 'EXECUTED',
             contractDocuments: [
                 {
+                    id: `contract${name}`,
                     s3URL: `s3://bucketname/key/contract${name}`,
                     sha256: 'fakesha',
                     name: `contract${name}`,
@@ -350,6 +353,7 @@ function mockRateRevision(
             rateCertificationName: 'fooname',
             rateDocuments: [
                 {
+                    id: `rate${name} doc`,
                     s3URL: 's3://bucketname/key/rate',
                     sha256: 'fakesha',
                     name: `rate${name} doc`,
@@ -358,12 +362,14 @@ function mockRateRevision(
             ],
             supportingDocuments: [
                 {
+                    id: `rate supporting ${name}1`,
                     s3URL: 's3://bucketname/key/rateSupporting1',
                     sha256: 'fakesha',
                     name: `rate supporting ${name}1`,
                     dateAdded: new Date('01/15/2023'),
                 },
                 {
+                    id: `rate supporting ${name}2`,
                     s3URL: 's3://bucketname/key/rateSupporting1',
                     sha256: 'fakesha',
                     name: `rate supporting ${name}2`,
@@ -591,6 +597,7 @@ function mockContractPackageSubmittedWithQuestions(
                         submissionDescription: 'A real submission',
                         supportingDocuments: [
                             {
+                                id: 'contractSupporting1',
                                 s3URL: 's3://bucketname/key/contractsupporting1',
                                 sha256: 'fakesha',
                                 name: 'contractSupporting1',
@@ -598,6 +605,7 @@ function mockContractPackageSubmittedWithQuestions(
                                 downloadURL: s3DlUrl,
                             },
                             {
+                                id: 'contractSupporting2',
                                 s3URL: 's3://bucketname/key/contractSupporting2',
                                 sha256: 'fakesha',
                                 name: 'contractSupporting2',
@@ -610,6 +618,7 @@ function mockContractPackageSubmittedWithQuestions(
                         contractExecutionStatus: 'EXECUTED',
                         contractDocuments: [
                             {
+                                id: 'contract',
                                 s3URL: 's3://bucketname/key/contract',
                                 sha256: 'fakesha',
                                 name: 'contract',
@@ -655,6 +664,7 @@ function mockContractPackageSubmittedWithQuestions(
                             rateCapitationType: 'RATE_CELL',
                             rateDocuments: [
                                 {
+                                    id: 'rate',
                                     s3URL: 's3://bucketname/key/rate',
                                     sha256: 'fakesha',
                                     name: 'rate',
@@ -664,6 +674,7 @@ function mockContractPackageSubmittedWithQuestions(
                             ],
                             supportingDocuments: [
                                 {
+                                    id: 'rate supporting 1',
                                     s3URL: 's3://bucketname/key/rateSupporting1',
                                     sha256: 'fakesha',
                                     name: 'rate supporting 1',
@@ -671,6 +682,7 @@ function mockContractPackageSubmittedWithQuestions(
                                     downloadURL: s3DlUrl,
                                 },
                                 {
+                                    id: 'rate supporting 2',
                                     s3URL: 's3://bucketname/key/rateSupporting1',
                                     sha256: 'fakesha',
                                     name: 'rate supporting 2',
@@ -1006,12 +1018,14 @@ function mockContractWithLinkedRateSubmitted(
                         submissionDescription: 'A real submission',
                         supportingDocuments: [
                             {
+                                id: 'contractSupporting1',
                                 s3URL: 's3://bucketname/key/contractsupporting1',
                                 sha256: 'fakesha',
                                 name: 'contractSupporting1',
                                 dateAdded: new Date('01/15/2024'),
                             },
                             {
+                                id: 'contractSupporting2',
                                 s3URL: 's3://bucketname/key/contractSupporting2',
                                 sha256: 'fakesha',
                                 name: 'contractSupporting2',
@@ -1023,6 +1037,7 @@ function mockContractWithLinkedRateSubmitted(
                         contractExecutionStatus: 'EXECUTED',
                         contractDocuments: [
                             {
+                                id: 'contract',
                                 s3URL: 's3://bucketname/key/contract',
                                 sha256: 'fakesha',
                                 name: 'contract',
@@ -1066,6 +1081,7 @@ function mockContractWithLinkedRateSubmitted(
                             rateCapitationType: 'RATE_CELL',
                             rateDocuments: [
                                 {
+                                    id: 'rate',
                                     s3URL: 's3://bucketname/key/rate',
                                     sha256: 'fakesha',
                                     name: 'rate',
@@ -1179,6 +1195,7 @@ function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
                         submissionDescription: 'A real submission',
                         supportingDocuments: [
                             {
+                                id: 'contractSupporting1',
                                 s3URL: 's3://bucketname/key/contractsupporting1',
                                 sha256: 'fakesha',
                                 name: 'contractSupporting1',
@@ -1186,6 +1203,7 @@ function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
                                 downloadURL: s3DlUrl,
                             },
                             {
+                                id: 'contractSupporting2',
                                 s3URL: 's3://bucketname/key/contractSupporting2',
                                 sha256: 'fakesha',
                                 name: 'contractSupporting2',
@@ -1198,6 +1216,7 @@ function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
                         contractExecutionStatus: 'EXECUTED',
                         contractDocuments: [
                             {
+                                id: 'contract',
                                 s3URL: 's3://bucketname/key/contract',
                                 sha256: 'fakesha',
                                 name: 'contract',
@@ -1258,6 +1277,7 @@ function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
                             rateCapitationType: 'RATE_CELL',
                             rateDocuments: [
                                 {
+                                    id: 'rate',
                                     s3URL: 's3://bucketname/key/rate',
                                     sha256: 'fakesha',
                                     name: 'rate',
@@ -1267,6 +1287,7 @@ function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
                             ],
                             supportingDocuments: [
                                 {
+                                    id: 'rate supporting 1',
                                     s3URL: 's3://bucketname/key/rateSupporting1',
                                     sha256: 'fakesha',
                                     name: 'rate supporting 1',
@@ -1274,6 +1295,7 @@ function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
                                     downloadURL: s3DlUrl,
                                 },
                                 {
+                                    id: 'rate supporting 2',
                                     s3URL: 's3://bucketname/key/rateSupporting1',
                                     sha256: 'fakesha',
                                     name: 'rate supporting 2',
@@ -1408,6 +1430,7 @@ function mockContractPackageApproved(
                         submissionDescription: 'A real submission',
                         supportingDocuments: [
                             {
+                                id: 'contractSupporting1',
                                 s3URL: 's3://bucketname/key/contractsupporting1',
                                 sha256: 'fakesha',
                                 name: 'contractSupporting1',
@@ -1415,6 +1438,7 @@ function mockContractPackageApproved(
                                 downloadURL: s3DlUrl,
                             },
                             {
+                                id: 'contractSupporting2',
                                 s3URL: 's3://bucketname/key/contractSupporting2',
                                 sha256: 'fakesha',
                                 name: 'contractSupporting2',
@@ -1427,6 +1451,7 @@ function mockContractPackageApproved(
                         contractExecutionStatus: 'EXECUTED',
                         contractDocuments: [
                             {
+                                id: 'contract',
                                 s3URL: 's3://bucketname/key/contract',
                                 sha256: 'fakesha',
                                 name: 'contract',
@@ -1475,6 +1500,7 @@ function mockContractPackageApproved(
                             rateCapitationType: 'RATE_CELL',
                             rateDocuments: [
                                 {
+                                    id: 'rate',
                                     s3URL: 's3://bucketname/key/rate',
                                     sha256: 'fakesha',
                                     name: 'rate',
@@ -1484,6 +1510,7 @@ function mockContractPackageApproved(
                             ],
                             supportingDocuments: [
                                 {
+                                    id: 'rate supporting 1',
                                     s3URL: 's3://bucketname/key/rateSupporting1',
                                     sha256: 'fakesha',
                                     name: 'rate supporting 1',
@@ -1491,6 +1518,7 @@ function mockContractPackageApproved(
                                     downloadURL: s3DlUrl,
                                 },
                                 {
+                                    id: 'rate supporting 2',
                                     s3URL: 's3://bucketname/key/rateSupporting1',
                                     sha256: 'fakesha',
                                     name: 'rate supporting 2',
@@ -1783,6 +1811,7 @@ function mockContractPackageWithDifferentProgramsInRevisions(): Contract {
                             ],
                             supportingDocuments: [
                                 {
+                                    id: 'State User Manual - MC-Review - January 2024.pdf',
                                     name: 'State User Manual - MC-Review - January 2024.pdf',
                                     s3URL: 's3://uploads-val-uploads-798659716464/b88e8dd1-f4f1-4d39-8591-645b64a15e27.pdf/State User Manual - MC-Review - January 2024.pdf',
                                     sha256: 'fakeSha',
@@ -1794,6 +1823,7 @@ function mockContractPackageWithDifferentProgramsInRevisions(): Contract {
                             contractExecutionStatus: 'EXECUTED',
                             contractDocuments: [
                                 {
+                                    id: 'Test document.pdf',
                                     name: 'Test document.pdf',
                                     s3URL: 's3://uploads-val-uploads-798659716464/63f44255-e82a-4156-996c-876a1ca86768.pdf/Test document.pdf',
                                     sha256: 'fakeSha',
@@ -1872,6 +1902,7 @@ function mockContractPackageWithDifferentProgramsInRevisions(): Contract {
                         ],
                         supportingDocuments: [
                             {
+                                id: 'State User Manual - MC-Review - January 2024.pdf',
                                 name: 'State User Manual - MC-Review - January 2024.pdf',
                                 s3URL: 's3://uploads-val-uploads-798659716464/b88e8dd1-f4f1-4d39-8591-645b64a15e27.pdf/State User Manual - MC-Review - January 2024.pdf',
                                 sha256: 'fakeSha',
@@ -1883,6 +1914,7 @@ function mockContractPackageWithDifferentProgramsInRevisions(): Contract {
                         contractExecutionStatus: 'EXECUTED',
                         contractDocuments: [
                             {
+                                id: 'Test document.pdf',
                                 name: 'Test document.pdf',
                                 s3URL: 's3://uploads-val-uploads-798659716464/63f44255-e82a-4156-996c-876a1ca86768.pdf/Test document.pdf',
                                 sha256: 'fakeSha',
@@ -1971,6 +2003,7 @@ function mockContractPackageWithDifferentProgramsInRevisions(): Contract {
                             contractExecutionStatus: 'EXECUTED',
                             contractDocuments: [
                                 {
+                                    id: 'Test document.pdf',
                                     name: 'Test document.pdf',
                                     s3URL: 's3://uploads-val-uploads-798659716464/63f44255-e82a-4156-996c-876a1ca86768.pdf/Test document.pdf',
                                     sha256: 'fakeSha',
@@ -2041,6 +2074,7 @@ function mockContractPackageWithDifferentProgramsInRevisions(): Contract {
                         contractExecutionStatus: 'EXECUTED',
                         contractDocuments: [
                             {
+                                id: 'Test document.pdf',
                                 name: 'Test document.pdf',
                                 s3URL: 's3://uploads-val-uploads-798659716464/63f44255-e82a-4156-996c-876a1ca86768.pdf/Test document.pdf',
                                 sha256: 'fakeSha',
@@ -2138,6 +2172,7 @@ function mockContractPackageUnlockedWithUnlockedType(
                 contractExecutionStatus: 'EXECUTED',
                 contractDocuments: [
                     {
+                        id: 'one two',
                         s3URL: 's3://bucketname/one-two/one-two.png',
                         sha256: 'fakesha',
                         name: 'one two',
@@ -2304,6 +2339,7 @@ function mockContractPackageUnlockedWithUnlockedType(
                             contractExecutionStatus: 'EXECUTED',
                             contractDocuments: [
                                 {
+                                    id: 'contract',
                                     s3URL: 's3://bucketname/key/contract',
                                     sha256: 'fakesha',
                                     name: 'contract',
@@ -2369,6 +2405,7 @@ function mockContractPackageUnlockedWithUnlockedType(
                         contractExecutionStatus: 'EXECUTED',
                         contractDocuments: [
                             {
+                                id: 'contract',
                                 s3URL: 's3://bucketname/key/contract',
                                 sha256: 'fakesha',
                                 name: 'contract',
@@ -2441,6 +2478,7 @@ function mockContractPackageUnlockedWithUnlockedType(
                             rateCapitationType: 'RATE_CELL',
                             rateDocuments: [
                                 {
+                                    id: 'rate',
                                     s3URL: 's3://bucketname/key/rate',
                                     sha256: 'fakesha',
                                     name: 'rate',
@@ -2506,6 +2544,7 @@ function mockContractFormData(
         submissionDescription: 'A real submission',
         supportingDocuments: [
             {
+                id: 'contractSupporting1',
                 s3URL: 's3://bucketname/key/contractsupporting1',
                 sha256: 'fakesha',
                 name: 'contractSupporting1',
@@ -2513,6 +2552,7 @@ function mockContractFormData(
                 downloadURL: s3DlUrl,
             },
             {
+                id: 'contractSupporting2',
                 s3URL: 's3://bucketname/key/contractSupporting2',
                 sha256: 'fakesha',
                 name: 'contractSupporting2',
@@ -2531,6 +2571,7 @@ function mockContractFormData(
         contractExecutionStatus: 'EXECUTED',
         contractDocuments: [
             {
+                id: 'contract document',
                 s3URL: 's3://bucketname/one-two/one-two.png',
                 sha256: 'fakesha',
                 name: 'contract document',
@@ -2588,6 +2629,7 @@ const mockEmptyDraftContractAndRate = (): Contract =>
                 submissionDescription: null,
                 supportingDocuments: [
                     {
+                        id: 'contractSupporting1',
                         s3URL: 's3://bucketname/key/contractsupporting1',
                         sha256: 'fakesha',
                         name: 'contractSupporting1',
@@ -2595,6 +2637,7 @@ const mockEmptyDraftContractAndRate = (): Contract =>
                         downloadURL: s3DlUrl,
                     },
                     {
+                        id: 'contractSupporting2',
                         s3URL: 's3://bucketname/key/contractSupporting2',
                         sha256: 'fakesha',
                         name: 'contractSupporting2',
@@ -2607,6 +2650,7 @@ const mockEmptyDraftContractAndRate = (): Contract =>
                 contractExecutionStatus: null,
                 contractDocuments: [
                     {
+                        id: 'contract document',
                         s3URL: 's3://bucketname/one-two/one-two.png',
                         sha256: 'fakesha',
                         name: 'contract document',
@@ -2664,6 +2708,7 @@ const mockEmptyDraftContractAndRate = (): Contract =>
                         rateCapitationType: null,
                         rateDocuments: [
                             {
+                                id: 'rate certification',
                                 s3URL: 's3://bucketname/key/rate',
                                 sha256: 'fakesha',
                                 name: 'rate certification',
@@ -2673,6 +2718,7 @@ const mockEmptyDraftContractAndRate = (): Contract =>
                         ],
                         supportingDocuments: [
                             {
+                                id: 'rateSupporting1',
                                 s3URL: 's3://bucketname/key/ratesupporting1',
                                 sha256: 'fakesha',
                                 name: 'rateSupporting1',
@@ -2680,6 +2726,7 @@ const mockEmptyDraftContractAndRate = (): Contract =>
                                 downloadURL: s3DlUrl,
                             },
                             {
+                                id: 'rateSupporting2',
                                 s3URL: 's3://bucketname/key/rateSupporting2',
                                 sha256: 'fakesha',
                                 name: 'rateSupporting2',

--- a/packages/mocks/src/apollo/contractPackageDataMock.ts
+++ b/packages/mocks/src/apollo/contractPackageDataMock.ts
@@ -257,6 +257,7 @@ function mockContractRevision(
             submissionDescription: `Submission ${name}`,
             supportingDocuments: [
                 {
+                    __typename: 'GenericDocument',
                     id: `contractSupporting${name}1`,
                     s3URL: `s3://bucketname/key/contractsupporting${name}1`,
                     sha256: 'fakesha',
@@ -265,6 +266,7 @@ function mockContractRevision(
                     downloadURL: s3DlUrl,
                 },
                 {
+                    __typename: 'GenericDocument',
                     id: `s3://bucketname/key/contractsupporting${name}2`,
                     s3URL: `s3://bucketname/key/contractsupporting${name}2`,
                     sha256: 'fakesha',
@@ -278,6 +280,7 @@ function mockContractRevision(
             contractExecutionStatus: 'EXECUTED',
             contractDocuments: [
                 {
+                    __typename: 'GenericDocument',
                     id: `contract${name}`,
                     s3URL: `s3://bucketname/key/contract${name}`,
                     sha256: 'fakesha',
@@ -353,6 +356,7 @@ function mockRateRevision(
             rateCertificationName: 'fooname',
             rateDocuments: [
                 {
+                    __typename: 'GenericDocument',
                     id: `rate${name} doc`,
                     s3URL: 's3://bucketname/key/rate',
                     sha256: 'fakesha',
@@ -362,6 +366,7 @@ function mockRateRevision(
             ],
             supportingDocuments: [
                 {
+                    __typename: 'GenericDocument',
                     id: `rate supporting ${name}1`,
                     s3URL: 's3://bucketname/key/rateSupporting1',
                     sha256: 'fakesha',
@@ -369,6 +374,7 @@ function mockRateRevision(
                     dateAdded: new Date('01/15/2023'),
                 },
                 {
+                    __typename: 'GenericDocument',
                     id: `rate supporting ${name}2`,
                     s3URL: 's3://bucketname/key/rateSupporting1',
                     sha256: 'fakesha',
@@ -470,6 +476,7 @@ function mockContractPackageDraft(partial?: Partial<Contract>): Contract {
                         rateCapitationType: 'RATE_CELL',
                         rateDocuments: [
                             {
+                                __typename: 'GenericDocument',
                                 s3URL: 's3://bucketname/key/rate',
                                 sha256: 'fakesha',
                                 name: 'rate certification',
@@ -478,12 +485,14 @@ function mockContractPackageDraft(partial?: Partial<Contract>): Contract {
                         ],
                         supportingDocuments: [
                             {
+                                __typename: 'GenericDocument',
                                 s3URL: 's3://bucketname/key/ratesupporting1',
                                 sha256: 'fakesha',
                                 name: 'rateSupporting1',
                                 dateAdded: new Date('01/15/2024'),
                             },
                             {
+                                __typename: 'GenericDocument',
                                 s3URL: 's3://bucketname/key/rateSupporting2',
                                 sha256: 'fakesha',
                                 name: 'rateSupporting2',
@@ -597,6 +606,7 @@ function mockContractPackageSubmittedWithQuestions(
                         submissionDescription: 'A real submission',
                         supportingDocuments: [
                             {
+                                __typename: 'GenericDocument',
                                 id: 'contractSupporting1',
                                 s3URL: 's3://bucketname/key/contractsupporting1',
                                 sha256: 'fakesha',
@@ -605,6 +615,7 @@ function mockContractPackageSubmittedWithQuestions(
                                 downloadURL: s3DlUrl,
                             },
                             {
+                                __typename: 'GenericDocument',
                                 id: 'contractSupporting2',
                                 s3URL: 's3://bucketname/key/contractSupporting2',
                                 sha256: 'fakesha',
@@ -618,6 +629,7 @@ function mockContractPackageSubmittedWithQuestions(
                         contractExecutionStatus: 'EXECUTED',
                         contractDocuments: [
                             {
+                                __typename: 'GenericDocument',
                                 id: 'contract',
                                 s3URL: 's3://bucketname/key/contract',
                                 sha256: 'fakesha',
@@ -664,6 +676,7 @@ function mockContractPackageSubmittedWithQuestions(
                             rateCapitationType: 'RATE_CELL',
                             rateDocuments: [
                                 {
+                                    __typename: 'GenericDocument',
                                     id: 'rate',
                                     s3URL: 's3://bucketname/key/rate',
                                     sha256: 'fakesha',
@@ -674,6 +687,7 @@ function mockContractPackageSubmittedWithQuestions(
                             ],
                             supportingDocuments: [
                                 {
+                                    __typename: 'GenericDocument',
                                     id: 'rate supporting 1',
                                     s3URL: 's3://bucketname/key/rateSupporting1',
                                     sha256: 'fakesha',
@@ -682,6 +696,7 @@ function mockContractPackageSubmittedWithQuestions(
                                     downloadURL: s3DlUrl,
                                 },
                                 {
+                                    __typename: 'GenericDocument',
                                     id: 'rate supporting 2',
                                     s3URL: 's3://bucketname/key/rateSupporting1',
                                     sha256: 'fakesha',
@@ -774,6 +789,7 @@ function mockContractWithLinkedRateDraft(
                 contractExecutionStatus: 'EXECUTED',
                 contractDocuments: [
                     {
+                        __typename: 'GenericDocument',
                         s3URL: 's3://bucketname/one-two/one-two.png',
                         sha256: 'fakesha',
                         name: 'one two',
@@ -856,6 +872,7 @@ function mockContractWithLinkedRateDraft(
                         rateCapitationType: 'RATE_CELL',
                         rateDocuments: [
                             {
+                                __typename: 'GenericDocument',
                                 s3URL: 's3://bucketname/key/rate',
                                 sha256: 'fakesha',
                                 name: 'rate',
@@ -910,6 +927,7 @@ function mockContractWithLinkedRateDraft(
                             rateCapitationType: 'RATE_CELL',
                             rateDocuments: [
                                 {
+                                    __typename: 'GenericDocument',
                                     s3URL: 's3://bucketname/key/rate',
                                     sha256: 'fakesha',
                                     name: 'rate',
@@ -1037,6 +1055,7 @@ function mockContractWithLinkedRateSubmitted(
                         contractExecutionStatus: 'EXECUTED',
                         contractDocuments: [
                             {
+                                __typename: 'GenericDocument',
                                 id: 'contract',
                                 s3URL: 's3://bucketname/key/contract',
                                 sha256: 'fakesha',
@@ -1081,6 +1100,7 @@ function mockContractWithLinkedRateSubmitted(
                             rateCapitationType: 'RATE_CELL',
                             rateDocuments: [
                                 {
+                                    __typename: 'GenericDocument',
                                     id: 'rate',
                                     s3URL: 's3://bucketname/key/rate',
                                     sha256: 'fakesha',
@@ -1195,6 +1215,7 @@ function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
                         submissionDescription: 'A real submission',
                         supportingDocuments: [
                             {
+                                __typename: 'GenericDocument',
                                 id: 'contractSupporting1',
                                 s3URL: 's3://bucketname/key/contractsupporting1',
                                 sha256: 'fakesha',
@@ -1203,6 +1224,7 @@ function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
                                 downloadURL: s3DlUrl,
                             },
                             {
+                                __typename: 'GenericDocument',
                                 id: 'contractSupporting2',
                                 s3URL: 's3://bucketname/key/contractSupporting2',
                                 sha256: 'fakesha',
@@ -1216,6 +1238,7 @@ function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
                         contractExecutionStatus: 'EXECUTED',
                         contractDocuments: [
                             {
+                                __typename: 'GenericDocument',
                                 id: 'contract',
                                 s3URL: 's3://bucketname/key/contract',
                                 sha256: 'fakesha',
@@ -1277,6 +1300,7 @@ function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
                             rateCapitationType: 'RATE_CELL',
                             rateDocuments: [
                                 {
+                                    __typename: 'GenericDocument',
                                     id: 'rate',
                                     s3URL: 's3://bucketname/key/rate',
                                     sha256: 'fakesha',
@@ -1287,6 +1311,7 @@ function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
                             ],
                             supportingDocuments: [
                                 {
+                                    __typename: 'GenericDocument',
                                     id: 'rate supporting 1',
                                     s3URL: 's3://bucketname/key/rateSupporting1',
                                     sha256: 'fakesha',
@@ -1295,6 +1320,7 @@ function mockContractPackageSubmitted(partial?: Partial<Contract>): Contract {
                                     downloadURL: s3DlUrl,
                                 },
                                 {
+                                    __typename: 'GenericDocument',
                                     id: 'rate supporting 2',
                                     s3URL: 's3://bucketname/key/rateSupporting1',
                                     sha256: 'fakesha',
@@ -1430,6 +1456,7 @@ function mockContractPackageApproved(
                         submissionDescription: 'A real submission',
                         supportingDocuments: [
                             {
+                                __typename: 'GenericDocument',
                                 id: 'contractSupporting1',
                                 s3URL: 's3://bucketname/key/contractsupporting1',
                                 sha256: 'fakesha',
@@ -1438,6 +1465,7 @@ function mockContractPackageApproved(
                                 downloadURL: s3DlUrl,
                             },
                             {
+                                __typename: 'GenericDocument',
                                 id: 'contractSupporting2',
                                 s3URL: 's3://bucketname/key/contractSupporting2',
                                 sha256: 'fakesha',
@@ -1451,6 +1479,7 @@ function mockContractPackageApproved(
                         contractExecutionStatus: 'EXECUTED',
                         contractDocuments: [
                             {
+                                __typename: 'GenericDocument',
                                 id: 'contract',
                                 s3URL: 's3://bucketname/key/contract',
                                 sha256: 'fakesha',
@@ -1500,6 +1529,7 @@ function mockContractPackageApproved(
                             rateCapitationType: 'RATE_CELL',
                             rateDocuments: [
                                 {
+                                    __typename: 'GenericDocument',
                                     id: 'rate',
                                     s3URL: 's3://bucketname/key/rate',
                                     sha256: 'fakesha',
@@ -1510,6 +1540,7 @@ function mockContractPackageApproved(
                             ],
                             supportingDocuments: [
                                 {
+                                    __typename: 'GenericDocument',
                                     id: 'rate supporting 1',
                                     s3URL: 's3://bucketname/key/rateSupporting1',
                                     sha256: 'fakesha',
@@ -1518,6 +1549,7 @@ function mockContractPackageApproved(
                                     downloadURL: s3DlUrl,
                                 },
                                 {
+                                    __typename: 'GenericDocument',
                                     id: 'rate supporting 2',
                                     s3URL: 's3://bucketname/key/rateSupporting1',
                                     sha256: 'fakesha',
@@ -2172,6 +2204,7 @@ function mockContractPackageUnlockedWithUnlockedType(
                 contractExecutionStatus: 'EXECUTED',
                 contractDocuments: [
                     {
+                        __typename: 'GenericDocument',
                         id: 'one two',
                         s3URL: 's3://bucketname/one-two/one-two.png',
                         sha256: 'fakesha',
@@ -2245,6 +2278,7 @@ function mockContractPackageUnlockedWithUnlockedType(
                         rateCapitationType: 'RATE_CELL',
                         rateDocuments: [
                             {
+                                __typename: 'GenericDocument',
                                 s3URL: 's3://bucketname/key/rate',
                                 sha256: 'fakesha',
                                 name: 'rate',
@@ -2339,6 +2373,7 @@ function mockContractPackageUnlockedWithUnlockedType(
                             contractExecutionStatus: 'EXECUTED',
                             contractDocuments: [
                                 {
+                                    __typename: 'GenericDocument',
                                     id: 'contract',
                                     s3URL: 's3://bucketname/key/contract',
                                     sha256: 'fakesha',
@@ -2405,6 +2440,7 @@ function mockContractPackageUnlockedWithUnlockedType(
                         contractExecutionStatus: 'EXECUTED',
                         contractDocuments: [
                             {
+                                __typename: 'GenericDocument',
                                 id: 'contract',
                                 s3URL: 's3://bucketname/key/contract',
                                 sha256: 'fakesha',
@@ -2478,6 +2514,7 @@ function mockContractPackageUnlockedWithUnlockedType(
                             rateCapitationType: 'RATE_CELL',
                             rateDocuments: [
                                 {
+                                    __typename: 'GenericDocument',
                                     id: 'rate',
                                     s3URL: 's3://bucketname/key/rate',
                                     sha256: 'fakesha',
@@ -2544,6 +2581,7 @@ function mockContractFormData(
         submissionDescription: 'A real submission',
         supportingDocuments: [
             {
+                __typename: 'GenericDocument',
                 id: 'contractSupporting1',
                 s3URL: 's3://bucketname/key/contractsupporting1',
                 sha256: 'fakesha',
@@ -2552,6 +2590,7 @@ function mockContractFormData(
                 downloadURL: s3DlUrl,
             },
             {
+                __typename: 'GenericDocument',
                 id: 'contractSupporting2',
                 s3URL: 's3://bucketname/key/contractSupporting2',
                 sha256: 'fakesha',
@@ -2571,6 +2610,7 @@ function mockContractFormData(
         contractExecutionStatus: 'EXECUTED',
         contractDocuments: [
             {
+                __typename: 'GenericDocument',
                 id: 'contract document',
                 s3URL: 's3://bucketname/one-two/one-two.png',
                 sha256: 'fakesha',
@@ -2629,6 +2669,7 @@ const mockEmptyDraftContractAndRate = (): Contract =>
                 submissionDescription: null,
                 supportingDocuments: [
                     {
+                        __typename: 'GenericDocument',
                         id: 'contractSupporting1',
                         s3URL: 's3://bucketname/key/contractsupporting1',
                         sha256: 'fakesha',
@@ -2637,6 +2678,7 @@ const mockEmptyDraftContractAndRate = (): Contract =>
                         downloadURL: s3DlUrl,
                     },
                     {
+                        __typename: 'GenericDocument',
                         id: 'contractSupporting2',
                         s3URL: 's3://bucketname/key/contractSupporting2',
                         sha256: 'fakesha',
@@ -2650,6 +2692,7 @@ const mockEmptyDraftContractAndRate = (): Contract =>
                 contractExecutionStatus: null,
                 contractDocuments: [
                     {
+                        __typename: 'GenericDocument',
                         id: 'contract document',
                         s3URL: 's3://bucketname/one-two/one-two.png',
                         sha256: 'fakesha',
@@ -2708,6 +2751,7 @@ const mockEmptyDraftContractAndRate = (): Contract =>
                         rateCapitationType: null,
                         rateDocuments: [
                             {
+                                __typename: 'GenericDocument',
                                 id: 'rate certification',
                                 s3URL: 's3://bucketname/key/rate',
                                 sha256: 'fakesha',
@@ -2718,6 +2762,7 @@ const mockEmptyDraftContractAndRate = (): Contract =>
                         ],
                         supportingDocuments: [
                             {
+                                __typename: 'GenericDocument',
                                 id: 'rateSupporting1',
                                 s3URL: 's3://bucketname/key/ratesupporting1',
                                 sha256: 'fakesha',
@@ -2726,6 +2771,7 @@ const mockEmptyDraftContractAndRate = (): Contract =>
                                 downloadURL: s3DlUrl,
                             },
                             {
+                                __typename: 'GenericDocument',
                                 id: 'rateSupporting2',
                                 s3URL: 's3://bucketname/key/rateSupporting2',
                                 sha256: 'fakesha',

--- a/packages/mocks/src/apollo/rateDataMock.ts
+++ b/packages/mocks/src/apollo/rateDataMock.ts
@@ -40,6 +40,7 @@ const rateRevisionDataMock = (data?: Partial<RateRevision>): RateRevision => {
             rateCapitationType: 'RATE_CELL',
             rateDocuments: [
                 {
+                    id: 'rate-document.pdf',
                     __typename: 'GenericDocument',
                     name: 'rate-document.pdf',
                     s3URL: 's3://bucketname/key/rate-document',
@@ -50,6 +51,7 @@ const rateRevisionDataMock = (data?: Partial<RateRevision>): RateRevision => {
             ],
             supportingDocuments: [
                 {
+                    id: 'rate-supporting-document.pdf',
                     __typename: 'GenericDocument',
                     name: 'rate-supporting-document.pdf',
                     s3URL: 's3://bucketname/key/rate-supporting-document',
@@ -401,6 +403,8 @@ function mockRateSubmittedWithQuestions(
                 rateCapitationType: 'RATE_CELL',
                 rateDocuments: [
                     {
+                        __typename: 'GenericDocument',
+                        id: 'rate',
                         s3URL: 's3://bucketname/key/rate',
                         sha256: 'fakesha',
                         name: 'rate',
@@ -410,6 +414,8 @@ function mockRateSubmittedWithQuestions(
                 ],
                 supportingDocuments: [
                     {
+                        __typename: 'GenericDocument',
+                        id: 'rate supporting 1',
                         s3URL: 's3://bucketname/key/rateSupporting1',
                         sha256: 'fakesha',
                         name: 'rate supporting 1',
@@ -417,6 +423,8 @@ function mockRateSubmittedWithQuestions(
                         downloadURL: s3DlUrl,
                     },
                     {
+                        __typename: 'GenericDocument',
+                        id: 'rate supporting 2',
                         s3URL: 's3://bucketname/key/rateSupporting1',
                         sha256: 'fakesha',
                         name: 'rate supporting 2',
@@ -524,6 +532,8 @@ function mockRateSubmittedWithQuestions(
                             submissionDescription: 'A real submission',
                             supportingDocuments: [
                                 {
+                                    __typename: 'GenericDocument',
+                                    id: 'contractSupporting1',
                                     s3URL: 's3://bucketname/key/contractsupporting1',
                                     sha256: 'fakesha',
                                     name: 'contractSupporting1',
@@ -531,6 +541,8 @@ function mockRateSubmittedWithQuestions(
                                     downloadURL: s3DlUrl,
                                 },
                                 {
+                                    __typename: 'GenericDocument',
+                                    id: 'contractSupporting2',
                                     s3URL: 's3://bucketname/key/contractSupporting2',
                                     sha256: 'fakesha',
                                     name: 'contractSupporting2',
@@ -543,6 +555,8 @@ function mockRateSubmittedWithQuestions(
                             contractExecutionStatus: 'EXECUTED',
                             contractDocuments: [
                                 {
+                                    __typename: 'GenericDocument',
+                                    id: 'contract',
                                     s3URL: 's3://bucketname/key/contract',
                                     sha256: 'fakesha',
                                     name: 'contract',

--- a/packages/mocks/src/apollo/withdrawRateGQLMock.ts
+++ b/packages/mocks/src/apollo/withdrawRateGQLMock.ts
@@ -50,7 +50,7 @@ const withdrawRateMockSuccess = (
             query: WithdrawRateDocument,
             variables: {
                 input: {
-                    rateID: 'test-abc-123',
+                    rateID: rateData?.id || rateID,
                     updatedReason,
                 },
             },
@@ -120,7 +120,7 @@ const undoWithdrawRateMockSuccess = (
             query: UndoWithdrawnRateDocument,
             variables: {
                 input: {
-                    rateID: 'test-abc-123',
+                    rateID: rateData?.id || rateID,
                     updatedReason,
                 },
             },

--- a/services/app-api/src/domain-models/contractAndRates/formDataTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/formDataTypes.ts
@@ -14,6 +14,7 @@ import { statusSchema } from './statusType'
 import type { RawCreateParams, ZodTypeAny } from 'zod/lib/types'
 
 const documentSchema = z.object({
+    id: z.string(),
     name: z.string(),
     s3URL: z.string(),
     sha256: z.string(),

--- a/services/app-api/src/domain-models/contractAndRates/formDataTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/formDataTypes.ts
@@ -14,7 +14,7 @@ import { statusSchema } from './statusType'
 import type { RawCreateParams, ZodTypeAny } from 'zod/lib/types'
 
 const documentSchema = z.object({
-    id: z.string(),
+    id: z.string().optional(),
     name: z.string(),
     s3URL: z.string(),
     sha256: z.string(),

--- a/services/app-api/src/postgres/contractAndRates/parseContractWithHistory.ts
+++ b/services/app-api/src/postgres/contractAndRates/parseContractWithHistory.ts
@@ -166,9 +166,6 @@ function contractWithHistoryToDomainModelWithoutRates(
                 submitedRevs.push(contractRev)
             }
             for (const rateRev of submittedRates) {
-                if (rateRev instanceof Error) {
-                    return rateRev
-                }
                 submitedRevs.push(rateRev)
             }
 
@@ -208,6 +205,7 @@ function contractWithHistoryToDomainModelWithoutRates(
     }
     setDateAddedForContractRevisions(packageContractRevisions)
 
+    //NOTE: This will not display the actual date added for linked rates because we do not query all the linked rate revisions
     for (const rrevs of Object.values(packageRateRevisions)) {
         setDateAddedForRateRevisions(rrevs)
     }

--- a/services/app-api/src/postgres/contractAndRates/prismaContractRateAdaptors.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaContractRateAdaptors.ts
@@ -2,14 +2,14 @@ import type {
     ContractFormEditableType,
     RateFormEditableType,
 } from '../../domain-models/contractAndRates'
-import type { GenericDocument } from '../../gen/gqlServer'
+import type { GenericDocumentInput } from '../../gen/gqlServer'
 import { emptify, nullify } from '../prismaDomainAdaptors'
 
 // ADD RETURN TYPES FROM PRISMA SEE "includes" "satifies"
 // contractTableFullPayload - contractTableCreateArgs / contract
 
 // Generic helpers
-const formatDocsForPrisma = (docs: GenericDocument[]) => {
+const formatDocsForPrisma = (docs: GenericDocumentInput[]) => {
     return docs.map((d, idx) => {
         delete d['dateAdded']
         delete d['downloadURL']

--- a/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
@@ -585,10 +585,6 @@ function ratesRevisionsToDomainModel(
     for (const revision of rateRevisions) {
         const domainRevision = rateRevisionToDomainModel(revision)
 
-        if (domainRevision instanceof Error) {
-            return domainRevision
-        }
-
         domainRevisions.push(domainRevision)
     }
 

--- a/services/app-api/src/resolvers/contract/submitContract.test.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.test.ts
@@ -88,7 +88,25 @@ describe('submitContract', () => {
         expect(submittedFormData.contractDocuments[0].dateAdded).toBeTruthy()
         submittedFormData.contractDocuments[0].dateAdded = null
 
-        expect(submittedFormData).toEqual(draftFormData)
+        expect(submittedFormData).toEqual({
+            ...draftFormData,
+            contractDocuments: expect.arrayContaining(
+                draftFormData.contractDocuments.map((doc) =>
+                    expect.objectContaining({
+                        ...doc,
+                        id: expect.any(String),
+                    })
+                )
+            ),
+            supportingDocuments: expect.arrayContaining(
+                draftFormData.supportingDocuments.map((doc) =>
+                    expect.objectContaining({
+                        ...doc,
+                        id: expect.any(String),
+                    })
+                )
+            ),
+        })
     })
 
     it('submits a contract and removes existing rates on the contract', async () => {

--- a/services/app-api/src/resolvers/rate/indexRatesStripped.test.ts
+++ b/services/app-api/src/resolvers/rate/indexRatesStripped.test.ts
@@ -47,6 +47,11 @@ describe('indexRatesStripped', () => {
         // index rates
         const result = await cmsServer.executeOperation({
             query: IndexRatesStrippedWithRelatedContractsDocument,
+            variables: {
+                input: {
+                    rateIDs: [submit1ID, submit2ID],
+                },
+            },
         })
 
         expect(result.data).toBeDefined()

--- a/services/app-api/src/resolvers/rate/undoWithdrawRate.test.ts
+++ b/services/app-api/src/resolvers/rate/undoWithdrawRate.test.ts
@@ -163,7 +163,25 @@ describe('undoWithdrawRate', () => {
         // Expect un-withdrawn rate formData to equal formData before it was withdrawn
         expect(
             unwithdrawnRate.packageSubmissions[0].rateRevision.formData
-        ).toEqual(formData)
+        ).toEqual({
+            ...formData,
+            rateDocuments: expect.arrayContaining(
+                formData.rateDocuments.map((doc) =>
+                    expect.objectContaining({
+                        ...doc,
+                        id: expect.any(String),
+                    })
+                )
+            ),
+            supportingDocuments: expect.arrayContaining(
+                formData.supportingDocuments.map((doc) =>
+                    expect.objectContaining({
+                        ...doc,
+                        id: expect.any(String),
+                    })
+                )
+            ),
+        })
         expect(unwithdrawnRate.withdrawnFromContracts).toHaveLength(0)
         expect(unwithdrawnRate.consolidatedStatus).toBe('RESUBMITTED')
         expect(unwithdrawnRate.parentContractID).toBe(contractA.id)
@@ -316,7 +334,25 @@ describe('undoWithdrawRate', () => {
         // Expect un-withdrawn rate formData to equal formData before it was withdrawn
         expect(
             unwithdrawnRate.packageSubmissions[0].rateRevision.formData
-        ).toEqual(formData)
+        ).toEqual({
+            ...formData,
+            rateDocuments: expect.arrayContaining(
+                formData.rateDocuments.map((doc) =>
+                    expect.objectContaining({
+                        ...doc,
+                        id: expect.any(String),
+                    })
+                )
+            ),
+            supportingDocuments: expect.arrayContaining(
+                formData.supportingDocuments.map((doc) =>
+                    expect.objectContaining({
+                        ...doc,
+                        id: expect.any(String),
+                    })
+                )
+            ),
+        })
         expect(unwithdrawnRate.withdrawnFromContracts).toHaveLength(0)
         expect(unwithdrawnRate.consolidatedStatus).toBe('RESUBMITTED')
         expect(unwithdrawnRate.parentContractID).toBe(contractA.id)

--- a/services/app-api/src/resolvers/rate/undoWithdrawRate.test.ts
+++ b/services/app-api/src/resolvers/rate/undoWithdrawRate.test.ts
@@ -806,13 +806,11 @@ describe('undo withdraw rate error handling', async () => {
         })
 
         const contractA = await createAndSubmitTestContractWithRate(stateServer)
-        const rate = contractA.packageSubmissions[0].rateRevisions[0].rate
+        const rateID = contractA.packageSubmissions[0].rateRevisions[0].rateID
 
-        if (!rate) {
+        if (!rateID) {
             throw new Error('Unexpected error: rate not found')
         }
-
-        const rateID = contractA.packageSubmissions[0].rateRevisions[0].rateID
 
         const unwithdrawnRate = await cmsServer.executeOperation({
             query: UndoWithdrawnRateDocument,
@@ -827,7 +825,7 @@ describe('undo withdraw rate error handling', async () => {
         // expect error for attempting to withdraw rate in postgres
         expect(unwithdrawnRate.errors?.[0]).toBeDefined()
         expect(unwithdrawnRate.errors?.[0].message).toBe(
-            `Attempted to undo rate withdrawal with wrong status. Rate: ${rate.consolidatedStatus}`
+            `Attempted to undo rate withdrawal with wrong status. Rate: SUBMITTED`
         )
     })
 })

--- a/services/app-api/src/testHelpers/documentHelpers.ts
+++ b/services/app-api/src/testHelpers/documentHelpers.ts
@@ -10,7 +10,9 @@ import type {
 const clearDocMetadata = (documents?: GenericDocument[]): GenericDocument[] => {
     if (!documents) return []
     return documents.map((doc) => {
-        // clear out metadata fields
+        // ID is metadata used on the frontend for caching, otherwise apollo client has no unique identifier for docs
+        // it is not needed on the BE.
+        delete doc['id']
         delete doc['dateAdded']
         return doc
     })

--- a/services/app-graphql/src/fragments/contractRevisionFragment.graphql
+++ b/services/app-graphql/src/fragments/contractRevisionFragment.graphql
@@ -42,6 +42,7 @@ fragment contractRevisionFragment on ContractRevision {
         }
 
         supportingDocuments {
+            id
             name
             s3URL
             sha256
@@ -52,6 +53,7 @@ fragment contractRevisionFragment on ContractRevision {
         contractType
         contractExecutionStatus
         contractDocuments {
+            id
             name
             s3URL
             sha256

--- a/services/app-graphql/src/fragments/contractRevisionFragment.graphql
+++ b/services/app-graphql/src/fragments/contractRevisionFragment.graphql
@@ -42,23 +42,13 @@ fragment contractRevisionFragment on ContractRevision {
         }
 
         supportingDocuments {
-            id
-            name
-            s3URL
-            sha256
-            dateAdded
-            downloadURL
+            ...genericDocumentFragment
         }
 
         contractType
         contractExecutionStatus
         contractDocuments {
-            id
-            name
-            s3URL
-            sha256
-            dateAdded
-            downloadURL
+            ...genericDocumentFragment
         }
 
         contractDateStart

--- a/services/app-graphql/src/fragments/genericDocumentFragment.graphql
+++ b/services/app-graphql/src/fragments/genericDocumentFragment.graphql
@@ -1,0 +1,8 @@
+fragment genericDocumentFragment on GenericDocument {
+    id
+    name
+    s3URL
+    sha256
+    dateAdded
+    downloadURL
+}

--- a/services/app-graphql/src/fragments/packageSubmissionsFragment.graphql
+++ b/services/app-graphql/src/fragments/packageSubmissionsFragment.graphql
@@ -5,7 +5,7 @@ fragment packageSubmissionsFragment on ContractPackageSubmission {
     }
 
     submittedRevisions {
-        ...submittableRevisionsFieldsFragement
+        ...submittableRevisionsFieldsFragment
     }
 
     contractRevision {

--- a/services/app-graphql/src/fragments/packageSubmissionsFragment.graphql
+++ b/services/app-graphql/src/fragments/packageSubmissionsFragment.graphql
@@ -13,14 +13,5 @@ fragment packageSubmissionsFragment on ContractPackageSubmission {
     }
     rateRevisions {
         ...rateRevisionFragment
-        rate {
-            ...rateFieldsFragment
-            revisions {
-                ...rateRevisionFragment
-            }
-            packageSubmissions {
-                ...ratePackageSubmissionsFragment
-            }
-        }
     }
 }

--- a/services/app-graphql/src/fragments/ratePackageSubmissionsFragment.graphql
+++ b/services/app-graphql/src/fragments/ratePackageSubmissionsFragment.graphql
@@ -5,7 +5,7 @@ fragment ratePackageSubmissionsFragment on RatePackageSubmission {
     }
 
     submittedRevisions {
-        ...submittableRevisionsFieldsFragement
+        ...submittableRevisionsFieldsFragment
     }
 
     rateRevision {

--- a/services/app-graphql/src/fragments/rateRevisionFragment.graphql
+++ b/services/app-graphql/src/fragments/rateRevisionFragment.graphql
@@ -13,20 +13,10 @@ fragment rateRevisionFragment on RateRevision {
         rateType
         rateCapitationType
         rateDocuments {
-            id
-            name
-            s3URL
-            sha256
-            dateAdded
-            downloadURL
+            ...genericDocumentFragment
         }
         supportingDocuments {
-            id
-            name
-            s3URL
-            sha256
-            dateAdded
-            downloadURL
+            ...genericDocumentFragment
         }
         rateDateStart
         rateDateEnd

--- a/services/app-graphql/src/fragments/rateRevisionFragment.graphql
+++ b/services/app-graphql/src/fragments/rateRevisionFragment.graphql
@@ -13,6 +13,7 @@ fragment rateRevisionFragment on RateRevision {
         rateType
         rateCapitationType
         rateDocuments {
+            id
             name
             s3URL
             sha256
@@ -20,6 +21,7 @@ fragment rateRevisionFragment on RateRevision {
             downloadURL
         }
         supportingDocuments {
+            id
             name
             s3URL
             sha256

--- a/services/app-graphql/src/fragments/submittableRevisionFieldsFragment.graphql
+++ b/services/app-graphql/src/fragments/submittableRevisionFieldsFragment.graphql
@@ -43,21 +43,14 @@ fragment submittableRevisionsFieldsFragment on SubmittableRevision {
             }
 
             supportingDocuments {
-                name
-                s3URL
-                sha256
-                dateAdded
-                downloadURL
+                ...genericDocumentFragment
             }
 
             contractType
             contractExecutionStatus
             contractDocuments {
-                name
-                s3URL
-                sha256
-                dateAdded
-                downloadURL
+                ...genericDocumentFragment
+
             }
 
             contractDateStart
@@ -101,18 +94,12 @@ fragment submittableRevisionsFieldsFragment on SubmittableRevision {
             rateType
             rateCapitationType
             rateDocuments {
-                name
-                s3URL
-                sha256
-                dateAdded
-                downloadURL
+                ...genericDocumentFragment
+
             }
             supportingDocuments {
-                name
-                s3URL
-                sha256
-                dateAdded
-                downloadURL
+                ...genericDocumentFragment
+
             }
             rateDateStart
             rateDateEnd

--- a/services/app-graphql/src/fragments/submittableRevisionFieldsFragment.graphql
+++ b/services/app-graphql/src/fragments/submittableRevisionFieldsFragment.graphql
@@ -1,4 +1,4 @@
-fragment submittableRevisionsFieldsFragement on SubmittableRevision {
+fragment submittableRevisionsFieldsFragment on SubmittableRevision {
     ... on ContractRevision {
         id
         createdAt

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -1375,7 +1375,7 @@ GenericDocument
 This document type should be used (or extended) everywhere we pass documents through GraphQL regardless of domain
 """
 type GenericDocument {
-    id: ID!
+    id: ID
     "The user created name of the document"
     name: String!
     "The S3 URL of the document, generated on the FE currently in the FileUpload component"

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -1375,6 +1375,7 @@ GenericDocument
 This document type should be used (or extended) everywhere we pass documents through GraphQL regardless of domain
 """
 type GenericDocument {
+    id: ID!
     "The user created name of the document"
     name: String!
     "The S3 URL of the document, generated on the FE currently in the FileUpload component"
@@ -1858,7 +1859,7 @@ type RateRevision {
     unlockInfo: UpdateInformation
     "Information on who, when, and why this revision was submitted."
     submitInfo: UpdateInformation
-    "The rate related form data that was inputed by the state"
+    "The rate related form data that was inputted by the state"
     formData: RateFormData!
 }
 
@@ -1913,7 +1914,7 @@ type Rate {
     """
     Synthesized field that represents if a rate's status or
     reviewStatus should take precedence
-    Options are DRAFT, SUBMITTED, RESUBMITTED UNLOCKED, UNDER_REVIEW, WITHDRAWN
+    Options are DRAFT, SUBMITTED, RESUBMITTED, UNLOCKED, WITHDRAWN
     """
     consolidatedStatus: ConsolidatedRateStatus!
     "The initial date this rate was submitted at. Is not changed by unlock or resubmission."

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
@@ -13,6 +13,7 @@ import { hasCMSUserPermissions } from '@mc-review/helpers'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { featureFlags } from '@mc-review/common-code'
 import { formatCalendarDate } from '@mc-review/dates'
+import { usePreviousSubmission } from '../../../hooks'
 // This is used to convert from deprecated FE domain types from protos to GQL GenericDocuments by added in a dateAdded
 export const convertFromSubmissionDocumentsToGenericDocuments = (
     deprecatedDocs: SubmissionDocument[],
@@ -66,15 +67,18 @@ export const UploadedDocumentsTable = ({
         featureFlags.HIDE_SUPPORTING_DOCS_PAGE.flag,
         featureFlags.HIDE_SUPPORTING_DOCS_PAGE.defaultValue
     )
+    const isPrevSubmission = usePreviousSubmission()
     const shouldShowEditButton =
         !hideDynamicFeedback && isSupportingDocuments && !hideSupportingDocs // at this point only contract supporting documents need the inline EDIT button - this can be deleted when we move supporting docs to ContractDetails page
     // canDisplayDateForDocument -  guards against passing in null or undefined to dayjs
     // don't display prior to the initial submission
     const canDisplayDateAddedForDocument = (doc: DocumentWithS3Data) => {
         return (
-            (doc.dateAdded && previousSubmissionDate) ||
-            (doc.dateAdded && isInitialSubmission) ||
-            (doc.dateAdded && isLinkedRate)
+            doc.dateAdded &&
+            (previousSubmissionDate ||
+                isInitialSubmission ||
+                isLinkedRate ||
+                isPrevSubmission)
         )
     }
 

--- a/services/app-web/src/index.tsx
+++ b/services/app-web/src/index.tsx
@@ -78,11 +78,6 @@ const cache = new InMemoryCache({
                 },
             },
         },
-        // GenericDocument: {
-        //     keyFields: (doc, context) => {
-        //         console.log(doc)
-        //     }
-        // }
     },
 })
 const defaultOptions: DefaultOptions = {

--- a/services/app-web/src/index.tsx
+++ b/services/app-web/src/index.tsx
@@ -78,6 +78,11 @@ const cache = new InMemoryCache({
                 },
             },
         },
+        // GenericDocument: {
+        //     keyFields: (doc, context) => {
+        //         console.log(doc)
+        //     }
+        // }
     },
 })
 const defaultOptions: DefaultOptions = {

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/RateQuestionResponse.test.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/RateQuestionResponse.test.tsx
@@ -327,8 +327,17 @@ describe('RateQuestionResponse', () => {
                             user: mockValidCMSUser(),
                             statusCode: 200,
                         }),
-                        fetchRateMockSuccess({
-                            id: 'test-rate-id',
+                        fetchRateWithQuestionsMockSuccess({
+                            rate: {
+                                id: 'test-rate-id',
+                                questions: indexRateQuestions,
+                            },
+                        }),
+                        fetchRateWithQuestionsMockSuccess({
+                            rate: {
+                                id: 'test-rate-id',
+                                questions: indexRateQuestions,
+                            },
                         }),
                         fetchRateWithQuestionsMockSuccess({
                             rate: {
@@ -361,8 +370,15 @@ describe('RateQuestionResponse', () => {
                             user: mockValidCMSUser(),
                             statusCode: 200,
                         }),
-                        fetchRateMockSuccess({
-                            id: 'test-rate-id',
+                        fetchRateWithQuestionsMockSuccess({
+                            rate: {
+                                id: 'test-rate-id',
+                            },
+                        }),
+                        fetchRateWithQuestionsMockSuccess({
+                            rate: {
+                                id: 'test-rate-id',
+                            },
                         }),
                         fetchRateWithQuestionsMockSuccess({
                             rate: {
@@ -539,6 +555,7 @@ describe('RateQuestionResponse', () => {
                             }),
                             statusCode: 200,
                         }),
+                        fetchRateWithQuestionsMockSuccess({ rate }),
                         fetchRateWithQuestionsMockSuccess({ rate }),
                         fetchRateWithQuestionsMockSuccess({ rate }),
                     ],

--- a/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
@@ -554,6 +554,7 @@ describe('RateSummary', () => {
         })
 
         it('redirects to RateEdit component from RateSummary without errors for unlocked rate', async () => {
+            let testLocation: Location
             renderWithProviders(
                 <Routes>
                     <Route
@@ -588,13 +589,12 @@ describe('RateSummary', () => {
                     featureFlags: {
                         'rate-edit-unlock': true,
                     },
+                    location: (location) => (testLocation = location),
                 }
             )
 
             await waitFor(() => {
-                expect(
-                    screen.queryByTestId('single-rate-edit')
-                ).toBeInTheDocument()
+                expect(testLocation.pathname).toBe('/rates/1337/edit')
             })
         })
 

--- a/services/app-web/src/pages/RateWithdraw/RateWithdraw.test.tsx
+++ b/services/app-web/src/pages/RateWithdraw/RateWithdraw.test.tsx
@@ -56,11 +56,11 @@ describe('RateWithdraw', () => {
                         path={RoutesRecord.RATES_SUMMARY}
                         element={<RateSummary />}
                     />
-                    <Route
-                        path={RoutesRecord.RATE_WITHDRAW}
-                        element={<RateWithdraw />}
-                    />
                 </Route>
+                <Route
+                    path={RoutesRecord.RATE_WITHDRAW}
+                    element={<RateWithdraw />}
+                />
             </Routes>,
             {
                 apolloProvider: {
@@ -69,10 +69,11 @@ describe('RateWithdraw', () => {
                             user: mockValidCMSUser(),
                             statusCode: 200,
                         }),
-                        fetchRateWithQuestionsMockSuccess({ rate }),
-                        fetchRateWithQuestionsMockSuccess({ rate }),
                         fetchRateMockSuccess(rate),
                         withdrawRateMockSuccess({ rateData: rate }),
+                        fetchRateWithQuestionsMockSuccess({
+                            rate: withdrawnRate,
+                        }),
                         fetchRateWithQuestionsMockSuccess({
                             rate: withdrawnRate,
                         }),
@@ -121,16 +122,10 @@ describe('RateWithdraw', () => {
 
         const { user } = renderWithProviders(
             <Routes>
-                <Route element={<RateSummarySideNav />}>
-                    <Route
-                        path={RoutesRecord.RATES_SUMMARY}
-                        element={<RateSummary />}
-                    />
-                    <Route
-                        path={RoutesRecord.RATE_WITHDRAW}
-                        element={<RateWithdraw />}
-                    />
-                </Route>
+                <Route
+                    path={RoutesRecord.RATE_WITHDRAW}
+                    element={<RateWithdraw />}
+                />
             </Routes>,
             {
                 apolloProvider: {
@@ -139,7 +134,6 @@ describe('RateWithdraw', () => {
                             user: mockValidCMSUser(),
                             statusCode: 200,
                         }),
-                        fetchRateWithQuestionsMockSuccess({ rate }),
                         fetchRateMockSuccess(rate),
                         withdrawRateMockFailure(),
                     ],
@@ -169,22 +163,12 @@ describe('RateWithdraw', () => {
     })
 
     it('renders form validation error when required withdraw reason field is missing', async () => {
-        const rate = mockRateSubmittedWithQuestions({
-            id: 'test-abc-123',
-            parentContractID: 'test-abc-123',
-        })
         const { user } = renderWithProviders(
             <Routes>
-                <Route element={<RateSummarySideNav />}>
-                    <Route
-                        path={RoutesRecord.RATES_SUMMARY}
-                        element={<RateSummary />}
-                    />
-                    <Route
-                        path={RoutesRecord.RATE_WITHDRAW}
-                        element={<RateWithdraw />}
-                    />
-                </Route>
+                <Route
+                    path={RoutesRecord.RATE_WITHDRAW}
+                    element={<RateWithdraw />}
+                />
             </Routes>,
             {
                 apolloProvider: {
@@ -193,7 +177,6 @@ describe('RateWithdraw', () => {
                             user: mockValidCMSUser(),
                             statusCode: 200,
                         }),
-                        fetchRateWithQuestionsMockSuccess({ rate }),
                         fetchRateMockSuccess({ id: 'test-abc-123' }),
                     ],
                 },

--- a/services/app-web/src/pages/RateWithdraw/RateWithdraw.test.tsx
+++ b/services/app-web/src/pages/RateWithdraw/RateWithdraw.test.tsx
@@ -21,11 +21,11 @@ import { Rate } from '../../gen/gqlClient'
 describe('RateWithdraw', () => {
     it('can withdraw a rate', async () => {
         const contract = mockContractPackageSubmitted({
-            id: 'test-abc-123',
+            id: 'test-contract-123',
         })
         const rate = mockRateSubmittedWithQuestions({
-            id: 'test-abc-123',
-            parentContractID: 'test-abc-123',
+            id: 'test-rate-123',
+            parentContractID: 'test-contract-123',
         })
         const withdrawnRate: Rate = {
             ...rate,
@@ -69,18 +69,20 @@ describe('RateWithdraw', () => {
                             user: mockValidCMSUser(),
                             statusCode: 200,
                         }),
+                        fetchRateWithQuestionsMockSuccess({ rate }),
+                        fetchRateWithQuestionsMockSuccess({ rate }),
+                        fetchRateMockSuccess(rate),
+                        withdrawRateMockSuccess({ rateData: rate }),
                         fetchRateWithQuestionsMockSuccess({
                             rate: withdrawnRate,
                         }),
-                        fetchRateMockSuccess(rate),
-                        withdrawRateMockSuccess({ rateData: rate }),
                         fetchContractMockSuccess({
                             contract,
                         }),
                     ],
                 },
                 routerProvider: {
-                    route: '/rate-reviews/test-abc-123/withdraw-rate',
+                    route: '/rate-reviews/test-rate-123/withdraw-rate',
                 },
             }
         )

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -675,7 +675,7 @@ describe('SubmissionSummary', () => {
                         }
                     )
                     await waitFor(() => {
-                        const rows = screen.getAllByRole('row')
+                        const rows = screen.queryAllByRole('row')
                         expect(rows).toHaveLength(10)
                         expect(
                             within(rows[0]).getByText('Date added')

--- a/services/app-web/src/pages/UndoRateWithdraw/UndoRateWithdraw.test.tsx
+++ b/services/app-web/src/pages/UndoRateWithdraw/UndoRateWithdraw.test.tsx
@@ -91,11 +91,11 @@ describe('UndoRateWithdraw', () => {
                         path={RoutesRecord.RATES_SUMMARY}
                         element={<RateSummary />}
                     />
-                    <Route
-                        path={RoutesRecord.UNDO_RATE_WITHDRAW}
-                        element={<UndoRateWithdraw />}
-                    />
                 </Route>
+                <Route
+                    path={RoutesRecord.UNDO_RATE_WITHDRAW}
+                    element={<UndoRateWithdraw />}
+                />
             </Routes>,
             {
                 apolloProvider: {
@@ -104,12 +104,13 @@ describe('UndoRateWithdraw', () => {
                             user: mockValidCMSUser(),
                             statusCode: 200,
                         }),
-                        fetchRateWithQuestionsMockSuccess({ rate }),
-                        fetchRateWithQuestionsMockSuccess({ rate }),
                         fetchRateMockSuccess(rate),
                         undoWithdrawRateMockSuccess({
                             rateID: 'test-rate-123',
                             updatedReason: 'Undo withdraw rate',
+                        }),
+                        fetchRateWithQuestionsMockSuccess({
+                            rate: undoWithdrawnRate,
                         }),
                         fetchRateWithQuestionsMockSuccess({
                             rate: undoWithdrawnRate,
@@ -151,13 +152,13 @@ describe('UndoRateWithdraw', () => {
             expect(testLocation.pathname).toBe(`/rates/${rate.id}`)
             // expect unlock rate button to exist
             expect(
-                screen.getByRole('button', {
+                screen.queryByRole('button', {
                     name: 'Unlock rate',
                 })
             ).toBeInTheDocument()
             // expect withdraw rate button to exist
             expect(
-                screen.getByRole('button', {
+                screen.queryByRole('button', {
                     name: 'Withdraw rate',
                 })
             ).toBeInTheDocument()
@@ -165,41 +166,12 @@ describe('UndoRateWithdraw', () => {
     })
 
     it('renders generic API banner error on failed undo rate withdraw', async () => {
-        const rate = mockRateSubmittedWithQuestions({
-            id: 'test-abc-123',
-            parentContractID: 'test-abc-123',
-            reviewStatus: 'WITHDRAWN',
-            consolidatedStatus: 'WITHDRAWN',
-            reviewStatusActions: [
-                {
-                    __typename: 'RateReviewStatusActions',
-                    actionType: 'WITHDRAW',
-                    rateID: 'test-abc-123',
-                    updatedReason: 'a valid note',
-                    updatedAt: new Date(),
-                    updatedBy: {
-                        __typename: 'UpdatedBy',
-                        email: 'cmsapprover@example.com',
-                        familyName: 'Smith',
-                        givenName: 'John',
-                        role: 'CMS_APPROVER_USER',
-                    },
-                },
-            ],
-        })
-
         const { user } = renderWithProviders(
             <Routes>
-                <Route element={<RateSummarySideNav />}>
-                    <Route
-                        path={RoutesRecord.RATES_SUMMARY}
-                        element={<RateSummary />}
-                    />
-                    <Route
-                        path={RoutesRecord.UNDO_RATE_WITHDRAW}
-                        element={<UndoRateWithdraw />}
-                    />
-                </Route>
+                <Route
+                    path={RoutesRecord.UNDO_RATE_WITHDRAW}
+                    element={<UndoRateWithdraw />}
+                />
             </Routes>,
             {
                 apolloProvider: {
@@ -208,7 +180,6 @@ describe('UndoRateWithdraw', () => {
                             user: mockValidCMSUser(),
                             statusCode: 200,
                         }),
-                        fetchRateWithQuestionsMockSuccess({ rate }),
                         fetchRateMockSuccess({ id: 'test-abc-123' }),
                         undoWithdrawRateMockFailure(),
                     ],
@@ -245,23 +216,12 @@ describe('UndoRateWithdraw', () => {
     })
 
     it('renders form validation error when required reason field is missing', async () => {
-        const rate = mockRateSubmittedWithQuestions({
-            id: 'test-abc-123',
-            parentContractID: 'test-abc-123',
-        })
-
         const { user } = renderWithProviders(
             <Routes>
-                <Route element={<RateSummarySideNav />}>
-                    <Route
-                        path={RoutesRecord.RATES_SUMMARY}
-                        element={<RateSummary />}
-                    />
-                    <Route
-                        path={RoutesRecord.UNDO_RATE_WITHDRAW}
-                        element={<UndoRateWithdraw />}
-                    />
-                </Route>
+                <Route
+                    path={RoutesRecord.UNDO_RATE_WITHDRAW}
+                    element={<UndoRateWithdraw />}
+                />
             </Routes>,
             {
                 apolloProvider: {
@@ -270,7 +230,6 @@ describe('UndoRateWithdraw', () => {
                             user: mockValidCMSUser(),
                             statusCode: 200,
                         }),
-                        fetchRateWithQuestionsMockSuccess({ rate }),
                         fetchRateMockSuccess({ id: 'test-abc-123' }),
                     ],
                 },

--- a/services/app-web/src/pages/UndoRateWithdraw/UndoRateWithdraw.test.tsx
+++ b/services/app-web/src/pages/UndoRateWithdraw/UndoRateWithdraw.test.tsx
@@ -23,11 +23,11 @@ describe('UndoRateWithdraw', () => {
     it('can undo rate withdraw', async () => {
         let testLocation: Location
         const contract = mockContractPackageSubmitted({
-            id: 'test-abc-123',
+            id: 'test-contract-123',
         })
         const rate = mockRateSubmittedWithQuestions({
-            id: 'test-abc-123',
-            parentContractID: 'test-abc-123',
+            id: 'test-rate-123',
+            parentContractID: 'test-contract-123',
             reviewStatus: 'WITHDRAWN',
             consolidatedStatus: 'WITHDRAWN',
             reviewStatusActions: [
@@ -105,21 +105,22 @@ describe('UndoRateWithdraw', () => {
                             statusCode: 200,
                         }),
                         fetchRateWithQuestionsMockSuccess({ rate }),
-                        fetchRateMockSuccess({ id: 'test-abc-123' }),
+                        fetchRateWithQuestionsMockSuccess({ rate }),
+                        fetchRateMockSuccess(rate),
                         undoWithdrawRateMockSuccess({
-                            rateID: 'test-abc-123',
+                            rateID: 'test-rate-123',
                             updatedReason: 'Undo withdraw rate',
-                        }),
-                        fetchContractMockSuccess({
-                            contract,
                         }),
                         fetchRateWithQuestionsMockSuccess({
                             rate: undoWithdrawnRate,
                         }),
+                        fetchContractMockSuccess({
+                            contract,
+                        }),
                     ],
                 },
                 routerProvider: {
-                    route: '/rate-reviews/test-abc-123/undo-withdraw',
+                    route: '/rate-reviews/test-rate-123/undo-withdraw',
                 },
                 featureFlags: {
                     'undo-withdraw-rate': true,
@@ -147,7 +148,7 @@ describe('UndoRateWithdraw', () => {
 
         await waitFor(() => {
             // expect redirect
-            expect(testLocation.pathname).toBe(`/rates/${contract.id}`)
+            expect(testLocation.pathname).toBe(`/rates/${rate.id}`)
             // expect unlock rate button to exist
             expect(
                 screen.getByRole('button', {


### PR DESCRIPTION
## Summary
[MCR-5332](https://jiraent.cms.gov/browse/MCR-5332)

The "Date added" field on the submission summary page was not showing the document date added for some submission summaries and not others.

Bug:
- This bug is caused by 2 things; inconsistent document `dateAdded` calculations and Apollo caching
   - We have 2 parsing functions `contractWithHistoryToDomainModelWithoutRates` and `rateWithoutDraftContractsToDomainModel`, both are inconsistently calculating `dateAdded` on the revisions contained in the return data. For example `packageSubmissions.contractRevision` has the date added, but `packageSubmission.submittedRevisions` does not. On the rate side, contractRevision doc date added were not added at all.
   - With the parsing functions, it's not a big deal if deeply nested docs do not get the date added, but on the frontend, Apollo caching will merge these revisions causing dates to be overridden with `null`
   - If you look in `app-web/src/index.tsx`, we set up Apollo cache with `typePolicies` that merge `ContractRevision` and `RateRevision`. This mean it will try to merge the data for revisions with the same ID. This was what caused the bug.
   - Specifically it was the deeply nested `Rate` data on `contract.packageSubmissions.rateRevision.rate.packageSubmissions.contratRevisions`. This confusing nested redundant data is what overwrote the `dateAdded` field.

FIx:
- The fix here is to remove that deeply nested `rate` data `contract.packageSubmissions.rateRevision.rate` from our query.
- Adding a `id` on the contract and rate documents did help with getting the `dateAdded` back, but not in all cases. We should still keep the `id` though.
- I also added calculating the contract doc `dateAdded` in the `rateWithoutDraftContractsToDomainModel` parsing function.


#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
- Create a contract and rate submission
- Unlock and resubmit multiple times and added documents each time
- Validate that the document date added matches when they were added.

Testing locally
- Dump prod data and load into your running app
- Validate the submission posted in the Jira.

<!---These are developer instructions on how to test or validate the work -->
