### PR TITLE
MCR-5403: Pin aws-amplify version to 5.3.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -811,7 +811,7 @@ importers:
         version: 6.21.0(eslint@8.57.0)(typescript@4.9.5)
       '@vitest/coverage-v8':
         specifier: ^3.1.1
-        version: 3.1.1(vitest@3.0.7)
+        version: 3.1.1(vitest@3.0.7(@types/node@20.14.12)(@vitest/ui@2.1.9)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.43.1)(tsx@4.19.3)(yaml@2.8.0))
       '@vitest/ui':
         specifier: ^2.1.9
         version: 2.1.9(vitest@3.0.7)
@@ -826,7 +826,7 @@ importers:
         version: 10.1.5(eslint@8.57.0)
       eslint-plugin-jest:
         specifier: ^27.0.1
-        version: 27.9.0(@typescript-eslint/eslint-plugin@8.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 27.9.0(@typescript-eslint/eslint-plugin@8.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(jest@29.7.0(@types/node@20.14.12))(typescript@4.9.5)
       eslint-plugin-jsx-a11y:
         specifier: ^6.5.1
         version: 6.8.0(eslint@8.57.0)
@@ -900,8 +900,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/hpp
       aws-amplify:
-        specifier: ^5.0.10
-        version: 5.3.10(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+        specifier: ^5.3.1
+        version: 5.3.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
       axios:
         specifier: ^1.9.0
         version: 1.9.0
@@ -1315,17 +1315,32 @@ packages:
     resolution: {integrity: sha512-O8PTXJnA7n8ONBSwqlWa+aZ/vlOdZYnSCGQt25h87ALWNItY/Yij79TOnzIkMTJZ8aCpGXQPuIRziLmBliV++Q==}
     engines: {node: '>=8.0.0'}
 
+  '@aws-amplify/analytics@6.3.1':
+    resolution: {integrity: sha512-k3GAmRMauyL+s2M8/ay2SOAraYCqEne/9rWyPNZkscZzSrHvOPtBSoWC0LypnZpftQwMZzfLE9oCv2MrnWnKwQ==}
+
   '@aws-amplify/analytics@6.5.4':
     resolution: {integrity: sha512-MwHRGshhgw7BOZW+amdaNdCjJP8cp2GWL4V0uFgdWdkbe6p7ONN4cfoAnWmv9EIPpg412mWTk1iWZck2dT4q5A==}
+
+  '@aws-amplify/api-graphql@3.4.1':
+    resolution: {integrity: sha512-W75OyJGFpu325NslmW0Bp+6MRmxX42NjdUSotNpztsAifCayHN8zHuitnjdGlagbrW+EfjyxBpVm1MiF2xBT6Q==}
 
   '@aws-amplify/api-graphql@3.4.10':
     resolution: {integrity: sha512-v4D6x+632N776pnAiIO312J91OFtt5wSHXk30GBQ99s0c4HDmFOyYpZFTQaAmrp24XtjyPLb3RHoEAc15vIwsA==}
 
+  '@aws-amplify/api-rest@3.3.1':
+    resolution: {integrity: sha512-LiAdZu6pjX4XU5kixS9Yvc6QHPZDfsZfPvgZsaB7mF9/PGI/CrD3DapivUd1/QMASwNvK0zR8JDTNSO9v17wzQ==}
+
   '@aws-amplify/api-rest@3.5.4':
     resolution: {integrity: sha512-JY0j2y8bqqIgRxoKQcKV8BDIRh4bYD1WKXYEBzrZly3rPaXXmQfe1UJF6QRFv7m9tqelAo1r/wvWuINM7iaEnA==}
 
+  '@aws-amplify/api@5.3.1':
+    resolution: {integrity: sha512-JqhSK38prsaaXphPoumLdYri/WoHiyeZ3tUlK+FF8GRTIcosWRA41JSpSaEMQx3Ag8Aq4yjTqoNsGXy4j73xYg==}
+
   '@aws-amplify/api@5.4.4':
     resolution: {integrity: sha512-Q7191OOkfT9SvJff85xQUscG3CkzEEzcWCShcNrnovocy46IgxIlsviMuHh9smpasv+2RqPovYE4LnVIC1h79A==}
+
+  '@aws-amplify/auth@5.5.1':
+    resolution: {integrity: sha512-K7Ms7+Yg2vEyZxOkJV5Kqi3N3OqNo52nel56+ZgOlNdVhAywp6WHY8otKiEGVBMDghoufC6zCpMzjd+m833SmQ==}
 
   '@aws-amplify/auth@5.6.4':
     resolution: {integrity: sha512-6b+ojQpwkrzWnyTVTsYtpPPSUo/B+F9bj4oS8bo1DXf40/3XnCeEZQehME2a7fDolVU24E1+pWEzVRqsadLSeQ==}
@@ -1333,29 +1348,59 @@ packages:
   '@aws-amplify/cache@5.1.10':
     resolution: {integrity: sha512-4svwr6CEhOwBf2PlUcE6Tl6HI5qL1gJa7X4vhOyYMBfsDaQzPbP4QxnvGMWM8O9OCdAIBCIWCdJPCMvDSYpOwQ==}
 
+  '@aws-amplify/cache@5.1.2':
+    resolution: {integrity: sha512-sD6SbBG2okG5kVTv96p01gR2cShh0i7lh5U9yYWM/whMNlrHJUVJmSZrIseCMpAO4X9oVurikzwX3bsDd7cvjw==}
+
+  '@aws-amplify/core@5.5.1':
+    resolution: {integrity: sha512-UAKS/hTaY6oKYKHuQeJzp+GCzULozvxYPE69gaf9jtR1ktzLHG/2TdO4z5BKJd2/iiY1+fvrFEID4PBBXvw1Fg==}
+
   '@aws-amplify/core@5.8.4':
     resolution: {integrity: sha512-xFLciGRhRGSzLNqQoS/rFA2PAhggVvh9AFljlAuPyKykmFhxhGKx/k8a/q3GBcF8HiBAlJ6jpNz5X8RONr9Nkw==}
+
+  '@aws-amplify/datastore@4.6.1':
+    resolution: {integrity: sha512-ktfTvk3OfIax5JsSHlAZ34Q58IbZ/VBiYjLHC2EPNkuwEmqx4fHtSfFFgKLcSPKFqi3vrUT3VAl89zsYeURNPg==}
 
   '@aws-amplify/datastore@4.7.4':
     resolution: {integrity: sha512-OhKASdljD94VQ1/15IanIJH9o1UexgsvjpJ/ybQKAL6xng4E9Ht0DK2D0ApU/5zNY+gN9mUKlQ3JZOdjBHSxnw==}
 
+  '@aws-amplify/geo@2.1.1':
+    resolution: {integrity: sha512-/ZzI0iweO2QWW49JoheMCe+hGPj1PFV56cib7pD+AwSU2I11obr8SPcSLHmLzl57Bk8Ly95AhHXlbPsgRQbGpA==}
+
   '@aws-amplify/geo@2.3.4':
     resolution: {integrity: sha512-EW5KQA+YFK1k00vG13kF+ADiEw+eNgvrxsn4N2dOY1VcpK9cnNXSX1ZOTXGnfdtoI+B7D6LY5veigpQRvFIqxQ==}
+
+  '@aws-amplify/interactions@5.2.1':
+    resolution: {integrity: sha512-vi55UDXXiCRci0geORs1HMqM+cnkitFEDqZPYAI2JIYKV/Q8KZqSOzpfRxU0VEOJMmBL1fv45wpa6/Rra7eWvQ==}
 
   '@aws-amplify/interactions@5.2.10':
     resolution: {integrity: sha512-T/eM2155TQXk+zviCp1ytWv5PRcZ2apXapTISbGQ2XONPv8PH75RdOWG8FO6ZGfj6vwj8IKXa1ZY+LiXDlemgQ==}
 
+  '@aws-amplify/notifications@1.3.1':
+    resolution: {integrity: sha512-q1bmO1b/ICCMIeGSh5CagNixjSH7uSOnky+yfhCRNgkhKX0QUBckt5MLEHiTtfzAtQQih03cjFCW0n9Uu9XBQw==}
+
   '@aws-amplify/notifications@1.6.4':
     resolution: {integrity: sha512-W87rF235FeGmJ539vDOAC2lO9CElB59VWlyw2ixPVLRww6wwcYj3Q+Ub4LxnQdj2C3WDkDF0JkyHXcXr22GOqQ==}
+
+  '@aws-amplify/predictions@5.4.1':
+    resolution: {integrity: sha512-3i5V2B3g6RJROZRAhgNOLVie4/EkYbDW5HdFIg6jauEX+XcdzSUJO+afwb8tuwjj4Z5T5swoh14K4FGYcZXmSg==}
 
   '@aws-amplify/predictions@5.5.4':
     resolution: {integrity: sha512-71J5QCa6lQmy62WRoXqIAsOt79LOarz/gl+ZIsfkzCY8BzHFigIirGmwJobNOZ108ghoYTmPsXvcYEvhnZwGFw==}
 
+  '@aws-amplify/pubsub@5.3.1':
+    resolution: {integrity: sha512-+jPWTgSR3B41pkpO+DKWLRihoAZOTxYV49sZbPtbVI5JtqwvnKlbrn6x2fimuuZ1YFm2Hzh+MT6236T7UAKWUg==}
+
   '@aws-amplify/pubsub@5.5.4':
     resolution: {integrity: sha512-C8ommVQM7R/rj7ZHAr/c2FK9DFgejH54zwK1cm3ECI4DRrYGy51eqAsJJsvAEJosbyKpXZw1prjI9Qmj1cpFzw==}
 
+  '@aws-amplify/rtn-push-notification@1.1.1':
+    resolution: {integrity: sha512-uYPyiNeK2r2g82U6ayluNrKA2z5280mlW9razEul94i/2XPt9LAXhIb1XnCtxGzxANMHd+FH9V7D7RAGK99pTQ==}
+
   '@aws-amplify/rtn-push-notification@1.1.6':
     resolution: {integrity: sha512-TKrnmERaVGAZqsQ/eiSB1sF7IGCmkpNzYqzwGJtnWBERhLs+a/391sVztNZ4A34x/HlYID3o1Q868051beJ85w==}
+
+  '@aws-amplify/storage@5.6.1':
+    resolution: {integrity: sha512-4OwQAQuUwclkACk91KC0cOpCWKT3v4VS1bL5umsYOrc9jp/Scc0qw+H+9CLSt2FRQHVYSLyrAEXPTwNP6jyvvQ==}
 
   '@aws-amplify/storage@5.9.4':
     resolution: {integrity: sha512-W9ST5HekL9UXVRi1vByh3sWt83qe7Sft+BeQ0zbXBz8GAroDb8NhPlgnrqQz/6D3h344mzkNLZmjOrTmLp/+1g==}
@@ -1427,6 +1472,12 @@ packages:
     resolution: {integrity: sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==}
     engines: {node: '>= 10.0.0'}
 
+  '@aws-sdk/chunked-blob-reader-native@3.6.1':
+    resolution: {integrity: sha512-vP6bc2v9h442Srmo7t2QcIbPjk5IqLSf4jGnKDAes8z+7eyjCtKugRP3lOM1fJCfGlPIsJGYnexxYdEGw008vA==}
+
+  '@aws-sdk/chunked-blob-reader@3.6.1':
+    resolution: {integrity: sha512-QBGUBoD8D5nsM/EKoc0rjpApa5NE5pQVzw1caE8sG00QMMPkCXWSB/gTVKVY0GOAhJFoA/VpVPQchIlZcOrBFg==}
+
   '@aws-sdk/client-amplify@3.835.0':
     resolution: {integrity: sha512-vu4x/3/Tcw5kzJkjtOCDq7zdFzXHYeHbVdMHtJ3Yj1IQhrY04BBATYhdnjacVjooAn9EszuZXN2W/nPPUWdePQ==}
     engines: {node: '>=18.0.0'}
@@ -1471,12 +1522,24 @@ packages:
     resolution: {integrity: sha512-r6ASrIyFIKjVceA/FVFr/7JOiXthUuYFoaqr/Dxfgkk397C6aR5KjDfVskXLSZjJi13KpXmjcJSn6FwH7klKaQ==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/client-lex-runtime-service@3.186.2':
+    resolution: {integrity: sha512-UzIDdbz04SxjQbUZJCSoDkKMfzfmi4QsoCBL52vdqB6wOW26yQvwxqJcXsSfGgD7YbEKJhlLb1dncFuSGUMuEQ==}
+    engines: {node: '>=12.0.0'}
+
   '@aws-sdk/client-lex-runtime-service@3.186.3':
     resolution: {integrity: sha512-YP+GDY9OxyW4rJDqjreaNpiDBvH1uzO3ShJKl57hT92Kw2auDQxttcMf//J8dQXvrVkW/fVXCLI9TmtxS7XJOQ==}
     engines: {node: '>=12.0.0'}
 
+  '@aws-sdk/client-lex-runtime-v2@3.186.2':
+    resolution: {integrity: sha512-OUO3wclrJIHNoczrCaTYnOhDayPNiz270I4jrOKORddepOeawbqmUZBIVeQh1JaL6/qlKz1ZId/zazBf2Mgcsw==}
+    engines: {node: '>=12.0.0'}
+
   '@aws-sdk/client-lex-runtime-v2@3.186.3':
     resolution: {integrity: sha512-4MJfSnb+qM8BYW4ToCvg7sDWN0NcEqK738hCZUV89cjp7pIHZ6osJuS/PsmZEommVj+71GviZ4buu5KUCfCGFQ==}
+    engines: {node: '>=12.0.0'}
+
+  '@aws-sdk/client-location@3.186.2':
+    resolution: {integrity: sha512-pjuwqfibyfkVOXbTaHzO4zNb/3NamlA/R+R8UvMex3NtxsDAWgqM3B9cYa2/Auqhzk+Wc/bhrz8FBskSEgdfWg==}
     engines: {node: '>=12.0.0'}
 
   '@aws-sdk/client-location@3.186.3':
@@ -1497,6 +1560,10 @@ packages:
 
   '@aws-sdk/client-rekognition@3.6.1':
     resolution: {integrity: sha512-Ia4FEog9RrI0IoDRbOJO6djwhVAAaEZutxEKrWbjrVz4bgib28L+V+yAio2SUneeirj8pNYXwBKPfoYOUqGHhA==}
+    engines: {node: '>=10.0.0'}
+
+  '@aws-sdk/client-s3@3.6.3':
+    resolution: {integrity: sha512-nDcz/vyQ+otYjt9AetCWw9X4Ii4sdKOxmBJA06bLufzaWeGyYzVT3oY9o+9GywUXMEkz6vFVeKDZuSptt3aycA==}
     engines: {node: '>=10.0.0'}
 
   '@aws-sdk/client-s3@3.837.0':
@@ -1526,6 +1593,10 @@ packages:
   '@aws-sdk/client-sso@3.835.0':
     resolution: {integrity: sha512-4J19IcBKU5vL8yw/YWEvbwEGcmCli0rpRyxG53v0K5/3weVPxVBbKfkWcjWVQ4qdxNz2uInfbTde4BRBFxWllQ==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/client-sts@3.186.2':
+    resolution: {integrity: sha512-v58K2uVt7Yy980cCMCWKnNiTL3WAP0a82rI4p/eisc0i6WmXNguUtR+F4FyFlhJtHogjV7Uj4MSoI/qPwT2unA==}
+    engines: {node: '>=12.0.0'}
 
   '@aws-sdk/client-sts@3.186.3':
     resolution: {integrity: sha512-mnttdyYBtqO+FkDtOT3F1FGi8qD11fF5/3zYLaNuFFULqKneaIwW2YIsjFlgvPGpmoyo/tNplnZwhQ9xQtT3Sw==}
@@ -1707,12 +1778,19 @@ packages:
   '@aws-sdk/fetch-http-handler@3.6.1':
     resolution: {integrity: sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==}
 
+  '@aws-sdk/hash-blob-browser@3.6.1':
+    resolution: {integrity: sha512-9jPaZ/e3F8gf9JZd44DD6MvbYV6bKnn99rkG3GFIINOy9etoxPrLehp2bH2DK/j0ow60RNuwgUjj5qHV/zF67g==}
+
   '@aws-sdk/hash-node@3.186.0':
     resolution: {integrity: sha512-G3zuK8/3KExDTxqrGqko+opOMLRF0BwcwekV/wm3GKIM/NnLhHblBs2zd/yi7VsEoWmuzibfp6uzxgFpEoJ87w==}
     engines: {node: '>= 12.0.0'}
 
   '@aws-sdk/hash-node@3.6.1':
     resolution: {integrity: sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==}
+    engines: {node: '>= 10.0.0'}
+
+  '@aws-sdk/hash-stream-node@3.6.1':
+    resolution: {integrity: sha512-ePaWjCItIWxuSxA/UnUM/keQ3IAOsQz3FYSxu0KK8K0e1bKTEUgDIG9oMLBq7jIl9TzJG0HBXuPfMe73QHUNug==}
     engines: {node: '>= 10.0.0'}
 
   '@aws-sdk/invalid-dependency@3.186.0':
@@ -1742,6 +1820,14 @@ packages:
   '@aws-sdk/md5-js@3.6.1':
     resolution: {integrity: sha512-lzCqkZF1sbzGFDyq1dI+lR3AmlE33rbC/JhZ5fzw3hJZvfZ6Beq3Su7YwDo65IWEu0zOKYaNywTeOloXP/CkxQ==}
 
+  '@aws-sdk/middleware-apply-body-checksum@3.6.1':
+    resolution: {integrity: sha512-IncmXR1MPk6aYvmD37It8dP6wVMzaxxzgrkIU2ACkN5UVwA+/0Sr3ZNd9dNwjpyoH1AwpL9BetnlJaWtT6K5ew==}
+    engines: {node: '>= 10.0.0'}
+
+  '@aws-sdk/middleware-bucket-endpoint@3.6.1':
+    resolution: {integrity: sha512-Frcqn2RQDNHy+e2Q9hv3ejT3mQWtGlfZESbXEF6toR4M0R8MmEVqIB/ohI6VKBj11lRmGwvpPsR6zz+PJ8HS7A==}
+    engines: {node: '>= 10.0.0'}
+
   '@aws-sdk/middleware-bucket-endpoint@3.830.0':
     resolution: {integrity: sha512-ElVeCReZSH5Ds+/pkL5ebneJjuo8f49e9JXV1cYizuH0OAOQfYaBU9+M+7+rn61pTttOFE8W//qKzrXBBJhfMg==}
     engines: {node: '>=18.0.0'}
@@ -1758,6 +1844,10 @@ packages:
     resolution: {integrity: sha512-7yjFiitTGgfKL6cHK3u3HYFnld26IW5aUAFuEd6ocR/FjliysfBd8g0g1bw3bRfIMgCDD8OIOkXK8iCk2iYGWQ==}
     engines: {node: '>= 12.0.0'}
 
+  '@aws-sdk/middleware-expect-continue@3.6.1':
+    resolution: {integrity: sha512-vvMOqVYU3uvdJzg/X6NHewZUEBZhSqND1IEcdahLb6RmvDhsS39iS97VZmEFsjj/UFGoePtYjrrdEgRG9Rm1kQ==}
+    engines: {node: '>= 10.0.0'}
+
   '@aws-sdk/middleware-expect-continue@3.821.0':
     resolution: {integrity: sha512-zAOoSZKe1njOrtynvK6ZORU57YGv5I7KP4+rwOvUN3ZhJbQ7QPf8gKtFUCYAPRMegaXCKF/ADPtDZBAmM+zZ9g==}
     engines: {node: '>=18.0.0'}
@@ -1765,6 +1855,10 @@ packages:
   '@aws-sdk/middleware-flexible-checksums@3.835.0':
     resolution: {integrity: sha512-9ezorQYlr5cQY28zWAReFhNKUTaXsi3TMvXIagMRrSeWtQ7R6TCYnt91xzHRCmFR2kp3zLI+dfoeH+wF3iCKUw==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/middleware-header-default@3.6.1':
+    resolution: {integrity: sha512-YD137iIctXVH8Eut0WOBalvvA+uL0jM0UXZ9N2oKrC8kPQPpqjK9lYGFKZQFsl/XlQHAjJi+gCAFrYsBntRWJQ==}
+    engines: {node: '>= 10.0.0'}
 
   '@aws-sdk/middleware-host-header@3.186.0':
     resolution: {integrity: sha512-5bTzrRzP2IGwyF3QCyMGtSXpOOud537x32htZf344IvVjrqZF/P8CDfGTkHkeBCIH+wnJxjK+l/QBb3ypAMIqQ==}
@@ -1781,6 +1875,10 @@ packages:
   '@aws-sdk/middleware-host-header@3.821.0':
     resolution: {integrity: sha512-xSMR+sopSeWGx5/4pAGhhfMvGBHioVBbqGvDs6pG64xfNwM5vq5s5v6D04e2i+uSTj4qGa71dLUs5I0UzAK3sw==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/middleware-location-constraint@3.6.1':
+    resolution: {integrity: sha512-nFisTc0O5D+4I+sRxiiLPasC/I4NDc3s+hgbPPt/b3uAdrujJjhwFBOSaTx8qQvz/xJPAA8pUA/bfWIyeZKi/w==}
+    engines: {node: '>= 10.0.0'}
 
   '@aws-sdk/middleware-location-constraint@3.821.0':
     resolution: {integrity: sha512-sKrm80k0t3R0on8aA/WhWFoMaAl4yvdk+riotmMElLUpcMcRXAd1+600uFVrxJqZdbrKQ0mjX0PjT68DlkYXLg==}
@@ -1830,6 +1928,10 @@ packages:
     resolution: {integrity: sha512-ahqU7PfIxspLQOc7j/8FkIfYZq3J9Fr9QrydDsgr64WhhVue6ROobZyboyF4JSbW5ZUwdjliigDy0G1NNsF0PA==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/middleware-sdk-s3@3.6.1':
+    resolution: {integrity: sha512-HEA9kynNTsOSIIz8p5GEEAH03pnn+SSohwPl80sGqkmI1yl1tzjqgYZRii0e6acJTh4j9655XFzSx36hYPeB2w==}
+    engines: {node: '>= 10.0.0'}
+
   '@aws-sdk/middleware-sdk-s3@3.835.0':
     resolution: {integrity: sha512-oPebxpVf9smInHhevHh3APFZagGU+4RPwXEWv9YtYapFvsMq+8QXFvOfxfVZ/mwpe0JVG7EiJzL9/9Kobmts8Q==}
     engines: {node: '>=18.0.0'}
@@ -1852,6 +1954,10 @@ packages:
 
   '@aws-sdk/middleware-signing@3.6.1':
     resolution: {integrity: sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==}
+    engines: {node: '>= 10.0.0'}
+
+  '@aws-sdk/middleware-ssec@3.6.1':
+    resolution: {integrity: sha512-svuH6s91uKUTORt51msiL/ZBjtYSW32c3uVoWxludd/PEf6zO5wCmUEsKoyVwa88L7rrCq+81UBv5A8S5kc3Cw==}
     engines: {node: '>= 10.0.0'}
 
   '@aws-sdk/middleware-ssec@3.821.0':
@@ -1946,6 +2052,10 @@ packages:
     resolution: {integrity: sha512-t8og+lRCIIy5nlId0bScNpCkif8sc0LhmtaKsbm0ZPm3sCa/WhCbSZibjbZ28FNjVCV+p0D9RYZx0VDDbtWyjw==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/s3-request-presigner@3.6.1':
+    resolution: {integrity: sha512-OI7UHCKBwuiO/RmHHewBKnL2NYqdilXRmpX67TJ4tTszIrWP2+vpm3lIfrx/BM8nf8nKTzgkO98uFhoJsEhmTg==}
+    engines: {node: '>= 10.0.0'}
+
   '@aws-sdk/s3-request-presigner@3.837.0':
     resolution: {integrity: sha512-h/D/cqeciBPGFSHIHRQm0q/CDvToV4rUoPef3tWzYtfoKzqfYaqRO175FnDv/4XgOYpdoqv6q36bx8KueVQ62w==}
     engines: {node: '>=18.0.0'}
@@ -2020,6 +2130,10 @@ packages:
   '@aws-sdk/url-parser@3.6.1':
     resolution: {integrity: sha512-pWFIePDx0PMCleQRsQDWoDl17YiijOLj0ZobN39rQt+wv5PhLSZDz9PgJsqS48nZ6hqsKgipRcjiBMhn5NtFcQ==}
 
+  '@aws-sdk/util-arn-parser@3.6.1':
+    resolution: {integrity: sha512-NFdYeuhaSrgnBG6Pt3zHNU7QwvhHq6sKUTWZShUayLMJYYbQr6IjmYVlPST4c84b+lyDoK68y/Zga621VfIdBg==}
+    engines: {node: '>= 10.0.0'}
+
   '@aws-sdk/util-arn-parser@3.804.0':
     resolution: {integrity: sha512-wmBJqn1DRXnZu3b4EkE6CWnoWMo1ZMvlfkqU5zPz67xx1GMaXlDCchFvKAXMjk4jn/L1O3tKnoFDNsoLV1kgNQ==}
     engines: {node: '>=18.0.0'}
@@ -2068,6 +2182,10 @@ packages:
     resolution: {integrity: sha512-71Qwu/PN02XsRLApyxG0EUy/NxWh/CXxtl2C7qY14t+KTiRapwbDkdJ1cMsqYqghYP4BwJoj1M+EFMQSSlkZQQ==}
     engines: {node: '>= 12.0.0'}
 
+  '@aws-sdk/util-create-request@3.6.1':
+    resolution: {integrity: sha512-jR1U8WpwXl+xZ9ThS42Jr5MXuegQ7QioHsZjQn3V5pbm8CXTkBF0B2BcULQu/2G1XtHOJb8qUZQlk/REoaORfQ==}
+    engines: {node: '>= 10.0.0'}
+
   '@aws-sdk/util-defaults-mode-browser@3.186.0':
     resolution: {integrity: sha512-U8GOfIdQ0dZ7RRVpPynGteAHx4URtEh+JfWHHVfS6xLPthPHWTbyRhkQX++K/F8Jk+T5U8Anrrqlea4TlcO2DA==}
     engines: {node: '>= 10.0.0'}
@@ -2083,6 +2201,10 @@ packages:
   '@aws-sdk/util-endpoints@3.828.0':
     resolution: {integrity: sha512-RvKch111SblqdkPzg3oCIdlGxlQs+k+P7Etory9FmxPHyPDvsP1j1c74PmgYqtzzMWmoXTjd+c9naUHh9xG8xg==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/util-format-url@3.6.1':
+    resolution: {integrity: sha512-FvhcXcqLyJ0j0WdlmGs7PtjCCv8NaY4zBuXYO2iwAmqoy2SIZXQL63uAvmilqWj25q47ASAsUwSFLReCCfMklQ==}
+    engines: {node: '>= 10.0.0'}
 
   '@aws-sdk/util-format-url@3.821.0':
     resolution: {integrity: sha512-h+xqmPToxDrZ0a7rxE1a8Oh4zpWfZe9oiQUphGtfiGFA6j75UiURH5J3MmGHa/G4t15I3iLLbYtUXxvb1i7evg==}
@@ -2178,6 +2300,10 @@ packages:
 
   '@aws-sdk/util-waiter@3.6.1':
     resolution: {integrity: sha512-CQMRteoxW1XZSzPBVrTsOTnfzsEGs8N/xZ8BuBnXLBjoIQmRKVxIH9lgphm1ohCtVHoSWf28XH/KoOPFULQ4Tg==}
+    engines: {node: '>= 10.0.0'}
+
+  '@aws-sdk/xml-builder@3.6.1':
+    resolution: {integrity: sha512-+HOCH4a0XO+I09okd0xdVP5Q5c9ZsEsDvnogiOcBQxoMivWhPUCo9pjXP3buCvVKP2oDHXQplBKSjGHvGaKFdg==}
     engines: {node: '>= 10.0.0'}
 
   '@aws-sdk/xml-builder@3.821.0':
@@ -6857,6 +6983,9 @@ packages:
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
+  amazon-cognito-identity-js@6.3.1:
+    resolution: {integrity: sha512-PxBdufgS8uZShrcIFAsRjmqNXsh/4fXOWUGQOUhKLHWWK1pcp/y+VeFF48avXIWefM8XwsT3JlN6m9J2eHt4LA==}
+
   amazon-cognito-identity-js@6.3.12:
     resolution: {integrity: sha512-s7NKDZgx336cp+oDeUtB2ZzT8jWJp/v2LWuYl+LQtMEODe22RF1IJ4nRiDATp+rp1pTffCZcm44Quw4jx2bqNg==}
 
@@ -7126,6 +7255,9 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  aws-amplify@5.3.1:
+    resolution: {integrity: sha512-L7bZz3glu9rAjEuUo+zDy+AXSg/OEebAtBf4x/j34MuKKc5ES4bo2w4dJM4W+BzHpTfAzo2N2EUVso5oHWAAmw==}
 
   aws-amplify@5.3.10:
     resolution: {integrity: sha512-vwm97np/ni37WIWuE9xalj92vctgzIJRYX+FXcP9rAQgF4F2eEAjYNIkHGErpYqodmbeYF5gN1f/diKnhdGaRw==}
@@ -8700,6 +8832,10 @@ packages:
 
   fast-xml-parser@3.21.1:
     resolution: {integrity: sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==}
+    hasBin: true
+
+  fast-xml-parser@4.2.4:
+    resolution: {integrity: sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==}
     hasBin: true
 
   fast-xml-parser@4.2.5:
@@ -13840,6 +13976,21 @@ snapshots:
       rimraf: 2.2.8
       streamsink: 1.2.0
 
+  '@aws-amplify/analytics@6.3.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      '@aws-amplify/cache': 5.1.2(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/core': 5.5.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-sdk/client-firehose': 3.6.1(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-sdk/client-kinesis': 3.6.1(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-sdk/client-personalize-events': 3.6.1(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-sdk/util-utf8-browser': 3.6.1
+      lodash: 4.17.21
+      tslib: 1.14.1
+      uuid: 3.4.0
+    transitivePeerDependencies:
+      - encoding
+      - react-native
+
   '@aws-amplify/analytics@6.5.4(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
     dependencies:
       '@aws-amplify/cache': 5.1.10(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
@@ -13852,6 +14003,22 @@ snapshots:
       tslib: 1.14.1
       uuid: 3.4.0
     transitivePeerDependencies:
+      - encoding
+      - react-native
+
+  '@aws-amplify/api-graphql@3.4.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      '@aws-amplify/api-rest': 3.3.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/auth': 5.5.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/cache': 5.1.2(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/core': 5.5.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/pubsub': 5.3.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      graphql: 15.8.0
+      tslib: 1.14.1
+      uuid: 3.4.0
+      zen-observable-ts: 0.8.19
+    transitivePeerDependencies:
+      - debug
       - encoding
       - react-native
 
@@ -13871,12 +14038,33 @@ snapshots:
       - encoding
       - react-native
 
+  '@aws-amplify/api-rest@3.3.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      '@aws-amplify/core': 5.5.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      axios: 0.26.0
+      tslib: 1.14.1
+      url: 0.11.0
+    transitivePeerDependencies:
+      - debug
+      - encoding
+      - react-native
+
   '@aws-amplify/api-rest@3.5.4(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
     dependencies:
       '@aws-amplify/core': 5.8.4(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
       axios: 0.26.0
       tslib: 1.14.1
       url: 0.11.0
+    transitivePeerDependencies:
+      - debug
+      - encoding
+      - react-native
+
+  '@aws-amplify/api@5.3.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      '@aws-amplify/api-graphql': 3.4.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/api-rest': 3.3.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      tslib: 1.14.1
     transitivePeerDependencies:
       - debug
       - encoding
@@ -13889,6 +14077,16 @@ snapshots:
       tslib: 1.14.1
     transitivePeerDependencies:
       - debug
+      - encoding
+      - react-native
+
+  '@aws-amplify/auth@5.5.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      '@aws-amplify/core': 5.5.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      amazon-cognito-identity-js: 6.3.1(encoding@0.1.13)
+      tslib: 1.14.1
+      url: 0.11.0
+    transitivePeerDependencies:
       - encoding
       - react-native
 
@@ -13911,6 +14109,29 @@ snapshots:
       - encoding
       - react-native
 
+  '@aws-amplify/cache@5.1.2(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      '@aws-amplify/core': 5.5.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      tslib: 1.14.1
+    transitivePeerDependencies:
+      - encoding
+      - react-native
+
+  '@aws-amplify/core@5.5.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      '@aws-crypto/sha256-js': 1.2.2
+      '@aws-sdk/client-cloudwatch-logs': 3.6.1(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-sdk/types': 3.6.1
+      '@aws-sdk/util-hex-encoding': 3.6.1
+      isomorphic-unfetch: 3.1.0(encoding@0.1.13)
+      react-native-url-polyfill: 1.3.0(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      tslib: 1.14.1
+      universal-cookie: 4.0.4
+      zen-observable-ts: 0.8.19
+    transitivePeerDependencies:
+      - encoding
+      - react-native
+
   '@aws-amplify/core@5.8.4(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
     dependencies:
       '@aws-crypto/sha256-js': 1.2.2
@@ -13924,6 +14145,24 @@ snapshots:
       universal-cookie: 4.0.4
       zen-observable-ts: 0.8.19
     transitivePeerDependencies:
+      - encoding
+      - react-native
+
+  '@aws-amplify/datastore@4.6.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      '@aws-amplify/api': 5.3.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/auth': 5.5.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/core': 5.5.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/pubsub': 5.3.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      amazon-cognito-identity-js: 6.3.1(encoding@0.1.13)
+      idb: 5.0.6
+      immer: 9.0.6
+      ulid: 2.3.0
+      uuid: 3.4.0
+      zen-observable-ts: 0.8.19
+      zen-push: 0.2.1
+    transitivePeerDependencies:
+      - debug
       - encoding
       - react-native
 
@@ -13946,12 +14185,38 @@ snapshots:
       - encoding
       - react-native
 
+  '@aws-amplify/geo@2.1.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      '@aws-amplify/core': 5.5.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-sdk/client-location': 3.186.2
+      '@turf/boolean-clockwise': 6.5.0
+      camelcase-keys: 6.2.2
+      tslib: 1.14.1
+    transitivePeerDependencies:
+      - aws-crt
+      - encoding
+      - react-native
+
   '@aws-amplify/geo@2.3.4(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
     dependencies:
       '@aws-amplify/core': 5.8.4(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
       '@aws-sdk/client-location': 3.186.3
       '@turf/boolean-clockwise': 6.5.0
       camelcase-keys: 6.2.2
+      tslib: 1.14.1
+    transitivePeerDependencies:
+      - aws-crt
+      - encoding
+      - react-native
+
+  '@aws-amplify/interactions@5.2.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      '@aws-amplify/core': 5.5.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-sdk/client-lex-runtime-service': 3.186.2
+      '@aws-sdk/client-lex-runtime-v2': 3.186.2
+      base-64: 1.0.0
+      fflate: 0.7.3
+      pako: 2.0.4
       tslib: 1.14.1
     transitivePeerDependencies:
       - aws-crt
@@ -13972,6 +14237,17 @@ snapshots:
       - encoding
       - react-native
 
+  '@aws-amplify/notifications@1.3.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      '@aws-amplify/cache': 5.1.2(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/core': 5.5.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/rtn-push-notification': 1.1.1
+      lodash: 4.17.21
+      uuid: 3.4.0
+    transitivePeerDependencies:
+      - encoding
+      - react-native
+
   '@aws-amplify/notifications@1.6.4(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
     dependencies:
       '@aws-amplify/cache': 5.1.10(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
@@ -13980,6 +14256,25 @@ snapshots:
       lodash: 4.17.21
       uuid: 3.4.0
     transitivePeerDependencies:
+      - encoding
+      - react-native
+
+  '@aws-amplify/predictions@5.4.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      '@aws-amplify/core': 5.5.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/storage': 5.6.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-sdk/client-comprehend': 3.6.1(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-sdk/client-polly': 3.6.1(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-sdk/client-rekognition': 3.6.1(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-sdk/client-textract': 3.6.1(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-sdk/client-translate': 3.6.1(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-sdk/eventstream-marshaller': 3.6.1
+      '@aws-sdk/util-utf8-node': 3.6.1
+      buffer: 4.9.2
+      tslib: 1.14.1
+      uuid: 3.4.0
+    transitivePeerDependencies:
+      - debug
       - encoding
       - react-native
 
@@ -14001,6 +14296,20 @@ snapshots:
       - encoding
       - react-native
 
+  '@aws-amplify/pubsub@5.3.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      '@aws-amplify/auth': 5.5.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/cache': 5.1.2(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/core': 5.5.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      graphql: 15.8.0
+      tslib: 1.14.1
+      url: 0.11.0
+      uuid: 3.4.0
+      zen-observable-ts: 0.8.19
+    transitivePeerDependencies:
+      - encoding
+      - react-native
+
   '@aws-amplify/pubsub@5.5.4(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
     dependencies:
       '@aws-amplify/auth': 5.6.4(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
@@ -14016,7 +14325,24 @@ snapshots:
       - encoding
       - react-native
 
+  '@aws-amplify/rtn-push-notification@1.1.1': {}
+
   '@aws-amplify/rtn-push-notification@1.1.6': {}
+
+  '@aws-amplify/storage@5.6.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      '@aws-amplify/core': 5.5.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-sdk/client-s3': 3.6.3(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-sdk/s3-request-presigner': 3.6.1
+      '@aws-sdk/util-create-request': 3.6.1
+      '@aws-sdk/util-format-url': 3.6.1
+      axios: 0.26.0
+      events: 3.3.0
+      tslib: 1.14.1
+    transitivePeerDependencies:
+      - debug
+      - encoding
+      - react-native
 
   '@aws-amplify/storage@5.9.4(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
     dependencies:
@@ -14159,6 +14485,15 @@ snapshots:
   '@aws-sdk/abort-controller@3.6.1':
     dependencies:
       '@aws-sdk/types': 3.6.1
+      tslib: 1.14.1
+
+  '@aws-sdk/chunked-blob-reader-native@3.6.1':
+    dependencies:
+      '@aws-sdk/util-base64-browser': 3.6.1
+      tslib: 1.14.1
+
+  '@aws-sdk/chunked-blob-reader@3.6.1':
+    dependencies:
       tslib: 1.14.1
 
   '@aws-sdk/client-amplify@3.835.0':
@@ -14638,6 +14973,45 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-lex-runtime-service@3.186.2':
+    dependencies:
+      '@aws-crypto/sha256-browser': 2.0.0
+      '@aws-crypto/sha256-js': 2.0.0
+      '@aws-sdk/client-sts': 3.186.2
+      '@aws-sdk/config-resolver': 3.186.0
+      '@aws-sdk/credential-provider-node': 3.186.0
+      '@aws-sdk/fetch-http-handler': 3.186.0
+      '@aws-sdk/hash-node': 3.186.0
+      '@aws-sdk/invalid-dependency': 3.186.0
+      '@aws-sdk/middleware-content-length': 3.186.0
+      '@aws-sdk/middleware-host-header': 3.186.0
+      '@aws-sdk/middleware-logger': 3.186.0
+      '@aws-sdk/middleware-recursion-detection': 3.186.0
+      '@aws-sdk/middleware-retry': 3.186.0
+      '@aws-sdk/middleware-serde': 3.186.0
+      '@aws-sdk/middleware-signing': 3.186.0
+      '@aws-sdk/middleware-stack': 3.186.0
+      '@aws-sdk/middleware-user-agent': 3.186.0
+      '@aws-sdk/node-config-provider': 3.186.0
+      '@aws-sdk/node-http-handler': 3.186.0
+      '@aws-sdk/protocol-http': 3.186.0
+      '@aws-sdk/smithy-client': 3.186.0
+      '@aws-sdk/types': 3.186.0
+      '@aws-sdk/url-parser': 3.186.0
+      '@aws-sdk/util-base64-browser': 3.186.0
+      '@aws-sdk/util-base64-node': 3.186.0
+      '@aws-sdk/util-body-length-browser': 3.186.0
+      '@aws-sdk/util-body-length-node': 3.186.0
+      '@aws-sdk/util-defaults-mode-browser': 3.186.0
+      '@aws-sdk/util-defaults-mode-node': 3.186.0
+      '@aws-sdk/util-user-agent-browser': 3.186.0
+      '@aws-sdk/util-user-agent-node': 3.186.0
+      '@aws-sdk/util-utf8-browser': 3.186.0
+      '@aws-sdk/util-utf8-node': 3.186.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/client-lex-runtime-service@3.186.3':
     dependencies:
       '@aws-crypto/sha256-browser': 2.0.0
@@ -14649,6 +15023,50 @@ snapshots:
       '@aws-sdk/hash-node': 3.186.0
       '@aws-sdk/invalid-dependency': 3.186.0
       '@aws-sdk/middleware-content-length': 3.186.0
+      '@aws-sdk/middleware-host-header': 3.186.0
+      '@aws-sdk/middleware-logger': 3.186.0
+      '@aws-sdk/middleware-recursion-detection': 3.186.0
+      '@aws-sdk/middleware-retry': 3.186.0
+      '@aws-sdk/middleware-serde': 3.186.0
+      '@aws-sdk/middleware-signing': 3.186.0
+      '@aws-sdk/middleware-stack': 3.186.0
+      '@aws-sdk/middleware-user-agent': 3.186.0
+      '@aws-sdk/node-config-provider': 3.186.0
+      '@aws-sdk/node-http-handler': 3.186.0
+      '@aws-sdk/protocol-http': 3.186.0
+      '@aws-sdk/smithy-client': 3.186.0
+      '@aws-sdk/types': 3.186.0
+      '@aws-sdk/url-parser': 3.186.0
+      '@aws-sdk/util-base64-browser': 3.186.0
+      '@aws-sdk/util-base64-node': 3.186.0
+      '@aws-sdk/util-body-length-browser': 3.186.0
+      '@aws-sdk/util-body-length-node': 3.186.0
+      '@aws-sdk/util-defaults-mode-browser': 3.186.0
+      '@aws-sdk/util-defaults-mode-node': 3.186.0
+      '@aws-sdk/util-user-agent-browser': 3.186.0
+      '@aws-sdk/util-user-agent-node': 3.186.0
+      '@aws-sdk/util-utf8-browser': 3.186.0
+      '@aws-sdk/util-utf8-node': 3.186.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-lex-runtime-v2@3.186.2':
+    dependencies:
+      '@aws-crypto/sha256-browser': 2.0.0
+      '@aws-crypto/sha256-js': 2.0.0
+      '@aws-sdk/client-sts': 3.186.2
+      '@aws-sdk/config-resolver': 3.186.0
+      '@aws-sdk/credential-provider-node': 3.186.0
+      '@aws-sdk/eventstream-handler-node': 3.186.0
+      '@aws-sdk/eventstream-serde-browser': 3.186.0
+      '@aws-sdk/eventstream-serde-config-resolver': 3.186.0
+      '@aws-sdk/eventstream-serde-node': 3.186.0
+      '@aws-sdk/fetch-http-handler': 3.186.0
+      '@aws-sdk/hash-node': 3.186.0
+      '@aws-sdk/invalid-dependency': 3.186.0
+      '@aws-sdk/middleware-content-length': 3.186.0
+      '@aws-sdk/middleware-eventstream': 3.186.0
       '@aws-sdk/middleware-host-header': 3.186.0
       '@aws-sdk/middleware-logger': 3.186.0
       '@aws-sdk/middleware-recursion-detection': 3.186.0
@@ -14693,6 +15111,45 @@ snapshots:
       '@aws-sdk/invalid-dependency': 3.186.0
       '@aws-sdk/middleware-content-length': 3.186.0
       '@aws-sdk/middleware-eventstream': 3.186.0
+      '@aws-sdk/middleware-host-header': 3.186.0
+      '@aws-sdk/middleware-logger': 3.186.0
+      '@aws-sdk/middleware-recursion-detection': 3.186.0
+      '@aws-sdk/middleware-retry': 3.186.0
+      '@aws-sdk/middleware-serde': 3.186.0
+      '@aws-sdk/middleware-signing': 3.186.0
+      '@aws-sdk/middleware-stack': 3.186.0
+      '@aws-sdk/middleware-user-agent': 3.186.0
+      '@aws-sdk/node-config-provider': 3.186.0
+      '@aws-sdk/node-http-handler': 3.186.0
+      '@aws-sdk/protocol-http': 3.186.0
+      '@aws-sdk/smithy-client': 3.186.0
+      '@aws-sdk/types': 3.186.0
+      '@aws-sdk/url-parser': 3.186.0
+      '@aws-sdk/util-base64-browser': 3.186.0
+      '@aws-sdk/util-base64-node': 3.186.0
+      '@aws-sdk/util-body-length-browser': 3.186.0
+      '@aws-sdk/util-body-length-node': 3.186.0
+      '@aws-sdk/util-defaults-mode-browser': 3.186.0
+      '@aws-sdk/util-defaults-mode-node': 3.186.0
+      '@aws-sdk/util-user-agent-browser': 3.186.0
+      '@aws-sdk/util-user-agent-node': 3.186.0
+      '@aws-sdk/util-utf8-browser': 3.186.0
+      '@aws-sdk/util-utf8-node': 3.186.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-location@3.186.2':
+    dependencies:
+      '@aws-crypto/sha256-browser': 2.0.0
+      '@aws-crypto/sha256-js': 2.0.0
+      '@aws-sdk/client-sts': 3.186.2
+      '@aws-sdk/config-resolver': 3.186.0
+      '@aws-sdk/credential-provider-node': 3.186.0
+      '@aws-sdk/fetch-http-handler': 3.186.0
+      '@aws-sdk/hash-node': 3.186.0
+      '@aws-sdk/invalid-dependency': 3.186.0
+      '@aws-sdk/middleware-content-length': 3.186.0
       '@aws-sdk/middleware-host-header': 3.186.0
       '@aws-sdk/middleware-logger': 3.186.0
       '@aws-sdk/middleware-recursion-detection': 3.186.0
@@ -14911,6 +15368,57 @@ snapshots:
       '@aws-sdk/util-utf8-browser': 3.6.1
       '@aws-sdk/util-utf8-node': 3.6.1
       '@aws-sdk/util-waiter': 3.6.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - react-native
+
+  '@aws-sdk/client-s3@3.6.3(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      '@aws-crypto/sha256-browser': 1.2.2
+      '@aws-crypto/sha256-js': 1.2.2
+      '@aws-sdk/config-resolver': 3.6.1
+      '@aws-sdk/credential-provider-node': 3.6.1
+      '@aws-sdk/eventstream-serde-browser': 3.6.1
+      '@aws-sdk/eventstream-serde-config-resolver': 3.6.1
+      '@aws-sdk/eventstream-serde-node': 3.6.1
+      '@aws-sdk/fetch-http-handler': 3.6.1
+      '@aws-sdk/hash-blob-browser': 3.6.1
+      '@aws-sdk/hash-node': 3.6.1
+      '@aws-sdk/hash-stream-node': 3.6.1
+      '@aws-sdk/invalid-dependency': 3.6.1
+      '@aws-sdk/md5-js': 3.6.1
+      '@aws-sdk/middleware-apply-body-checksum': 3.6.1
+      '@aws-sdk/middleware-bucket-endpoint': 3.6.1
+      '@aws-sdk/middleware-content-length': 3.6.1
+      '@aws-sdk/middleware-expect-continue': 3.6.1
+      '@aws-sdk/middleware-host-header': 3.6.1
+      '@aws-sdk/middleware-location-constraint': 3.6.1
+      '@aws-sdk/middleware-logger': 3.6.1
+      '@aws-sdk/middleware-retry': 3.6.1(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-sdk/middleware-sdk-s3': 3.6.1
+      '@aws-sdk/middleware-serde': 3.6.1
+      '@aws-sdk/middleware-signing': 3.6.1
+      '@aws-sdk/middleware-ssec': 3.6.1
+      '@aws-sdk/middleware-stack': 3.6.1
+      '@aws-sdk/middleware-user-agent': 3.6.1
+      '@aws-sdk/node-config-provider': 3.6.1
+      '@aws-sdk/node-http-handler': 3.6.1
+      '@aws-sdk/protocol-http': 3.6.1
+      '@aws-sdk/smithy-client': 3.6.1
+      '@aws-sdk/types': 3.6.1
+      '@aws-sdk/url-parser': 3.6.1
+      '@aws-sdk/url-parser-native': 3.6.1
+      '@aws-sdk/util-base64-browser': 3.6.1
+      '@aws-sdk/util-base64-node': 3.6.1
+      '@aws-sdk/util-body-length-browser': 3.6.1
+      '@aws-sdk/util-body-length-node': 3.6.1
+      '@aws-sdk/util-user-agent-browser': 3.6.1
+      '@aws-sdk/util-user-agent-node': 3.6.1
+      '@aws-sdk/util-utf8-browser': 3.6.1
+      '@aws-sdk/util-utf8-node': 3.6.1
+      '@aws-sdk/util-waiter': 3.6.1
+      '@aws-sdk/xml-builder': 3.6.1
+      fast-xml-parser: 4.2.4
       tslib: 2.8.1
     transitivePeerDependencies:
       - react-native
@@ -15234,6 +15742,47 @@ snapshots:
       '@smithy/util-middleware': 4.0.4
       '@smithy/util-retry': 4.0.6
       '@smithy/util-utf8': 4.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-sts@3.186.2':
+    dependencies:
+      '@aws-crypto/sha256-browser': 2.0.0
+      '@aws-crypto/sha256-js': 2.0.0
+      '@aws-sdk/config-resolver': 3.186.0
+      '@aws-sdk/credential-provider-node': 3.186.0
+      '@aws-sdk/fetch-http-handler': 3.186.0
+      '@aws-sdk/hash-node': 3.186.0
+      '@aws-sdk/invalid-dependency': 3.186.0
+      '@aws-sdk/middleware-content-length': 3.186.0
+      '@aws-sdk/middleware-host-header': 3.186.0
+      '@aws-sdk/middleware-logger': 3.186.0
+      '@aws-sdk/middleware-recursion-detection': 3.186.0
+      '@aws-sdk/middleware-retry': 3.186.0
+      '@aws-sdk/middleware-sdk-sts': 3.186.0
+      '@aws-sdk/middleware-serde': 3.186.0
+      '@aws-sdk/middleware-signing': 3.186.0
+      '@aws-sdk/middleware-stack': 3.186.0
+      '@aws-sdk/middleware-user-agent': 3.186.0
+      '@aws-sdk/node-config-provider': 3.186.0
+      '@aws-sdk/node-http-handler': 3.186.0
+      '@aws-sdk/protocol-http': 3.186.0
+      '@aws-sdk/smithy-client': 3.186.0
+      '@aws-sdk/types': 3.186.0
+      '@aws-sdk/url-parser': 3.186.0
+      '@aws-sdk/util-base64-browser': 3.186.0
+      '@aws-sdk/util-base64-node': 3.186.0
+      '@aws-sdk/util-body-length-browser': 3.186.0
+      '@aws-sdk/util-body-length-node': 3.186.0
+      '@aws-sdk/util-defaults-mode-browser': 3.186.0
+      '@aws-sdk/util-defaults-mode-node': 3.186.0
+      '@aws-sdk/util-user-agent-browser': 3.186.0
+      '@aws-sdk/util-user-agent-node': 3.186.0
+      '@aws-sdk/util-utf8-browser': 3.186.0
+      '@aws-sdk/util-utf8-node': 3.186.0
+      entities: 2.2.0
+      fast-xml-parser: 4.2.4
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -15763,6 +16312,13 @@ snapshots:
       '@aws-sdk/util-base64-browser': 3.6.1
       tslib: 1.14.1
 
+  '@aws-sdk/hash-blob-browser@3.6.1':
+    dependencies:
+      '@aws-sdk/chunked-blob-reader': 3.6.1
+      '@aws-sdk/chunked-blob-reader-native': 3.6.1
+      '@aws-sdk/types': 3.6.1
+      tslib: 1.14.1
+
   '@aws-sdk/hash-node@3.186.0':
     dependencies:
       '@aws-sdk/types': 3.186.0
@@ -15773,6 +16329,11 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.6.1
       '@aws-sdk/util-buffer-from': 3.6.1
+      tslib: 1.14.1
+
+  '@aws-sdk/hash-stream-node@3.6.1':
+    dependencies:
+      '@aws-sdk/types': 3.6.1
       tslib: 1.14.1
 
   '@aws-sdk/invalid-dependency@3.186.0':
@@ -15814,6 +16375,20 @@ snapshots:
       '@aws-sdk/util-utf8-browser': 3.6.1
       tslib: 1.14.1
 
+  '@aws-sdk/middleware-apply-body-checksum@3.6.1':
+    dependencies:
+      '@aws-sdk/is-array-buffer': 3.6.1
+      '@aws-sdk/protocol-http': 3.6.1
+      '@aws-sdk/types': 3.6.1
+      tslib: 1.14.1
+
+  '@aws-sdk/middleware-bucket-endpoint@3.6.1':
+    dependencies:
+      '@aws-sdk/protocol-http': 3.6.1
+      '@aws-sdk/types': 3.6.1
+      '@aws-sdk/util-arn-parser': 3.6.1
+      tslib: 1.14.1
+
   '@aws-sdk/middleware-bucket-endpoint@3.830.0':
     dependencies:
       '@aws-sdk/types': 3.821.0
@@ -15842,6 +16417,13 @@ snapshots:
       '@aws-sdk/types': 3.186.0
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-expect-continue@3.6.1':
+    dependencies:
+      '@aws-sdk/middleware-header-default': 3.6.1
+      '@aws-sdk/protocol-http': 3.6.1
+      '@aws-sdk/types': 3.6.1
+      tslib: 1.14.1
+
   '@aws-sdk/middleware-expect-continue@3.821.0':
     dependencies:
       '@aws-sdk/types': 3.821.0
@@ -15864,6 +16446,12 @@ snapshots:
       '@smithy/util-stream': 4.2.2
       '@smithy/util-utf8': 4.0.0
       tslib: 2.8.1
+
+  '@aws-sdk/middleware-header-default@3.6.1':
+    dependencies:
+      '@aws-sdk/protocol-http': 3.6.1
+      '@aws-sdk/types': 3.6.1
+      tslib: 1.14.1
 
   '@aws-sdk/middleware-host-header@3.186.0':
     dependencies:
@@ -15890,6 +16478,11 @@ snapshots:
       '@smithy/protocol-http': 5.1.2
       '@smithy/types': 4.3.1
       tslib: 2.8.1
+
+  '@aws-sdk/middleware-location-constraint@3.6.1':
+    dependencies:
+      '@aws-sdk/types': 3.6.1
+      tslib: 1.14.1
 
   '@aws-sdk/middleware-location-constraint@3.821.0':
     dependencies:
@@ -15980,6 +16573,13 @@ snapshots:
       '@smithy/types': 4.3.1
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-sdk-s3@3.6.1':
+    dependencies:
+      '@aws-sdk/protocol-http': 3.6.1
+      '@aws-sdk/types': 3.6.1
+      '@aws-sdk/util-arn-parser': 3.6.1
+      tslib: 1.14.1
+
   '@aws-sdk/middleware-sdk-s3@3.835.0':
     dependencies:
       '@aws-sdk/core': 3.835.0
@@ -16029,6 +16629,11 @@ snapshots:
     dependencies:
       '@aws-sdk/protocol-http': 3.6.1
       '@aws-sdk/signature-v4': 3.6.1
+      '@aws-sdk/types': 3.6.1
+      tslib: 1.14.1
+
+  '@aws-sdk/middleware-ssec@3.6.1':
+    dependencies:
       '@aws-sdk/types': 3.6.1
       tslib: 1.14.1
 
@@ -16254,6 +16859,16 @@ snapshots:
       '@smithy/util-middleware': 4.0.4
       tslib: 2.8.1
 
+  '@aws-sdk/s3-request-presigner@3.6.1':
+    dependencies:
+      '@aws-sdk/protocol-http': 3.6.1
+      '@aws-sdk/signature-v4': 3.6.1
+      '@aws-sdk/smithy-client': 3.6.1
+      '@aws-sdk/types': 3.6.1
+      '@aws-sdk/util-create-request': 3.6.1
+      '@aws-sdk/util-format-url': 3.6.1
+      tslib: 1.14.1
+
   '@aws-sdk/s3-request-presigner@3.837.0':
     dependencies:
       '@aws-sdk/signature-v4-multi-region': 3.835.0
@@ -16372,6 +16987,10 @@ snapshots:
       '@aws-sdk/types': 3.6.1
       tslib: 1.14.1
 
+  '@aws-sdk/util-arn-parser@3.6.1':
+    dependencies:
+      tslib: 1.14.1
+
   '@aws-sdk/util-arn-parser@3.804.0':
     dependencies:
       tslib: 2.8.1
@@ -16429,6 +17048,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@aws-sdk/util-create-request@3.6.1':
+    dependencies:
+      '@aws-sdk/middleware-stack': 3.6.1
+      '@aws-sdk/smithy-client': 3.6.1
+      '@aws-sdk/types': 3.6.1
+      tslib: 1.14.1
+
   '@aws-sdk/util-defaults-mode-browser@3.186.0':
     dependencies:
       '@aws-sdk/property-provider': 3.186.0
@@ -16458,6 +17084,12 @@ snapshots:
       '@smithy/types': 4.3.1
       '@smithy/util-endpoints': 3.0.6
       tslib: 2.8.1
+
+  '@aws-sdk/util-format-url@3.6.1':
+    dependencies:
+      '@aws-sdk/querystring-builder': 3.6.1
+      '@aws-sdk/types': 3.6.1
+      tslib: 1.14.1
 
   '@aws-sdk/util-format-url@3.821.0':
     dependencies:
@@ -16575,6 +17207,10 @@ snapshots:
     dependencies:
       '@aws-sdk/abort-controller': 3.6.1
       '@aws-sdk/types': 3.6.1
+      tslib: 1.14.1
+
+  '@aws-sdk/xml-builder@3.6.1':
+    dependencies:
       tslib: 1.14.1
 
   '@aws-sdk/xml-builder@3.821.0':
@@ -19402,7 +20038,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5))':
+  '@jest/core@29.7.0':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -19416,7 +20052,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5))
+      jest-config: 29.7.0(@types/node@20.17.24)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -22425,6 +23061,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@3.1.1(vitest@3.0.7(@types/node@20.14.12)(@vitest/ui@2.1.9)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.43.1)(tsx@4.19.3)(yaml@2.8.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      debug: 4.4.0(supports-color@8.1.1)
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.1.7
+      magic-string: 0.30.17
+      magicast: 0.3.5
+      std-env: 3.9.0
+      test-exclude: 7.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.0.7(@types/node@20.14.12)(@vitest/ui@2.1.9)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.43.1)(tsx@4.19.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/coverage-v8@3.1.1(vitest@3.0.7(@types/node@20.17.24)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.43.1)(tsx@4.19.3)(yaml@2.8.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -22440,24 +23094,6 @@ snapshots:
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
       vitest: 3.0.7(@types/node@20.17.24)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.43.1)(tsx@4.19.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@vitest/coverage-v8@3.1.1(vitest@3.0.7)':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@bcoe/v8-coverage': 1.0.2
-      debug: 4.4.0(supports-color@8.1.1)
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
-      istanbul-reports: 3.1.7
-      magic-string: 0.30.17
-      magicast: 0.3.5
-      std-env: 3.9.0
-      test-exclude: 7.0.1
-      tinyrainbow: 2.0.0
-      vitest: 3.0.7(@types/node@20.14.12)(@vitest/ui@2.1.9)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.43.1)(tsx@4.19.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -22779,6 +23415,16 @@ snapshots:
       fast-uri: 3.0.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  amazon-cognito-identity-js@6.3.1(encoding@0.1.13):
+    dependencies:
+      '@aws-crypto/sha256-js': 1.2.2
+      buffer: 4.9.2
+      fast-base64-decode: 1.0.0
+      isomorphic-unfetch: 3.1.0(encoding@0.1.13)
+      js-cookie: 2.2.1
+    transitivePeerDependencies:
+      - encoding
 
   amazon-cognito-identity-js@6.3.12(encoding@0.1.13):
     dependencies:
@@ -23135,6 +23781,27 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.0.0
+
+  aws-amplify@5.3.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1)):
+    dependencies:
+      '@aws-amplify/analytics': 6.3.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/api': 5.3.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/auth': 5.5.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/cache': 5.1.2(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/core': 5.5.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/datastore': 4.6.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/geo': 2.1.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/interactions': 5.2.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/notifications': 1.3.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/predictions': 5.4.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/pubsub': 5.3.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      '@aws-amplify/storage': 5.6.1(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+      - debug
+      - encoding
+      - react-native
 
   aws-amplify@5.3.10(encoding@0.1.13)(react-native@0.74.3(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1)):
     dependencies:
@@ -24052,13 +24719,13 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 4.5.2
 
-  create-jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5)):
+  create-jest@29.7.0(@types/node@20.14.12):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5))
+      jest-config: 29.7.0(@types/node@20.14.12)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -24767,13 +25434,13 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@8.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5)))(typescript@4.9.5):
+  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@8.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(jest@29.7.0(@types/node@20.14.12))(typescript@4.9.5):
     dependencies:
       '@typescript-eslint/utils': 5.57.0(eslint@8.57.0)(typescript@4.9.5)
       eslint: 8.57.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5)
-      jest: 29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5))
+      jest: 29.7.0(@types/node@20.14.12)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -25103,6 +25770,10 @@ snapshots:
   fast-xml-parser@3.21.1:
     dependencies:
       strnum: 1.0.5
+
+  fast-xml-parser@4.2.4:
+    dependencies:
+      strnum: 1.1.2
 
   fast-xml-parser@4.2.5:
     dependencies:
@@ -26276,16 +26947,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5)):
+  jest-cli@29.7.0(@types/node@20.14.12):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5))
+      '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5))
+      create-jest: 29.7.0(@types/node@20.14.12)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5))
+      jest-config: 29.7.0(@types/node@20.14.12)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -26334,7 +27005,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5)):
+  jest-config@29.7.0(@types/node@20.14.12):
     dependencies:
       '@babel/core': 7.24.7
       '@jest/test-sequencer': 29.7.0
@@ -26360,7 +27031,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.12
-      ts-node: 10.9.2(@types/node@20.14.12)(typescript@4.9.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -26397,7 +27067,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5)):
+  jest-config@29.7.0(@types/node@20.17.24):
     dependencies:
       '@babel/core': 7.24.7
       '@jest/test-sequencer': 29.7.0
@@ -26423,7 +27093,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.17.24
-      ts-node: 10.9.2(@types/node@20.14.12)(typescript@4.9.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -26720,12 +27389,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5)):
+  jest@29.7.0(@types/node@20.14.12):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5))
+      '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5))
+      jest-cli: 29.7.0(@types/node@20.14.12)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -30150,25 +30819,6 @@ snapshots:
       webpack: 5.93.0(esbuild@0.25.4)
 
   ts-log@2.2.4: {}
-
-  ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.14.12
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.9.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
 
   ts-node@10.9.2(@types/node@20.16.5)(typescript@5.5.4):
     dependencies:

--- a/services/cypress/package.json
+++ b/services/cypress/package.json
@@ -56,10 +56,10 @@
         "@apollo/client": "3.8.8",
         "@mc-review/common-code": "workspace:*",
         "@mc-review/hpp": "workspace:*",
-        "aws-amplify": "^5.0.10",
+        "aws-amplify": "^5.3.1",
+        "axios": "^1.9.0",
         "cypress-file-upload": "^5.0.8",
         "cypress-pipe": "^2.0.0",
-        "axios": "^1.9.0",
         "graphql": "^16.9.0"
     }
 }


### PR DESCRIPTION
## Summary

This PR pins the aws-amplify package to 5.3.1 for cypress

#### Related issues

https://jiraent.cms.gov/browse/MCR-5403

## PR Reminders
- [x] Updated the API Changelog (if this PR changes the API schema)
- [x] Checked accessibility with ANDI and Wave tools as needed