### PR TITLE
Prevent network stack deploys from mutating in-use Lambda SG exports

### DIFF
--- a/.github/workflows/deploy-cdk.yml
+++ b/.github/workflows/deploy-cdk.yml
@@ -295,7 +295,19 @@ jobs:
           SUBNET_PRIVATE_C_ID: ${{ secrets.DEV_SUBNET_PRIVATE_C_ID }}
         run: |
           echo "=== Deploying Network stack ==="
-          pnpm cdk deploy network-${STAGE_NAME}-cdk \
+          export_name="network-${STAGE_NAME}-cdk-LambdaSecurityGroupId"
+          existing_sg_id=$(aws cloudformation list-exports \
+            --query "Exports[?Name=='${export_name}'].Value" \
+            --output text)
+
+          if [ -n "$existing_sg_id" ] && [ "$existing_sg_id" != "None" ]; then
+            echo "Preserving existing Lambda security group export for ${export_name}"
+            deploy_sg_id="$existing_sg_id"
+          else
+            deploy_sg_id="$SG_ID"
+          fi
+
+          SG_ID="$deploy_sg_id" pnpm cdk deploy network-${STAGE_NAME}-cdk \
             --app 'pnpm tsx bin/network.ts' \
             --context stage=${STAGE_NAME} \
             --require-approval never

--- a/.github/workflows/promote-cdk.yml
+++ b/.github/workflows/promote-cdk.yml
@@ -267,7 +267,19 @@ jobs:
           SUBNET_PRIVATE_C_ID: ${{ secrets.DEV_SUBNET_PRIVATE_C_ID }}
         run: |
           echo "=== Deploying Network stack ==="
-          pnpm cdk deploy network-dev-cdk \
+          export_name="network-dev-cdk-LambdaSecurityGroupId"
+          existing_sg_id=$(aws cloudformation list-exports \
+            --query "Exports[?Name=='${export_name}'].Value" \
+            --output text)
+
+          if [ -n "$existing_sg_id" ] && [ "$existing_sg_id" != "None" ]; then
+            echo "Preserving existing Lambda security group export for ${export_name}"
+            deploy_sg_id="$existing_sg_id"
+          else
+            deploy_sg_id="$SG_ID"
+          fi
+
+          SG_ID="$deploy_sg_id" pnpm cdk deploy network-dev-cdk \
             --app 'pnpm tsx bin/network.ts' \
             --context stage=dev \
             --require-approval never
@@ -614,7 +626,19 @@ jobs:
           SUBNET_PRIVATE_C_ID: ${{ secrets.VAL_SUBNET_PRIVATE_C_ID }}
         run: |
           echo "=== Deploying Network stack ==="
-          pnpm cdk deploy network-val-cdk \
+          export_name="network-val-cdk-LambdaSecurityGroupId"
+          existing_sg_id=$(aws cloudformation list-exports \
+            --query "Exports[?Name=='${export_name}'].Value" \
+            --output text)
+
+          if [ -n "$existing_sg_id" ] && [ "$existing_sg_id" != "None" ]; then
+            echo "Preserving existing Lambda security group export for ${export_name}"
+            deploy_sg_id="$existing_sg_id"
+          else
+            deploy_sg_id="$SG_ID"
+          fi
+
+          SG_ID="$deploy_sg_id" pnpm cdk deploy network-val-cdk \
             --app 'pnpm tsx bin/network.ts' \
             --context stage=val \
             --require-approval never
@@ -953,7 +977,19 @@ jobs:
           SUBNET_PRIVATE_C_ID: ${{ secrets.PROD_SUBNET_PRIVATE_C_ID }}
         run: |
           echo "=== Deploying Network stack ==="
-          pnpm cdk deploy network-prod-cdk \
+          export_name="network-prod-cdk-LambdaSecurityGroupId"
+          existing_sg_id=$(aws cloudformation list-exports \
+            --query "Exports[?Name=='${export_name}'].Value" \
+            --output text)
+
+          if [ -n "$existing_sg_id" ] && [ "$existing_sg_id" != "None" ]; then
+            echo "Preserving existing Lambda security group export for ${export_name}"
+            deploy_sg_id="$existing_sg_id"
+          else
+            deploy_sg_id="$SG_ID"
+          fi
+
+          SG_ID="$deploy_sg_id" pnpm cdk deploy network-prod-cdk \
             --app 'pnpm tsx bin/network.ts' \
             --context stage=prod \
             --require-approval never


### PR DESCRIPTION
Summary

This change fixes CDK deploy failures on the network stack caused by CloudFormation trying to replace the exported LambdaSecurityGroupId while that export is still imported by downstream stacks like app-api and postgres.

The workflow now looks up the currently deployed network-<stage>-cdk-LambdaSecurityGroupId export before deploying the network stack. If that export already exists, we reuse its value for SG_ID during the deploy. If it does not exist, we fall back to the stage secret as before. This keeps existing environments stable while still allowing first-time stack creation.

