### PR TITLE
MCR-5300: add logging and alerting for large api payload

### DIFF
--- a/services/app-api/src/handlers/apollo_gql.ts
+++ b/services/app-api/src/handlers/apollo_gql.ts
@@ -365,7 +365,10 @@ const gqlHandler: Handler = async (event, context, completion) => {
     const initializedHandler = await handlerPromise
 
     const response = await initializedHandler(event, context, completion)
-
+    const payloadSize = Buffer.from(event.body).length
+    if (payloadSize > 5.5 * 1024 * 1024) {
+        console.warn(`Large payload detected: ${payloadSize} bytes`)
+    }
     // Log response size metrics without modifying the response
     if (response && response.body) {
         const bodySize = Buffer.from(response.body).length

--- a/services/app-api/src/handlers/apollo_gql.ts
+++ b/services/app-api/src/handlers/apollo_gql.ts
@@ -385,8 +385,10 @@ const gqlHandler: Handler = async (event, context, completion) => {
     if (response && response.body) {
         const bodySize = Buffer.from(response.body).length
         console.info(`Response size: ${bodySize} bytes`)
-        if (bodySize > 4 * 1024 * 1024) {
-            console.warn(`Large response detected: ${bodySize} bytes`)
+        if (bodySize > 5.5 * 1024 * 1024) {
+            const errMsg = `Large response detected: ${bodySize} bytes`
+            console.warn(errMsg)
+            recordException(errMsg, serviceName, 'responsePayload')
         }
     }
 

--- a/services/app-api/src/handlers/apollo_gql.ts
+++ b/services/app-api/src/handlers/apollo_gql.ts
@@ -7,6 +7,7 @@ import type {
     APIGatewayProxyHandler,
     Handler,
 } from 'aws-lambda'
+
 import typeDefs from '../../../app-graphql/src/schema.graphql'
 import { assertIsAuthMode } from '@mc-review/common-code'
 import type { UserType } from '../domain-models'
@@ -376,7 +377,7 @@ const gqlHandler: Handler = async (event, context, completion) => {
     }
     initTracer(serviceName, otelCollectorUrl)
     if (payloadSize > 5.5 * 1024 * 1024) {
-        const errMsg = `Large payload detected: ${payloadSize} bytes`
+        const errMsg = `Large request payload detected: ${payloadSize} bytes`
         console.warn(errMsg)
         recordException(errMsg, serviceName, 'requestPayload')
     }


### PR DESCRIPTION
## Summary

This PR adds logging and alerting for when a API request's payload exceeds 5.5mb

#### Related issues

https://jiraent.cms.gov/browse/MCR-5300

