### PR TITLE
MCR-5480: Rate DSNP question not retaining answer on unlock

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/unlockRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/unlockRate.ts
@@ -1,4 +1,4 @@
-import type { RateType } from '../../domain-models/contractAndRates'
+import type { RateType } from '../../domain-models'
 import type { ExtendedPrismaClient } from '../prismaClient'
 import type { PrismaTransactionType } from '../prismaTypes'
 import { findRateWithHistory } from './findRateWithHistory'
@@ -109,6 +109,7 @@ async function unlockRateInDB(
             rateCertificationName: currentRev.rateCertificationName,
             actuaryCommunicationPreference:
                 currentRev.actuaryCommunicationPreference,
+            rateMedicaidPopulations: currentRev.rateMedicaidPopulations,
 
             rateDocuments: {
                 create: currentRev.rateDocuments.map((d) => ({

--- a/services/app-api/src/resolvers/rate/undoWithdrawRate.test.ts
+++ b/services/app-api/src/resolvers/rate/undoWithdrawRate.test.ts
@@ -165,7 +165,6 @@ describe('undoWithdrawRate', () => {
             unwithdrawnRate.packageSubmissions[0].rateRevision.formData
         ).toEqual({
             ...formData,
-            rateMedicaidPopulations: [],
             rateDocuments: expect.arrayContaining(
                 formData.rateDocuments.map((doc) =>
                     expect.objectContaining({
@@ -337,7 +336,6 @@ describe('undoWithdrawRate', () => {
             unwithdrawnRate.packageSubmissions[0].rateRevision.formData
         ).toEqual({
             ...formData,
-            rateMedicaidPopulations: [],
             rateDocuments: expect.arrayContaining(
                 formData.rateDocuments.map((doc) =>
                     expect.objectContaining({


### PR DESCRIPTION
## Summary
[MCR-5480](https://jiraent.cms.gov/browse/MCR-5480)

Unlocking submission was not copying over the DNSP answer to the new rate revision.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

- Create a D-SNP contract and rate submissions
- Make sure `Medicaid populations included in this rate certification` is answered on the rate details page.
- Submit the submission
- Unlock the submission
- `Medicaid populations included in this rate certification` should retain answers.

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed