### PR TITLE
MCR-5307: A11y Table row-cell association fixes

### DIFF
--- a/services/app-web/src/components/ContractTable/ContractTable.tsx
+++ b/services/app-web/src/components/ContractTable/ContractTable.tsx
@@ -614,6 +614,10 @@ export const ContractTable = ({
                                     {row.getVisibleCells().map((cell) => (
                                         <RowCellElement
                                             key={cell.id}
+                                            data-testid={
+                                                cell.column.columnDef.meta
+                                                    ?.dataTestID
+                                            }
                                             element={
                                                 cell.column.id === 'ID'
                                                     ? 'th'

--- a/services/app-web/src/components/ContractTable/ContractTable.tsx
+++ b/services/app-web/src/components/ContractTable/ContractTable.tsx
@@ -33,6 +33,7 @@ import useDeepCompareEffect from 'use-deep-compare-effect'
 import { getTealiumFiltersChanged } from '../../tealium/tealiumHelpers'
 import { titleCaseString } from '@mc-review/common-code'
 import { formatCalendarDate } from '@mc-review/dates'
+import { RowCellElement } from '..'
 
 export type ContractInDashboardType = {
     id: string
@@ -587,7 +588,11 @@ export const ContractTable = ({
                             {reactTable.getHeaderGroups().map((headerGroup) => (
                                 <tr key={headerGroup.id}>
                                     {headerGroup.headers.map((header) => (
-                                        <th scope="col" key={header.id}>
+                                        <th
+                                            scope="col"
+                                            key={header.id}
+                                            id={header.id}
+                                        >
                                             {header.isPlaceholder
                                                 ? null
                                                 : flexRender(
@@ -607,18 +612,19 @@ export const ContractTable = ({
                                     data-testid={`row-${row.original.id}`}
                                 >
                                     {row.getVisibleCells().map((cell) => (
-                                        <td
+                                        <RowCellElement
                                             key={cell.id}
-                                            data-testid={
-                                                cell.column.columnDef.meta
-                                                    ?.dataTestID
+                                            element={
+                                                cell.column.id === 'ID'
+                                                    ? 'th'
+                                                    : 'td'
                                             }
                                         >
                                             {flexRender(
                                                 cell.column.columnDef.cell,
                                                 cell.getContext()
                                             )}
-                                        </td>
+                                        </RowCellElement>
                                     ))}
                                 </tr>
                             ))}

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
@@ -14,6 +14,7 @@ import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { featureFlags } from '@mc-review/common-code'
 import { formatCalendarDate } from '@mc-review/dates'
 import { usePreviousSubmission } from '../../../hooks'
+
 // This is used to convert from deprecated FE domain types from protos to GQL GenericDocuments by added in a dateAdded
 export const convertFromSubmissionDocumentsToGenericDocuments = (
     deprecatedDocs: SubmissionDocument[],
@@ -193,7 +194,7 @@ export const UploadedDocumentsTable = ({
                     {refreshedDocs.map((doc) => (
                         <tr key={doc.name}>
                             {doc.url && doc.s3Key ? (
-                                <td>
+                                <th scope="row">
                                     <DocumentTag
                                         isNew={shouldHaveNewTag(doc)}
                                         isShared={showLegacySharedRatesAcross}
@@ -206,15 +207,15 @@ export const UploadedDocumentsTable = ({
                                     >
                                         {doc.name}
                                     </LinkWithLogging>
-                                </td>
+                                </th>
                             ) : (
-                                <td>
+                                <th scope="row">
                                     <DocumentTag
                                         isNew={shouldHaveNewTag(doc)}
                                         isShared={showLegacySharedRatesAcross}
                                     />
                                     {doc.name}
-                                </td>
+                                </th>
                             )}
                             <td>
                                 {canDisplayDateAddedForDocument(doc) ? (

--- a/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsTable.tsx
+++ b/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsTable.tsx
@@ -39,6 +39,7 @@ import { getTealiumFiltersChanged } from '../../../tealium/tealiumHelpers'
 import { formatCalendarDate } from '@mc-review/dates'
 import { InfoTag, TagProps } from '../../../components/InfoTag/InfoTag'
 import { ConsolidatedRateStatusRecord } from '@mc-review/constants'
+import { RowCellElement } from '../../../components'
 
 type RatingPeriodFilterType = [string, string] | []
 
@@ -672,7 +673,11 @@ export const RateReviewsTable = ({
                             {reactTable.getHeaderGroups().map((headerGroup) => (
                                 <tr key={headerGroup.id}>
                                     {headerGroup.headers.map((header) => (
-                                        <th scope="col" key={header.id}>
+                                        <th
+                                            scope="col"
+                                            key={header.id}
+                                            id={header.id}
+                                        >
                                             {header.isPlaceholder
                                                 ? null
                                                 : flexRender(
@@ -692,18 +697,19 @@ export const RateReviewsTable = ({
                                     data-testid={`row-${row.original.id}`}
                                 >
                                     {row.getVisibleCells().map((cell) => (
-                                        <td
+                                        <RowCellElement
                                             key={cell.id}
-                                            data-testid={
-                                                cell.column.columnDef.meta
-                                                    ?.dataTestID
+                                            element={
+                                                cell.column.id === 'Rate review'
+                                                    ? 'th'
+                                                    : 'td'
                                             }
                                         >
                                             {flexRender(
                                                 cell.column.columnDef.cell,
                                                 cell.getContext()
                                             )}
-                                        </td>
+                                        </RowCellElement>
                                     ))}
                                 </tr>
                             ))}

--- a/services/app-web/src/pages/QuestionResponse/QATable/QuestionDisplayTable.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/QuestionDisplayTable.tsx
@@ -35,7 +35,7 @@ export const QuestionDisplayTable = ({
             <tbody>
                 {displayDocuments.map((doc, index) => (
                     <tr key={doc.name + index}>
-                        <td>
+                        <th scope="row">
                             {doc.downloadURL ? (
                                 <LinkWithLogging
                                     className={styles.inlineLink}
@@ -48,7 +48,7 @@ export const QuestionDisplayTable = ({
                             ) : (
                                 doc.name
                             )}
-                        </td>
+                        </th>
                         <td>
                             {formatCalendarDate(
                                 doc.createdAt,


### PR DESCRIPTION
## Summary

- Fixes a reoccurring A11y issue with our tables so that the read out for each cell includes the correct row association

#### Related issues
This PR for  https://jiraent.cms.gov/browse/MCR-5307: also covers

- documents table https://jiraent.cms.gov/browse/MCR-5310
- CMS submissions dashboard https://jiraent.cms.gov/browse/MCR-5308
- CMS rate reviews dashboard https://jiraent.cms.gov/browse/MCR-5309

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

- Use ANDI to check the tables on the state submission, CMS submission, CMS rate review and documents tables. Expected output is specified in each ticket

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed