### PR TITLE
Bump max file size for zips

### DIFF
--- a/services/app-api/src/zip/generateZip.ts
+++ b/services/app-api/src/zip/generateZip.ts
@@ -16,6 +16,9 @@ const s3Client = new S3Client({
     region: process.env.AWS_REGION || 'us-east-1',
 })
 
+// Maximum total size for document zip packages (1.5GB)
+const MAX_ZIP_SIZE_BYTES = 1536 * 1024 * 1024
+
 /**
  * Extracts bucket name from S3 URL
  */
@@ -72,7 +75,7 @@ export async function generateDocumentZip(
     outputPath: string,
     options = {
         batchSize: 50,
-        maxTotalSize: 1024 * 1024 * 1024, // 1GB default limit
+        maxTotalSize: MAX_ZIP_SIZE_BYTES,
         baseTimeout: 120000,
         timeoutPerMB: 1000,
     }


### PR DESCRIPTION
## Summary

There is a contract in val that is causing the migration script to fail, as it is right on the edge of the max filesize. This bumps the value to 1.5GB in order to get us under that for this one CA contract. 

Note: val uses a bunch of generated test documents, so I think that's why this particular contract is so big. The submission that corresponds to this in prod is a little bit smaller.