### PR TITLE
MCR-5364: Styling and ally fixes

### DIFF
--- a/API_Changelog.md
+++ b/API_Changelog.md
@@ -1,7 +1,7 @@
 # Managed Care Review - API Changelog
 ## This document highlights API changes that have been introduced since May 2025
 
-### July 9, 2025
+### July 16, 2025
 #### Added
 - `rateMedicaidPopulations` optional array field, possible values: `["MEDICARE_MEDICAID_WITH_DSNP", "MEDICAID_ONLY", "MEDICARE_MEDICAID_WITHOUT_DSNP"]`, added to `formData` on `RateRevision`. This change affects all queries and mutations that include `RateFormData`
 

--- a/API_Changelog.md
+++ b/API_Changelog.md
@@ -1,7 +1,7 @@
 # Managed Care Review - API Changelog
 ## This document highlights API changes that have been introduced since May 2025
 
-### July 16, 2025
+### July 9, 2025
 #### Added
 - `rateMedicaidPopulations` optional array field, possible values: `["MEDICARE_MEDICAID_WITH_DSNP", "MEDICAID_ONLY", "MEDICARE_MEDICAID_WITHOUT_DSNP"]`, added to `formData` on `RateRevision`. This change affects all queries and mutations that include `RateFormData`
 

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -2010,7 +2010,7 @@ describe('RateDetails', () => {
             await screen.findByText('Rate Details')
             // rate Medicaid populations question to not be present
             expect(
-                screen.queryByText('Which Medicaid populations are included in this rate certifications')
+                screen.queryByText('Which Medicaid populations are included in this rate certification')
             ).not.toBeInTheDocument()
         })
     })

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -1971,7 +1971,7 @@ describe('RateDetails', () => {
             await screen.findByText('Rate Details')
             // rate Medicaid populations question to be present
             expect(
-                screen.getByText('Rate Medicaid populations')
+                screen.getByText('Which Medicaid populations are included in this rate certification?')
             ).toBeInTheDocument()
         })
 
@@ -2010,7 +2010,7 @@ describe('RateDetails', () => {
             await screen.findByText('Rate Details')
             // rate Medicaid populations question to not be present
             expect(
-                screen.queryByText('Rate Medicaid populations')
+                screen.queryByText('Which Medicaid populations are included in this rate certifications')
             ).not.toBeInTheDocument()
         })
     })

--- a/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateFormFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateFormFields.tsx
@@ -267,7 +267,7 @@ export const SingleRateFormFields = ({
                     error={Boolean(showFieldErrors('rateMedicaidPopulations'))}
                 >
                     <Fieldset
-                        legend="Rate Medicaid populations"
+                        legend="Which Medicaid populations are included in this rate certification?"
                         aria-required
                         id={`${fieldNamePrefix}.rateMedicaidPopulations`}
                     >
@@ -281,22 +281,21 @@ export const SingleRateFormFields = ({
                         >
                             See 42 CFR § 422.2
                         </div>
-                        <Link
+                        <LinkWithLogging
+                            aria-label="Medicaid Managed Care Rate Development Guide (opens in new window)"
+                            href={'https://www.medicaid.gov/medicaid/managed-care/guidance/rate-review-and-rate-guides'}
                             variant="external"
-                            href={
-                                'https://www.medicaid.gov/medicaid/managed-care/guidance/rate-review-and-rate-guides'
-                            }
                             target="_blank"
                         >
                             Medicaid Managed Care Rate Development Guide
-                        </Link>
+                        </LinkWithLogging>
                         <div className="usa-hint">
                             <span>Check all that apply</span>
                         </div>
                         {Boolean(
                             showFieldErrors('rateMedicaidPopulations')
                         ) && (
-                            <PoliteErrorMessage formFieldLabel="Rate medicaid populations">
+                            <PoliteErrorMessage formFieldLabel="Which Medicaid populations are included in this rate certification">
                                 {showFieldErrors('rateMedicaidPopulations')}
                             </PoliteErrorMessage>
                         )}
@@ -307,7 +306,7 @@ export const SingleRateFormFields = ({
                                 RateMedicaidPopulationsRecord.MEDICARE_MEDICAID_WITH_DSNP
                             }
                             value="MEDICARE_MEDICAID_WITH_DSNP"
-                            heading="Rate Medicaid populations"
+                            heading="Which Medicaid populations are included in this rate certification"
                             parent_component_heading={formHeading}
                         />
                         <FieldCheckbox
@@ -315,7 +314,7 @@ export const SingleRateFormFields = ({
                             name={`${fieldNamePrefix}.rateMedicaidPopulations`}
                             label={RateMedicaidPopulationsRecord.MEDICAID_ONLY}
                             value="MEDICAID_ONLY"
-                            heading="Rate Medicaid populations"
+                            heading="Which Medicaid populations are included in this rate certification"
                             parent_component_heading={formHeading}
                         />
                         <FieldCheckbox
@@ -325,7 +324,7 @@ export const SingleRateFormFields = ({
                                 <span>
                                     Medicare-Medicaid dually eligible
                                     individuals{' '}
-                                    <span style={{ fontWeight: 'bold' }}>
+                                    <span style={{ fontWeight: 600 }}>
                                         not
                                     </span>{' '}
                                     enrolled through a D-SNP
@@ -335,7 +334,7 @@ export const SingleRateFormFields = ({
                                 RateMedicaidPopulationsRecord.MEDICARE_MEDICAID_WITHOUT_DSNP
                             }
                             value="MEDICARE_MEDICAID_WITHOUT_DSNP"
-                            heading="Rate Medicaid populations"
+                            heading="Which Medicaid populations are included in this rate certification"
                             parent_component_heading={formHeading}
                         />
                     </Fieldset>

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.module.scss
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.module.scss
@@ -59,6 +59,12 @@
     margin-top: 0;
 }
 
+[class^='usa-checkbox__label'] {
+    &::before {
+        top: 4px;
+    }
+}
+
 .buttonGroup {
     justify-content: flex-end;
     margin-right: 0;


### PR DESCRIPTION
## Summary

 This PR addresses design feedback. Things changed:

- Vertical alignment of the checkboxes on the rate medicaid populations question
- Ally change to have the label read out that the help link opens in a new tab
- "Medicare-Medicaid dually eligible individuals not enrolled through a D-SNP "checkbox item: the not is semi-bold rather than bold
- Field label copy updated to: "Which Medicaid populations are included in this rate certification?"

#### Related issues

https://jiraent.cms.gov/browse/MCR-5364

#### Screenshots

<img width="593" height="341" alt="Screenshot 2025-07-17 at 1 24 55 PM" src="https://github.com/user-attachments/assets/36bad957-7f22-4e14-b468-16d7d5e5e6e8" />

## PR Reminders
- [x] Updated the API Changelog (if this PR changes the API schema)
- [x] Checked accessibility with ANDI and Wave tools as needed