### PR TITLE
[MCR-5443] Sechub Fix

### DIFF
--- a/.github/workflows/sechub-jira-sync.yml
+++ b/.github/workflows/sechub-jira-sync.yml
@@ -2,7 +2,6 @@ name: Security Sync
 
 on:
   workflow_dispatch: # for testing and manual runs
-  push:
   schedule:
     - cron: "25 1 * * *" # daily at 8:25 PM EST
 
@@ -17,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: ["dev"]  # add more like "val","master" later if needed
+        environment: ["prod"]  # add more like "val","master" later if needed
       fail-fast: false
     environment:
       name: ${{ matrix.environment }}


### PR DESCRIPTION
The security hub sync github action that runs nightly has been throwing errors. This is the job that syncs our AWS security hub findings to Jira. It looks like the pat for github expired.

This is a follow up PR to add jira-host to the sechub yml

AC:
- The token has been replaced
- The github action runs without error

Related issues
- [MCR-5443](https://jiraent.cms.gov/browse/MCR-5443)