### PR TITLE
Pin localstack to 4.4.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       timeout: 5s
       retries: 5
 
-  # LocalStack for S3 emulation (Pinned to 4.4.0 further versions are no longer free)
+  # LocalStack for S3 emulation (Pinned to 4.4.0 further versions require a license)
   localstack:
     image: localstack/localstack:4.4.0
     container_name: mcr-localstack

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   # LocalStack for S3 emulation (Community Edition - Free, no license required)
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:4.4.0
     container_name: mcr-localstack
     ports:
       - "4566:4566" # LocalStack edge port

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       timeout: 5s
       retries: 5
 
-  # LocalStack for S3 emulation (Community Edition - Free, no license required)
+  # LocalStack for S3 emulation (Pinned to 4.4.0 further versions are no longer free)
   localstack:
     image: localstack/localstack:4.4.0
     container_name: mcr-localstack

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       timeout: 5s
       retries: 5
 
-  # LocalStack for S3 emulation (Pinned to 4.4.0 further versions require a license)
+  # LocalStack for S3 emulation (Pinned to 4.4.0 later versions require a license)
   localstack:
     image: localstack/localstack:4.4.0
     container_name: mcr-localstack

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       timeout: 5s
       retries: 5
 
-  # LocalStack for S3 emulation (Pinned to 4.4.0 later versions require a license)
+  # LocalStack for S3 emulation (Pinned to 4.4.0; later versions require a license)
   localstack:
     image: localstack/localstack:4.4.0
     container_name: mcr-localstack


### PR DESCRIPTION
## Summary

Pinning `localstack` for local deployment to `4.4.0` as later versions are no longer free for the Community Edition. 

#### Related issues

- https://github.com/microcks/microcks/issues/2008

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
- Local deployment
   - Clean up docker volumes and images
   - Deploy local application
   - Validate that deployment was successful 