### PR TITLE
MCR-5453: Rate details D-SNP content fix

### DIFF
--- a/packages/hpp/src/healthPlanPackages.ts
+++ b/packages/hpp/src/healthPlanPackages.ts
@@ -33,7 +33,7 @@ const RateTypeRecord: Record<RateType, string> = {
 }
 
 const RateMedicaidPopulationsRecord: Record<RateMedicaidPopulations, string> = {
-    MEDICARE_MEDICAID_WITH_DSNP: 'Medicare-Medicaid dually eligible individuals enrolled through a Dual-Eligible Special Needs Plan (D-SNP)',
+    MEDICARE_MEDICAID_WITH_DSNP: 'Medicare-Medicaid dual eligibles enrolled through a D-SNP (on summary page)',
     MEDICAID_ONLY: 'Medicaid-only',
     MEDICARE_MEDICAID_WITHOUT_DSNP: `Medicare-Medicaid dually eligible individuals not enrolled through a D-SNP`
 }

--- a/packages/hpp/src/healthPlanPackages.ts
+++ b/packages/hpp/src/healthPlanPackages.ts
@@ -35,7 +35,7 @@ const RateTypeRecord: Record<RateType, string> = {
 const RateMedicaidPopulationsRecord: Record<RateMedicaidPopulations, string> = {
     MEDICARE_MEDICAID_WITH_DSNP: 'Medicare-Medicaid dual eligibles enrolled through a D-SNP (on summary page)',
     MEDICAID_ONLY: 'Medicaid-only',
-    MEDICARE_MEDICAID_WITHOUT_DSNP: `Medicare-Medicaid dually eligible individuals not enrolled through a D-SNP`
+    MEDICARE_MEDICAID_WITHOUT_DSNP: `Medicare-Medicaid dual eligibles not enrolled through a D-SNP`
 }
 const ContractExecutionStatusRecord: Record<ContractExecutionStatus, string> = {
     EXECUTED: 'Fully executed',

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummary/RateDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummary/RateDetailsSummarySection.test.tsx
@@ -362,7 +362,7 @@ describe('RateDetailsSummarySection', () => {
             ).toBeInTheDocument()
             expect(
                 screen.getByTestId(
-                    'Medicare-Medicaid dually eligible individuals enrolled through a Dual-Eligible Special Needs Plan (D-SNP)'
+                    'Medicare-Medicaid dual eligibles enrolled through a D-SNP (on summary page)'
                 )
             ).toBeInTheDocument()
             expect(screen.getByTestId('Medicaid-only')).toBeInTheDocument()

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummary/RateDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummary/RateDetailsSummarySection.test.tsx
@@ -368,7 +368,7 @@ describe('RateDetailsSummarySection', () => {
             expect(screen.getByTestId('Medicaid-only')).toBeInTheDocument()
             expect(
                 screen.getByTestId(
-                    'Medicare-Medicaid dually eligible individuals not enrolled through a D-SNP'
+                    'Medicare-Medicaid dual eligibles not enrolled through a D-SNP'
                 )
             ).toBeInTheDocument()
             expect(

--- a/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateFormFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateFormFields.tsx
@@ -5,7 +5,6 @@ import {
     Fieldset,
     FormGroup,
     Label,
-    Link,
 } from '@trussworks/react-uswds'
 import classnames from 'classnames'
 import {
@@ -26,7 +25,6 @@ import {
     ACCEPTED_RATE_CERTIFICATION_FILE_TYPES,
 } from '../../../components/FileUpload'
 import { useS3 } from '../../../contexts/S3Context'
-import { RateMedicaidPopulationsRecord } from '@mc-review/hpp'
 
 import {
     FieldArray,
@@ -283,7 +281,9 @@ export const SingleRateFormFields = ({
                         </div>
                         <LinkWithLogging
                             aria-label="Medicaid Managed Care Rate Development Guide (opens in new window)"
-                            href={'https://www.medicaid.gov/medicaid/managed-care/guidance/rate-review-and-rate-guides'}
+                            href={
+                                'https://www.medicaid.gov/medicaid/managed-care/guidance/rate-review-and-rate-guides'
+                            }
                             variant="external"
                             target="_blank"
                         >
@@ -302,9 +302,7 @@ export const SingleRateFormFields = ({
                         <FieldCheckbox
                             id={`${fieldNamePrefix}.withDSNP`}
                             name={`${fieldNamePrefix}.rateMedicaidPopulations`}
-                            label={
-                                RateMedicaidPopulationsRecord.MEDICARE_MEDICAID_WITH_DSNP
-                            }
+                            label="Medicare-Medicaid dually eligible individuals enrolled through a Dual-Eligible Special Needs Plan (D-SNP)"
                             value="MEDICARE_MEDICAID_WITH_DSNP"
                             heading="Which Medicaid populations are included in this rate certification"
                             parent_component_heading={formHeading}
@@ -312,7 +310,7 @@ export const SingleRateFormFields = ({
                         <FieldCheckbox
                             id={`${fieldNamePrefix}.medicaidOnly`}
                             name={`${fieldNamePrefix}.rateMedicaidPopulations`}
-                            label={RateMedicaidPopulationsRecord.MEDICAID_ONLY}
+                            label="Medicaid-only"
                             value="MEDICAID_ONLY"
                             heading="Which Medicaid populations are included in this rate certification"
                             parent_component_heading={formHeading}
@@ -324,14 +322,9 @@ export const SingleRateFormFields = ({
                                 <span>
                                     Medicare-Medicaid dually eligible
                                     individuals{' '}
-                                    <span style={{ fontWeight: 600 }}>
-                                        not
-                                    </span>{' '}
+                                    <span style={{ fontWeight: 600 }}>not</span>{' '}
                                     enrolled through a D-SNP
                                 </span>
-                            }
-                            tealiumLabel={
-                                RateMedicaidPopulationsRecord.MEDICARE_MEDICAID_WITHOUT_DSNP
                             }
                             value="MEDICARE_MEDICAID_WITHOUT_DSNP"
                             heading="Which Medicaid populations are included in this rate certification"

--- a/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateFormFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/SingleRateFormFields.tsx
@@ -35,7 +35,7 @@ import {
 } from 'formik'
 import { ActuaryContactFields } from '../Contacts'
 import { FormikRateForm, RateDetailFormConfig } from './V2/RateDetailsV2'
-import { useFocus } from '../../../hooks/useFocus'
+import { useFocus } from '../../../hooks'
 import { ContactSupportLink } from '../../../components/ErrorAlert/ContactSupportLink'
 import { Contract } from '../../../gen/gqlClient'
 import { featureFlags } from '@mc-review/common-code'


### PR DESCRIPTION
## Summary
[MCR-5453](https://jiraent.cms.gov/browse/MCR-5453)

Update rate details/summary `Medicaid populations included in this rate certification` section.
- `Medicare-Medicaid dually eligible individuals enrolled through a Dual-Eligible Special Needs Plan (D-SNP)` -> `Medicare-Medicaid dual eligibles enrolled through a D-SNP (on summary page)`
- `Medicare-Medicaid dually eligible individuals not enrolled through a D-SNP` -> `Medicare-Medicaid dual eligibles not enrolled through a D-SNP`

Fix `Which Medicaid populations are included in this rate certification?` on rate details page. Check box selections should not be the same as the summary descriptions of the selections

#### Related issues

#### Screenshots
Current Copy
<img width="389" height="282" alt="Screenshot 2025-09-05 at 10 00 04 AM" src="https://github.com/user-attachments/assets/7f8e62f8-ac28-41a6-bc71-1bfe1f339e46" />

Updated Copy
<img width="362" height="243" alt="Screenshot 2025-09-05 at 11 03 24 AM" src="https://github.com/user-attachments/assets/2c96a782-4248-4b7f-a2e8-c07e4e09ba47" />


#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed