### PR TITLE
MCR-5356: combobox has sufficient contrast had recent pushes

### DIFF
--- a/services/app-web/src/components/Select/AccessibleSelect/AccessibleSelect.tsx
+++ b/services/app-web/src/components/Select/AccessibleSelect/AccessibleSelect.tsx
@@ -27,6 +27,18 @@ export const AccessibleSelect = <
                     color: '#3D4551', // 7:1 contrast rule. Not aware of background color
                     ...passedStyles?.placeholder,
                 }),
+                dropdownIndicator: (baseStyles) => ({
+                    ...baseStyles,
+                    color: '#565C65', // 3:1 UI contrast rule
+                }),
+                clearIndicator: (baseStyles) => ({
+                    ...baseStyles,
+                    color: '#565C65', // 3:1 UI contrast rule
+                }),
+                control: (baseStyles) => ({
+                    ...baseStyles,
+                    borderColor: '#565C65', // 3:1 UI contrast rule
+                }),
             }}
         />
     )


### PR DESCRIPTION
## Summary
[MCR-5356](https://jiraent.cms.gov/browse/MCR-5356)

User interface components are required to meet a 3:1 contrast ratio. The select component does not meet this requirement.

Acceptance criteria
- Change border color to base-dark #565C65
- Change X and Chevron border color to base-dark #565C65
- Placeholder text is base-darker #3D4551

[Design for reference](https://www.figma.com/design/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?node-id=20402-89438&t=7DCuO6lFucZSRBsp-4)

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed