### PR TITLE
MCR-6040 Design Review/Feedback

### DIFF
--- a/services/app-web/src/components/ChangeHistory/ChangeHistory.module.scss
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistory.module.scss
@@ -17,7 +17,6 @@
     }
     h5[class*='usa-accordion__heading'] {
         @include custom.mcr-h5-style;
-        margin: 0;
     }
 }
 


### PR DESCRIPTION
## Summary
Anna noticed that the spacing in between Change History accordions was off. This is only noticed on this branch - where we changed the heading to h5 and applied some styles to make sure it had the heading 5 look. This PR addresses that by removing the margin: 0 and letting the existing styles for margin inherit.
The other reported issue was around the padding of the text - but I'm correctly seeing 16px above, 20 px on left and right, and 12px below (2nd screenshot)

#### Related issues
https://jiraent.cms.gov/browse/MCR-6040

#### Screenshots
<img width="843" height="365" alt="image" src="https://github.com/user-attachments/assets/7a461ca6-00ab-4ecc-9bb6-f1a72e51c2e1" />

<img width="1176" height="368" alt="image" src="https://github.com/user-attachments/assets/57e33b75-c3ff-4e22-9202-9f4ae29fb565" />

#### Test cases covered
N/A - styling update only, no test cases affected

## QA guidance
Review a submission that has multiple change history sections and confirm spacing/padding of the change history accordions 

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed