### PR TITLE
Make antivirus rescan parallel

### DIFF
--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -136,6 +136,22 @@ functions:
       OPENTELEMETRY_COLLECTOR_CONFIG_FILE: /var/task/collector.yml
       VITE_APP_OTEL_COLLECTOR_URL: ${self:custom.reactAppOtelCollectorUrl}
 
+  rescanWorker:
+    handler: src/lambdas/rescanWorker.main
+    timeout: 300 # 300 seconds = 5 minutes. Average scan is 25 seconds.
+    maximumRetryAttempts: 0
+    layers:
+      - !Ref ClamAvLambdaLayer
+      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:4
+    environment:
+      stage: ${sls:stage}
+      AUDIT_BUCKET_NAME: !Ref DocumentUploadsBucket
+      CLAMAV_BUCKET_NAME: !Ref ClamDefsBucket
+      PATH_TO_AV_DEFINITIONS: 'lambda/s3-antivirus/av-definitions'
+      AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-handler
+      OPENTELEMETRY_COLLECTOR_CONFIG_FILE: /var/task/collector.yml
+      VITE_APP_OTEL_COLLECTOR_URL: ${self:custom.reactAppOtelCollectorUrl}
+
 resources:
   Conditions:
     IsDevValProd: !Or

--- a/services/uploads/src/lambdas/rescanWorker.ts
+++ b/services/uploads/src/lambdas/rescanWorker.ts
@@ -1,0 +1,168 @@
+import { Context } from 'aws-lambda'
+import { NewS3UploadsClient } from '../deps/s3'
+import { NewClamAV } from '../deps/clamAV'
+import { generateVirusScanTagSet } from '../lib/tags'
+import { mkdtemp, rm } from 'fs/promises'
+import crypto from 'crypto'
+import path from 'path'
+
+interface ScanFilesInput {
+    bucket: string
+    keys: string[]
+}
+
+export interface ScanFilesOutput {
+    infectedKeys: string[]
+}
+
+// Scan a list of files and return the infected keys (scan files individually to avoid ClamAV directory issues)
+async function scanAndTagFiles(
+    bucketName: string,
+    keys: string[]
+): Promise<string[] | Error> {
+    // Check required environment variables
+    const clamAVBucketName = process.env.CLAMAV_BUCKET_NAME
+    if (!clamAVBucketName || clamAVBucketName === '') {
+        throw new Error('Configuration Error: CLAMAV_BUCKET_NAME must be set')
+    }
+
+    const clamAVDefinitionsPath = process.env.PATH_TO_AV_DEFINITIONS
+    if (!clamAVDefinitionsPath || clamAVDefinitionsPath === '') {
+        throw new Error(
+            'Configuration Error: PATH_TO_AV_DEFINITIONS must be set'
+        )
+    }
+
+    // Initialize clients
+    const s3Client = NewS3UploadsClient()
+    const clamAV = NewClamAV(
+        {
+            bucketName: clamAVBucketName,
+            definitionsPath: clamAVDefinitionsPath,
+        },
+        s3Client
+    )
+
+    const infectedKeys: string[] = []
+
+    // Process each file individually to avoid ClamAV "File tree walk aborted" errors
+    for (const key of keys) {
+        console.info('Downloading and scanning individual file:', key)
+
+        // Create a unique temp file for this specific scan
+        const individualScanDir = await mkdtemp('/tmp/individual-scan-')
+        const scanFileName = `${crypto.randomUUID()}.tmp`
+        const scanFilePath = path.join(individualScanDir, scanFileName)
+
+        try {
+            // Download the file
+            const downloadErr = await s3Client.downloadFileFromS3(
+                key,
+                bucketName,
+                scanFilePath
+            )
+            if (downloadErr instanceof Error) {
+                console.error(`Failed to download ${key}:`, downloadErr)
+                continue // Skip this file but continue with others
+            }
+
+            // Scan just this one file
+            console.info(`Scanning individual file: ${key}`)
+            const virusScanResult =
+                clamAV.scanForInfectedFiles(individualScanDir)
+
+            if (virusScanResult instanceof Error) {
+                console.error(`Failed to scan ${key}:`, virusScanResult)
+                continue // Skip this file but continue with others
+            }
+
+            // Determine scan status
+            let scanStatus: 'CLEAN' | 'INFECTED'
+            if (Array.isArray(virusScanResult) && virusScanResult.length > 0) {
+                console.info(`File ${key} is infected:`, virusScanResult)
+                scanStatus = 'INFECTED'
+                infectedKeys.push(key)
+            } else {
+                console.info(`File ${key} is clean`)
+                scanStatus = 'CLEAN'
+            }
+
+            // Tag the file with scan result
+            console.info(`Tagging ${key} as ${scanStatus}`)
+
+            try {
+                const tags = generateVirusScanTagSet(scanStatus)
+                const currentTags = await s3Client.getObjectTags(
+                    key,
+                    bucketName
+                )
+                if (currentTags instanceof Error) {
+                    console.error(
+                        `Failed to get current tags for ${key}:`,
+                        currentTags
+                    )
+                    continue
+                }
+
+                // Filter out existing virus scan tags and add the new ones
+                const nonVirusScanTags = currentTags.filter(
+                    (tag) =>
+                        tag.Key !== 'virusScanStatus' &&
+                        tag.Key !== 'virusScanTimestamp'
+                )
+                const updatedTags = {
+                    TagSet: nonVirusScanTags.concat(tags.TagSet),
+                }
+
+                console.info(`Updating tags for ${key}:`, updatedTags)
+                const tagResult = await s3Client.tagObject(
+                    key,
+                    bucketName,
+                    updatedTags
+                )
+                if (tagResult instanceof Error) {
+                    console.error(`Failed to tag ${key}:`, tagResult)
+                } else {
+                    console.info(`Successfully tagged ${key} as ${scanStatus}`)
+                }
+            } catch (error) {
+                console.error(`Exception while tagging ${key}:`, error)
+            }
+        } catch (fileError) {
+            console.error(`Error processing individual file ${key}:`, fileError)
+            continue // Skip this file but continue with others
+        } finally {
+            // Clean up individual scan directory
+            await rm(individualScanDir, { force: true, recursive: true })
+        }
+    }
+
+    console.info(
+        'Individual file scanning complete. Infected files:',
+        infectedKeys
+    )
+    return infectedKeys
+}
+
+async function main(
+    event: ScanFilesInput,
+    _context: Context
+): Promise<ScanFilesOutput> {
+    console.info('-----Start Rescan Worker function-----')
+    console.info(
+        `Scanning ${event.keys.length} files in bucket ${event.bucket}`
+    )
+
+    const result = await scanAndTagFiles(event.bucket, event.keys)
+
+    if (result instanceof Error) {
+        console.error('Error scanning files', result)
+        throw result
+    }
+
+    return {
+        infectedKeys: result,
+    }
+}
+
+module.exports = { main }


### PR DESCRIPTION
## Summary

The `rescanFailedFiles` lambda that we merged to support the val data epic is hitting limits with lambda sizes due to how many files it is trying to process. This takes a slightly different approach, where we are doing the setup in the original lambda, but then calling out to a secondary lambda to do the scan. That way we can fan out for parallelism.

The other option would have been to use an SQS queue, but we don't have that infra stood up in our environment and I didn't want to introduce new infra components for this.
