### PR TITLE
[MCR-5312] File upload body text is coded as h5

### DIFF
--- a/services/app-web/src/components/FileUpload/FileUpload.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.tsx
@@ -404,9 +404,9 @@ export const FileUpload = ({
                 // eslint-disable-next-line @typescript-eslint/no-empty-function
                 onPointerLeaveCapture={() => {}}
             />
-            <h5 tabIndex={-1} ref={summaryRef} className={styles.fileSummary}>
+            <p tabIndex={-1} ref={summaryRef} className={styles.fileSummary}>
                 {`${summary} ${summaryDetailText}`}
-            </h5>
+            </p>
             <FileItemsList
                 retryItem={retryFile}
                 deleteItem={deleteItem}


### PR DESCRIPTION
## Summary
This PR changes the `# files added` text within the file upload component from a header to body text to satisfy accessibility requirements
#### Related issues
[MCR-5312](https://jiraent.cms.gov/browse/MCR-5312)
#### Screenshots
![image](https://github.com/user-attachments/assets/6d2dffc6-5e44-4643-8445-27dbddcebe5a)