### PR TITLE
[MCR-5470] Updated Michigan program nickname

### DIFF
--- a/packages/hpp/src/data/statePrograms.json
+++ b/packages/hpp/src/data/statePrograms.json
@@ -636,7 +636,7 @@
                 {
                     "id": "f1194072-b554-4247-8ba7-6d29ccf5d27b",
                     "fullName": "Managed Care Health Plan Comprehensive Health Care Program",
-                    "name": "MCHP CHCP",
+                    "name": "MCHP",
                     "isRateProgram": false
                 }
             ],


### PR DESCRIPTION
## Summary
Michigan is making their first MC-Review submission this September. None of their programs are rate programs.

Acceptance Criteria

Update the programs.json and the [State programs spreadsheet](https://docs.google.com/spreadsheets/d/138HHJTs4sGZucyffNFDe2dlSvYxPRSrP/edit?gid=687010743#gid=687010743) using [these instructions](https://github.com/Enterprise-CMCS/managed-care-review/blob/main/docs/technical-design/howto-update-state-programs.md)
Managed Care Health Plan Comprehensive Health Care Program's nickname is updated to MCHP
#### Related issues
[MCR-5470](https://jiraent.cms.gov/browse/MCR-5470)
#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [x] Updated the API Changelog (if this PR changes the API schema)
- [x] Checked accessibility with ANDI and Wave tools as needed