### PR TITLE
Refactor document zip as resolver dependency

### DIFF
--- a/services/app-api/src/handlers/apollo_gql.ts
+++ b/services/app-api/src/handlers/apollo_gql.ts
@@ -36,6 +36,11 @@ import {
 } from 'apollo-server-core'
 import { newDeployedS3Client, newLocalS3Client } from '../s3'
 import type { S3ClientT, S3BucketConfigType } from '../s3'
+import {
+    documentZipService,
+    generateDocumentZip,
+    localGenerateDocumentZip,
+} from '../zip/generateZip'
 
 let ldClient: LDClient
 let s3Client: S3ClientT
@@ -329,6 +334,11 @@ async function initializeGQLHandler(): Promise<Handler> {
         s3Client = newDeployedS3Client(S3_BUCKETS_CONFIG, region)
     }
 
+    // Service for zipping documents
+    const generateDocZip =
+        authMode === 'LOCAL' ? localGenerateDocumentZip : generateDocumentZip
+    const documentZip = documentZipService(store, generateDocZip)
+
     // Print out all the variables we've been configured with. Leave sensitive ones out, please.
     console.info('Running With Config: ', {
         authMode,
@@ -348,7 +358,8 @@ async function initializeGQLHandler(): Promise<Handler> {
         launchDarkly,
         jwtLib,
         s3Client,
-        applicationEndpoint
+        applicationEndpoint,
+        documentZip
     )
 
     const userFetcher =

--- a/services/app-api/src/resolvers/configureResolvers.ts
+++ b/services/app-api/src/resolvers/configureResolvers.ts
@@ -70,6 +70,7 @@ import {
     deleteOauthClientResolver,
     updateOauthClientResolver,
 } from './oauthClient'
+import type { DocumentZipService } from '../zip/generateZip'
 
 export function configureResolvers(
     store: Store,
@@ -77,7 +78,8 @@ export function configureResolvers(
     launchDarkly: LDService,
     jwt: JWTLib,
     s3Client: S3ClientT,
-    applicationEndpoint: string
+    applicationEndpoint: string,
+    documentZip: DocumentZipService
 ): Resolvers {
     const resolvers: Resolvers = {
         Date: GraphQLDate,
@@ -106,7 +108,12 @@ export function configureResolvers(
                 store,
                 launchDarkly
             ),
-            submitContract: submitContract(store, emailer, launchDarkly),
+            submitContract: submitContract(
+                store,
+                emailer,
+                launchDarkly,
+                documentZip
+            ),
             unlockHealthPlanPackage: unlockHealthPlanPackageResolver(
                 store,
                 emailer
@@ -140,7 +147,7 @@ export function configureResolvers(
             ),
             createAPIKey: createAPIKeyResolver(jwt),
             unlockRate: unlockRate(store),
-            submitRate: submitRate(store, launchDarkly),
+            submitRate: submitRate(store, launchDarkly, documentZip),
             updateEmailSettings: updateEmailSettings(store),
             createOauthClient: createOauthClientResolver(store),
             deleteOauthClient: deleteOauthClientResolver(store),

--- a/services/app-api/src/resolvers/contract/submitContract.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.ts
@@ -17,13 +17,7 @@ import {
 } from '../attributeHelper'
 import type { MutationResolvers, State } from '../../gen/gqlServer'
 import { parseContract } from '../../domain-models/contractAndRates/dataValidatorHelpers'
-import type {
-    UpdateInfoType,
-    PackageStatusType,
-    ContractType,
-    ContractRevisionType,
-    RateRevisionType,
-} from '../../domain-models'
+import type { UpdateInfoType, PackageStatusType } from '../../domain-models'
 import type { UpdateDraftContractRatesArgsType } from '../../postgres/contractAndRates/updateDraftContractRates'
 import type { StateCodeType } from '@mc-review/hpp'
 import type { Span } from '@opentelemetry/api'
@@ -33,8 +27,8 @@ import {
     generateApplicableProvisionsList,
 } from '../../domain-models/contractAndRates'
 import type { GeneralizedModifiedProvisions } from '@mc-review/hpp'
-import { generateDocumentZip } from '../../zip'
 import { canWrite } from '../../authorization/oauthAuthorization'
+import type { DocumentZipService } from '../../zip/generateZip'
 
 const validateStatusAndUpdateInfo = (
     status: PackageStatusType,
@@ -63,7 +57,8 @@ const validateStatusAndUpdateInfo = (
 export function submitContract(
     store: Store,
     emailer: Emailer,
-    launchDarkly: LDService
+    launchDarkly: LDService,
+    documentZip: DocumentZipService
 ): MutationResolvers['submitContract'] {
     return async (_parent, { input }, context) => {
         const featureFlags = await launchDarkly.allFlags({
@@ -371,8 +366,7 @@ export function submitContract(
         }
 
         // Generate zips!
-        const contractZipRes = await createContractZips(
-            store,
+        const contractZipRes = await documentZip.createContractZips(
             submitContractResult,
             span
         )
@@ -382,8 +376,7 @@ export function submitContract(
             setErrorAttributesOnActiveSpan(errMessage, span)
         }
 
-        const rateZipRes = await createRateZips(
-            store,
+        const rateZipRes = await documentZip.createRateZips(
             submitContractResult,
             span
         )
@@ -498,311 +491,5 @@ export function submitContract(
         logSuccess('submitContract')
         setSuccessAttributesOnActiveSpan(span)
         return { contract: submitContractResult }
-    }
-}
-
-/**
- * Helper function to generate and store zip files for contract documents
- *
- * @param store Prisma store instance
- * @param contractRevision The contract revision with documents to zip
- * @param span Optional OpenTelemetry span for tracing
- * @returns void if successful, Error if something failed
- */
-export async function generateContractDocumentsZip(
-    store: Store,
-    contractRevision: ContractRevisionType,
-    span?: Span
-): Promise<void | Error> {
-    const contractRevisionID = contractRevision.id
-    const contractDocuments = contractRevision.formData.contractDocuments
-
-    if (!contractDocuments || contractDocuments.length === 0) {
-        // No documents to zip
-        return
-    }
-
-    try {
-        // Create an S3 key (destination path) for the zip file. This is where
-        // we are storing it in the S3 bucket.
-        const s3DestinationKey = `zips/contracts/${contractRevisionID}/contract-documents.zip`
-
-        // Generate the zip file and upload it to S3
-        const zipResult = await generateDocumentZip(
-            contractDocuments,
-            s3DestinationKey
-        )
-
-        if (zipResult instanceof Error) {
-            // Return the error to the caller
-            logError('generateContractDocumentsZip', zipResult)
-            if (span) {
-                setErrorAttributesOnActiveSpan(
-                    'contract documents zip generation failed',
-                    span
-                )
-            }
-            return zipResult
-        }
-
-        // Store zip information in database
-        const createResult = await store.createDocumentZipPackage({
-            s3URL: zipResult.s3URL,
-            sha256: zipResult.sha256,
-            contractRevisionID,
-            documentType: 'CONTRACT_DOCUMENTS',
-        })
-
-        if (createResult instanceof Error) {
-            logError(
-                'generateContractDocumentsZip - database storage failed',
-                createResult
-            )
-            if (span) {
-                setErrorAttributesOnActiveSpan(
-                    'contract documents zip database storage failed',
-                    span
-                )
-            }
-            return createResult
-        }
-
-        console.info(
-            `Successfully generated zip for contract documents: ${zipResult.s3URL}`
-        )
-        return
-    } catch (error: unknown) {
-        const errorMessage =
-            error instanceof Error ? error.message : String(error)
-        const err = new Error(
-            `Unexpected error in generateContractDocumentsZip: ${errorMessage}`
-        )
-        logError('generateContractDocumentsZip', err)
-        if (span) {
-            setErrorAttributesOnActiveSpan(
-                'contract documents zip generation failed',
-                span
-            )
-        }
-        return err
-    }
-}
-
-export async function createContractZips(
-    store: Store,
-    submitContractResult: ContractType,
-    span?: Span
-): Promise<void | Error> {
-    const contractRevision =
-        submitContractResult.packageSubmissions[0]?.contractRevision
-
-    if (!contractRevision) {
-        return
-    }
-
-    // Only attempt to generate zip if there are actually documents to zip
-    if (
-        contractRevision.formData.contractDocuments &&
-        contractRevision.formData.contractDocuments.length > 0
-    ) {
-        console.info(
-            `Generating zip for ${contractRevision.formData.contractDocuments.length} contract documents for contract revision ${contractRevision.id}`
-        )
-
-        const zipResult = await generateContractDocumentsZip(
-            store,
-            contractRevision,
-            span
-        )
-
-        if (zipResult instanceof Error) {
-            const errorWithContext = new Error(
-                `Contract document zip generation failed for revision ${contractRevision.id}: ${zipResult.message}`
-            )
-
-            logError(
-                'createContractZips - contract documents zip generation failed',
-                errorWithContext
-            )
-            setErrorAttributesOnActiveSpan(
-                'contract documents zip generation failed',
-                span
-            )
-            console.warn(
-                `Contract document zip generation failed for revision ${contractRevision.id}, but continuing with submission process`
-            )
-
-            return errorWithContext
-        } else {
-            console.info(
-                `Successfully generated contract document zip for revision ${contractRevision.id}`
-            )
-        }
-    } else {
-        console.info(
-            `No contract documents found for revision ${contractRevision.id}, skipping zip generation`
-        )
-    }
-    return
-}
-
-export async function createRateZips(
-    store: Store,
-    submitContractResult: ContractType,
-    span?: Span
-): Promise<void | Error[]> {
-    if (!submitContractResult.packageSubmissions[0]?.rateRevisions) {
-        return
-    }
-
-    const rateRevisions =
-        submitContractResult.packageSubmissions[0].rateRevisions
-    const errors: Error[] = []
-
-    for (const rateRev of rateRevisions) {
-        // Only attempt to generate a zip if there are actually documents to zip
-        const hasRateDocuments =
-            rateRev.formData.rateDocuments &&
-            rateRev.formData.rateDocuments.length > 0
-        const hasSupportingDocuments =
-            rateRev.formData.supportingDocuments &&
-            rateRev.formData.supportingDocuments.length > 0
-
-        if (hasRateDocuments || hasSupportingDocuments) {
-            const totalDocs =
-                (rateRev.formData.rateDocuments?.length || 0) +
-                (rateRev.formData.supportingDocuments?.length || 0)
-
-            console.info(
-                `Generating zip for ${totalDocs} rate documents for rate revision ${rateRev.id}`
-            )
-
-            const zipResult = await generateRateDocumentsZip(
-                store,
-                rateRev,
-                span
-            )
-
-            if (zipResult instanceof Error) {
-                const errorWithContext = new Error(
-                    `Rate document zip generation failed for revision ${rateRev.id}: ${zipResult.message}`
-                )
-                errors.push(errorWithContext)
-
-                logError(
-                    'createRateZips - rate documents zip generation failed',
-                    errorWithContext
-                )
-                setErrorAttributesOnActiveSpan(
-                    'rate documents zip generation failed',
-                    span
-                )
-                console.warn(
-                    `Rate document zip generation failed for revision ${rateRev.id}, but continuing with other revisions`
-                )
-            } else {
-                console.info(
-                    `Successfully generated rate document zip for revision ${rateRev.id}`
-                )
-            }
-        } else {
-            console.info(
-                `No rate documents found for rate revision ${rateRev.id}, skipping zip generation`
-            )
-        }
-    }
-
-    // Return errors if any occurred, otherwise return void
-    return errors.length > 0 ? errors : undefined
-}
-
-/**
- * Helper function to generate and store zip files for rate documents
- *
- * @param store Prisma store instance
- * @param rateRevision The rate revision with documents to zip
- * @param span Optional OpenTelemetry span for tracing
- * @returns void if successful, Error if something failed
- */
-export async function generateRateDocumentsZip(
-    store: Store,
-    rateRevision: RateRevisionType,
-    span?: Span
-): Promise<void | Error> {
-    const rateRevisionID = rateRevision.id
-
-    // Get all rate-related documents
-    // Adapt these field names as needed based on your actual data structure
-    const rateDocuments = [
-        ...(rateRevision.formData.rateDocuments || []),
-        ...(rateRevision.formData.supportingDocuments || []),
-    ]
-
-    if (!rateDocuments || rateDocuments.length === 0) {
-        // No documents to zip
-        return
-    }
-
-    try {
-        // Create an S3 key (destination path) for the zip file
-        const s3DestinationKey = `zips/rates/${rateRevisionID}/rate-documents.zip`
-
-        // Generate the zip file and upload it to S3
-        const zipResult = await generateDocumentZip(
-            rateDocuments,
-            s3DestinationKey
-        )
-
-        if (zipResult instanceof Error) {
-            logError('generateRateDocumentsZip', zipResult)
-            if (span) {
-                setErrorAttributesOnActiveSpan(
-                    'rate documents zip generation failed',
-                    span
-                )
-            }
-            return zipResult
-        }
-
-        // Store zip information in database
-        const createResult = await store.createDocumentZipPackage({
-            s3URL: zipResult.s3URL,
-            sha256: zipResult.sha256,
-            rateRevisionID,
-            documentType: 'RATE_DOCUMENTS',
-        })
-
-        if (createResult instanceof Error) {
-            logError(
-                'generateRateDocumentsZip - database storage failed',
-                createResult
-            )
-            if (span) {
-                setErrorAttributesOnActiveSpan(
-                    'rate documents zip database storage failed',
-                    span
-                )
-            }
-            return createResult
-        }
-
-        console.info(
-            `Successfully generated zip for rate documents: ${zipResult.s3URL}`
-        )
-        return
-    } catch (error: unknown) {
-        const errorMessage =
-            error instanceof Error ? error.message : String(error)
-        const err = new Error(
-            `Unexpected error in generateRateDocumentsZip: ${errorMessage}`
-        )
-        logError('generateRateDocumentsZip', err)
-        if (span) {
-            setErrorAttributesOnActiveSpan(
-                'rate documents zip generation failed',
-                span
-            )
-        }
-        return err
     }
 }

--- a/services/app-api/src/resolvers/rate/submitRate.ts
+++ b/services/app-api/src/resolvers/rate/submitRate.ts
@@ -13,8 +13,8 @@ import type { LDService } from '../../launchDarkly/launchDarkly'
 import { generateRateCertificationName } from './generateRateCertificationName'
 import { findStatePrograms } from '@mc-review/hpp'
 import { nullsToUndefined } from '../../domain-models/nullstoUndefined'
-import { generateRateDocumentsZip } from '../contract/submitContract'
 import { canWrite } from '../../authorization/oauthAuthorization'
+import type { DocumentZipService } from '../../zip/generateZip'
 
 /*
     Submit rate will change a draft revision to submitted and generate a rate name if one is missing
@@ -22,7 +22,8 @@ import { canWrite } from '../../authorization/oauthAuthorization'
 */
 export function submitRate(
     store: Store,
-    launchDarkly: LDService
+    launchDarkly: LDService,
+    documentZip: DocumentZipService
 ): MutationResolvers['submitRate'] {
     return async (_parent, { input }, context) => {
         const { user, ctx, tracer } = context
@@ -221,10 +222,8 @@ export function submitRate(
         // generate zips
         const rateRevision = submittedRate.revisions[0]
         if (rateRevision) {
-            const zipResult = await generateRateDocumentsZip(
-                store,
-                rateRevision
-            )
+            const zipResult =
+                await documentZip.generateRateDocumentsZip(rateRevision)
             if (zipResult instanceof Error) {
                 // Log the error but don't fail the submission
                 logError(

--- a/services/app-api/src/resolvers/rate/submitRate.zipGeneration.test.ts
+++ b/services/app-api/src/resolvers/rate/submitRate.zipGeneration.test.ts
@@ -6,20 +6,20 @@ import {
     createSubmitAndUnlockTestRate,
     submitTestRate,
 } from '../../testHelpers/gqlRateHelpers'
-import { generateDocumentZip } from '../../zip'
+import {
+    documentZipService,
+    type GenerateDocumentZipFunctionType,
+} from '../../zip'
 import { vi } from 'vitest'
-
-// Mock the zip generation function
-vi.mock('../../zip')
-const mockGenerateDocumentZip = generateDocumentZip as vi.MockedFunction<
-    typeof generateDocumentZip
->
+import { sharedTestPrismaClient } from '../../testHelpers/storeHelpers'
+import { NewPostgresStore } from '../../postgres'
 
 describe('Rate Submission Zip Generation - Rate-Specific Scenarios', () => {
     const ldService = testLDService({
         'rate-edit-unlock': true,
     })
     const mockS3 = testS3Client()
+    const mockGenerateDocumentZip = vi.fn<GenerateDocumentZipFunctionType>()
 
     beforeEach(() => {
         vi.clearAllMocks()
@@ -33,15 +33,27 @@ describe('Rate Submission Zip Generation - Rate-Specific Scenarios', () => {
         it('generates zip for standalone rate resubmission (after unlock)', async () => {
             const stateUser = testStateUser()
             const cmsUser = testCMSUser()
+            const prismaClient = await sharedTestPrismaClient()
+            const postgresStore = NewPostgresStore(prismaClient)
+
+            const mockDocumentZipService = documentZipService(
+                postgresStore,
+                mockGenerateDocumentZip
+            )
+
             const stateServer = await constructTestPostgresServer({
                 context: { user: stateUser },
                 ldService,
                 s3Client: mockS3,
+                store: postgresStore,
+                documentZip: mockDocumentZipService,
             })
             const cmsServer = await constructTestPostgresServer({
                 context: { user: cmsUser },
                 ldService,
                 s3Client: mockS3,
+                store: postgresStore,
+                documentZip: mockDocumentZipService,
             })
 
             // Create, submit, and unlock a rate
@@ -87,15 +99,27 @@ describe('Rate Submission Zip Generation - Rate-Specific Scenarios', () => {
         it('combines rate documents and supporting documents in zip', async () => {
             const stateUser = testStateUser()
             const cmsUser = testCMSUser()
+            const prismaClient = await sharedTestPrismaClient()
+            const postgresStore = NewPostgresStore(prismaClient)
+
+            const mockDocumentZipService = documentZipService(
+                postgresStore,
+                mockGenerateDocumentZip
+            )
+
             const stateServer = await constructTestPostgresServer({
                 context: { user: stateUser },
                 ldService,
                 s3Client: mockS3,
+                store: postgresStore,
+                documentZip: mockDocumentZipService,
             })
             const cmsServer = await constructTestPostgresServer({
                 context: { user: cmsUser },
                 ldService,
                 s3Client: mockS3,
+                store: postgresStore,
+                documentZip: mockDocumentZipService,
             })
 
             const unlockedRate = await createSubmitAndUnlockTestRate(
@@ -131,15 +155,27 @@ describe('Rate Submission Zip Generation - Rate-Specific Scenarios', () => {
         it('uses correct S3 destination path for standalone rate resubmission', async () => {
             const stateUser = testStateUser()
             const cmsUser = testCMSUser()
+            const prismaClient = await sharedTestPrismaClient()
+            const postgresStore = NewPostgresStore(prismaClient)
+
+            const mockDocumentZipService = documentZipService(
+                postgresStore,
+                mockGenerateDocumentZip
+            )
+
             const stateServer = await constructTestPostgresServer({
                 context: { user: stateUser },
                 ldService,
                 s3Client: mockS3,
+                store: postgresStore,
+                documentZip: mockDocumentZipService,
             })
             const cmsServer = await constructTestPostgresServer({
                 context: { user: cmsUser },
                 ldService,
                 s3Client: mockS3,
+                store: postgresStore,
+                documentZip: mockDocumentZipService,
             })
 
             const unlockedRate = await createSubmitAndUnlockTestRate(

--- a/services/app-api/src/s3/s3Client.d.ts
+++ b/services/app-api/src/s3/s3Client.d.ts
@@ -1,5 +1,6 @@
 import type { BucketShortName } from './s3Amplify'
 import type { S3Error } from './s3Error'
+import type { GenerateDocumentZipFunctionType } from '../zip/generateZip'
 
 export type S3ClientT = {
     uploadFile: (
@@ -19,4 +20,5 @@ export type S3ClientT = {
         filename: string,
         bucket: BucketShortName
     ) => Promise<string | Error>
+    generateDocumentZip: GenerateDocumentZipFunctionType
 }

--- a/services/app-api/src/zip/generateZip.ts
+++ b/services/app-api/src/zip/generateZip.ts
@@ -11,6 +11,14 @@ import * as crypto from 'crypto'
 import Archiver from 'archiver'
 import { pipeline } from 'stream/promises'
 import { logError } from '../logger'
+import type { Store } from '../postgres'
+import type {
+    ContractRevisionType,
+    ContractType,
+    RateRevisionType,
+} from '../domain-models'
+import type { Span } from '@opentelemetry/api'
+import { setErrorAttributesOnActiveSpan } from '../resolvers/attributeHelper'
 
 const s3Client = new S3Client({
     region: process.env.AWS_REGION || 'us-east-1',
@@ -62,26 +70,46 @@ export function extractS3Key(s3URL: string): string | Error {
     }
 }
 
+export type GenerateDocumentZipFunctionType = (
+    documents: Array<{ s3URL: string; name: string; sha256?: string }>,
+    outputPath: string,
+    options?: Partial<{
+        batchSize: number
+        maxTotalSize: number
+        baseTimeout: number
+        timeoutPerMB: number
+    }>
+) => Promise<{ s3URL: string; sha256: string } | Error>
+
 /**
  * Generates a zip file containing the provided documents and uploads it to S3
  * Reimplemented from our zip lambda handler, bulk_downloads.ts
  *
  * @param documents Array of document information with s3URLs
  * @param outputPath The S3 path where the zip file should be stored
+ * @param options Configuration options for zip generation
  * @returns Object with the S3 URL and SHA256 hash of the generated zip, or Error
  */
-export async function generateDocumentZip(
-    documents: Array<{ s3URL: string; name: string; sha256?: string }>,
-    outputPath: string,
+export const generateDocumentZip: GenerateDocumentZipFunctionType = async (
+    documents,
+    outputPath,
     options = {
         batchSize: 50,
         maxTotalSize: MAX_ZIP_SIZE_BYTES,
         baseTimeout: 120000,
         timeoutPerMB: 1000,
     }
-): Promise<{ s3URL: string; sha256: string } | Error> {
+) => {
     if (documents.length === 0) {
         return new Error('No documents provided for zip generation')
+    }
+
+    const mergedOptions = {
+        batchSize: 50,
+        maxTotalSize: MAX_ZIP_SIZE_BYTES,
+        baseTimeout: 120000,
+        timeoutPerMB: 1000,
+        ...options, // Override with any provided values
     }
 
     // Create a temporary directory for our downloads
@@ -126,15 +154,16 @@ export async function generateDocumentZip(
         let totalBytes = 0
         const downloadedFiles = []
 
-        for (let i = 0; i < documentKeys.length; i += options.batchSize) {
-            const batch = documentKeys.slice(i, i + options.batchSize)
+        for (let i = 0; i < documentKeys.length; i += mergedOptions.batchSize) {
+            const batch = documentKeys.slice(i, i + mergedOptions.batchSize)
             console.info(
-                `Processing batch ${i / options.batchSize + 1}/${Math.ceil(documentKeys.length / options.batchSize)}`
+                `Processing batch ${i / mergedOptions.batchSize + 1}/${Math.ceil(documentKeys.length / mergedOptions.batchSize)}`
             )
 
             const batchPromises = batch.map(async (docInfo) => {
                 const timeout =
-                    options.baseTimeout + options.timeoutPerMB * 1000
+                    mergedOptions.baseTimeout +
+                    mergedOptions.timeoutPerMB * 1000
                 const downloadResult = await downloadFile(
                     s3Client,
                     bucket,
@@ -163,10 +192,10 @@ export async function generateDocumentZip(
                 }
 
                 totalBytes += result.size
-                if (totalBytes > options.maxTotalSize) {
+                if (totalBytes > mergedOptions.maxTotalSize) {
                     const totalMB = (totalBytes / (1024 * 1024)).toFixed(2)
                     const maxMB = (
-                        options.maxTotalSize /
+                        mergedOptions.maxTotalSize /
                         (1024 * 1024)
                     ).toFixed(2)
                     return new Error(
@@ -230,6 +259,47 @@ export async function generateDocumentZip(
         } catch (cleanupError) {
             logError('generateDocumentZip cleanup', cleanupError)
         }
+    }
+}
+
+/**
+ * Mock version of generateDocumentZip for unit tests
+ * Generates realistic s3URL and sha256 without actual S3 operations
+ *
+ * @param documents Array of document information with s3URLs
+ * @param outputPath The S3 path where the zip file should be stored
+ * @param options Configuration options for zip generation
+ * @returns Object with the S3 URL and SHA256 hash of the generated zip, or Error
+ */
+export const localGenerateDocumentZip: GenerateDocumentZipFunctionType = async (
+    documents,
+    outputPath
+) => {
+    if (documents.length === 0) {
+        return new Error('No documents provided for zip generation')
+    }
+
+    // Extract bucket name from first document (simulate real behavior)
+    const bucketMatch = documents[0].s3URL.match(/^s3:\/\/([^/]+)/)
+    if (!bucketMatch) {
+        return new Error('Could not extract bucket name from S3 URL')
+    }
+    const bucket = bucketMatch[1]
+
+    // Generate realistic s3URL
+    const s3URL = `s3://${bucket}/${outputPath}`
+
+    // Generate random 64-character hex string (SHA256 format)
+    const sha256 = Array.from({ length: 64 }, () =>
+        Math.floor(Math.random() * 16).toString(16)
+    ).join('')
+
+    // Simulate async processing delay
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    return {
+        s3URL,
+        sha256,
     }
 }
 
@@ -311,4 +381,303 @@ function calculateSHA256(filePath: string): Promise<string | Error> {
             resolve(new Error(`Error calculating hash: ${error.message}`))
         }
     })
+}
+
+export type DocumentZipService = {
+    createContractZips: (
+        contract: ContractType,
+        span?: Span
+    ) => Promise<Error | undefined>
+    createRateZips: (
+        contract: ContractType,
+        span?: Span
+    ) => Promise<Error[] | undefined>
+    generateRateDocumentsZip: (
+        rateRevision: RateRevisionType,
+        span?: Span
+    ) => Promise<void | Error>
+    generateContractDocumentsZip: (
+        contractRevision: ContractRevisionType,
+        span?: Span
+    ) => Promise<void | Error>
+}
+
+export function documentZipService(
+    store: Store,
+    generateDocumentZip: GenerateDocumentZipFunctionType
+): DocumentZipService {
+    const documentZipMethods: DocumentZipService = {
+        createContractZips: async (contract, span) => {
+            const contractRevision =
+                contract.packageSubmissions[0]?.contractRevision
+
+            if (!contractRevision) {
+                return
+            }
+
+            // Only attempt to generate zip if there are actually documents to zip
+            if (
+                contractRevision.formData.contractDocuments &&
+                contractRevision.formData.contractDocuments.length > 0
+            ) {
+                console.info(
+                    `Generating zip for ${contractRevision.formData.contractDocuments.length} contract documents for contract revision ${contractRevision.id}`
+                )
+
+                const zipResult =
+                    await documentZipMethods.generateContractDocumentsZip(
+                        contractRevision,
+                        span
+                    )
+
+                if (zipResult instanceof Error) {
+                    const errorWithContext = new Error(
+                        `Contract document zip generation failed for revision ${contractRevision.id}: ${zipResult.message}`
+                    )
+
+                    logError(
+                        'createContractZips - contract documents zip generation failed',
+                        errorWithContext
+                    )
+                    setErrorAttributesOnActiveSpan(
+                        'contract documents zip generation failed',
+                        span
+                    )
+                    console.warn(
+                        `Contract document zip generation failed for revision ${contractRevision.id}, but continuing with submission process`
+                    )
+
+                    return errorWithContext
+                } else {
+                    console.info(
+                        `Successfully generated contract document zip for revision ${contractRevision.id}`
+                    )
+                }
+            } else {
+                console.info(
+                    `No contract documents found for revision ${contractRevision.id}, skipping zip generation`
+                )
+            }
+            return
+        },
+        createRateZips: async (contract, span) => {
+            if (!contract.packageSubmissions[0]?.rateRevisions) {
+                return
+            }
+
+            const rateRevisions = contract.packageSubmissions[0].rateRevisions
+            const errors: Error[] = []
+
+            for (const rateRev of rateRevisions) {
+                // Only attempt to generate a zip if there are actually documents to zip
+                const hasRateDocuments =
+                    rateRev.formData.rateDocuments &&
+                    rateRev.formData.rateDocuments.length > 0
+                const hasSupportingDocuments =
+                    rateRev.formData.supportingDocuments &&
+                    rateRev.formData.supportingDocuments.length > 0
+
+                if (hasRateDocuments || hasSupportingDocuments) {
+                    const totalDocs =
+                        (rateRev.formData.rateDocuments?.length || 0) +
+                        (rateRev.formData.supportingDocuments?.length || 0)
+
+                    console.info(
+                        `Generating zip for ${totalDocs} rate documents for rate revision ${rateRev.id}`
+                    )
+
+                    const zipResult =
+                        await documentZipMethods.generateRateDocumentsZip(
+                            rateRev,
+                            span
+                        )
+
+                    if (zipResult instanceof Error) {
+                        const errorWithContext = new Error(
+                            `Rate document zip generation failed for revision ${rateRev.id}: ${zipResult.message}`
+                        )
+                        errors.push(errorWithContext)
+
+                        logError(
+                            'createRateZips - rate documents zip generation failed',
+                            errorWithContext
+                        )
+                        setErrorAttributesOnActiveSpan(
+                            'rate documents zip generation failed',
+                            span
+                        )
+                        console.warn(
+                            `Rate document zip generation failed for revision ${rateRev.id}, but continuing with other revisions`
+                        )
+                    } else {
+                        console.info(
+                            `Successfully generated rate document zip for revision ${rateRev.id}`
+                        )
+                    }
+                } else {
+                    console.info(
+                        `No rate documents found for rate revision ${rateRev.id}, skipping zip generation`
+                    )
+                }
+            }
+
+            // Return errors if any occurred, otherwise return void
+            return errors.length > 0 ? errors : undefined
+        },
+        generateRateDocumentsZip: async (rateRevision, span) => {
+            const rateRevisionID = rateRevision.id
+
+            // Get all rate-related documents
+            // Adapt these field names as needed based on your actual data structure
+            const rateDocuments = [
+                ...(rateRevision.formData.rateDocuments || []),
+                ...(rateRevision.formData.supportingDocuments || []),
+            ]
+
+            if (!rateDocuments || rateDocuments.length === 0) {
+                // No documents to zip
+                return
+            }
+
+            try {
+                // Create an S3 key (destination path) for the zip file
+                const s3DestinationKey = `zips/rates/${rateRevisionID}/rate-documents.zip`
+
+                // Generate the zip file and upload it to S3
+                const zipResult = await generateDocumentZip(
+                    rateDocuments,
+                    s3DestinationKey
+                )
+
+                if (zipResult instanceof Error) {
+                    logError('generateRateDocumentsZip', zipResult)
+                    if (span) {
+                        setErrorAttributesOnActiveSpan(
+                            'rate documents zip generation failed',
+                            span
+                        )
+                    }
+                    return zipResult
+                }
+
+                // Store zip information in database
+                const createResult = await store.createDocumentZipPackage({
+                    s3URL: zipResult.s3URL,
+                    sha256: zipResult.sha256,
+                    rateRevisionID,
+                    documentType: 'RATE_DOCUMENTS',
+                })
+
+                if (createResult instanceof Error) {
+                    logError(
+                        'generateRateDocumentsZip - database storage failed',
+                        createResult
+                    )
+                    if (span) {
+                        setErrorAttributesOnActiveSpan(
+                            'rate documents zip database storage failed',
+                            span
+                        )
+                    }
+                    return createResult
+                }
+
+                console.info(
+                    `Successfully generated zip for rate documents: ${zipResult.s3URL}`
+                )
+                return
+            } catch (error: unknown) {
+                const errorMessage =
+                    error instanceof Error ? error.message : String(error)
+                const err = new Error(
+                    `Unexpected error in generateRateDocumentsZip: ${errorMessage}`
+                )
+                logError('generateRateDocumentsZip', err)
+                if (span) {
+                    setErrorAttributesOnActiveSpan(
+                        'rate documents zip generation failed',
+                        span
+                    )
+                }
+                return err
+            }
+        },
+        generateContractDocumentsZip: async (contractRevision, span) => {
+            const contractRevisionID = contractRevision.id
+            const contractDocuments =
+                contractRevision.formData.contractDocuments
+
+            if (!contractDocuments || contractDocuments.length === 0) {
+                // No documents to zip
+                return
+            }
+
+            try {
+                // Create an S3 key (destination path) for the zip file. This is where
+                // we are storing it in the S3 bucket.
+                const s3DestinationKey = `zips/contracts/${contractRevisionID}/contract-documents.zip`
+
+                // Generate the zip file and upload it to S3
+                const zipResult = await generateDocumentZip(
+                    contractDocuments,
+                    s3DestinationKey
+                )
+
+                if (zipResult instanceof Error) {
+                    // Return the error to the caller
+                    logError('generateContractDocumentsZip', zipResult)
+                    if (span) {
+                        setErrorAttributesOnActiveSpan(
+                            'contract documents zip generation failed',
+                            span
+                        )
+                    }
+                    return zipResult
+                }
+
+                // Store zip information in database
+                const createResult = await store.createDocumentZipPackage({
+                    s3URL: zipResult.s3URL,
+                    sha256: zipResult.sha256,
+                    contractRevisionID,
+                    documentType: 'CONTRACT_DOCUMENTS',
+                })
+
+                if (createResult instanceof Error) {
+                    logError(
+                        'generateContractDocumentsZip - database storage failed',
+                        createResult
+                    )
+                    if (span) {
+                        setErrorAttributesOnActiveSpan(
+                            'contract documents zip database storage failed',
+                            span
+                        )
+                    }
+                    return createResult
+                }
+
+                console.info(
+                    `Successfully generated zip for contract documents: ${zipResult.s3URL}`
+                )
+                return
+            } catch (error: unknown) {
+                const errorMessage =
+                    error instanceof Error ? error.message : String(error)
+                const err = new Error(
+                    `Unexpected error in generateContractDocumentsZip: ${errorMessage}`
+                )
+                logError('generateContractDocumentsZip', err)
+                if (span) {
+                    setErrorAttributesOnActiveSpan(
+                        'contract documents zip generation failed',
+                        span
+                    )
+                }
+                return err
+            }
+        },
+    }
+
+    return documentZipMethods
 }

--- a/services/app-api/src/zip/index.ts
+++ b/services/app-api/src/zip/index.ts
@@ -1,1 +1,6 @@
-export { generateDocumentZip } from './generateZip'
+export {
+    generateDocumentZip,
+    localGenerateDocumentZip,
+    documentZipService,
+} from './generateZip'
+export type { GenerateDocumentZipFunctionType } from './generateZip'


### PR DESCRIPTION
## Summary

While working on dependabot updates, I noticed a lot of our tests were timing out at > `25000` ms. Figured out it was because unit tests and local deployment used the same code as `dev`, `val` and `prod` deployed environments. This meant in unit tests and local deployments it would try to perform actual document zip by calling S3. Errors because it was not configured and increased unit test times.

The work I did here was to refactor this code as a dependency for our resolvers and creating a local version of `generateDocumentZip`. This eliminates the errors in the API and increased unit test time.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

- Make sure zips still generate in the review app.

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed