### PR TITLE
MCR-5419: remove setDateAdded helper functions for contract and rate docs

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/parseContractWithHistory.ts
+++ b/services/app-api/src/postgres/contractAndRates/parseContractWithHistory.ts
@@ -8,11 +8,7 @@ import type { ContractWithoutDraftRatesType } from '../../domain-models/contract
 import type { ContractPackageSubmissionType } from '../../domain-models/contractAndRates/packageSubmissions'
 import { rateWithoutDraftContractsToDomainModel } from './parseRateWithHistory'
 import type { ContractRevisionTableWithFormData } from './prismaSharedContractRateHelpers'
-import {
-    getConsolidatedContractStatus,
-    setDateAddedForContractRevisions,
-    setDateAddedForRateRevisions,
-} from './prismaSharedContractRateHelpers'
+import { getConsolidatedContractStatus } from './prismaSharedContractRateHelpers'
 import {
     rateRevisionToDomainModel,
     unsortedRatesRevisionsToDomainModel,
@@ -202,12 +198,6 @@ function contractWithHistoryToDomainModelWithoutRates(
             }
             packageRateRevisions[rrev.rateID].push(rrev)
         }
-    }
-    setDateAddedForContractRevisions(packageContractRevisions)
-
-    //NOTE: This will not display the actual date added for linked rates because we do not query all the linked rate revisions
-    for (const rrevs of Object.values(packageRateRevisions)) {
-        setDateAddedForRateRevisions(rrevs)
     }
 
     const status = getContractRateStatus(contract.revisions)

--- a/services/app-api/src/postgres/contractAndRates/parseRateWithHistory.ts
+++ b/services/app-api/src/postgres/contractAndRates/parseRateWithHistory.ts
@@ -28,8 +28,6 @@ import {
     rateFormDataToDomainModel,
     getParentContractID,
     DRAFT_PARENT_PLACEHOLDER,
-    setDateAddedForContractRevisions,
-    setDateAddedForRateRevisions,
 } from './prismaSharedContractRateHelpers'
 import type {
     RateTableWithoutDraftContractsPayload,
@@ -177,9 +175,6 @@ function rateWithoutDraftContractsToDomainModel(
         return parentContractID
     }
 
-    // Set the document date added
-    setDateAddedForRateRevisions(submittedRevisions)
-
     // Add contract date added
     const packageRateRevisions: RateRevisionType[] = []
     //NOTE: This will not display the actual date added for linked contracts because we do not query all the linked contract revisions
@@ -193,17 +188,6 @@ function rateWithoutDraftContractsToDomainModel(
             }
             packageContractRevisions[cRev.contract.id].push(cRev)
         }
-    }
-
-    /**
-     * Set dateAdded for packageSubmissions.
-     * Frontend currently uses rate.revisions but will migrate to packageSubmissions.
-     * This temporary fix will be removed once dateAdded is set at submission time.
-     */
-    setDateAddedForRateRevisions(packageRateRevisions)
-
-    for (const cRevs of Object.values(packageContractRevisions)) {
-        setDateAddedForContractRevisions(cRevs)
     }
 
     const status = getContractRateStatus(rateRevisions)

--- a/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
+++ b/services/app-api/src/postgres/contractAndRates/prismaSharedContractRateHelpers.ts
@@ -6,7 +6,6 @@ import type {
     RateRevisionType,
     PackageStatusType,
     UpdateInfoType,
-    ContractRevisionType,
     ConsolidatedContractStatusType,
 } from '../../domain-models/contractAndRates'
 import { findStatePrograms } from '../state'
@@ -530,67 +529,6 @@ function rateRevisionToDomainModel(
     }
 }
 
-// setDateAddedForContractRevisions takes a list of contractRevs and sets dateAdded
-// for all documents based on when the doc first appears in the list. The contractRevs
-// should be in createdAt order.
-function setDateAddedForContractRevisions(
-    contractRevs: ContractRevisionType[]
-) {
-    const firstSeenDate: { [sha: string]: Date } = {}
-    for (const contractRev of contractRevs) {
-        const sinceDate = contractRev.submitInfo?.updatedAt
-        if (!sinceDate) break
-        for (const doc of contractRev.formData.contractDocuments) {
-            if (!firstSeenDate[doc.sha256]) {
-                // still set the hashmap of docs with db date added.
-                firstSeenDate[doc.sha256] = doc.dateAdded ?? sinceDate
-            }
-            // use db date added, fallback to hashmap
-            doc.dateAdded = doc.dateAdded ?? firstSeenDate[doc.sha256]
-        }
-        for (const doc of contractRev.formData.supportingDocuments) {
-            if (!firstSeenDate[doc.sha256]) {
-                // still set the hashmap of docs with db date added.
-                firstSeenDate[doc.sha256] = doc.dateAdded ?? sinceDate
-            }
-            // use db date added, fallback to hashmap
-            doc.dateAdded = doc.dateAdded ?? firstSeenDate[doc.sha256]
-        }
-    }
-}
-
-// setDateAddedForRateRevisions takes a list of rateRevs and sets dateAdded
-// for all documents based on when the doc first appears in the list. The contractRevs
-// should be in createdAt order.
-function setDateAddedForRateRevisions(rateRevs: RateRevisionType[]) {
-    const firstSeenDate: { [sha: string]: Date } = {}
-
-    for (const rateRev of rateRevs) {
-        const sinceDate = rateRev.submitInfo?.updatedAt
-        if (!sinceDate) break
-        if (rateRev.formData.rateDocuments) {
-            for (const doc of rateRev.formData.rateDocuments) {
-                if (!firstSeenDate[doc.sha256]) {
-                    // still set the hashmap of docs with db date added.
-                    firstSeenDate[doc.sha256] = doc.dateAdded ?? sinceDate
-                }
-                // use db date added, fallback to hashmap
-                doc.dateAdded = doc.dateAdded ?? firstSeenDate[doc.sha256]
-            }
-        }
-        if (rateRev.formData.supportingDocuments) {
-            for (const doc of rateRev.formData.supportingDocuments) {
-                if (!firstSeenDate[doc.sha256]) {
-                    // still set the hashmap of docs with db date added.
-                    firstSeenDate[doc.sha256] = doc.dateAdded ?? sinceDate
-                }
-                // use db date added, fallback to hashmap
-                doc.dateAdded = doc.dateAdded ?? firstSeenDate[doc.sha256]
-            }
-        }
-    }
-}
-
 function ratesRevisionsToDomainModel(
     rateRevisions: RateRevisionTableWithFormData[]
 ): RateRevisionType[] | Error {
@@ -740,8 +678,6 @@ export {
     rateRevisionToDomainModel,
     ratesRevisionsToDomainModel,
     unsortedRatesRevisionsToDomainModel,
-    setDateAddedForContractRevisions,
-    setDateAddedForRateRevisions,
     getRateReviewStatus,
     getParentContractID,
     getRelatedContracts,


### PR DESCRIPTION
## Summary

This PR removes functions `setDateAddedForContractRevisions` and `setDateAddedForRateRevisions` previously used to calculate dateAdded on fetch.

To be merged after https://jiraent.cms.gov/browse/MCR-5418

#### Related issues

https://jiraent.cms.gov/browse/MCR-5419

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed