### PR TITLE
MCR-4855: Breadcrumbs should not display link for active page

### DIFF
--- a/services/app-web/src/components/Breadcrumbs/Breadcrumb.test.tsx
+++ b/services/app-web/src/components/Breadcrumbs/Breadcrumb.test.tsx
@@ -17,11 +17,12 @@ describe('Breadcrumbs', () => {
         const items = [
             { text: 'First link', link: '/firstlink' },
             { text: 'Second link', link: '/secondlink' },
-            { text: 'Active link', link: '/thirdlink' },
+            { text: 'Active link', link: '/thirdlink', current: true },
         ]
         renderWithProviders(<Breadcrumbs items={items} />)
         expect(screen.getAllByRole('listitem')).toHaveLength(items.length)
-        expect(screen.getAllByRole('link')).toHaveLength(items.length)
+        //Expect links to be 1 less than the total amount of crumbs, last crumb is current page.
+        expect(screen.getAllByRole('link')).toHaveLength(items.length - 1)
     })
 
     it('renders nothing if no items passed in', () => {

--- a/services/app-web/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/services/app-web/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,23 +1,28 @@
 import { BreadcrumbBar, Breadcrumb } from '@trussworks/react-uswds'
 import styles from './Breadcrumbs.module.scss'
-import { NavLinkWithLogging } from '../TealiumLogging/Link'
+import { NavLinkWithLogging } from '../TealiumLogging'
 import classNames from 'classnames'
 
 type BreadcrumbItem = {
     text: string
     link: string
+    current?: boolean
 }
 export type BreadcrumbsProps = {
     items: BreadcrumbItem[]
 } & JSX.IntrinsicElements['nav']
 
 const Crumb = (crumb: BreadcrumbItem) => {
-    const { link, text } = crumb
+    const { link, text, current = false } = crumb
     return (
-        <Breadcrumb className={styles.crumb}>
-            <NavLinkWithLogging to={link} end>
+        <Breadcrumb className={styles.crumb} current>
+            {current ? (
                 <span>{text}</span>
-            </NavLinkWithLogging>
+            ) : (
+                <NavLinkWithLogging to={link} end>
+                    <span>{text}</span>
+                </NavLinkWithLogging>
+            )}
         </Breadcrumb>
     )
 }
@@ -28,7 +33,11 @@ const Breadcrumbs = ({ items, className }: BreadcrumbsProps) => {
     return (
         <BreadcrumbBar className={classes}>
             {items.map((item, index) => (
-                <Crumb key={index} {...item} />
+                <Crumb
+                    key={index}
+                    {...item}
+                    current={index === items.length - 1}
+                />
             ))}
         </BreadcrumbBar>
     )


### PR DESCRIPTION
## Summary
[MCR-4855](https://jiraent.cms.gov/browse/MCR-4855)

Remove link from the last breadcrumb item.

AC: 
As a CMS or state user when tabbing through the Add questions/Add responses upload page:
- The breadcrumb's current page is not a link
- The breadcrumbs current page is body text
- The breadcrumbs current page does not receive keyboard focus


#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
Last breadcrumb should no longer be a link. Please validate on the following pages
- Withdraw submission/rate pages
- Add Q&A question/response pages
- Create OAuth client page
- Edit state assignments page
- Release to state page
- Double check if I missed any pages

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [x] Checked accessibility with ANDI and Wave tools as needed