### PR TITLE
MCR-5367: update landing page copy for D-SNPs

### DIFF
--- a/services/app-web/src/pages/Landing/Landing.tsx
+++ b/services/app-web/src/pages/Landing/Landing.tsx
@@ -101,6 +101,11 @@ export const Landing = (): React.ReactElement => {
                                 </li>
                                 <li>Rate certifications and rate amendments</li>
                                 <li>
+                                    Contracts related to Dual Eligible Special
+                                    Needs Plans (D-SNPs) with Medicaid-covered
+                                    benefits
+                                </li>
+                                <li>
                                     <LinkWithLogging
                                         aria-label="Document definitions and requirements"
                                         href={'/help#key-documents'}
@@ -116,16 +121,19 @@ export const Landing = (): React.ReactElement => {
                                 <li>State directed preprints</li>
                                 <li>Rate-only submissions</li>
                                 <li>
+                                    Contracts without Medicaid-covered benefits
+                                </li>
+                                <li>
+                                    Some submissions related to programs for
+                                    dual-eligible beneficiaries, such as
+                                    Programs of All-Inclusive Care for the
+                                    Elderly (PACE), and dual demonstration
+                                    contracts
+                                </li>
+                                <li>
                                     Non-health plan submissions such as External
                                     Quality Review Organization (EQRO) or
                                     enrollment broker
-                                </li>
-                                <li>
-                                    Submissions related to programs for
-                                    dual-eligible beneficiaries, such as Dual
-                                    Eligible Special Needs Plans (D-SNP),
-                                    Programs of All-Inclusive Care for the
-                                    Elderly (PACE), dual demonstration contracts
                                 </li>
                             </ul>
                         </Grid>


### PR DESCRIPTION
## Summary

Under “This portal accepts” add:
- “Contracts related to Dual Eligible Special Needs Plans (D-SNPs) with Medicaid-covered benefits”

Under “Not accepted by MC-Review at this time,” add:

- “Some submissions related to programs for dual-eligible beneficiaries, such as Programs of All-Inclusive Care for the Elderly (PACE), and dual demonstration contracts.”
- "Contracts without Medicaid-covered benefits"


#### Related issues

https://jiraent.cms.gov/browse/MCR-5367

#### Screenshots

<img width="565" alt="Screenshot 2025-06-23 at 12 28 31 PM" src="https://github.com/user-attachments/assets/b2c1fe91-f371-44bb-b453-26cda9c26b89" />


#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
