### PR TITLE
Fix destroy action

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -78,18 +78,3 @@ jobs:
           SLACK_COLOR: ${{job.status}}
           SLACK_FOOTER: ''
           MSG_MINIMAL: actions url,commit,ref
-
-  otel-export-trace:
-    if: always()
-    name: OpenTelemetry Export Trace
-    runs-on: ubuntu-latest
-    needs: [destroy] # must run when all jobs are complete
-    steps:
-      - name: Export Workflow Trace
-        uses: inception-health/otel-export-trace-action@latest
-        env:
-          NR_LICENSE_KEY: ${{ secrets.NR_LICENSE_KEY }}}
-        with:
-          otlpEndpoint: https://gov-otlp.nr-data.net:4317
-          otlpHeaders: 'api-key: $NR_LICENSE_KEY'
-          githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

We've been getting alerts that our destroy action fails each time a PR is merged. This is from the OTEL phase of the action, which honestly has never worked afaik. Removing that step from the destroy action to reduce the volume of un-actionable alerts.