### PR TITLE
Bump @prisma/client from 5.17.0 to 5.21.1 in the prisma group

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,8 +386,8 @@ importers:
         specifier: ^1.30.0
         version: 1.30.0
       '@prisma/client':
-        specifier: ^5.17.0
-        version: 5.17.0(prisma@5.17.0)
+        specifier: ^5.21.1
+        version: 5.22.0(prisma@5.17.0)
       apollo-server-core:
         specifier: ^3.11.1
         version: 3.13.0(encoding@0.1.13)(graphql@16.9.0)
@@ -814,7 +814,7 @@ importers:
         version: 6.21.0(eslint@8.57.0)(typescript@4.9.5)
       '@vitest/coverage-v8':
         specifier: ^3.1.1
-        version: 3.1.1(vitest@3.0.7)
+        version: 3.1.1(vitest@3.0.7(@types/node@20.14.12)(@vitest/ui@2.1.9)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.43.1)(tsx@4.19.3)(yaml@2.8.0))
       '@vitest/ui':
         specifier: ^2.1.9
         version: 2.1.9(vitest@3.0.7)
@@ -829,7 +829,7 @@ importers:
         version: 10.1.5(eslint@8.57.0)
       eslint-plugin-jest:
         specifier: ^27.0.1
-        version: 27.9.0(@typescript-eslint/eslint-plugin@8.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 27.9.0(@typescript-eslint/eslint-plugin@8.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(jest@29.7.0(@types/node@20.14.12))(typescript@4.9.5)
       eslint-plugin-jsx-a11y:
         specifier: ^6.5.1
         version: 6.8.0(eslint@8.57.0)
@@ -1006,8 +1006,8 @@ importers:
         specifier: ^3.840.0
         version: 3.840.0
       '@prisma/client':
-        specifier: ^5.17.0
-        version: 5.17.0(prisma@5.17.0)
+        specifier: ^5.21.1
+        version: 5.22.0(prisma@5.17.0)
       pg:
         specifier: ^8.13.1
         version: 8.13.1
@@ -5307,8 +5307,8 @@ packages:
   '@polka/url@1.0.0-next.25':
     resolution: {integrity: sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==}
 
-  '@prisma/client@5.17.0':
-    resolution: {integrity: sha512-N2tnyKayT0Zf7mHjwEyE8iG7FwTmXDHFZ1GnNhQp0pJUObsuel4ZZ1XwfuAYkq5mRIiC/Kot0kt0tGCfLJ70Jw==}
+  '@prisma/client@5.22.0':
+    resolution: {integrity: sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==}
     engines: {node: '>=16.13'}
     peerDependencies:
       prisma: '*'
@@ -20416,7 +20416,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5))':
+  '@jest/core@29.7.0':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -20430,7 +20430,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5))
+      jest-config: 29.7.0(@types/node@20.17.24)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -21675,7 +21675,7 @@ snapshots:
 
   '@polka/url@1.0.0-next.25': {}
 
-  '@prisma/client@5.17.0(prisma@5.17.0)':
+  '@prisma/client@5.22.0(prisma@5.17.0)':
     optionalDependencies:
       prisma: 5.17.0
 
@@ -23494,6 +23494,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@3.1.1(vitest@3.0.7(@types/node@20.14.12)(@vitest/ui@2.1.9)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.43.1)(tsx@4.19.3)(yaml@2.8.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      debug: 4.4.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.1.7
+      magic-string: 0.30.17
+      magicast: 0.3.5
+      std-env: 3.9.0
+      test-exclude: 7.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.0.7(@types/node@20.14.12)(@vitest/ui@2.1.9)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.43.1)(tsx@4.19.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/coverage-v8@3.1.1(vitest@3.0.7(@types/node@20.17.24)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.43.1)(tsx@4.19.3)(yaml@2.8.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -23509,24 +23527,6 @@ snapshots:
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
       vitest: 3.0.7(@types/node@20.17.24)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.43.1)(tsx@4.19.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@vitest/coverage-v8@3.1.1(vitest@3.0.7)':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@bcoe/v8-coverage': 1.0.2
-      debug: 4.4.0
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
-      istanbul-reports: 3.1.7
-      magic-string: 0.30.17
-      magicast: 0.3.5
-      std-env: 3.9.0
-      test-exclude: 7.0.1
-      tinyrainbow: 2.0.0
-      vitest: 3.0.7(@types/node@20.14.12)(@vitest/ui@2.1.9)(jiti@1.21.0)(jsdom@25.0.1)(sass@1.77.2)(terser@5.43.1)(tsx@4.19.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -25176,13 +25176,13 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 4.5.2
 
-  create-jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5)):
+  create-jest@29.7.0(@types/node@20.14.12):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5))
+      jest-config: 29.7.0(@types/node@20.14.12)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -25897,13 +25897,13 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@8.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5)))(typescript@4.9.5):
+  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@8.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(jest@29.7.0(@types/node@20.14.12))(typescript@4.9.5):
     dependencies:
       '@typescript-eslint/utils': 5.57.0(eslint@8.57.0)(typescript@4.9.5)
       eslint: 8.57.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5)
-      jest: 29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5))
+      jest: 29.7.0(@types/node@20.14.12)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -27361,16 +27361,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5)):
+  jest-cli@29.7.0(@types/node@20.14.12):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5))
+      '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5))
+      create-jest: 29.7.0(@types/node@20.14.12)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5))
+      jest-config: 29.7.0(@types/node@20.14.12)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -27419,7 +27419,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5)):
+  jest-config@29.7.0(@types/node@20.14.12):
     dependencies:
       '@babel/core': 7.24.7
       '@jest/test-sequencer': 29.7.0
@@ -27445,7 +27445,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.12
-      ts-node: 10.9.2(@types/node@20.14.12)(typescript@4.9.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -27482,7 +27481,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5)):
+  jest-config@29.7.0(@types/node@20.17.24):
     dependencies:
       '@babel/core': 7.24.7
       '@jest/test-sequencer': 29.7.0
@@ -27508,7 +27507,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.17.24
-      ts-node: 10.9.2(@types/node@20.14.12)(typescript@4.9.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -27805,12 +27803,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5)):
+  jest@29.7.0(@types/node@20.14.12):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5))
+      '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5))
+      jest-cli: 29.7.0(@types/node@20.14.12)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -31236,25 +31234,6 @@ snapshots:
       webpack: 5.93.0(esbuild@0.25.4)
 
   ts-log@2.2.4: {}
-
-  ts-node@10.9.2(@types/node@20.14.12)(typescript@4.9.5):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.14.12
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.9.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
 
   ts-node@10.9.2(@types/node@20.16.5)(typescript@5.5.4):
     dependencies:

--- a/services/app-api/package.json
+++ b/services/app-api/package.json
@@ -50,7 +50,7 @@
         "@opentelemetry/sdk-trace-base": "^1.30.1",
         "@opentelemetry/sdk-trace-node": "^1.30.1",
         "@opentelemetry/semantic-conventions": "^1.30.0",
-        "@prisma/client": "^5.17.0",
+        "@prisma/client": "^5.21.1",
         "apollo-server-core": "^3.11.1",
         "apollo-server-lambda": "^3.5.0",
         "apollo-server-types": "^3.8.0",

--- a/services/postgres/package.json
+++ b/services/postgres/package.json
@@ -25,7 +25,7 @@
         "@aws-sdk/client-secrets-manager": "^3.840.0",
         "@aws-sdk/client-s3": "^3.842.0",
         "pg": "^8.13.1",
-        "@prisma/client": "^5.17.0",
+        "@prisma/client": "^5.21.1",
         "prisma": "^5.17.0"
     }
 }


### PR DESCRIPTION
NOTE: Recreated this [PR](https://github.com/Enterprise-CMCS/managed-care-review/pull/3466) due to CI issues. Creating a new PR from a new branch creates new resources so that should fix the error. Fastest way I could fix CI issues.

Bumps the prisma group with 1 update: [@prisma/client](https://github.com/prisma/prisma/tree/HEAD/packages/client).

Updates `@prisma/client` from 5.17.0 to 5.21.1
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/prisma/prisma/releases"><code>@​prisma/client</code>'s releases</a>.</em></p>
<blockquote>
<h2>5.21.1</h2>
<ul>
<li>Fixed a bug where migrations were not using shadow database correctly in some edge cases</li>
</ul>
<h2>5.21.0</h2>
<p>Today, we are excited to share the <code>5.21.0</code> release 🎉</p>
<p>🌟 <strong>Help us spread the word about Prisma by starring the repo ☝️ or <a href="https://twitter.com/intent/tweet?text=Check%20out%20the%20latest%20@prisma%20release%20v5.21.0%20%F0%9F%9A%80%0D%0A%0D%0Ahttps://github.com/prisma/prisma/releases/tag/5.21.0">posting on X</a> about the release.</strong></p>
<h2>Highlights</h2>
<h3>Better support for tracing in MongoDB</h3>
<p>The <code>tracing</code> Preview feature now has full support for MongoDB with previously missing functionality now implemented. This is a part of the ongoing effort to stabilize this Preview feature and release it in General Availability.</p>
<p><code>tracing</code> is a Preview feature that enables built-in support for OpenTelemetry instrumentation inside the Prisma Client and provides deep insights into the performance and timing of your queries. See our <a href="https://www.prisma.io/docs/orm/prisma-client/observability-and-logging/opentelemetry-tracing">documentation for more information</a>.</p>
<p>For an easy to use and zero-configuration tracing instrumentation tool with a dashboard that provides an overview of your queries, statistics, and AI-powered recommendations, try <a href="https://pris.ly/gh/optimize">Prisma Optimize</a>.</p>
<h3>WebAssembly engine size decrease for edge functions</h3>
<p>Due to recent changes, some users experienced a steep increase of the bundle size in Prisma 5.20 when using <a href="https://www.prisma.io/docs/orm/overview/databases/database-drivers#driver-adapters">the <code>driverAdapters</code> Preview feature</a>, going over the 1 MB limit on the free tier of Cloudflare Workers. This has now been fixed.</p>
<h2>Fixes and improvements</h2>
<h3>Prisma Engines</h3>
<ul>
<li><a href="https://redirect.github.com/prisma/prisma-engines/issues/5008">Avoid regex crate for wasm bundle size (to keep cloudflare free plan)</a></li>
</ul>
<h2>Credits</h2>
<p>Huge thanks to <a href="https://github.com/austin-tildei"><code>@​austin-tildei</code></a>, <a href="https://github.com/LucianBuzzo"><code>@​LucianBuzzo</code></a>, <a href="https://github.com/mcuelenaere"><code>@​mcuelenaere</code></a>, <a href="https://github.com/pagewang0"><code>@​pagewang0</code></a>, <a href="https://github.com/key-moon"><code>@​key-moon</code></a>, <a href="https://github.com/pranayat"><code>@​pranayat</code></a>, <a href="https://github.com/yubrot"><code>@​yubrot</code></a>, <a href="https://github.com/skyzh"><code>@​skyzh</code></a> for helping!</p>
<h2>5.20.0</h2>
<p>🌟 <strong>Help us spread the word about Prisma by starring the repo or <a href="https://twitter.com/intent/tweet?text=Check%20out%20the%20latest%20@prisma%20release%20v5.20.0%20%F0%9F%9A%80%0D%0A%0D%0Ahttps://github.com/prisma/prisma/releases/tag/5.20.0">posting on X</a> about the release.</strong> 🌟</p>
<h2>Highlights</h2>
<h3><code>strictUndefinedChecks</code> in Preview</h3>
<p>With Prisma ORM 5.20.0, the Preview feature <code>strictUndefinedChecks</code> will disallow any value that is explicitly <code>undefined</code> and will be a runtime error. This change is direct feedback from <a href="https://redirect.github.com/prisma/prisma/issues/20169">this GitHub issue</a> and follows <a href="https://redirect.github.com/prisma/prisma/issues/20169#issuecomment-2338360300">our latest proposal</a> on the same issue.</p>
<p>To demonstrate the change, take the following code snippet:</p>
<pre lang="tsx"><code>prisma.table.deleteMany({
  where: {
    // If `nullableThing` is nullish, this query will remove all data.
    email: nullableThing?.property,
  }
})
&lt;/tr&gt;&lt;/table&gt; 
</code></pre>
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/prisma/prisma/commit/a9dd792ade61ffa5ad283da56f0c1f1eaac2eff4"><code>a9dd792</code></a> chore(deps): patch 5.21.x 5.21.1-1.bf0e5e8a04cada8225617067eaa03d041e2bba36 (...</li>
<li><a href="https://github.com/prisma/prisma/commit/6819678dd575677ccd5c6a72ea51f8421f6a82ce"><code>6819678</code></a> chore(deps): update engines to 5.21.0-36.08713a93b99d58f31485621c634b04983ae0...</li>
<li><a href="https://github.com/prisma/prisma/commit/b11a6c247157cf853d6e3de7099301879d254949"><code>b11a6c2</code></a> feat(client): Support prisma+postgres URL scheme for postgres migrations (<a href="https://github.com/prisma/prisma/tree/HEAD/packages/client/issues/25">#25</a>...</li>
<li><a href="https://github.com/prisma/prisma/commit/5c59fac505da65989bf2d90e5fcfedb1d7b70014"><code>5c59fac</code></a> chore(deps): update engines to 5.21.0-33.edd552ca6fe6bb4ebbfe57bafc00a55aef8e...</li>
<li><a href="https://github.com/prisma/prisma/commit/6792f13a07bff447ab219b8bde0275d3a1ee4989"><code>6792f13</code></a> test(e2e): bumped &quot;<code>@​prisma/extension-accelerate</code>&quot; to 1.2.1, fix failing e2e te...</li>
<li><a href="https://github.com/prisma/prisma/commit/7aae7ec2146f03c58a639f69dfe48f093e1e8250"><code>7aae7ec</code></a> chore(deps): update engines to 5.21.0-32.6a192e231962f2731353b2df0d76ad5a1227...</li>
<li><a href="https://github.com/prisma/prisma/commit/9952c28e2b087d203adcdd16929ffe2f95cbdf03"><code>9952c28</code></a> test(client): add count and aggregate tracing tests (<a href="https://github.com/prisma/prisma/tree/HEAD/packages/client/issues/25385">#25385</a>)</li>
<li><a href="https://github.com/prisma/prisma/commit/d43178ae011a7ecd9b4e73c014380ac8c706c837"><code>d43178a</code></a> chore(deps): update engines to 5.21.0-31.00f0d739277ee51ca227615ad3f1c4c36eea...</li>
<li><a href="https://github.com/prisma/prisma/commit/4c6498fe8abfb8dc224fe13ae7e5c1d24e933b4c"><code>4c6498f</code></a> chore(client): remove dead code in fixtures/generate.ts (<a href="https://github.com/prisma/prisma/tree/HEAD/packages/client/issues/25351">#25351</a>)</li>
<li><a href="https://github.com/prisma/prisma/commit/f19a3e28a37327eb0a5e45941c0e4abf3dbab136"><code>f19a3e2</code></a> chore(deps): update engines to 5.21.0-8.031f4d3fc290d071071bf02083dc6e7b78346...</li>
<li>Additional commits viewable in <a href="https://github.com/prisma/prisma/commits/5.21.1/packages/client">compare view</a></li>
</ul>
</details>
<br />

<details>
<summary>Most Recent Ignore Conditions Applied to This Pull Request</summary>

| Dependency Name | Ignore Conditions |
| --- | --- |
| @prisma/client | [>= 4.13.a, < 4.14] |
| @prisma/client | [>= 6.a, < 7] |
| @prisma/client | [>= 5.22.a, < 5.23] |
</details>
