### PR TITLE
MCR-5283: Remove fetchHealthPlanPackage from test

### DIFF
--- a/packages/mocks/src/apollo/healthPlanPackageGQLMock.ts
+++ b/packages/mocks/src/apollo/healthPlanPackageGQLMock.ts
@@ -49,96 +49,6 @@ type fetchHealthPlanPackageMockProps = {
     id: string
 }
 
-const fetchHealthPlanPackageMockSuccess = ({
-    submission = mockDraftHealthPlanPackage(),
-    id,
-}: fetchHealthPlanPackageMockProps): MockedResponse<FetchHealthPlanPackageQuery> => {
-    // override the ID of the returned draft to match the queried id.
-    const mergedDraftSubmission = Object.assign({}, submission, { id })
-    return {
-        request: {
-            query: FetchHealthPlanPackageDocument,
-            variables: { input: { pkgID: id } },
-        },
-        result: {
-            data: {
-                fetchHealthPlanPackage: {
-                    pkg: mergedDraftSubmission,
-                },
-            },
-        },
-    }
-}
-
-const fetchHealthPlanPackageMockNotFound = ({
-    id,
-}: fetchHealthPlanPackageMockProps): MockedResponse<FetchHealthPlanPackageQuery> => {
-    const graphQLError = new GraphQLError(
-        'Issue finding a package with id a6039ed6-39cc-4814-8eaa-0c99f25e325d. Message: Result was undefined.',
-        {
-            extensions: {
-                code: 'NOT_FOUND',
-            },
-        }
-    )
-
-    return {
-        request: {
-            query: FetchHealthPlanPackageDocument,
-            variables: { input: { pkgID: id } },
-        },
-        result: {
-            errors: [graphQLError],
-        },
-    }
-}
-
-const fetchHealthPlanPackageMockAuthFailure =
-    (): MockedResponse<FetchHealthPlanPackageQuery> => {
-        return {
-            request: { query: FetchHealthPlanPackageDocument },
-            error: new Error('You are not logged in'),
-        }
-    }
-
-const fetchHealthPlanPackageMockNetworkFailure =
-    (): MockedResponse<FetchHealthPlanPackageQuery> => {
-        return {
-            request: { query: FetchHealthPlanPackageDocument },
-            error: new Error('A network error occurred'),
-        }
-    }
-
-type fetchStateHealthPlanPackageMockSuccessProps = {
-    stateSubmission?: HealthPlanPackage | Partial<HealthPlanPackage>
-    id: string
-}
-
-const fetchStateHealthPlanPackageMockSuccess = ({
-    stateSubmission = mockSubmittedHealthPlanPackage(),
-    id,
-}: fetchStateHealthPlanPackageMockSuccessProps): MockedResponse<
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    Record<string, any>
-> => {
-    // override the ID of the returned draft to match the queried id.
-    const mergedStateSubmission = Object.assign({}, stateSubmission, { id })
-
-    return {
-        request: {
-            query: FetchHealthPlanPackageDocument,
-            variables: { input: { pkgID: id } },
-        },
-        result: {
-            data: {
-                fetchHealthPlanPackage: {
-                    pkg: mergedStateSubmission,
-                },
-            },
-        },
-    }
-}
-
 const mockSubmittedHealthPlanPackageWithRevision = ({
     currentSubmissionData,
     currentSubmitInfo,
@@ -668,11 +578,6 @@ const indexHealthPlanPackagesMockSuccess = (
 }
 
 export {
-    fetchHealthPlanPackageMockSuccess,
-    fetchHealthPlanPackageMockNotFound,
-    fetchHealthPlanPackageMockNetworkFailure,
-    fetchHealthPlanPackageMockAuthFailure,
-    fetchStateHealthPlanPackageMockSuccess,
     updateHealthPlanFormDataMockAuthFailure,
     updateHealthPlanFormDataMockNetworkFailure,
     updateHealthPlanFormDataMockSuccess,

--- a/packages/mocks/src/apollo/questionResponseGQLMock.ts
+++ b/packages/mocks/src/apollo/questionResponseGQLMock.ts
@@ -155,66 +155,11 @@ const createRateQuestionResponseNetworkFailure = (
     }
 }
 
-const fetchStateHealthPlanPackageWithQuestionsMockSuccess = ({
-    stateSubmission = mockSubmittedHealthPlanPackage(),
-    id,
-    questions,
-}: fetchStateHealthPlanPackageWithQuestionsProps): MockedResponse<
-    Record<string, unknown>
-> => {
-    const questionPayload = questions || mockQuestionsPayload(id)
-    const pkg = {
-        ...stateSubmission,
-        questions: questionPayload,
-    }
-
-    // override the ID of the returned draft to match the queried id.
-    const mergedStateSubmission = Object.assign({}, pkg, { id })
-
-    return {
-        request: {
-            query: FetchHealthPlanPackageWithQuestionsDocument,
-            variables: { input: { pkgID: id } },
-        },
-        result: {
-            data: {
-                fetchHealthPlanPackage: {
-                    pkg: mergedStateSubmission,
-                },
-            },
-        },
-    }
-}
-
-const fetchStateHealthPlanPackageWithQuestionsMockNotFound = ({
-    id,
-}: fetchStateHealthPlanPackageWithQuestionsProps): MockedResponse<FetchHealthPlanPackageWithQuestionsQuery> => {
-    const graphQLError = new GraphQLError(
-        'Issue finding a package with id a6039ed6-39cc-4814-8eaa-0c99f25e325d. Message: Result was undefined.',
-        {
-            extensions: {
-                code: 'NOT_FOUND',
-            },
-        }
-    )
-
-    return {
-        request: {
-            query: FetchHealthPlanPackageWithQuestionsDocument,
-            variables: { input: { pkgID: id } },
-        },
-        result: {
-            errors: [graphQLError],
-        },
-    }
-}
 
 export {
     createContractQuestionNetworkFailure,
     createContractQuestionResponseNetworkFailure,
     createContractQuestionSuccess,
-    fetchStateHealthPlanPackageWithQuestionsMockSuccess,
-    fetchStateHealthPlanPackageWithQuestionsMockNotFound,
     createRateQuestionNetworkFailure,
     createRateQuestionResponseNetworkFailure,
     createRateQuestionSuccess,


### PR DESCRIPTION
## Summary
This PR
- Remove all instances of fetchHealthPlanPackage from tests
- Removes fetchHPP related test mocks
- Refactors StateSubmission test to no longer use the deprecated supporting documents page (that pages uses the old HPP api and is currently not used in prod under the hide-supporting-docs flag)

#### Related issues
https://jiraent.cms.gov/browse/MCR-5283

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed