### PR TITLE
MCR-6071 Dashboard Table Styles

### DIFF
--- a/services/app-web/src/components/ContractTable/ContractTable.module.scss
+++ b/services/app-web/src/components/ContractTable/ContractTable.module.scss
@@ -32,8 +32,8 @@
     tbody td {
         padding-top: uswds.units(2);
         padding-bottom: uswds.units(2);
-        padding-left: uswds.units(1);
-        padding-right: uswds.units(1);
+        padding-left: uswds.units(2);
+        padding-right: uswds.units(2);
         vertical-align: top;
     }
 
@@ -58,20 +58,25 @@
 }
 
 .columnID {
-    min-width: 90px;
-    max-width: 224px;
+    min-width: 5.625rem;
+    max-width: 14rem;
 }
 
 .contractTypeColumn {
-    width: 130px;
+    width: 8.125rem;
+}
+
+.dateColumn {
+    width: 8rem;
+    white-space: nowrap;
 }
 
 .statusColumn {
-    min-width: 181.83px;
+    min-width: 11.375rem;
 }
 
 .programsColumn {
-    max-width: 143px;
+    max-width: 16rem;
 }
 
 .programTag {
@@ -107,4 +112,10 @@
     text-align: center;
     justify-content: center;
     white-space: nowrap;
+}
+
+@media (max-width: 70rem) {
+    .notSubjectToReviewTag {
+        white-space: normal;
+    }
 }

--- a/services/app-web/src/components/ContractTable/ContractTable.module.scss
+++ b/services/app-web/src/components/ContractTable/ContractTable.module.scss
@@ -109,8 +109,6 @@
 
 .notSubjectToReviewTag {
     display: inline-block;
-    text-align: center;
-    justify-content: center;
     white-space: nowrap;
 }
 

--- a/services/app-web/src/components/ContractTable/ContractTable.module.scss
+++ b/services/app-web/src/components/ContractTable/ContractTable.module.scss
@@ -32,6 +32,8 @@
     tbody td {
         padding-top: uswds.units(2);
         padding-bottom: uswds.units(2);
+        padding-left: uswds.units(1);
+        padding-right: uswds.units(1);
         vertical-align: top;
     }
 
@@ -57,6 +59,15 @@
 
 .columnID {
     min-width: 90px;
+    max-width: 224px;
+}
+
+.contractTypeColumn {
+    width: 130px;
+}
+
+.statusColumn {
+    min-width: 181.83px;
 }
 
 .programsColumn {
@@ -94,4 +105,6 @@
 .notSubjectToReviewTag {
     display: inline-block;
     text-align: center;
+    justify-content: center;
+    white-space: nowrap;
 }

--- a/services/app-web/src/components/ContractTable/ContractTable.tsx
+++ b/services/app-web/src/components/ContractTable/ContractTable.tsx
@@ -197,6 +197,14 @@ const getColumnClassName = (columnId: string): string | undefined => {
         return styles.columnID
     }
 
+    if (columnId === 'contractSubmissionType') {
+        return styles.contractTypeColumn
+    }
+
+    if (columnId === 'status') {
+        return styles.statusColumn
+    }
+
     if (columnId === 'programs') {
         return styles.programsColumn
     }

--- a/services/app-web/src/components/ContractTable/ContractTable.tsx
+++ b/services/app-web/src/components/ContractTable/ContractTable.tsx
@@ -201,6 +201,14 @@ const getColumnClassName = (columnId: string): string | undefined => {
         return styles.contractTypeColumn
     }
 
+    if (columnId === 'submittedAt') {
+        return styles.dateColumn
+    }
+
+    if (columnId === 'updatedAt') {
+        return styles.dateColumn
+    }
+
     if (columnId === 'status') {
         return styles.statusColumn
     }


### PR DESCRIPTION
## Summary
Anna saw some table issues with the spacing and width of columns. After meeting with her, these are the changes I made. Note, I converted the pixels to rems for the table widths so they'd scale better when user's adjust the browser zoom.

- Anna liked the 16pt padding all around when we paired, so made the change to keep that 
- Programs column should have a max-width of ~143px (Note: adjusted the width for the best responsive view for State dashboard, although it's less responsive for CMS b/c of the extra columns)
- The ID column should have a minimum width of ~90px and max width of ~224px on both dashboards
- Add fixed width of ~130px to contract type column on both CMS and State dashboards

Additionally, I adjusted all the column widths to rem instead of pixels. Also added css to prevent the Not Subject to Review tag from wrapping in desktop view, but remove that nowrap when the screen is sized down. 

Global padding styles are shared with Rate Review, as well as the ID and Programs column widths. The rest of the changes were specifically for submissions dashboards (both state and cms). 

#### Related issues
https://jiraent.cms.gov/browse/MCR-6071
https://jiraent.cms.gov/browse/MCR-6069
https://jiraent.cms.gov/browse/MCR-6070

#### Screenshots


#### Test cases covered
N/A - only styling changes that did not affect test cases

## QA guidance


## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed