### PR TITLE
[MCR-5363] State indicates if a contract is associated with a D-SNP

### DIFF
--- a/services/app-web/src/pages/Help/Help.tsx
+++ b/services/app-web/src/pages/Help/Help.tsx
@@ -67,6 +67,35 @@ export const Help = (): React.ReactElement => {
                     your base contract.
                 </p>
             </section>
+            <section
+                className={styles.helpSection}
+                id="dual-eligible-special-needs-plans"
+            >
+                <h3>Dual Eligible Special Needs Plan (D-SNP) guidance</h3>
+                <h4>
+                    Is this contract associated with a Dual-Eligible Special
+                    Needs Plan (D-SNP) that covers Medicaid benefits?
+                </h4>
+                <p className="line-height-sans-4 measure-6">
+                    Choose ‘Yes’ if either of the following applies:
+                    <ul>
+                        <li>
+                            This contract includes both Medicaid managed care
+                            and D-SNP requirements
+                        </li>
+                        <li>
+                            This contract is with a D-SNP that covers Medicaid
+                            benefits directly, or the contract fulfills a
+                            regulatory requirement under 42 CFR § 422 for a
+                            Highly Integrated Dual Eligible Special Needs Plan
+                            (HIDE D-SNP) (or affiliated legal entity) or a Fully
+                            Integrated Dual Eligible Special Needs Plan (FIDE
+                            D-SNP) entity to also offer a Medicaid managed care
+                            plan
+                        </li>
+                    </ul>
+                </p>
+            </section>
             <section className={styles.helpSection}>
                 <h3 id="non-compliance-guidance">Non-compliance guidance</h3>
                 <h4>Contractual versus operational compliance</h4>

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -406,6 +406,11 @@ export const ContractDetails = ({
         if (options.type === 'SAVE_AS_DRAFT' && draftSaved) {
             setDraftSaved(false)
         }
+
+        const dsnpTrigger = values.federalAuthorities.some((type) =>
+            dsnpTriggers.includes(type)
+        )
+
         const updatedDraftSubmissionFormData: ContractDraftRevisionFormDataInput =
             {
                 contractExecutionStatus: values.contractExecutionStatus,
@@ -427,7 +432,11 @@ export const ContractDetails = ({
                     formatDocumentsForGQL(values.supportingDocuments) || [],
                 managedCareEntities: values.managedCareEntities,
                 federalAuthorities: values.federalAuthorities,
-                dsnpContract: yesNoFormValueAsBoolean(values.dsnpContract),
+                // Clear dsnpContract if all dsnp trigger federalAuthorities are removed after a value was previously selected for dsnpContract
+                dsnpContract:
+                    values.dsnpContract && dsnpTrigger
+                        ? yesNoFormValueAsBoolean(values.dsnpContract)
+                        : undefined,
                 submissionType:
                     draftSubmission.draftRevision.formData.submissionType,
                 statutoryRegulatoryAttestation: formatYesNoForProto(

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -126,6 +126,7 @@ export type ContractDetailsFormValues = {
     contractDateEnd: string
     managedCareEntities: ManagedCareEntity[]
     federalAuthorities: FederalAuthority[]
+    dsnpContract: string | undefined
     inLieuServicesAndSettings: string | undefined
     modifiedBenefitsProvided: string | undefined
     modifiedGeoAreaServed: string | undefined
@@ -257,6 +258,10 @@ export const ContractDetails = ({
                 .managedCareEntities as ManagedCareEntity[]) ?? [],
         federalAuthorities:
             draftSubmission.draftRevision.formData.federalAuthorities ?? [],
+        dsnpContract:
+            booleanAsYesNoFormValue(
+                draftSubmission.draftRevision.formData.dsnpContract
+            ) ?? '',
         inLieuServicesAndSettings:
             booleanAsYesNoFormValue(
                 draftSubmission.draftRevision.formData.inLieuServicesAndSettings
@@ -401,6 +406,7 @@ export const ContractDetails = ({
         if (options.type === 'SAVE_AS_DRAFT' && draftSaved) {
             setDraftSaved(false)
         }
+        //TODO: will have to use yesNoFormValueAsBoolean here for the dsnp field
         const updatedDraftSubmissionFormData: ContractDraftRevisionFormDataInput =
             {
                 contractExecutionStatus: values.contractExecutionStatus,
@@ -543,6 +549,13 @@ export const ContractDetails = ({
     }
 
     const formHeading = 'Contract Details Form'
+
+    const dsnpTriggers = [
+        'STATE_PLAN',
+        'WAIVER_1915B',
+        'WAIVER_1115',
+        'VOLUNTARY',
+    ]
 
     return (
         <>
@@ -1265,6 +1278,59 @@ export const ContractDetails = ({
                                                     )}
                                                 </Fieldset>
                                             </FormGroup>
+                                            {values.federalAuthorities.some(
+                                                (type) =>
+                                                    dsnpTriggers.includes(type)
+                                            ) && (
+                                                <FormGroup
+                                                    error={Boolean(
+                                                        showFieldErrors(
+                                                            'dsnpContract',
+                                                            errors
+                                                        )
+                                                    )}
+                                                >
+                                                    <Fieldset
+                                                        aria-required
+                                                        legend="Is this contract associated with a Dual-Eligible Special Needs Plan (D-SNP) that covers Medicaid benefits?"
+                                                    >
+                                                        <span
+                                                            className={
+                                                                styles.requiredOptionalText
+                                                            }
+                                                        >
+                                                            Required
+                                                        </span>
+                                                        <span
+                                                            className={
+                                                                styles.requiredOptionalText
+                                                            }
+                                                        >
+                                                            See 42 CFR § 422.2
+                                                        </span>
+                                                        <LinkWithLogging
+                                                            variant="external"
+                                                            href={
+                                                                'https://mc-review-dev.onemac.cms.gov/help#dual-eligible-special-needs-plans'
+                                                            }
+                                                            target="_blank"
+                                                        >
+                                                            D-SNP guidance
+                                                        </LinkWithLogging>
+                                                        <FieldYesNo
+                                                            id="dsnpContract"
+                                                            name="dsnpContract"
+                                                            label=""
+                                                            showError={Boolean(
+                                                                showFieldErrors(
+                                                                    'dsnpContract',
+                                                                    errors
+                                                                )
+                                                            )}
+                                                        />
+                                                    </Fieldset>
+                                                </FormGroup>
+                                            )}
                                             {isContractWithProvisions(
                                                 draftSubmission
                                             ) && (

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -406,7 +406,6 @@ export const ContractDetails = ({
         if (options.type === 'SAVE_AS_DRAFT' && draftSaved) {
             setDraftSaved(false)
         }
-        //TODO: will have to use yesNoFormValueAsBoolean here for the dsnp field
         const updatedDraftSubmissionFormData: ContractDraftRevisionFormDataInput =
             {
                 contractExecutionStatus: values.contractExecutionStatus,
@@ -428,6 +427,7 @@ export const ContractDetails = ({
                     formatDocumentsForGQL(values.supportingDocuments) || [],
                 managedCareEntities: values.managedCareEntities,
                 federalAuthorities: values.federalAuthorities,
+                dsnpContract: yesNoFormValueAsBoolean(values.dsnpContract),
                 submissionType:
                     draftSubmission.draftRevision.formData.submissionType,
                 statutoryRegulatoryAttestation: formatYesNoForProto(
@@ -1314,6 +1314,7 @@ export const ContractDetails = ({
                                                                 '/help#dual-eligible-special-needs-plans'
                                                             }
                                                             target="_blank"
+                                                            data-testid="dsnpGuidanceLink"
                                                         >
                                                             D-SNP guidance
                                                         </LinkWithLogging>

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -1311,7 +1311,7 @@ export const ContractDetails = ({
                                                         <LinkWithLogging
                                                             variant="external"
                                                             href={
-                                                                'https://mc-review-dev.onemac.cms.gov/help#dual-eligible-special-needs-plans'
+                                                                '/help#dual-eligible-special-needs-plans'
                                                             }
                                                             target="_blank"
                                                         >

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -1314,6 +1314,9 @@ export const ContractDetails = ({
                                                             className={
                                                                 styles.requiredOptionalText
                                                             }
+                                                            style={{
+                                                                color: '#1B1B1B',
+                                                            }}
                                                         >
                                                             See 42 CFR § 422.2
                                                         </span>

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetailsSchema.ts
@@ -53,7 +53,7 @@ export const ContractDetailsFormSchema = (
         }
     }
 
-    // Errors in the error summary is ordered by the position of each ket in the yup object.
+    // Errors in the error summary is ordered by the position of each key in the yup object.
     return Yup.object().shape({
         statutoryRegulatoryAttestation: activeFeatureFlags['438-attestation']
             ? Yup.string().defined('You must select yes or no')
@@ -120,6 +120,11 @@ export const ContractDetailsFormSchema = (
                     : Boolean(value && value.length > 0)
             }
         ),
+        dsnpContract: Yup.string().when('federalAuthorities', {
+            is: (authorities: string[]) => authorities.some(type => ['VOLUNTARY', 'WAIVER_1115', 'WAIVER_1915B', 'STATE_PLAN'].includes(type)),
+            then: schema => schema.required('You must select yes or no'),
+            otherwise: schema => schema.notRequired()
+        }),
         inLieuServicesAndSettings: yesNoError('inLieuServicesAndSettings'),
         modifiedBenefitsProvided: yesNoError('modifiedBenefitsProvided'),
         modifiedGeoAreaServed: yesNoError('modifiedGeoAreaServed'),

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
@@ -246,6 +246,8 @@ export const SubmissionType = ({
                     federalAuthorities:
                         draftSubmission.draftRevision.formData
                             .federalAuthorities,
+                    dsnpContract:
+                        draftSubmission.draftRevision.formData.dsnpContract,
                     contractDocuments:
                         draftSubmission.draftRevision.formData
                             .contractDocuments,

--- a/services/cypress/support/stateSubmissionFormCommands.ts
+++ b/services/cypress/support/stateSubmissionFormCommands.ts
@@ -218,7 +218,11 @@ Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
         .blur()
     cy.findByLabelText('Managed Care Organization (MCO)').check({force: true})
     cy.findByLabelText('1932(a) State Plan Authority').check({force: true})
-
+    cy.findByText('Is this contract associated with a Dual-Eligible Special Needs Plan (D-SNP) that covers Medicaid benefits?')
+    .parent()
+    .within(() => {
+        cy.findByText('Yes').click()
+    })
     // fill out the yes/nos
     cy.findByText('In Lieu-of Services and Settings (ILOSs) in accordance with 42 CFR § 438.3(e)(2)')
     .parent()

--- a/services/cypress/support/stateSubmissionFormCommands.ts
+++ b/services/cypress/support/stateSubmissionFormCommands.ts
@@ -130,6 +130,11 @@ Cypress.Commands.add('fillOutBaseContractDetails', () => {
         .blur()
     cy.findByLabelText('Managed Care Organization (MCO)').check({force: true})
     cy.findByLabelText('1932(a) State Plan Authority').check({force: true})
+    cy.findByText('Is this contract associated with a Dual-Eligible Special Needs Plan (D-SNP) that covers Medicaid benefits?')
+    .parent()
+    .within(() => {
+        cy.findByText('Yes').click()
+    })
     cy.findAllByTestId('file-input-input').should('have.length', 2)
     cy.findAllByTestId('file-input-input').each((fileInput) =>
         cy.wrap(fileInput).attachFile(


### PR DESCRIPTION
## Summary
Add a new required field to the Contract Details form that displays conditionally when a triggering waiver is selected. The field asks whether the contract is associated with a Dual-Eligible Special Needs Plan (D-SNP) that covers Medicaid benefits.

Acceptance Criteria:

- Field displays if user selects any of the triggering waivers. 
- Question: “Is this contract associated with a Dual-Eligible Special Needs Plan (D-SNP) that covers Medicaid benefits?”
- Response options: Yes / No (radio buttons)
- Update the [help page](https://www.figma.com/design/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?node-id=20786-5084&t=SJBmfDxZxSY4CBcH-4) and add link under field per designs
- Field is required when shown.

#### Related issues
[MCR-5363](https://jiraent.cms.gov/browse/MCR-5363)
#### Screenshots

https://github.com/user-attachments/assets/a9fc0002-5d37-4b0e-9a97-b67eff22dbef


#### Test cases covered
1. test added for dsnp field behavior
<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
1. Start a new state form
2. navigate to contract details page
3. Select one of the following: 1932(a) State Plan Authority, 1915(b) Waiver Authority, 1115 Waiver Authority, 1915(a) Voluntary Authority
4. Expect new dsnp field to render

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed