### PR TITLE
MCR-6100: Block submission of deprecated programs at api level

### DIFF
--- a/services/app-api/src/domain-models/contractAndRates/dataValidatorHelpers.test.ts
+++ b/services/app-api/src/domain-models/contractAndRates/dataValidatorHelpers.test.ts
@@ -7,6 +7,7 @@ import {
 } from './dataValidatorHelpers'
 import {
     mockGqlContractDraftRevisionFormDataInput,
+    mockSubmittableHealthPlanContract,
     must,
 } from '../../testHelpers'
 import type {
@@ -23,6 +24,7 @@ import {
 } from '../../testHelpers/gqlHelpers'
 import type { ContractFormDataType } from './formDataTypes'
 import { eqroValidationAndReviewDetermination } from '@mc-review/submissions'
+import { vi } from 'vitest'
 
 describe('Health plan parsing and validation', () => {
     describe('validateContractDraftRevisionInput', () => {
@@ -747,6 +749,74 @@ describe('Health plan parsing and validation', () => {
                 'dsnpContract is required when any of the following Federal Authorities are present: STATE_PLAN,WAIVER_1915B,WAIVER_1115,VOLUNTARY'
             )
         })
+        it('return error if a submitted programID is deprecated', async () => {
+            const prismaClient = await sharedTestPrismaClient()
+            const postgresStore = NewPostgresStore(prismaClient)
+            const floridaProgram = defaultFloridaProgram()
+            const floridaRateProgram = defaultFloridaRateProgram()
+
+            // Force findPrograms to mark the contract program as deprecated
+            vi.spyOn(postgresStore, 'findPrograms').mockReturnValue([
+                { ...floridaProgram, isDeprecated: true },
+                floridaRateProgram,
+            ])
+
+            const contract = mockSubmittableHealthPlanContract()
+
+            const parsedContract = parseContract(
+                contract,
+                'FL',
+                postgresStore,
+                { '438-attestation': true, dsnp: true }
+            )
+            if (!(parsedContract instanceof Error)) {
+                throw new Error(
+                    'Expected parseContract to return an error for deprecated programID'
+                )
+            }
+            const errMessages = parsedContract.issues.map((err) => err.message)
+            expect(
+                errMessages.some((m) =>
+                    m.includes('Submission contains deprecated program(s)')
+                )
+            ).toBe(true)
+        })
+        it('ignores deprecated programs referenced only by deprecatedRateProgramIDs', async () => {
+            const prismaClient = await sharedTestPrismaClient()
+            const postgresStore = NewPostgresStore(prismaClient)
+            const floridaProgram = defaultFloridaProgram()
+            const floridaRateProgram = defaultFloridaRateProgram()
+            const deprecatedRateProgramID =
+                '00000000-0000-0000-0000-000000000001'
+
+            // Deprecated program only referenced via deprecatedRateProgramIDs — should not block submission
+            vi.spyOn(postgresStore, 'findPrograms').mockReturnValue([
+                floridaProgram,
+                floridaRateProgram,
+                {
+                    id: deprecatedRateProgramID,
+                    name: 'OLD',
+                    fullName: 'Old Program',
+                    isRateProgram: true,
+                    isDeprecated: true,
+                },
+            ])
+
+            const contract = mockSubmittableHealthPlanContract({
+                contractID: '28b00852-00e3-467c-9311-519e60d43284',
+                stateNumber: 6,
+                deprecatedRateProgramIDs: [deprecatedRateProgramID],
+            })
+
+            const parsedContract = parseContract(
+                contract,
+                'FL',
+                postgresStore,
+                { '438-attestation': true, dsnp: true }
+            )
+
+            expect(parsedContract).toEqual(contract)
+        })
     })
 })
 
@@ -1435,6 +1505,42 @@ describe('EQRO parsing and validation', () => {
             }
 
             expect(parsedContract).toEqual(contract)
+        })
+
+        it('should return an error if a submitted programID is deprecated', async () => {
+            const prismaClient = await sharedTestPrismaClient()
+            const postgresStore = NewPostgresStore(prismaClient)
+            const stateCode = 'FL'
+            const contract = createValidEQROContract()
+
+            // Force findPrograms to return every program as deprecated
+            vi.spyOn(postgresStore, 'findPrograms').mockImplementation(
+                (_stateCode, programIDs) =>
+                    programIDs.map((id) => ({
+                        id,
+                        name: 'DEP',
+                        fullName: 'Deprecated Program',
+                        isRateProgram: false,
+                        isDeprecated: true,
+                    }))
+            )
+
+            const parsedContract = parseEQROContract(
+                contract,
+                stateCode,
+                postgresStore
+            )
+
+            if (!(parsedContract instanceof Error)) {
+                throw new Error('Expected parseEQROContract to return an error')
+            }
+
+            const errMessages = parsedContract.issues.map((err) => err.message)
+            expect(
+                errMessages.some((m) =>
+                    m.includes('Submission contains deprecated program(s)')
+                )
+            ).toBe(true)
         })
     })
 })

