### PR TITLE
Fix val import of Q&A documents

### DIFF
--- a/services/postgres/package.json
+++ b/services/postgres/package.json
@@ -4,7 +4,8 @@
     "version": "1.0.0",
     "main": "index.js",
     "scripts": {
-        "build": "tsc"
+        "build": "tsc",
+        "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
         "@aws-sdk/types": "^3.862.0",

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -77,6 +77,14 @@ provider:
             - 's3:ListObjectsV2'
           Resource:
             - !Sub 'arn:aws:s3:::${self:custom.documentUploadsBucketName}/*'
+        - Effect: 'Allow'
+          Action:
+            - 's3:GetObject'
+            - 's3:PutObject'
+            - 's3:ListObjects'
+            - 's3:ListObjectsV2'
+          Resource:
+            - !Sub 'arn:aws:s3:::${self:custom.qaUploadsBucketName}/*'
         - Effect: Allow
           Action:
             - 's3:ListBucket'
@@ -107,6 +115,7 @@ custom:
   dbSecretsArn: ${env:CF_CONFIG_IGNORED_LOCALLY, env:DB_SM_ARN}
   slackWebhookUrl: ${env:SLACK_WEBHOOK}
   documentUploadsBucketName: ${env:CF_CONFIG_IGNORED_LOCALLY, cf:uploads-${sls:stage}.DocumentUploadsBucketName}
+  qaUploadsBucketName: ${env:CF_CONFIG_IGNORED_LOCALLY, cf:uploads-${sls:stage}.QAUploadsBucketName}
   serverlessTerminationProtection:
     stages:
       - dev
@@ -192,6 +201,7 @@ functions:
     environment:
       S3_BUCKET: ${self:custom.importBucket.${opt:stage}, self:custom.importBucket.other}
       DOCS_S3_BUCKET: ${self:custom.documentUploadsBucketName}
+      QA_S3_BUCKET: ${self:custom.qaUploadsBucketName}
       DB_SECRET_ARN: !Ref PostgresSecret
       SECRETS_MANAGER_ENDPOINT: !Sub 'https://secretsmanager.${AWS::Region}.amazonaws.com'
     layers:


### PR DESCRIPTION
## Summary

The Salesforce team was trying to test on a submission in val (mimicking prod), but the dummy document there was missing in the val environment. It turns out that when I wrote the val data import lambda I forgot that we have a separate bucket for Q&A documents. That means when the lambda generated the fake document for the test environment it placed it in the regular `uploads` bucket, whereas the link points to the `qa` bucket. 

This adds the Q&A bucket and places any Q&A document records into that separate s3 bucket. We probably should refactor this to have a single bucket for all documents, but for the time being this should fix that bug. 

We'll need to re-run the export/import once this promotes.

#### Related issues
https://jiraent.cms.gov/secure/RapidBoard.jspa?rapidView=6115