### PR TITLE
MCR-5418: Migrate existing documents to populate "dateAdded"

### DIFF
--- a/services/app-api/prisma/migrations/20250827184558_populate_date_added_column_for_contract_and_rate_documents/migration.sql
+++ b/services/app-api/prisma/migrations/20250827184558_populate_date_added_column_for_contract_and_rate_documents/migration.sql
@@ -1,0 +1,35 @@
+BEGIN;
+
+UPDATE "ContractDocument" cd
+SET "dateAdded" = ui."updatedAt"
+FROM "ContractRevisionTable" cr
+INNER JOIN "UpdateInfoTable" ui ON cr."submitInfoID" = ui."id"
+WHERE cd."dateAdded" IS NULL
+  AND cd."contractRevisionID" = cr."id"
+  AND cr."submitInfoID" IS NOT NULL;
+
+UPDATE "ContractSupportingDocument" csd
+SET "dateAdded" = ui."updatedAt"
+FROM "ContractRevisionTable" cr
+INNER JOIN "UpdateInfoTable" ui ON cr."submitInfoID" = ui."id"
+WHERE csd."dateAdded" IS NULL
+  AND csd."contractRevisionID" = cr."id"
+  AND cr."submitInfoID" IS NOT NULL;
+
+UPDATE "RateDocument" rd
+SET "dateAdded" = ui."updatedAt"
+FROM "RateRevisionTable" rr
+INNER JOIN "UpdateInfoTable" ui ON rr."submitInfoID" = ui."id"
+WHERE rd."dateAdded" IS NULL
+  AND rd."rateRevisionID" = rr."id"
+  AND rr."submitInfoID" IS NOT NULL;
+
+UPDATE "RateSupportingDocument" rsd
+SET "dateAdded" = ui."updatedAt"
+FROM "RateRevisionTable" rr
+INNER JOIN "UpdateInfoTable" ui ON rr."submitInfoID" = ui."id"
+WHERE rsd."dateAdded" IS NULL
+  AND rsd."rateRevisionID" = rr."id"
+  AND rr."submitInfoID" IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
## Summary

This PR updates the contract and rate documents that exists in the db without a dateAdded field. The dateAdded field is set to equal to the `submitInfo.updatedAt` for its associated Contract/Rate revision. This matches the logic in `setDateAddedForContractRevisions` and `setDateAddedForRateRevisions`

AC
- Migrate the following existing documents in DEV, VAL , and PROD:
  - ContractDocument
  - ContractSupportingDocument
  - RateDocument
  - RateSupportingDocument
- Validate that all submitted documents have dateAdded

#### Related issues

https://jiraent.cms.gov/browse/MCR-5418

#### Screenshots

## QA guidance

There's a few ways to test this I'll just outline my approach:

- Pull data from val or prod locally using[ jumpbox](https://github.com/Enterprise-CMCS/managed-care-review/blob/main/docs/technical-design/howto-migrations.md#how-to-dump-deployed-data-for-local-testing)
- Open a DB viewer (I use Beekeeper) and first select the documents to see that some have null dateAddded fields
- Apply the migration
- Select the documents again and ensure that the dateAdded fields are populated as expected (should match the updatedAt field of the submitInfo for the related contract or rate revision)
- For each table you can run a query like this to ensure that there are no lingering documents that are missing a dateAdded field after submission

```sql
SELECT cd.*
FROM "ContractDocument" cd
JOIN "ContractRevisionTable" cr ON cd."contractRevisionID" = cr."id"
WHERE cr."submitInfoID" IS NOT NULL
  AND cd."dateAdded" IS NULL;
```

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed