### PR TITLE
MCR-5549: unable to download error

### DIFF
--- a/services/app-api/src/resolvers/configureResolvers.ts
+++ b/services/app-api/src/resolvers/configureResolvers.ts
@@ -129,8 +129,12 @@ export function configureResolvers(
             ),
             updateDraftContractRates: updateDraftContractRates(store),
             approveContract: approveContract(store),
-            withdrawContract: withdrawContract(store, emailer),
-            undoWithdrawContract: undoWithdrawContract(store, emailer),
+            withdrawContract: withdrawContract(store, emailer, documentZip),
+            undoWithdrawContract: undoWithdrawContract(
+                store,
+                emailer,
+                documentZip
+            ),
             withdrawRate: withdrawRate(store, emailer),
             undoWithdrawRate: undoWithdrawRate(store, emailer),
             updateDivisionAssignment: updateDivisionAssignment(store),


### PR DESCRIPTION
## Summary

Currently download zip urls are only generated in the `submitContract` resolver. There are 2 actions that a CMS user can take that don't use the `submitContract` resolver. This PR adds the generate zip urls to the `withdrawContract` and `undoWithdrawContract` resolvers to resolve the bug

#### Related issues
https://jiraent.cms.gov/browse/MCR-5549

## QA guidance

Withdraw/undo withdraw contract: 
- Sign in as a CMS user
- Withdraw a submission
- There should no longer be a 'unable to download files' error banner
- Undo the withdraw 
- There should no longer be a 'unable to download files' error banner

Resubmit (I wasn't able to reproduce this and saw that it was working -- please confirm)
- Sign in as a state user in val
- Resubmit an unlocked submission 
- Sign in as a CMS user and view the submission. The document download error banner is present

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed