### PR TITLE
Fix export syntax in rescanFailedFiles lambda

### DIFF
--- a/services/uploads/src/lambdas/rescanFailedFiles.ts
+++ b/services/uploads/src/lambdas/rescanFailedFiles.ts
@@ -297,4 +297,4 @@ async function main(_event: unknown, _context: Context): Promise<string> {
     return message
 }
 
-export { main }
+module.exports = { main }


### PR DESCRIPTION
## Summary

When working through the file av rescanning the lambda threw ```"errorMessage": "Cannot redefine property: main"```. This just fixes the export syntax for the lambda runtime.
