### PR TITLE
[MCR-5443] updated sechub token

### DIFF
--- a/.github/workflows/sechub-jira-sync.yml
+++ b/.github/workflows/sechub-jira-sync.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: ["prod"]  # add more like "val","master" later if needed
+        environment: ["dev"]  # add more like "val","master" later if needed
       fail-fast: false
     environment:
       name: ${{ matrix.environment }}

--- a/.github/workflows/sechub-jira-sync.yml
+++ b/.github/workflows/sechub-jira-sync.yml
@@ -49,7 +49,7 @@ jobs:
         id: sync_step
         uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v2.1.10
         with:
-          jira-token: ${{ secrets.JIRA_TOKEN }}
+          jira-token: ${{ secrets.ENT_JIRA_TOKEN }}
           jira-username: ${{ secrets.JIRA_USERNAME }}
           jira-project-key: MCR
           jira-ignore-statuses: Done, Closed, Canceled

--- a/.github/workflows/sechub-jira-sync.yml
+++ b/.github/workflows/sechub-jira-sync.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: ["dev"]  # add more like "val","master" later if needed
+        environment: ["prod"]  # add more like "val","master" later if needed
       fail-fast: false
     environment:
       name: ${{ matrix.environment }}
@@ -50,7 +50,7 @@ jobs:
         id: sync_step
         uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v2.1.10
         with:
-          jira-token: ${{ secrets.ZARATE_ENT_JIRA_TOKEN }}
+          jira-token: ${{ secrets.ENT_JIRA_TOKEN }}
           jira-username: ${{ secrets.JIRA_USERNAME }}
           jira-project-key: MCR
           jira-ignore-statuses: Done, Closed, Canceled

--- a/.github/workflows/sechub-jira-sync.yml
+++ b/.github/workflows/sechub-jira-sync.yml
@@ -50,7 +50,7 @@ jobs:
         id: sync_step
         uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v2.1.10
         with:
-          jira-token: ${{ secrets.ENT_JIRA_TOKEN }}
+          jira-token: ${{ secrets.ZARATE_ENT_JIRA_TOKEN }}
           jira-username: ${{ secrets.JIRA_USERNAME }}
           jira-project-key: MCR
           jira-ignore-statuses: Done, Closed, Canceled

--- a/.github/workflows/sechub-jira-sync.yml
+++ b/.github/workflows/sechub-jira-sync.yml
@@ -3,8 +3,6 @@ name: Security Sync
 on:
   workflow_dispatch: # for testing and manual runs
   push:
-  branches:
-    - ruizaj-mcr-5443-fix-sechub-sync-github-action
   schedule:
     - cron: "25 1 * * *" # daily at 8:25 PM EST
 

--- a/.github/workflows/sechub-jira-sync.yml
+++ b/.github/workflows/sechub-jira-sync.yml
@@ -2,6 +2,9 @@ name: Security Sync
 
 on:
   workflow_dispatch: # for testing and manual runs
+  push:
+  branches:
+    - ruizaj-mcr-5443-fix-sechub-sync-github-action
   schedule:
     - cron: "25 1 * * *" # daily at 8:25 PM EST
 


### PR DESCRIPTION
## Summary
The security hub sync github action that runs nightly has been throwing errors. This is the job that syncs our AWS security hub findings to Jira. It looks like the pat for github expired.

AC:
- The token has been replaced
- The github action runs without error

#### Related issues
[MCR-5443](https://jiraent.cms.gov/browse/MCR-5443)
