### PR TITLE
MCR-5548: Zip file download bug

### DIFF
--- a/services/app-api/src/resolvers/configureResolvers.ts
+++ b/services/app-api/src/resolvers/configureResolvers.ts
@@ -97,7 +97,7 @@ export function configureResolvers(
             indexRates: indexRatesResolver(store),
             indexRatesStripped: indexRatesStripped(store),
             fetchRate: fetchRateResolver(store),
-            fetchContract: fetchContractResolver(store),
+            fetchContract: fetchContractResolver(store, documentZip),
             fetchOauthClients: fetchOauthClientsResolver(store),
         },
         Mutation: {


### PR DESCRIPTION
## Summary

Currently zip file generation only happen on `submitContract` this PR adds zip file generation on `fetchContract`. Since the bug cannot be tested locally or on the review app, the hope is adding this code will help add logging for debugging the prod issue. Currently there's only 1 instance of the zip download error being captured in cloudwatch on prod and that's from July. 

#### Related issues

https://jiraent.cms.gov/browse/MCR-5548

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed