### PR TITLE
MCR-5448: 404 Error When Editing State Assignments in MC-Review Portal

### DIFF
--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -346,16 +346,16 @@ const CMSUserRoutes = ({
                         path={RoutesRecord.SUPPORT_EMAILS}
                         element={<SupportEmailsTable />}
                     />
+                    <Route
+                        path={RoutesRecord.EDIT_STATE_ASSIGNMENTS}
+                        element={<EditStateAssign />}
+                    />
                     {isAdminUser && (
                         //For Admin user only routes.
                         <>
                             <Route
                                 path={RoutesRecord.OAUTH_CLIENTS}
                                 element={<OauthClients />}
-                            />
-                            <Route
-                                path={RoutesRecord.EDIT_STATE_ASSIGNMENTS}
-                                element={<EditStateAssign />}
                             />
                             <Route
                                 path={RoutesRecord.CREATE_OAUTH_CLIENT}


### PR DESCRIPTION
## Summary
[MCR-5448](https://jiraent.cms.gov/browse/MCR-5448)

Edit state assignment page was move into admin routes. This moves it back so any CMS user can edit state assignments.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
- Test that CMS usr has access to the edit state assignment page.

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed