### PR TITLE
MCR-4191: MCCRS ID page refactored to use contract api

### DIFF
--- a/services/app-api/src/resolvers/contract/updateContract.ts
+++ b/services/app-api/src/resolvers/contract/updateContract.ts
@@ -1,8 +1,5 @@
 import { ForbiddenError, UserInputError } from 'apollo-server-lambda'
-import {
-    convertContractWithRatesToUnlockedHPP,
-    hasCMSPermissions,
-} from '../../domain-models'
+import { hasCMSPermissions } from '../../domain-models'
 import type { MutationResolvers } from '../../gen/gqlServer'
 import { logError } from '../../logger'
 import type { Store } from '../../postgres'
@@ -92,22 +89,8 @@ export function updateContract(
             })
         }
 
-        const convertedPkg =
-            convertContractWithRatesToUnlockedHPP(updatedContract)
-
-        if (convertedPkg instanceof Error) {
-            const errMessage = `Issue converting contract. Message: ${convertedPkg.message}`
-            logError('updateContract', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-            throw new GraphQLError(errMessage, {
-                extensions: {
-                    code: 'INTERNAL_SERVER_ERROR',
-                    cause: 'PROTO_DECODE_ERROR',
-                },
-            })
-        }
         return {
-            pkg: convertedPkg,
+            contract: updatedContract,
         }
     }
 }

--- a/services/app-graphql/src/mutations/updateContract.graphql
+++ b/services/app-graphql/src/mutations/updateContract.graphql
@@ -1,33 +1,36 @@
 mutation updateContract($input: UpdateContractInput!) {
     updateContract(input: $input) {
-        pkg {
-            id
-            stateCode
-            mccrsID
-            state {
-                code
-                name
-                programs {
-                    id
-                    name
-                    fullName
-                    isRateProgram
+        contract {
+            ...contractFieldsFragment
+
+            draftRevision {
+                ...contractRevisionFragment
+            }
+
+            draftRates {
+                ...rateFieldsFragment
+
+                draftRevision {
+                    ...rateRevisionFragment
+                }
+
+                revisions {
+                    ...rateRevisionFragment
                 }
             }
-            status
-            initiallySubmittedAt
-            revisions {
-                node {
-                    id
-                    unlockInfo {
-                        ...updateInformationFields
-                    }
-                    submitInfo {
-                        ...updateInformationFields
-                    }
-                    createdAt
-                    formDataProto
+
+            withdrawnRates {
+                ...rateFieldsFragment,
+                revisions {
+                    ...rateRevisionFragment
                 }
+                packageSubmissions {
+                    ...ratePackageSubmissionsFragment
+                }
+            }
+
+            packageSubmissions {
+                ...packageSubmissionsFragment
             }
         }
     }

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -961,7 +961,7 @@ input UpdateContractInput {
 }
 
 type UpdateContractPayload {
-    pkg: HealthPlanPackage!
+    contract: Contract!
 }
 
 type CreateAPIKeyPayload {

--- a/services/app-web/src/pages/MccrsId/MccrsId.test.tsx
+++ b/services/app-web/src/pages/MccrsId/MccrsId.test.tsx
@@ -4,12 +4,12 @@ import { Route, Routes } from 'react-router'
 import { RoutesRecord } from '@mc-review/constants'
 import {
     fetchCurrentUserMock,
-    fetchStateHealthPlanPackageWithQuestionsMockSuccess,
+    fetchContractMockSuccess,
+    mockContractPackageSubmitted,
     iterableCmsUsersMockData,
 } from '@mc-review/mocks'
 import { renderWithProviders } from '../../testHelpers/jestHelpers'
 import { MccrsId } from './MccrsId'
-import { mockSubmittedHealthPlanPackage } from '@mc-review/mocks'
 
 describe('MCCRSID', () => {
     afterEach(() => {
@@ -19,6 +19,8 @@ describe('MCCRSID', () => {
     describe.each(iterableCmsUsersMockData)(
         '$userRole MCCRSID tests',
         ({ userRole, mockUser }) => {
+            const contract = mockContractPackageSubmitted()
+            contract.id = '15'
             it('renders without errors', async () => {
                 renderWithProviders(
                     <Routes>
@@ -34,11 +36,7 @@ describe('MCCRSID', () => {
                                     user: mockUser(),
                                     statusCode: 200,
                                 }),
-                                fetchStateHealthPlanPackageWithQuestionsMockSuccess(
-                                    {
-                                        id: '15',
-                                    }
-                                ),
+                                fetchContractMockSuccess({ contract }),
                             ],
                         },
                         routerProvider: {
@@ -72,11 +70,7 @@ describe('MCCRSID', () => {
                                     user: mockUser(),
                                     statusCode: 200,
                                 }),
-                                fetchStateHealthPlanPackageWithQuestionsMockSuccess(
-                                    {
-                                        id: '15',
-                                    }
-                                ),
+                                fetchContractMockSuccess({ contract }),
                             ],
                         },
                         routerProvider: {
@@ -105,11 +99,7 @@ describe('MCCRSID', () => {
                                     user: mockUser(),
                                     statusCode: 200,
                                 }),
-                                fetchStateHealthPlanPackageWithQuestionsMockSuccess(
-                                    {
-                                        id: '15',
-                                    }
-                                ),
+                                fetchContractMockSuccess({ contract }),
                             ],
                         },
                         routerProvider: {
@@ -138,6 +128,7 @@ describe('MCCRSID', () => {
             })
 
             it('edit - prepopulates the mccrs id when a submission has one', async () => {
+                contract.mccrsID = '3333'
                 renderWithProviders(
                     <Routes>
                         <Route
@@ -152,15 +143,7 @@ describe('MCCRSID', () => {
                                     user: mockUser(),
                                     statusCode: 200,
                                 }),
-                                fetchStateHealthPlanPackageWithQuestionsMockSuccess(
-                                    {
-                                        id: '15',
-                                        stateSubmission: {
-                                            ...mockSubmittedHealthPlanPackage(),
-                                            mccrsID: '3333',
-                                        },
-                                    }
-                                ),
+                                fetchContractMockSuccess({ contract }),
                             ],
                         },
                         routerProvider: {

--- a/services/app-web/src/pages/MccrsId/MccrsId.tsx
+++ b/services/app-web/src/pages/MccrsId/MccrsId.tsx
@@ -58,7 +58,7 @@ export const MccrsId = (): React.ReactElement => {
     } = useFetchContractQuery({
         variables: {
             input: {
-                contractID: id ?? 'unknown-contract',
+                contractID: id,
             },
         },
         fetchPolicy: 'cache-and-network',

--- a/services/app-web/src/pages/MccrsId/MccrsId.tsx
+++ b/services/app-web/src/pages/MccrsId/MccrsId.tsx
@@ -16,16 +16,14 @@ import { Loading } from '../../components'
 import { useAuth } from '../../contexts/AuthContext'
 import { Breadcrumbs } from '../../components/Breadcrumbs/Breadcrumbs'
 import { RoutesRecord } from '@mc-review/constants'
-import { ApolloError } from '@apollo/client'
-import { handleApolloError } from '@mc-review/helpers'
 import { GenericErrorPage } from '../Errors/GenericErrorPage'
 import { Error404 } from '../Errors/Error404Page'
+import { ErrorForbiddenPage } from '../Errors/ErrorForbiddenPage'
 import {
-    HealthPlanPackage,
     useUpdateContractMutation,
+    useFetchContractQuery,
+    Contract,
 } from '../../gen/gqlClient'
-import { useFetchHealthPlanPackageWithQuestionsWrapper } from '@mc-review/helpers'
-import { packageName } from '@mc-review/hpp'
 import styles from './MccrsId.module.scss'
 
 export interface MccrsIdFormValues {
@@ -48,68 +46,75 @@ export const MccrsId = (): React.ReactElement => {
 
     // page context
     const { updateHeading } = usePage()
-    const [pkgName, setPkgName] = useState<string | undefined>(undefined)
-
-    useEffect(() => {
-        updateHeading({ customHeading: pkgName })
-    }, [pkgName, updateHeading])
 
     const [showPageErrorMessage, setShowPageErrorMessage] = useState<
         boolean | string
     >(false) // string is a custom error message, defaults to generic of true
-    const [updateFormData] = useUpdateContractMutation()
-    const { result: fetchResult } =
-        useFetchHealthPlanPackageWithQuestionsWrapper(id)
-    if (fetchResult.status === 'ERROR') {
-        const err = fetchResult.error
-        console.error('Error from API fetch', fetchResult.error)
-        if (err instanceof ApolloError) {
-            handleApolloError(err, true)
+    const [updateContract] = useUpdateContractMutation()
+    const {
+        data: fetchContractData,
+        loading: fetchContractLoading,
+        error: fetchContractError,
+    } = useFetchContractQuery({
+        variables: {
+            input: {
+                contractID: id ?? 'unknown-contract',
+            },
+        },
+        fetchPolicy: 'cache-and-network',
+    })
 
-            if (err.graphQLErrors[0]?.extensions?.code === 'NOT_FOUND') {
-                return <Error404 />
-            }
-        }
+    const contract = fetchContractData?.fetchContract.contract
+    const contractName =
+        contract && contract?.packageSubmissions.length > 0
+            ? contract.packageSubmissions[0].contractRevision.contractName
+            : ''
 
-        recordJSException(err)
-        return <GenericErrorPage /> // api failure or protobuf decode failure
-    }
+    useEffect(() => {
+        updateHeading({
+            customHeading: contractName,
+        })
+    }, [contractName, updateHeading])
 
-    if (fetchResult.status === 'LOADING') {
+    // Handle loading and error states for fetching data while using cached data
+    if (!fetchContractData && fetchContractLoading) {
         return (
             <GridContainer>
                 <Loading />
             </GridContainer>
         )
-    }
-
-    const { data, revisionsLookup } = fetchResult
-    const pkg = data.fetchHealthPlanPackage.pkg
-
-    // Display generic error page if getting logged in user returns undefined.
-    if (!loggedInUser) {
+    } else if (fetchContractError && !fetchContractData) {
+        //error handling for a state user that tries to access contracts for a different state
+        if (
+            fetchContractError?.graphQLErrors[0]?.extensions?.code ===
+            'FORBIDDEN'
+        ) {
+            return (
+                <ErrorForbiddenPage
+                    errorMsg={fetchContractError.graphQLErrors[0].message}
+                />
+            )
+        } else if (
+            fetchContractError?.graphQLErrors[0]?.extensions?.code ===
+            'NOT_FOUND'
+        ) {
+            return <Error404 />
+        } else {
+            return <GenericErrorPage />
+        }
+    } else if (!contract || !loggedInUser) {
         return <GenericErrorPage />
     }
-    const edge = pkg.revisions.find((rEdge) => rEdge.node.submitInfo)
-    if (!edge) {
-        const errMsg = `No currently submitted revision for this package: ${pkg.id}, programming error. `
+
+    const submitInfo = contract.packageSubmissions[0].submitInfo
+    if (!submitInfo) {
+        const errMsg = `No currently submitted revision for this package: ${contract.id}, programming error. `
         recordJSException(errMsg)
         return <GenericErrorPage />
     }
-    const currentRevision = edge.node
-    const packageData = revisionsLookup[currentRevision.id].formData
-    const healthPkgName = packageName(
-        packageData.stateCode,
-        packageData.stateNumber,
-        packageData.programIDs,
-        pkg.state.programs
-    )
-    if (pkgName !== healthPkgName) {
-        setPkgName(healthPkgName)
-    }
 
     const mccrsIDInitialValues: MccrsIdFormValues = {
-        mccrsId: pkg.mccrsID ? Number(pkg.mccrsID) : undefined,
+        mccrsId: contract.mccrsID ? Number(contract.mccrsID) : undefined,
     }
 
     const showFieldErrors = (error?: FormError) =>
@@ -118,7 +123,7 @@ export const MccrsId = (): React.ReactElement => {
     const handleFormSubmit = async (values: MccrsIdFormValues) => {
         setShowPageErrorMessage(false)
         try {
-            const updateResult = await updateFormData({
+            const updateResult = await updateContract({
                 variables: {
                     input: {
                         mccrsID:
@@ -129,8 +134,8 @@ export const MccrsId = (): React.ReactElement => {
                 },
             })
 
-            const updatedSubmission: HealthPlanPackage | undefined =
-                updateResult?.data?.updateContract.pkg
+            const updatedSubmission: Contract | undefined =
+                updateResult?.data?.updateContract.contract
 
             if (!updatedSubmission) {
                 setShowPageErrorMessage(true)
@@ -170,7 +175,7 @@ export const MccrsId = (): React.ReactElement => {
                                 },
                                 {
                                     link: `/submissions/${id}`,
-                                    text: pkgName || '',
+                                    text: contractName || '',
                                 },
                                 {
                                     text: 'MC-CRS record number',


### PR DESCRIPTION
## Summary

This PR updates the Mccrs ID form page so that it no longer uses the old health plan API and types.

- Replaces `fetchHealthPlanPackage` with `fetchContract`
- updates the `updateContract` to no longer use hpp 

#### Related issues

https://jiraent.cms.gov/browse/MCR-4191

#### Test cases covered

- Existing `updateContract` resolver and `MccrsId` page test updated to use contract API 

## QA guidance

- As a CMS user, select a submission and navigate to the submission summary page 
- Click the 'Add MCCRS record number' link and add a new number
- Clicking save, as well going back and updating the number should work
