### PR TITLE
MCR-5311: cms state assignments table header accessibility

### DIFF
--- a/services/app-web/src/components/Tables/RowCellElement.tsx
+++ b/services/app-web/src/components/Tables/RowCellElement.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+type RowCellElementPropType = {
+    element: 'td' | 'th'
+    children: React.ReactNode
+} & React.HTMLAttributes<HTMLElement>
+
+/**
+ * A flexible row cell component that renders either a table header (th) or table data (td) element.
+ * Automatically applies the appropriate scope attribute for accessibility when rendering as a header.
+ * This sets up table cell association for tables.
+ *
+ * @param element - The HTML element type to render ('th' for headers, 'td' for data cells)
+ * @returns A table cell element with proper semantic markup and accessibility attributes
+ */
+export const RowCellElement = ({
+    element,
+    children,
+    ...rest
+}: RowCellElementPropType): React.ReactElement => {
+    const Element = element
+    return (
+        <Element {...rest} scope={element === 'th' ? 'row' : undefined}>
+            {children}
+        </Element>
+    )
+}

--- a/services/app-web/src/components/Tables/index.ts
+++ b/services/app-web/src/components/Tables/index.ts
@@ -1,0 +1,1 @@
+export { RowCellElement } from './RowCellElement'

--- a/services/app-web/src/components/index.ts
+++ b/services/app-web/src/components/index.ts
@@ -88,3 +88,4 @@ export { SectionCard } from './SectionCard'
 export { NavLinkWithLogging, LinkWithLogging, ReactRouterLinkWithLogging, ButtonWithLogging } from './TealiumLogging'
 
 export { FormContainer, FormNotificationContainer} from './FormContainer'
+export { RowCellElement } from './Tables'

--- a/services/app-web/src/pages/Settings/SettingsTables/StateAssignmentTable.tsx
+++ b/services/app-web/src/pages/Settings/SettingsTables/StateAssignmentTable.tsx
@@ -17,7 +17,7 @@ import {
     FilterSelect,
     FilterSelectedOptionsType,
 } from '../../../components/FilterAccordion'
-import { MultiColumnGrid, Loading } from '../../../components'
+import { MultiColumnGrid, Loading, RowCellElement } from '../../../components'
 import { GridContainer, Table } from '@trussworks/react-uswds'
 
 import styles from '../Settings.module.scss'
@@ -320,20 +320,26 @@ const StateAssignmentTable = () => {
                     ))}
                 </thead>
                 <tbody>
-                    {filteredRows.map((row) => {
-                        return (
-                            <tr key={row.id}>
-                                {row.getVisibleCells().map((cell) => (
-                                    <td key={cell.id}>
-                                        {flexRender(
-                                            cell.column.columnDef.cell,
-                                            cell.getContext()
-                                        )}
-                                    </td>
-                                ))}
-                            </tr>
-                        )
-                    })}
+                    {filteredRows.map((row) => (
+                        <tr key={row.id}>
+                            {row.getVisibleCells().map((cell) => (
+                                // stateCode column must be th for table accessibility with cell associations.
+                                <RowCellElement
+                                    key={cell.id}
+                                    element={
+                                        cell.column.id === 'stateCode'
+                                            ? 'th'
+                                            : 'td'
+                                    }
+                                >
+                                    {flexRender(
+                                        cell.column.columnDef.cell,
+                                        cell.getContext()
+                                    )}
+                                </RowCellElement>
+                            ))}
+                        </tr>
+                    ))}
                 </tbody>
             </Table>
         </>


### PR DESCRIPTION
## Summary
[MCR-5311](https://jiraent.cms.gov/browse/MCR-5311)

State assignments row cell association was incorrect. The `State` column values should have associations with the other column values. 

Here is the example of what the output of a row cell with correct associations in the **ANDI Output**.
![Screenshot 2025-06-10 at 3 54 01 PM](https://github.com/user-attachments/assets/617052d2-0ec5-4450-a79a-83f9c6ac8d6b)

AC:
- The data table is programmatically associated with all data cells with both their row (state acronym) and column headers 
- When ANDI is opened and focused on data in the Assigned DMCO staff column, the ANDI output is:
Assigned DMCO staff | [State acronym] | [analyst name] 
- When ANDI is opened and focused on data in the Edit state assignment column, the ANDI output is 
Edit state assignment | [State acronym] | Edit Alabama

FIX:
- The fix here was to make the `State` column row cells to be `th` as that is what the example above has the `Name` column row cells as.
- To help with the rest of the tables in the app, a new component `RowCellElement` is made to switch between `th` and `td`.

#### Related issues

#### Screenshots
- When ANDI is opened and focused on data in the Assigned DMCO staff column, the ANDI output is:
Assigned DMCO staff | [State acronym] | [analyst name] 
![Screenshot 2025-06-10 at 3 56 16 PM](https://github.com/user-attachments/assets/931fac74-de65-4130-86e9-d0f819d2585f)

- When ANDI is opened and focused on data in the Edit state assignment column, the ANDI output is 
Edit state assignment | [State acronym] | Edit Alabama
![Screenshot 2025-06-10 at 3 56 53 PM](https://github.com/user-attachments/assets/2ea1e460-2838-4b7c-88c1-c145de648d31)


#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