--- a/services/app-api/src/domain-models/contractAndRates/dataValidatorHelpers.test.ts
+++ b/services/app-api/src/domain-models/contractAndRates/dataValidatorHelpers.test.ts
@@ -22,9 +22,9 @@ import {
     defaultFloridaProgram,
     defaultFloridaRateProgram,
 } from '../../testHelpers/gqlHelpers'
+import { findStatePrograms } from '../../postgres'
 import type { ContractFormDataType } from './formDataTypes'
 import { eqroValidationAndReviewDetermination } from '@mc-review/submissions'
-import { vi } from 'vitest'
 
 describe('Health plan parsing and validation', () => {
     describe('validateContractDraftRevisionInput', () => {
@@ -499,7 +499,7 @@ describe('Health plan parsing and validation', () => {
                                 // amendmentEffectiveDateEnd: new Date('2020-02-04'),
                                 amendmentEffectiveDateStart: undefined,
                                 amendmentEffectiveDateEnd: undefined,
-                                rateProgramIDs: ['fakerateprogramid'],
+                                rateProgramIDs: ['linked-rate-program'],
                                 deprecatedRateProgramIDs: [],
                                 certifyingActuaryContacts: [
                                     {
@@ -558,9 +558,13 @@ describe('Health plan parsing and validation', () => {
             expect(errMessages[4]).toContain(
                 'rateMedicaidPopulations is required when dsnpContract is true'
             )
+            // The rate is linked (parentContractID !== contract.id), so its rateProgramIDs
+            // are excluded from this contract's program validation. Only the contract's own
+            // 'fake-id' should surface in the error.
             expect(errMessages[5]).toContain(
-                'Program(s) in [fake-id,fakerateprogramid] are not valid FL programs'
+                'Program(s) in [fake-id] are not valid FL programs'
             )
+            expect(errMessages[5]).not.toContain('fakerateprogramid')
         })
         it('return error if dnspContract is required but not populated', async () => {
             const prismaClient = await sharedTestPrismaClient()
@@ -752,20 +756,22 @@ describe('Health plan parsing and validation', () => {
         it('return error if a submitted programID is deprecated', async () => {
             const prismaClient = await sharedTestPrismaClient()
             const postgresStore = NewPostgresStore(prismaClient)
-            const floridaProgram = defaultFloridaProgram()
-            const floridaRateProgram = defaultFloridaRateProgram()
+            const deprecatedProgram = must(findStatePrograms('KY')).find(
+                (p) => p.isDeprecated
+            )
+            if (!deprecatedProgram) {
+                throw new Error(
+                    'Test setup error: expected KY to have at least one deprecated program in statePrograms.json'
+                )
+            }
 
-            // Force findPrograms to mark the contract program as deprecated
-            vi.spyOn(postgresStore, 'findPrograms').mockReturnValue([
-                { ...floridaProgram, isDeprecated: true },
-                floridaRateProgram,
-            ])
-
-            const contract = mockSubmittableHealthPlanContract()
+            const contract = mockSubmittableHealthPlanContract({
+                programIDs: [deprecatedProgram.id],
+            })
 
             const parsedContract = parseContract(
                 contract,
-                'FL',
+                'KY',
                 postgresStore,
                 { '438-attestation': true, dsnp: true }
             )
@@ -781,36 +787,66 @@ describe('Health plan parsing and validation', () => {
                 )
             ).toBe(true)
         })
-        it('ignores deprecated programs referenced only by deprecatedRateProgramIDs', async () => {
+        it('return error if a child rate has a deprecated rateProgramID', async () => {
             const prismaClient = await sharedTestPrismaClient()
             const postgresStore = NewPostgresStore(prismaClient)
-            const floridaProgram = defaultFloridaProgram()
-            const floridaRateProgram = defaultFloridaRateProgram()
-            const deprecatedRateProgramID =
-                '00000000-0000-0000-0000-000000000001'
+            const deprecatedProgram = must(findStatePrograms('KY')).find(
+                (p) => p.isDeprecated
+            )
+            if (!deprecatedProgram) {
+                throw new Error(
+                    'Test setup error: expected KY to have at least one deprecated program in statePrograms.json'
+                )
+            }
 
-            // Deprecated program only referenced via deprecatedRateProgramIDs — should not block submission
-            vi.spyOn(postgresStore, 'findPrograms').mockReturnValue([
-                floridaProgram,
-                floridaRateProgram,
-                {
-                    id: deprecatedRateProgramID,
-                    name: 'OLD',
-                    fullName: 'Old Program',
-                    isRateProgram: true,
-                    isDeprecated: true,
-                },
-            ])
-
+            // Default mock rate is a child (parentContractID === contract.id).
             const contract = mockSubmittableHealthPlanContract({
-                contractID: '28b00852-00e3-467c-9311-519e60d43284',
-                stateNumber: 6,
-                deprecatedRateProgramIDs: [deprecatedRateProgramID],
+                rateProgramIDs: [deprecatedProgram.id],
             })
 
             const parsedContract = parseContract(
                 contract,
-                'FL',
+                'KY',
+                postgresStore,
+                { '438-attestation': true, dsnp: true }
+            )
+            if (!(parsedContract instanceof Error)) {
+                throw new Error(
+                    'Expected parseContract to return an error for deprecated rateProgramID on a child rate'
+                )
+            }
+            const errMessages = parsedContract.issues.map((err) => err.message)
+            expect(
+                errMessages.some(
+                    (m) =>
+                        m.includes(
+                            'Submission contains deprecated program(s)'
+                        ) && m.includes(deprecatedProgram.id)
+                )
+            ).toBe(true)
+        })
+        it('ignores deprecated rateProgramIDs on linked rates', async () => {
+            const prismaClient = await sharedTestPrismaClient()
+            const postgresStore = NewPostgresStore(prismaClient)
+            const deprecatedProgram = must(findStatePrograms('KY')).find(
+                (p) => p.isDeprecated
+            )
+            if (!deprecatedProgram) {
+                throw new Error(
+                    'Test setup error: expected KY to have at least one deprecated program in statePrograms.json'
+                )
+            }
+
+            const contract = mockSubmittableHealthPlanContract({
+                rateProgramIDs: [deprecatedProgram.id],
+            })
+            // Make the rate linked by pointing its parentContractID at a different contract.
+            contract.draftRates![0].parentContractID =
+                'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+
+            const parsedContract = parseContract(
+                contract,
+                'KY',
                 postgresStore,
                 { '438-attestation': true, dsnp: true }
             )
@@ -1510,24 +1546,20 @@ describe('EQRO parsing and validation', () => {
         it('should return an error if a submitted programID is deprecated', async () => {
             const prismaClient = await sharedTestPrismaClient()
             const postgresStore = NewPostgresStore(prismaClient)
-            const stateCode = 'FL'
-            const contract = createValidEQROContract()
-
-            // Force findPrograms to return every program as deprecated
-            vi.spyOn(postgresStore, 'findPrograms').mockImplementation(
-                (_stateCode, programIDs) =>
-                    programIDs.map((id) => ({
-                        id,
-                        name: 'DEP',
-                        fullName: 'Deprecated Program',
-                        isRateProgram: false,
-                        isDeprecated: true,
-                    }))
-            )
+            const kyPrograms = must(findStatePrograms('KY'))
+            const deprecatedProgram = kyPrograms.find((p) => p.isDeprecated)
+            if (!deprecatedProgram) {
+                throw new Error(
+                    'Test setup error: expected KY to have at least one deprecated program in statePrograms.json'
+                )
+            }
+            const contract = createValidEQROContract({
+                programIDs: [deprecatedProgram.id],
+            })
 
             const parsedContract = parseEQROContract(
                 contract,
-                stateCode,
+                'KY',
                 postgresStore
             )
 

--- a/services/app-api/src/domain-models/contractAndRates/dataValidatorHelpers.ts
+++ b/services/app-api/src/domain-models/contractAndRates/dataValidatorHelpers.ts
@@ -258,8 +258,13 @@ const parseContract = (
             const contractProgramsIDs = new Set(
                 contract.draftRevision.formData.programIDs
             )
+            // Collect deprecated programs to validate programs being submitted.
+            const nonDeprecatableIDs = new Set(contractProgramsIDs)
             const allProgramIDs = contract.draftRates.reduce((acc, rate) => {
                 const rateFormData = rate.draftRevision.formData
+                rateFormData.rateProgramIDs.forEach((id) =>
+                    nonDeprecatableIDs.add(id)
+                )
                 const rateProgramIDs = rateFormData.rateProgramIDs.concat(
                     rateFormData.deprecatedRateProgramIDs
                 )
@@ -271,6 +276,22 @@ const parseContract = (
                 ctx.addIssue({
                     code: 'custom',
                     message: findResult.message,
+                })
+                return
+            }
+
+            // Reject submission if any current contract/rate program has been deprecated in statePrograms.json
+            const deprecatedMatches = findResult.filter(
+                (program) =>
+                    program.isDeprecated && nonDeprecatableIDs.has(program.id)
+            )
+            if (deprecatedMatches.length > 0) {
+                const names = deprecatedMatches
+                    .map((p) => `${p.name} (${p.id})`)
+                    .join(', ')
+                ctx.addIssue({
+                    code: 'custom',
+                    message: `Submission contains deprecated program(s): ${names}`,
                 })
             }
         }
@@ -305,6 +326,20 @@ const parseEQROContract = (
                     code: 'custom',
                     message: findResult.message,
                 })
+            } else {
+                // Reject EQRO submission if any selected program has been deprecated in statePrograms.json
+                const deprecatedMatches = findResult.filter(
+                    (program) => program.isDeprecated
+                )
+                if (deprecatedMatches.length > 0) {
+                    const names = deprecatedMatches
+                        .map((p) => `${p.name} (${p.id})`)
+                        .join(', ')
+                    ctx.addIssue({
+                        code: 'custom',
+                        message: `Submission contains deprecated program(s): ${names}`,
+                    })
+                }
             }
 
             const hasRates = contract.draftRates && contract.draftRates.length

--- a/services/app-api/src/domain-models/contractAndRates/dataValidatorHelpers.ts
+++ b/services/app-api/src/domain-models/contractAndRates/dataValidatorHelpers.ts
@@ -255,22 +255,20 @@ const parseContract = (
     // to make it part of the core zod parsing.
     const contractWithProgramsParser = contractParser.superRefine(
         (contract, ctx) => {
-            const contractProgramsIDs = new Set(
+            // collect all contract and rate program IDs for validation
+            const allProgramIDs = new Set<string>(
                 contract.draftRevision.formData.programIDs
             )
-            // Collect deprecated programs to validate programs being submitted.
-            const nonDeprecatableIDs = new Set(contractProgramsIDs)
-            const allProgramIDs = contract.draftRates.reduce((acc, rate) => {
-                const rateFormData = rate.draftRevision.formData
-                rateFormData.rateProgramIDs.forEach((id) =>
-                    nonDeprecatableIDs.add(id)
+            for (const rate of contract.draftRates) {
+                if (rate.parentContractID !== contract.id) {
+                    continue
+                }
+                rate.draftRevision.formData.rateProgramIDs.forEach((id) =>
+                    allProgramIDs.add(id)
                 )
-                const rateProgramIDs = rateFormData.rateProgramIDs.concat(
-                    rateFormData.deprecatedRateProgramIDs
-                )
-                return new Set([...acc, ...rateProgramIDs])
-            }, contractProgramsIDs)
+            }
 
+            // find programs full data using collected ids
             const findResult = store.findPrograms(stateCode, [...allProgramIDs])
             if (findResult instanceof Error) {
                 ctx.addIssue({
@@ -280,11 +278,12 @@ const parseContract = (
                 return
             }
 
-            // Reject submission if any current contract/rate program has been deprecated in statePrograms.json
+            // filter out any deprecated programs
             const deprecatedMatches = findResult.filter(
-                (program) =>
-                    program.isDeprecated && nonDeprecatableIDs.has(program.id)
+                (program) => program.isDeprecated
             )
+
+            // add parsing error message for deprecated programs
             if (deprecatedMatches.length > 0) {
                 const names = deprecatedMatches
                     .map((p) => `${p.name} (${p.id})`)

--- a/services/app-api/src/resolvers/contract/submitContract.test.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.test.ts
@@ -1493,6 +1493,53 @@ describe('submitContract', () => {
             )
         })
 
+        it('returns an error when submitting a contract whose child rate has a deprecated rateProgramID', async () => {
+            const kyPrograms = must(findStatePrograms('KY'))
+            const deprecatedProgram = kyPrograms.find((p) => p.isDeprecated)
+            const activeProgram = kyPrograms.find((p) => !p.isDeprecated)
+            if (!deprecatedProgram || !activeProgram) {
+                throw new Error(
+                    'Test setup error: expected KY to have at least one deprecated and one active program in statePrograms.json'
+                )
+            }
+
+            const stateServer = await constructTestPostgresServer({
+                s3Client: mockS3,
+                context: {
+                    user: testStateUser({ stateCode: 'KY' }),
+                },
+            })
+
+            const draft = await createAndUpdateTestContractWithoutRates(
+                stateServer,
+                'KY',
+                {
+                    submissionType: 'CONTRACT_AND_RATES',
+                    programIDs: [activeProgram.id],
+                }
+            )
+
+            await addNewRateToTestContract(stateServer, draft, {
+                rateProgramIDs: [deprecatedProgram.id],
+                deprecatedRateProgramIDs: [],
+            })
+
+            const response = await executeGraphQLOperation(stateServer, {
+                query: SubmitContractDocument,
+                variables: {
+                    input: {
+                        contractID: draft.id,
+                    },
+                },
+            })
+
+            expect(response.errors).toBeDefined()
+            expect(response.errors?.[0].message).toContain(
+                'Submission contains deprecated program(s)'
+            )
+            expect(response.errors?.[0].message).toContain(deprecatedProgram.id)
+        })
+
         describe('emails', () => {
             it('sends two emails', async () => {
                 const mockEmailer = testEmailer()

--- a/services/app-api/src/resolvers/contract/submitContract.test.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.test.ts
@@ -9,8 +9,10 @@ import {
     clearMetadataFromContractFormData,
     createAndUpdateTestEQROContract,
     mockGqlContractDraftRevisionFormDataInput,
+    must,
     testS3Client,
 } from '../../testHelpers'
+import { findStatePrograms } from '../../postgres'
 
 import {
     createDBUsersWithFullData,
@@ -1448,6 +1450,47 @@ describe('submitContract', () => {
                     }),
                 }),
             ])
+        })
+
+        it('returns an error when submitting a contract with a deprecated program', async () => {
+            // Find a real deprecated program from KY's statePrograms entry so the test stays valid if IDs change.
+            const kyPrograms = must(findStatePrograms('KY'))
+            const deprecatedProgram = kyPrograms.find((p) => p.isDeprecated)
+            if (!deprecatedProgram) {
+                throw new Error(
+                    'Test setup error: expected KY to have at least one deprecated program in statePrograms.json'
+                )
+            }
+
+            const stateServer = await constructTestPostgresServer({
+                s3Client: mockS3,
+                context: {
+                    user: testStateUser({ stateCode: 'KY' }),
+                },
+            })
+
+            const draft = await createAndUpdateTestContractWithoutRates(
+                stateServer,
+                'KY',
+                {
+                    submissionType: 'CONTRACT_ONLY',
+                    programIDs: [deprecatedProgram.id],
+                }
+            )
+
+            const response = await executeGraphQLOperation(stateServer, {
+                query: SubmitContractDocument,
+                variables: {
+                    input: {
+                        contractID: draft.id,
+                    },
+                },
+            })
+
+            expect(response.errors).toBeDefined()
+            expect(response.errors?.[0].message).toContain(
+                'Submission contains deprecated program(s)'
+            )
         })
 
         describe('emails', () => {

--- a/services/app-api/src/testHelpers/contractDataMocks.ts
+++ b/services/app-api/src/testHelpers/contractDataMocks.ts
@@ -12,7 +12,6 @@ import type {
 import { findStatePrograms, type InsertContractArgsType } from '../postgres'
 import { must } from './assertionHelpers'
 import { s3DlUrl } from './documentHelpers'
-import { defaultFloridaProgram, defaultFloridaRateProgram } from './gqlHelpers'
 
 const defaultContractData = () => ({
     id: uuidv4(),
@@ -169,24 +168,32 @@ const mockContractRevision = (
     }
 }
 
-// Minimal-but-fully-submittable FL HEALTH_PLAN draft ContractType for parseContract tests.
+// Minimal-but-fully-submittable KY HEALTH_PLAN draft ContractType for parseContract tests.
 // Uses real UUIDs and sets every submittableContractFormDataSchema-required field.
 const mockSubmittableHealthPlanContract = (opts?: {
     contractID?: string
     stateNumber?: number
     programIDs?: string[]
     rateProgramIDs?: string[]
-    deprecatedRateProgramIDs?: string[]
 }): ContractType => {
-    const floridaProgram = defaultFloridaProgram()
-    const floridaRateProgram = defaultFloridaRateProgram()
+    const activeKYProgram = must(findStatePrograms('KY')).find(
+        (p) => !p.isDeprecated
+    )
+    if (!activeKYProgram) {
+        throw new Error(
+            'Test setup error: expected KY to have at least one active program in statePrograms.json'
+        )
+    }
+    const contractID =
+        opts?.contractID ?? '28b00852-00e3-467c-9311-519e60d43283'
+    const stateNumber = opts?.stateNumber ?? 5
     return {
         status: 'DRAFT',
         createdAt: new Date(),
         updatedAt: new Date(),
-        id: opts?.contractID ?? '28b00852-00e3-467c-9311-519e60d43283',
-        stateCode: 'FL',
-        stateNumber: opts?.stateNumber ?? 5,
+        id: contractID,
+        stateCode: 'KY',
+        stateNumber,
         contractSubmissionType: 'HEALTH_PLAN',
         reviewStatus: 'UNDER_REVIEW',
         consolidatedStatus: 'DRAFT',
@@ -197,15 +204,15 @@ const mockSubmittableHealthPlanContract = (opts?: {
             submitInfo: undefined,
             unlockInfo: undefined,
             contract: {
-                id: '88a54ccd-a36d-494d-a386-8ecf8b7438e6',
-                stateCode: 'FL',
-                stateNumber: 4,
+                id: contractID,
+                stateCode: 'KY',
+                stateNumber,
                 contractSubmissionType: 'HEALTH_PLAN',
             },
             createdAt: new Date('2023-11-27'),
             updatedAt: new Date('2023-11-27'),
             formData: {
-                programIDs: opts?.programIDs ?? [floridaProgram.id],
+                programIDs: opts?.programIDs ?? [activeKYProgram.id],
                 populationCovered: 'MEDICAID',
                 submissionType: 'CONTRACT_AND_RATES',
                 riskBasedContract: true,
@@ -263,9 +270,9 @@ const mockSubmittableHealthPlanContract = (opts?: {
                 status: 'DRAFT',
                 reviewStatus: 'UNDER_REVIEW',
                 consolidatedStatus: 'DRAFT',
-                stateCode: 'FL',
-                stateNumber: opts?.stateNumber ?? 5,
-                parentContractID: 'cb9a1ecb-cdb6-4ef2-956d-3fba8776cd8b',
+                stateCode: 'KY',
+                stateNumber,
+                parentContractID: contractID,
                 packageSubmissions: [],
                 draftRevision: {
                     id: '6c7862a2-f3a1-4171-9fdd-6a8c9c2dd24b',
@@ -295,10 +302,9 @@ const mockSubmittableHealthPlanContract = (opts?: {
                         amendmentEffectiveDateStart: new Date('1/1/2023'),
                         amendmentEffectiveDateEnd: new Date('1/1/2024'),
                         rateProgramIDs: opts?.rateProgramIDs ?? [
-                            floridaRateProgram.id,
+                            activeKYProgram.id,
                         ],
-                        deprecatedRateProgramIDs:
-                            opts?.deprecatedRateProgramIDs ?? [],
+                        deprecatedRateProgramIDs: [],
                         certifyingActuaryContacts: [
                             {
                                 actuarialFirm: 'DELOITTE',

--- a/services/app-api/src/testHelpers/contractDataMocks.ts
+++ b/services/app-api/src/testHelpers/contractDataMocks.ts
@@ -7,9 +7,12 @@ import type { StateCodeType } from '@mc-review/submissions'
 import type {
     ContractFormDataType,
     ContractSubmissionType,
+    ContractType,
 } from '../domain-models'
 import { findStatePrograms, type InsertContractArgsType } from '../postgres'
 import { must } from './assertionHelpers'
+import { s3DlUrl } from './documentHelpers'
+import { defaultFloridaProgram, defaultFloridaRateProgram } from './gqlHelpers'
 
 const defaultContractData = () => ({
     id: uuidv4(),
@@ -166,4 +169,165 @@ const mockContractRevision = (
     }
 }
 
-export { mockInsertContractArgs, mockContractRevision }
+// Minimal-but-fully-submittable FL HEALTH_PLAN draft ContractType for parseContract tests.
+// Uses real UUIDs and sets every submittableContractFormDataSchema-required field.
+const mockSubmittableHealthPlanContract = (opts?: {
+    contractID?: string
+    stateNumber?: number
+    programIDs?: string[]
+    rateProgramIDs?: string[]
+    deprecatedRateProgramIDs?: string[]
+}): ContractType => {
+    const floridaProgram = defaultFloridaProgram()
+    const floridaRateProgram = defaultFloridaRateProgram()
+    return {
+        status: 'DRAFT',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        id: opts?.contractID ?? '28b00852-00e3-467c-9311-519e60d43283',
+        stateCode: 'FL',
+        stateNumber: opts?.stateNumber ?? 5,
+        contractSubmissionType: 'HEALTH_PLAN',
+        reviewStatus: 'UNDER_REVIEW',
+        consolidatedStatus: 'DRAFT',
+        mccrsID: undefined,
+        revisions: [],
+        draftRevision: {
+            id: 'e5bccaa3-d91c-499a-9f2f-c6ce8dbf8a5f',
+            submitInfo: undefined,
+            unlockInfo: undefined,
+            contract: {
+                id: '88a54ccd-a36d-494d-a386-8ecf8b7438e6',
+                stateCode: 'FL',
+                stateNumber: 4,
+                contractSubmissionType: 'HEALTH_PLAN',
+            },
+            createdAt: new Date('2023-11-27'),
+            updatedAt: new Date('2023-11-27'),
+            formData: {
+                programIDs: opts?.programIDs ?? [floridaProgram.id],
+                populationCovered: 'MEDICAID',
+                submissionType: 'CONTRACT_AND_RATES',
+                riskBasedContract: true,
+                dsnpContract: true,
+                submissionDescription: 'A real submission',
+                supportingDocuments: [],
+                stateContacts: [
+                    {
+                        name: 'Someone',
+                        email: 'someone@example.com',
+                        titleRole: 'sometitle',
+                    },
+                ],
+                contractType: 'AMENDMENT',
+                contractExecutionStatus: 'EXECUTED',
+                contractDocuments: [
+                    {
+                        s3URL: 's3://bucketname/key/contract',
+                        sha256: 'fakesha',
+                        name: 'contract',
+                        dateAdded: new Date('01/15/2024'),
+                        downloadURL: s3DlUrl,
+                    },
+                ],
+                contractDateStart: new Date(),
+                contractDateEnd: new Date(),
+                managedCareEntities: ['MCO'],
+                federalAuthorities: ['STATE_PLAN'],
+                inLieuServicesAndSettings: true,
+                modifiedBenefitsProvided: true,
+                modifiedGeoAreaServed: false,
+                modifiedMedicaidBeneficiaries: true,
+                modifiedRiskSharingStrategy: true,
+                modifiedIncentiveArrangements: false,
+                modifiedWitholdAgreements: false,
+                modifiedStateDirectedPayments: true,
+                modifiedPassThroughPayments: true,
+                modifiedPaymentsForMentalDiseaseInstitutions: false,
+                modifiedMedicalLossRatioStandards: true,
+                modifiedOtherFinancialPaymentIncentive: false,
+                modifiedEnrollmentProcess: true,
+                modifiedGrevienceAndAppeal: false,
+                modifiedNetworkAdequacyStandards: true,
+                modifiedLengthOfContract: false,
+                modifiedNonRiskPaymentArrangements: true,
+                statutoryRegulatoryAttestation: true,
+                statutoryRegulatoryAttestationDescription: 'valid description',
+            },
+        },
+        draftRates: [
+            {
+                id: '6ab1b4c0-f9d2-4567-958a-3123e98328eb',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                status: 'DRAFT',
+                reviewStatus: 'UNDER_REVIEW',
+                consolidatedStatus: 'DRAFT',
+                stateCode: 'FL',
+                stateNumber: opts?.stateNumber ?? 5,
+                parentContractID: 'cb9a1ecb-cdb6-4ef2-956d-3fba8776cd8b',
+                packageSubmissions: [],
+                draftRevision: {
+                    id: '6c7862a2-f3a1-4171-9fdd-6a8c9c2dd24b',
+                    rateID: '6ab1b4c0-f9d2-4567-958a-3123e98328eb',
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                    submitInfo: undefined,
+                    unlockInfo: undefined,
+                    formData: {
+                        rateType: 'AMENDMENT',
+                        rateCapitationType: 'RATE_CELL',
+                        rateCertificationName: 'fake-name',
+                        rateMedicaidPopulations: ['MEDICAID_ONLY'],
+                        rateDocuments: [
+                            {
+                                s3URL: 's3://bucketname/key/rate',
+                                sha256: 'fakesha',
+                                name: 'rate',
+                                dateAdded: new Date('01/15/2024'),
+                                downloadURL: s3DlUrl,
+                            },
+                        ],
+                        supportingDocuments: [],
+                        rateDateStart: new Date('2020-02-02'),
+                        rateDateEnd: new Date('2021-02-02'),
+                        rateDateCertified: new Date(),
+                        amendmentEffectiveDateStart: new Date('1/1/2023'),
+                        amendmentEffectiveDateEnd: new Date('1/1/2024'),
+                        rateProgramIDs: opts?.rateProgramIDs ?? [
+                            floridaRateProgram.id,
+                        ],
+                        deprecatedRateProgramIDs:
+                            opts?.deprecatedRateProgramIDs ?? [],
+                        certifyingActuaryContacts: [
+                            {
+                                actuarialFirm: 'DELOITTE',
+                                name: 'Actuary Contact 1',
+                                titleRole: 'Test Actuary Contact 1',
+                                email: 'actuarycontact1@test.com',
+                            },
+                        ],
+                        addtlActuaryContacts: [
+                            {
+                                actuarialFirm: 'DELOITTE',
+                                name: 'Actuary Contact 1',
+                                titleRole: 'Test Actuary Contact 1',
+                                email: 'additionalactuarycontact1@test.com',
+                            },
+                        ],
+                        actuaryCommunicationPreference: 'OACT_TO_ACTUARY',
+                        packagesWithSharedRateCerts: [],
+                    },
+                },
+                revisions: [],
+            },
+        ],
+        packageSubmissions: [],
+    }
+}
+
+export {
+    mockInsertContractArgs,
+    mockContractRevision,
+    mockSubmittableHealthPlanContract,
+}

--- a/services/app-api/src/testHelpers/index.ts
+++ b/services/app-api/src/testHelpers/index.ts
@@ -9,6 +9,7 @@ export { must } from './assertionHelpers'
 export {
     mockInsertContractArgs,
     mockContractRevision,
+    mockSubmittableHealthPlanContract,
 } from './contractDataMocks'
 
 export {


### PR DESCRIPTION
## Summary
[MCR-6100](https://jiraent.cms.gov/browse/MCR-6100)

This work prevents submitContract from submitting or resubmitting `HEALTH_PLAN` and `EQRO` submissions when contract or child rates (only for `HEALTH_PLAN`) contain a deprecated program.

Acceptance criteria:
- Confirm that we do not need to make changes to createContract related to rejecting requests that include deprecated program IDs
   - **Confirmed**: On new submission, deprecated programs will not be available as a selection.
- Return an error when trying to submit or resubmit a submission with a deprecated program name
   - Includes contract and child rate programs
- Unit tests for each

Possibility unnecessary AC:
- updateContractDraftRevision allows deprecated program IDs only if they were already part of the existing draft's programIDs
   - What is the use case here? I would think we would want them to not use deprecated programs. Also they would still hit an error at submit.
   - Form the UI perspective if we restricted deprecated from being updated at the API level, the UI would not surface a descriptive user error.
- updateDraftContractRates rejects deprecated rateProgramIDs on new rate creation, but allows them on rate updates only if already present on the existing rate
   -  I think this should be handled at the UI level on the rate details page.  New rates would not see the deprecated programs anyways. Trying to figure out the scenario were this would happen.
   - Form the UI perspective if we restricted deprecated from being updated at the API level, the UI would not surface a descriptive user error.

Suggestion: I think we need a new ticket for contract details, rate details and review submit pages that display inline errors and error summaries when users are trying to continue or submit with a deprecated program.
 - Contract details & Rate Details
   - On `Continue` display inline error and error summary when trying to continue with a deprecated program
- Review and Submit page
   - Inline error when a program is deprecated
   - Submit button is disabled?

#### Related issues

#### Screenshots

#### Test cases covered

- `dataValidatorHelpers.test.ts`
    - return error if a submitted programID is deprecated
    - return error if a child rate has a deprecated rateProgramID
    - ignores deprecated rateProgramIDs on linked rates
    - should return an error if a submitted programID is deprecated (EQRO parsing and validation)
- `submitContract.test.ts`
    - returns an error when submitting a contract with a deprecated program
    - returns an error when submitting a contract whose child rate has a deprecated rateProgramID
    
<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->