### PR TITLE
Debug OIDC in promote

### DIFF
--- a/.github/actions/get_aws_credentials/action.yml
+++ b/.github/actions/get_aws_credentials/action.yml
@@ -43,13 +43,20 @@ runs:
       id: set-oidc-stage-name
       shell: bash
       run: |
+        echo "DEBUG: inputs.stage-name = ${{ inputs.stage-name }}"
+        echo "DEBUG: inputs.account-id = ${{ inputs.account-id }}"
+        echo "DEBUG: inputs.changed-services = ${{ inputs.changed-services }}"
+        echo "DEBUG: contains('main, val, prod', inputs.stage-name) = ${{ contains('main, val, prod', inputs.stage-name) }}"
         echo "stage-name=${{ (contains('main, val, prod', inputs.stage-name) || inputs.changed-services == '' || contains(inputs.changed-services, 'github-oidc')) && inputs.stage-name || 'main' }}" >> $GITHUB_OUTPUT
 
     - name: Format OIDC role ARN
       shell: bash
       id: format-oidc-role-arn
       run: |
+        echo "DEBUG: inputs.account-id = '${{ inputs.account-id }}'"
+        echo "DEBUG: set-oidc-stage-name.outputs.stage-name = '${{ steps.set-oidc-stage-name.outputs.stage-name }}'"
         ARN="arn:aws:iam::${{ inputs.account-id }}:role/delegatedadmin/developer/github-oidc-${{ steps.set-oidc-stage-name.outputs.stage-name }}-ServiceRole"
+        echo "DEBUG: Generated ARN = $ARN"
         echo "arn=$ARN" >> $GITHUB_OUTPUT
 
     - name: Configure AWS credentials


### PR DESCRIPTION
## Summary
Promotes are blocked right now as all of a sudden the ARN for the OIDC in val is not getting the appropriate AWS ID from the github action config. This is weird, as nothing has changed on our end in regards to that configuration value.

This adds some debug output to promote so we can see a little bit more of what's going on.