### PR TITLE
MCR-4104: Upgrade Apollo Client

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -51,6 +51,7 @@ export IAM_PATH='/'
 export CLOUDFRONT_CERT_ARN='local'
 export CLOUDFRONT_SB_DOMAIN_NAME='local'
 export CLOUDFRONT_DOMAIN_NAME='local'
+export SECRETS_MANAGER_SECRET='local-secrets-manager'
 export stage='local'
 export REGION='us-east-1'
 

--- a/packages/common-code/package.json
+++ b/packages/common-code/package.json
@@ -11,7 +11,8 @@
         "test:coverage": "vitest --coverage"
     },
     "dependencies": {
-        "@apollo/client": "3.8.8",
+        "@apollo/client": "^4.1.7",
+        "rxjs": "^7.8.1",
         "@graphql-typed-document-node/core": "^3.2.0",
         "@mc-review/constants": "workspace:*",
         "@mc-review/helpers": "workspace:*",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -8,7 +8,8 @@
     },
     "license": "ISC",
     "dependencies": {
-        "@apollo/client": "3.8.8",
+        "@apollo/client": "^4.1.7",
+        "rxjs": "^7.8.1",
         "@graphql-typed-document-node/core": "^3.2.0",
         "typescript": "5.9.3"
     }

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -10,7 +10,9 @@
         "test:coverage": "vitest --coverage"
     },
     "dependencies": {
-        "@apollo/client": "3.8.8",
+        "@apollo/client": "^4.1.7",
+        "rxjs": "^7.8.1",
+        "graphql": "^16.13.2",
         "@graphql-typed-document-node/core": "^3.2.0",
         "@mc-review/constants": "workspace:*",
         "@mc-review/submissions": "workspace:*",

--- a/packages/helpers/src/gql/apolloErrors.ts
+++ b/packages/helpers/src/gql/apolloErrors.ts
@@ -1,5 +1,11 @@
-import { ServerError } from '@apollo/client'
-import { ApolloError, GraphQLErrors, NetworkError } from '@apollo/client/errors'
+import {
+    CombinedGraphQLErrors,
+    CombinedProtocolErrors,
+    ServerError,
+    ServerParseError,
+} from '@apollo/client/errors'
+import type { ErrorLike } from '@apollo/client'
+import type { GraphQLFormattedError } from 'graphql'
 import { recordJSException } from '@mc-review/otel'
 
 /*
@@ -8,26 +14,29 @@ Adds OTEL logging for graphql api errors
 */
 
 const handleNetworkError = (
-    networkError: NetworkError,
+    networkError: Error,
     isAuthenticated: boolean
 ) => {
-    if (networkError?.name === 'ServerError') {
-        const serverError = networkError as ServerError
-        if (serverError.statusCode === 403 && !isAuthenticated) {
+    if (networkError instanceof ServerError) {
+        if (networkError.statusCode === 403 && !isAuthenticated) {
             // Log nothing, this is an expected 403 for a logged out user trying to load a page where we query auth
             return
-        } else if (serverError.statusCode === 403 && isAuthenticated) {
+        } else if (networkError.statusCode === 403 && isAuthenticated) {
             // Something has caused the user to lose their session entirely outside the scope of MC-Review.
             // Log this so we have a record of it, but not entirely unexpected if user is opening application in multiple tabs and only logging out of one of them.
             recordJSException(
-                `[User auth error]: Code: ${serverError.statusCode} Message: ${serverError.message} ${serverError.stack}`
+                `[User auth error]: Code: ${networkError.statusCode} Message: ${networkError.message} ${networkError.stack}`
             )
         } else {
             // Server could be down. Log this.
             recordJSException(
-                `[Server error]: Code: ${serverError.statusCode} Message: ${serverError.message} ${serverError.stack}`
+                `[Server error]: Code: ${networkError.statusCode} Message: ${networkError.message} ${networkError.stack}`
             )
         }
+    } else if (networkError instanceof ServerParseError) {
+        recordJSException(
+            `[Server parse error]: Code: ${networkError.statusCode} Message: ${networkError.message} ${networkError.stack}`
+        )
     } else {
         // Unknown general network issue
         recordJSException(
@@ -36,7 +45,9 @@ const handleNetworkError = (
     }
 }
 
-const handleGQLErrors = (graphQLErrors: GraphQLErrors) => {
+const handleGQLErrors = (
+    graphQLErrors: ReadonlyArray<GraphQLFormattedError>
+) => {
     graphQLErrors.forEach(({ message, locations, path }) => {
         recordJSException(
             // Graphql errors mean something is wrong inside our api, maybe bad request or errors we return from api for known edge cases
@@ -45,24 +56,30 @@ const handleGQLErrors = (graphQLErrors: GraphQLErrors) => {
     })
 }
 
-const handleApolloError = (error: ApolloError, isAuthenticated: boolean) => {
-    const { graphQLErrors, networkError } = error
-    if (graphQLErrors) handleGQLErrors(graphQLErrors)
-    if (networkError) handleNetworkError(networkError, isAuthenticated)
+const handleApolloError = (
+    error: ErrorLike | Error,
+    isAuthenticated: boolean
+) => {
+    if (CombinedGraphQLErrors.is(error)) {
+        handleGQLErrors(error.errors)
+    } else if (CombinedProtocolErrors.is(error)) {
+        error.errors.forEach(({ message }) =>
+            recordJSException(`[GraphQL protocol error]: Message: ${message}`)
+        )
+    } else if (error instanceof Error) {
+        handleNetworkError(error, isAuthenticated)
+    }
 }
 
 // User auth errors are not necessarily worth logging.
 // For example, they are expected when an IDM session times out while user was in the application but inactive
 const isLikelyUserAuthError = (
-    error: ApolloError,
+    error: ErrorLike | Error,
     isAuthenticated: boolean
 ) => {
-    const { networkError } = error
-    if (networkError?.name === 'ServerError') {
-        const serverError = networkError as ServerError
-        return serverError.statusCode === 403 && isAuthenticated
-    } else {
-        return false
+    if (error instanceof ServerError) {
+        return error.statusCode === 403 && isAuthenticated
     }
+    return false
 }
 export { handleApolloError, isLikelyUserAuthError, handleGQLErrors }

--- a/packages/helpers/src/gql/apolloErrors.ts
+++ b/packages/helpers/src/gql/apolloErrors.ts
@@ -17,7 +17,7 @@ const handleNetworkError = (
     networkError: Error,
     isAuthenticated: boolean
 ) => {
-    if (networkError instanceof ServerError) {
+    if (ServerError.is(networkError)) {
         if (networkError.statusCode === 403 && !isAuthenticated) {
             // Log nothing, this is an expected 403 for a logged out user trying to load a page where we query auth
             return
@@ -33,7 +33,7 @@ const handleNetworkError = (
                 `[Server error]: Code: ${networkError.statusCode} Message: ${networkError.message} ${networkError.stack}`
             )
         }
-    } else if (networkError instanceof ServerParseError) {
+    } else if (ServerParseError.is(networkError)) {
         recordJSException(
             `[Server parse error]: Code: ${networkError.statusCode} Message: ${networkError.message} ${networkError.stack}`
         )
@@ -77,7 +77,7 @@ const isLikelyUserAuthError = (
     error: ErrorLike | Error,
     isAuthenticated: boolean
 ) => {
-    if (error instanceof ServerError) {
+    if (ServerError.is(error)) {
         return error.statusCode === 403 && isAuthenticated
     }
     return false

--- a/packages/helpers/src/gql/graphQLErrorAccessors.test.ts
+++ b/packages/helpers/src/gql/graphQLErrorAccessors.test.ts
@@ -1,0 +1,129 @@
+import { CombinedGraphQLErrors, ServerError } from '@apollo/client/errors'
+import { toGQLError } from './graphQLErrorAccessors'
+
+const buildGraphQLErrorsResponse = (
+    errors: Array<{
+        message: string
+        extensions?: Record<string, unknown>
+    }>
+) => new CombinedGraphQLErrors({ errors }, errors)
+
+describe('toGQLError', () => {
+    it('returns undefined when error is null or undefined', () => {
+        expect(toGQLError(null)).toBeUndefined()
+        expect(toGQLError(undefined)).toBeUndefined()
+    })
+
+    it('returns undefined for a plain Error that is not a CombinedGraphQLErrors', () => {
+        expect(toGQLError(new Error('boom'))).toBeUndefined()
+    })
+
+    it('returns undefined for a ServerError (network error, not a GraphQL response error)', () => {
+        const networkError = new ServerError('bad gateway', {
+            response: new Response('', { status: 502 }),
+            bodyText: '',
+        })
+        expect(toGQLError(networkError)).toBeUndefined()
+    })
+
+    it('returns undefined when CombinedGraphQLErrors has an empty errors array', () => {
+        const err = buildGraphQLErrorsResponse([])
+        expect(toGQLError(err)).toBeUndefined()
+    })
+
+    it('flattens the first GraphQL error with all resolver-provided extension fields', () => {
+        const err = buildGraphQLErrorsResponse([
+            {
+                message: 'Contract not found',
+                extensions: {
+                    code: 'NOT_FOUND',
+                    cause: 'DB_ERROR',
+                },
+            },
+        ])
+
+        const result = toGQLError(err)
+
+        expect(result).toBeDefined()
+        expect(result?.message).toBe('Contract not found')
+        expect(result?.extensions.code).toBe('NOT_FOUND')
+        expect(result?.extensions.cause).toBe('DB_ERROR')
+        expect(result?.extensions.argumentName).toBeUndefined()
+        expect(result?.extensions.argumentValues).toBeUndefined()
+    })
+
+    it('surfaces BAD_USER_INPUT extensions (argumentName / argumentValues)', () => {
+        const err = buildGraphQLErrorsResponse([
+            {
+                message: 'Invalid submission',
+                extensions: {
+                    code: 'BAD_USER_INPUT',
+                    argumentName: 'contractID',
+                    argumentValues: { id: 'abc-123' },
+                },
+            },
+        ])
+
+        const result = toGQLError(err)
+
+        expect(result?.extensions.code).toBe('BAD_USER_INPUT')
+        expect(result?.extensions.argumentName).toBe('contractID')
+        expect(result?.extensions.argumentValues).toEqual({ id: 'abc-123' })
+        expect(result?.extensions.cause).toBeUndefined()
+    })
+
+    it('only surfaces the first error when multiple GraphQL errors are returned', () => {
+        const err = buildGraphQLErrorsResponse([
+            {
+                message: 'first',
+                extensions: { code: 'FORBIDDEN' },
+            },
+            {
+                message: 'second',
+                extensions: { code: 'NOT_FOUND' },
+            },
+        ])
+
+        const result = toGQLError(err)
+
+        expect(result?.message).toBe('first')
+        expect(result?.extensions.code).toBe('FORBIDDEN')
+    })
+
+    it('leaves extension fields undefined when they are missing', () => {
+        const err = buildGraphQLErrorsResponse([
+            { message: 'unknown failure' },
+        ])
+
+        const result = toGQLError(err)
+
+        expect(result?.message).toBe('unknown failure')
+        expect(result?.extensions.code).toBeUndefined()
+        expect(result?.extensions.cause).toBeUndefined()
+        expect(result?.extensions.argumentName).toBeUndefined()
+        expect(result?.extensions.argumentValues).toBeUndefined()
+    })
+
+    it('guards against non-string extension values for string fields', () => {
+        const err = buildGraphQLErrorsResponse([
+            {
+                message: 'bad extension shape',
+                extensions: {
+                    code: 500, // wrong type: number instead of string
+                    cause: { reason: 'db' }, // wrong type: object
+                    argumentName: null,
+                    argumentValues: 'this one is fine as unknown',
+                },
+            },
+        ])
+
+        const result = toGQLError(err)
+
+        expect(result?.extensions.code).toBeUndefined()
+        expect(result?.extensions.cause).toBeUndefined()
+        expect(result?.extensions.argumentName).toBeUndefined()
+        expect(result?.extensions.argumentValues).toBe(
+            'this one is fine as unknown'
+        )
+    })
+})

--- a/packages/helpers/src/gql/graphQLErrorAccessors.ts
+++ b/packages/helpers/src/gql/graphQLErrorAccessors.ts
@@ -1,0 +1,40 @@
+import { CombinedGraphQLErrors } from '@apollo/client/errors'
+import type { ErrorLike } from '@apollo/client'
+import type { GraphQLFormattedError } from 'graphql'
+
+// Reuses the standard `GraphQLFormattedError` shape from the `graphql`
+// package (`message`, `path`, `locations`) and narrows `extensions` to the
+// bag MC-Review resolvers populate — `code` and `cause` come from every
+// error, while `argumentName` / `argumentValues` only come from
+// BAD_USER_INPUT. See services/app-api/src/resolvers/errorUtils.ts.
+export type GQLError = Omit<GraphQLFormattedError, 'extensions'> & {
+    extensions: {
+        code: string | undefined
+        cause: string | undefined
+        argumentName: string | undefined
+        argumentValues: unknown
+    }
+}
+
+// Surfaces the first GraphQL error from Apollo's `CombinedGraphQLErrors`.
+// Returns undefined for non-GraphQL errors (e.g. network errors). Only the
+// first error is surfaced since callers use this to pick a single UI branch.
+export const toGQLError = (
+    error: ErrorLike | Error | undefined | null
+): GQLError | undefined => {
+    if (!error || !CombinedGraphQLErrors.is(error)) return undefined
+    const first = error.errors[0]
+    if (!first) return undefined
+    const extensions = first.extensions
+    const asString = (value: unknown): string | undefined =>
+        typeof value === 'string' ? value : undefined
+    return {
+        ...first,
+        extensions: {
+            code: asString(extensions?.code),
+            cause: asString(extensions?.cause),
+            argumentName: asString(extensions?.argumentName),
+            argumentValues: extensions?.argumentValues,
+        },
+    }
+}

--- a/packages/helpers/src/gql/index.ts
+++ b/packages/helpers/src/gql/index.ts
@@ -1,4 +1,8 @@
-import { GraphQLErrors } from '@apollo/client/errors'
+import type { GraphQLFormattedError } from 'graphql'
+
+type GraphQLErrors = ReadonlyArray<GraphQLFormattedError>
+
+export type { GraphQLErrors }
 
 export const isGraphQLErrors = (input: unknown): input is GraphQLErrors => {
     if (Array.isArray(input)) {
@@ -11,6 +15,7 @@ export const isGraphQLErrors = (input: unknown): input is GraphQLErrors => {
 
 export * from './apolloErrors'
 export * from './apolloQueryWrapper'
+export * from './graphQLErrorAccessors'
 export * from './mutationWrappersForUserFriendlyErrors'
 export * from './updateCMSUser'
 export * from './userHelpers'

--- a/packages/helpers/src/gql/mutationWrappersForUserFriendlyErrors.ts
+++ b/packages/helpers/src/gql/mutationWrappersForUserFriendlyErrors.ts
@@ -1,4 +1,4 @@
-import type { MutationFunction } from '@apollo/client'
+import type { useMutation } from '@apollo/client/react'
 import {
     FetchContractWithQuestionsQuery,
     FetchContractWithQuestionsDocument,
@@ -33,12 +33,14 @@ import {
     ApproveContractMutation,
     ApproveContractMutationVariables,
 } from '../gen/gqlClient'
-import { GraphQLErrors } from '@apollo/client/errors'
+import type { GraphQLFormattedError } from 'graphql'
+import { CombinedGraphQLErrors } from '@apollo/client/errors'
 
 import { recordJSException } from '@mc-review/otel'
 import { handleGQLErrors as handleGQLErrorLogging } from './apolloErrors'
-import { ApolloError } from '@apollo/client/errors'
 import { ERROR_MESSAGES } from '@mc-review/constants'
+
+type GraphQLErrors = ReadonlyArray<GraphQLFormattedError>
 
 /*
 Adds user friendly/facing error messages to GraphQL mutations.
@@ -68,7 +70,7 @@ const divisionToIndexQuestionDivision = (
     `${division.toUpperCase()}Questions` as IndexQuestionDivisions
 
 export const handleGraphQLErrorsAndAddUserFacingMessages = (
-    error: ApolloError | Error,
+    error: Error,
     mutation: MutationType
 ) => {
     let message
@@ -88,12 +90,10 @@ export const handleGraphQLErrorsAndAddUserFacingMessages = (
         cause: {},
     }
 
-    // Extract GraphQL errors from ApolloError
-    let graphQLErrors: GraphQLErrors = []
-
-    if (error instanceof ApolloError && error.graphQLErrors) {
-        graphQLErrors = error.graphQLErrors
-    }
+    // Extract GraphQL errors from the v4 CombinedGraphQLErrors class
+    const graphQLErrors: GraphQLErrors = CombinedGraphQLErrors.is(error)
+        ? error.errors
+        : []
 
     if (graphQLErrors.length > 0) {
         handleGQLErrorLogging(graphQLErrors)
@@ -128,7 +128,7 @@ export const handleGraphQLErrorsAndAddUserFacingMessages = (
 }
 
 export const unlockMutationWrapper = async (
-    unlockContract: MutationFunction<UnlockContractMutation, UnlockContractMutationVariables>,
+    unlockContract: useMutation.MutationFunction<UnlockContractMutation, UnlockContractMutationVariables>,
     id: string,
     unlockedReason: string
 ): Promise<Partial<UnlockedContract> | GraphQLErrors | Error> => {
@@ -159,7 +159,7 @@ export const unlockMutationWrapper = async (
 }
 
 export const submitMutationWrapper = async (
-    submitContract: MutationFunction<SubmitContractMutation, SubmitContractMutationVariables>,
+    submitContract: useMutation.MutationFunction<SubmitContractMutation, SubmitContractMutationVariables>,
     id: string,
     submittedReason?: string
 ): Promise<Partial<Contract> | GraphQLErrors | Error> => {
@@ -195,7 +195,7 @@ export const submitMutationWrapper = async (
 }
 
 export const approveMutationWrapper = async (
-    approveContract: MutationFunction<ApproveContractMutation, ApproveContractMutationVariables>,
+    approveContract: useMutation.MutationFunction<ApproveContractMutation, ApproveContractMutationVariables>,
     id: string,
     dateApprovalReleasedToState: string
 ): Promise<Partial<Contract> | GraphQLErrors | Error> => {
@@ -228,7 +228,7 @@ export const approveMutationWrapper = async (
 }
 
 export async function updateStateAssignmentsWrapper(
-    updateStateAssignments: MutationFunction<UpdateStateAssignmentsByStateMutation, UpdateStateAssignmentsByStateMutationVariables>,
+    updateStateAssignments: useMutation.MutationFunction<UpdateStateAssignmentsByStateMutation, UpdateStateAssignmentsByStateMutationVariables>,
     stateCode: string,
     assignedUserIDs: string[]
 ): Promise<undefined | GraphQLErrors | Error> {
@@ -311,7 +311,7 @@ export async function updateStateAssignmentsWrapper(
  * cache.evict() to force a refetch, but would then cause the loading UI to show.
  **/
 export const createContractQuestionWrapper = async (
-    createQuestion: MutationFunction<CreateContractQuestionMutation, CreateContractQuestionMutationVariables>,
+    createQuestion: useMutation.MutationFunction<CreateContractQuestionMutation, CreateContractQuestionMutationVariables>,
     input: CreateContractQuestionInput
 ): Promise<CreateContractQuestionMutation | GraphQLErrors | Error> => {
     try {
@@ -394,7 +394,7 @@ export const createContractQuestionWrapper = async (
 }
 
 export const createRateQuestionWrapper = async (
-    createQuestion: MutationFunction<CreateRateQuestionMutation, CreateRateQuestionMutationVariables>,
+    createQuestion: useMutation.MutationFunction<CreateRateQuestionMutation, CreateRateQuestionMutationVariables>,
     input: CreateRateQuestionInput
 ): Promise<CreateRateQuestionMutation | GraphQLErrors | Error> => {
     try {
@@ -488,7 +488,7 @@ export const createRateQuestionWrapper = async (
 }
 
 export const createContractResponseWrapper = async (
-    createResponse: MutationFunction<CreateContractQuestionResponseMutation, CreateContractQuestionResponseMutationVariables>,
+    createResponse: useMutation.MutationFunction<CreateContractQuestionResponseMutation, CreateContractQuestionResponseMutationVariables>,
     contractID: string,
     input: CreateQuestionResponseInput,
     division: Division
@@ -580,7 +580,7 @@ export const createContractResponseWrapper = async (
 }
 
 export const createRateQuestionResponseWrapper = async (
-    createResponse: MutationFunction<CreateRateQuestionResponseMutation, CreateRateQuestionResponseMutationVariables>,
+    createResponse: useMutation.MutationFunction<CreateRateQuestionResponseMutation, CreateRateQuestionResponseMutationVariables>,
     rateID: string,
     input: CreateQuestionResponseInput,
     division: Division

--- a/packages/helpers/src/gql/updateCMSUser.ts
+++ b/packages/helpers/src/gql/updateCMSUser.ts
@@ -1,4 +1,4 @@
-import type { MutationFunction } from '@apollo/client'
+import type { useMutation } from '@apollo/client/react'
 import {
     UpdateDivisionAssignmentInput,
     UpdateDivisionAssignmentMutation,
@@ -7,7 +7,7 @@ import {
 } from '../gen/gqlClient'
 
 async function updateDivisionAssignment(
-    updateUserMutation: MutationFunction<UpdateDivisionAssignmentMutation, UpdateDivisionAssignmentMutationVariables>,
+    updateUserMutation: useMutation.MutationFunction<UpdateDivisionAssignmentMutation, UpdateDivisionAssignmentMutationVariables>,
     input: UpdateDivisionAssignmentInput
 ): Promise<UpdateCmsUserPayload | Error> {
     try {

--- a/packages/helpers/src/gql/updateDivisionAssignment.ts
+++ b/packages/helpers/src/gql/updateDivisionAssignment.ts
@@ -1,4 +1,4 @@
-import type { MutationFunction } from '@apollo/client'
+import type { useMutation } from '@apollo/client/react'
 import {
     UpdateDivisionAssignmentInput,
     UpdateDivisionAssignmentMutation,
@@ -7,7 +7,7 @@ import {
 } from '../gen/gqlClient'
 
 async function updateDivisionAssignment(
-    updateUserMutation: MutationFunction<UpdateDivisionAssignmentMutation, UpdateDivisionAssignmentMutationVariables>,
+    updateUserMutation: useMutation.MutationFunction<UpdateDivisionAssignmentMutation, UpdateDivisionAssignmentMutationVariables>,
     input: UpdateDivisionAssignmentInput
 ): Promise<UpdateCmsUserPayload | Error> {
     try {

--- a/packages/mocks/package.json
+++ b/packages/mocks/package.json
@@ -6,7 +6,8 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@apollo/client": "3.8.8",
+        "@apollo/client": "^4.1.7",
+        "rxjs": "^7.8.1",
         "@graphql-typed-document-node/core": "^3.2.0",
         "@mc-review/dates": "workspace:*",
         "@mc-review/submissions": "workspace:*",

--- a/packages/mocks/src/apollo/approveContractMocks.ts
+++ b/packages/mocks/src/apollo/approveContractMocks.ts
@@ -1,4 +1,4 @@
-import { MockedResponse } from '@apollo/client/testing'
+import { MockLink } from '@apollo/client/testing'
 import {
     ApproveContractDocument,
     ApproveContractMutation,
@@ -19,7 +19,7 @@ const approveContractMockSuccess = (
         contractData?: Partial<Contract>
         dateApprovalReleasedToState?: string
     } = {}
-): MockedResponse<ApproveContractMutation> => {
+): MockLink.MockedResponse<ApproveContractMutation> => {
     const {
         contractID = 'test-abc-123',
         contractData,
@@ -76,7 +76,7 @@ const approveContractMockFailure = ({
         code: GraphQLErrorCodeTypes
         cause: GraphQLErrorCauseTypes
     }
-}): MockedResponse<ApproveContractMutation> => {
+}): MockLink.MockedResponse<ApproveContractMutation> => {
     const graphQLError = new GraphQLError(
         error
             ? GRAPHQL_ERROR_CAUSE_MESSAGES[error.cause]

--- a/packages/mocks/src/apollo/contractGQLMock.ts
+++ b/packages/mocks/src/apollo/contractGQLMock.ts
@@ -21,7 +21,7 @@ import {
     UnlockContractDocument,
 } from '../gen/gqlClient'
 import type { ContractStripped } from '../gen/gqlClient'
-import { MockedResponse } from '@apollo/client/testing'
+import { MockLink } from '@apollo/client/testing'
 import {
     mockContractPackageDraft,
     mockContractPackageSubmittedWithQuestions,
@@ -43,7 +43,7 @@ const fetchContractMockSuccess = ({
     contract,
 }: {
     contract?: Contract | UnlockedContract
-}): MockedResponse<FetchContractQuery> => {
+}): MockLink.MockedResponse<FetchContractQuery> => {
     let newContract: Contract | undefined
     // contract can be an unlockedContract type
     // however this API returns a contract type
@@ -88,7 +88,7 @@ const fetchContractMockFail = ({
         code: GraphQLErrorCodeTypes
         cause: GraphQLErrorCauseTypes
     }
-}): MockedResponse<FetchContractQuery | GraphQLError> => {
+}): MockLink.MockedResponse<FetchContractQuery | GraphQLError> => {
     const graphQLError = new GraphQLError(
         error
             ? GRAPHQL_ERROR_CAUSE_MESSAGES[error.cause]
@@ -117,7 +117,7 @@ const fetchContractWithQuestionsMockSuccess = ({
     contract,
 }: {
     contract?: Contract | UnlockedContract
-}): MockedResponse<FetchContractWithQuestionsQuery> => {
+}): MockLink.MockedResponse<FetchContractWithQuestionsQuery> => {
     let newContract: Contract | undefined
     // contract can be an unlockedContract type
     // however this API returns a contract type
@@ -161,7 +161,7 @@ const createContractMockFail = ({
         code: GraphQLErrorCodeTypes
         cause: GraphQLErrorCauseTypes
     }
-}): MockedResponse<CreateContractMutation | GraphQLError> => {
+}): MockLink.MockedResponse<CreateContractMutation | GraphQLError> => {
     const graphQLError = new GraphQLError(
         error
             ? GRAPHQL_ERROR_CAUSE_MESSAGES[error.cause]
@@ -204,7 +204,7 @@ const fetchContractWithQuestionsMockFail = ({
         code: GraphQLErrorCodeTypes
         cause: GraphQLErrorCauseTypes
     }
-}): MockedResponse<FetchContractWithQuestionsQuery | GraphQLError> => {
+}): MockLink.MockedResponse<FetchContractWithQuestionsQuery | GraphQLError> => {
     const graphQLError = new GraphQLError(
         error
             ? GRAPHQL_ERROR_CAUSE_MESSAGES[error.cause]
@@ -233,7 +233,7 @@ const createContractMockSuccess = ({
     contract,
 }: {
     contract?: Partial<Contract>
-}): MockedResponse<CreateContractMutation> => {
+}): MockLink.MockedResponse<CreateContractMutation> => {
     const contractData = mockContractPackageDraft(contract)
 
     return {
@@ -257,7 +257,7 @@ const updateDraftContractRatesMockSuccess = ({
     contract,
 }: {
     contract?: Partial<Contract>
-}): MockedResponse<UpdateDraftContractRatesMutation> => {
+}): MockLink.MockedResponse<UpdateDraftContractRatesMutation> => {
     const contractData = mockContractPackageDraft(contract)
     const contractInput = {
         contractID: contractData.id,
@@ -314,7 +314,7 @@ const updateContractDraftRevisionMockSuccess = ({
     contract,
 }: {
     contract?: Partial<Contract>
-}): MockedResponse<UpdateContractDraftRevisionMutation> => {
+}): MockLink.MockedResponse<UpdateContractDraftRevisionMutation> => {
     const contractData = mockContractPackageDraft(contract)
     const contractInput = {
         contractID: contractData.id,
@@ -348,7 +348,7 @@ const updateContractDraftRevisionMockFail = ({
         code: GraphQLErrorCodeTypes
         cause: GraphQLErrorCauseTypes
     }
-}): MockedResponse<UpdateContractDraftRevisionMutation | GraphQLError> => {
+}): MockLink.MockedResponse<UpdateContractDraftRevisionMutation | GraphQLError> => {
     const contractData = mockContractPackageDraft(contract)
     const contractInput = {
         contractID: contractData.id,
@@ -386,7 +386,7 @@ const submitContractMockSuccess = ({
 }: {
     submittedReason?: string
     id: string
-}): MockedResponse<SubmitContractMutation> => {
+}): MockLink.MockedResponse<SubmitContractMutation> => {
     const contractData = mockContractPackageSubmittedWithRevisions({ id })
     return {
         request: {
@@ -406,7 +406,7 @@ const submitContractMockError = ({
         code: GraphQLErrorCodeTypes
         cause: GraphQLErrorCauseTypes
     }
-}): MockedResponse<SubmitContractMutation | GraphQLError> => {
+}): MockLink.MockedResponse<SubmitContractMutation | GraphQLError> => {
     const graphQLError = new GraphQLError(
         error
             ? GRAPHQL_ERROR_CAUSE_MESSAGES[error.cause]
@@ -440,7 +440,7 @@ const indexContractsMockSuccess = (
         },
         { ...mockContractPackageSubmittedWithRevisions(), id: 'test-id-124' },
     ]
-): MockedResponse<IndexContractsForDashboardQuery> => {
+): MockLink.MockedResponse<IndexContractsForDashboardQuery> => {
     const submissionEdges = submissions.map((sub) => {
         return {
             node: sub,
@@ -465,7 +465,7 @@ const indexContractsStrippedMockSuccess = (
     contracts: ContractStripped[] = [
         mockContractStripped({ id: 'test-stripped-id-123' }),
     ]
-): MockedResponse<IndexContractsStrippedQuery> => {
+): MockLink.MockedResponse<IndexContractsStrippedQuery> => {
     const edges = contracts.map((contract) => ({
         node: contract,
     }))
@@ -504,7 +504,7 @@ const unlockContractMockSuccess = ({
     ),
     id,
     reason,
-}: unlockContractMockSuccessProps): MockedResponse<UnlockContractMutation> => {
+}: unlockContractMockSuccessProps): MockLink.MockedResponse<UnlockContractMutation> => {
     // HACK, for some reason tests started failing with getting the types just right
     // As we get those types everywhere we can revisit this.
     const unlockedContract = contract as UnlockedContract
@@ -529,7 +529,7 @@ const unlockContractMockError = ({
         code: GraphQLErrorCodeTypes
         cause: GraphQLErrorCauseTypes
     }
-}): MockedResponse<UnlockContractMutation> => {
+}): MockLink.MockedResponse<UnlockContractMutation> => {
     const graphQLError = new GraphQLError(
         error
             ? GRAPHQL_ERROR_CAUSE_MESSAGES[error.cause]

--- a/packages/mocks/src/apollo/mcReviewSettingsGQLMocks.ts
+++ b/packages/mocks/src/apollo/mcReviewSettingsGQLMocks.ts
@@ -1,4 +1,4 @@
-import { MockedResponse } from '@apollo/client/testing'
+import { MockLink } from '@apollo/client/testing'
 import {
     FetchMcReviewSettingsDocument,
     FetchMcReviewSettingsQuery,
@@ -8,7 +8,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { GraphQLError } from 'graphql/index'
 
 const fetchMcReviewSettingsMock =
-    (): MockedResponse<FetchMcReviewSettingsQuery> => {
+    (): MockLink.MockedResponse<FetchMcReviewSettingsQuery> => {
         return {
             request: {
                 query: FetchMcReviewSettingsDocument,
@@ -121,7 +121,7 @@ const fetchMcReviewSettingsMock =
         }
     }
 
-const fetchMcReviewSettingsFailMock = (): MockedResponse<GraphQLError> => {
+const fetchMcReviewSettingsFailMock = (): MockLink.MockedResponse<GraphQLError> => {
     const graphQLError = new GraphQLError(
         'Error fetching mc-review settings data.',
         {

--- a/packages/mocks/src/apollo/oauthGQLMocks.ts
+++ b/packages/mocks/src/apollo/oauthGQLMocks.ts
@@ -1,4 +1,4 @@
-import { MockedResponse } from '@apollo/client/testing'
+import { MockLink } from '@apollo/client/testing'
 import {
     FetchOauthClientsDocument,
     FetchOauthClientsQuery,
@@ -7,12 +7,11 @@ import {
     CreateOauthClientInput,
     CreateOauthClientMutation,
 } from '../gen/gqlClient'
-import { ApolloError } from '@apollo/client'
 import { GraphQLError } from 'graphql'
 import { v4 as uuidv4 } from 'uuid'
 
 const fetchOauthClientsMockSuccess =
-    (): MockedResponse<FetchOauthClientsQuery> => {
+    (): MockLink.MockedResponse<FetchOauthClientsQuery> => {
         return {
             request: {
                 query: FetchOauthClientsDocument,
@@ -50,7 +49,8 @@ const fetchOauthClientsMockSuccess =
         }
     }
 
-const fetchOauthClientsMockFail = (): MockedResponse<ApolloError> => {
+const fetchOauthClientsMockFail =
+    (): MockLink.MockedResponse<FetchOauthClientsQuery> => {
     const graphQLError = new GraphQLError('Error fetching Oauth clients.', {
         extensions: {
             code: 'INTERNAL_SERVER_ERROR',
@@ -75,7 +75,7 @@ const createOauthClientMockSuccess = ({
 }: {
     input: CreateOauthClientInput
     user: CmsUsersUnion
-}): MockedResponse<CreateOauthClientMutation> => {
+}): MockLink.MockedResponse<CreateOauthClientMutation> => {
     return {
         request: {
             query: CreateOauthClientDocument,
@@ -106,7 +106,7 @@ const createOauthClientMockSuccess = ({
 }
 
 const createOauthClientMockFailure =
-    (): MockedResponse<CreateOauthClientMutation> => {
+    (): MockLink.MockedResponse<CreateOauthClientMutation> => {
         const graphQLError = new GraphQLError('Issue creating Oauth client', {
             extensions: {
                 code: 'NOT_FOUND',

--- a/packages/mocks/src/apollo/questionResponseGQLMock.ts
+++ b/packages/mocks/src/apollo/questionResponseGQLMock.ts
@@ -1,4 +1,4 @@
-import { MockedResponse } from '@apollo/client/testing'
+import { MockLink } from '@apollo/client/testing'
 import {
     CreateContractQuestionDocument,
     CreateContractQuestionResponseDocument,
@@ -17,7 +17,7 @@ const createContractQuestionSuccess = (
     question?:
         | CreateContractQuestionInput
         | Partial<CreateContractQuestionInput>
-): MockedResponse<CreateContractQuestionMutation> => {
+): MockLink.MockedResponse<CreateContractQuestionMutation> => {
     const defaultQuestionInput: CreateContractQuestionInput = {
         // dueDate: new Date('11-11-2100'),
         contractID: '123-abc',
@@ -60,7 +60,7 @@ const createContractQuestionSuccess = (
 
 const createContractQuestionNetworkFailure = (
     input: CreateContractQuestionInput
-): MockedResponse<CreateContractQuestionMutation> => {
+): MockLink.MockedResponse<CreateContractQuestionMutation> => {
     return {
         request: {
             query: CreateContractQuestionDocument,
@@ -72,7 +72,7 @@ const createContractQuestionNetworkFailure = (
 
 const createRateQuestionSuccess = (
     question?: CreateRateQuestionInput | Partial<CreateRateQuestionInput>
-): MockedResponse<CreateRateQuestionMutation> => {
+): MockLink.MockedResponse<CreateRateQuestionMutation> => {
     const defaultQuestionInput: CreateRateQuestionInput = {
         // dueDate: new Date('11-11-2100'),
         rateID: '123-abc',
@@ -115,7 +115,7 @@ const createRateQuestionSuccess = (
 
 const createRateQuestionNetworkFailure = (
     input: CreateRateQuestionInput
-): MockedResponse<CreateRateQuestionMutation> => {
+): MockLink.MockedResponse<CreateRateQuestionMutation> => {
     return {
         request: {
             query: CreateRateQuestionDocument,
@@ -127,7 +127,7 @@ const createRateQuestionNetworkFailure = (
 
 const createContractQuestionResponseNetworkFailure = (
     _question?: QuestionResponseType | Partial<QuestionResponseType>
-): MockedResponse<CreateContractQuestionMutation> => {
+): MockLink.MockedResponse<CreateContractQuestionMutation> => {
     return {
         request: { query: CreateContractQuestionResponseDocument },
         error: new Error('A network error occurred'),
@@ -136,7 +136,7 @@ const createContractQuestionResponseNetworkFailure = (
 
 const createRateQuestionResponseNetworkFailure = (
     _question?: QuestionResponseType | Partial<QuestionResponseType>
-): MockedResponse<CreateRateQuestionResponseMutation> => {
+): MockLink.MockedResponse<CreateRateQuestionResponseMutation> => {
     return {
         request: { query: CreateRateQuestionResponseDocument },
         error: new Error('A network error occurred'),

--- a/packages/mocks/src/apollo/rateGQLMocks.ts
+++ b/packages/mocks/src/apollo/rateGQLMocks.ts
@@ -13,7 +13,7 @@ import {
     IndexRatesStrippedWithRelatedContractsQuery,
     IndexRatesStrippedWithRelatedContractsDocument,
 } from '../gen/gqlClient'
-import { MockedResponse } from '@apollo/client/testing'
+import { MockLink } from '@apollo/client/testing'
 import {
     draftRateDataMock,
     rateDataMock,
@@ -25,7 +25,7 @@ import { GraphQLError } from 'graphql/index'
 const fetchRateMockSuccess = (
     rate?: Partial<Rate>,
     revision?: Partial<RateRevision>
-): MockedResponse<FetchRateQuery> => {
+): MockLink.MockedResponse<FetchRateQuery> => {
     const rateData = rateDataMock(revision, rate)
 
     return {
@@ -48,7 +48,7 @@ const fetchRateMockSuccess = (
 const fetchDraftRateMockSuccess = (
     rate?: Partial<Rate>,
     revision?: Partial<RateRevision>
-): MockedResponse<FetchRateQuery> => {
+): MockLink.MockedResponse<FetchRateQuery> => {
     const rateData = draftRateDataMock(rate, revision)
 
     return {
@@ -71,7 +71,7 @@ const fetchDraftRateMockSuccess = (
 const indexRatesStrippedMockSuccess = (
     stateCode?: string,
     rates?: RateStripped[]
-): MockedResponse<IndexRatesStrippedQuery> => {
+): MockLink.MockedResponse<IndexRatesStrippedQuery> => {
     const mockRates = rates ?? [
         { ...strippedRateDataMock(), id: 'test-id-123', stateNumber: 3 },
         { ...strippedRateDataMock(), id: 'test-id-124', stateNumber: 2 },
@@ -105,7 +105,7 @@ const indexRatesStrippedMockSuccess = (
 const indexRatesStrippedWithRelatedContractsMockSuccess = (
     stateCode?: string,
     rateIDs?: string[]
-): MockedResponse<IndexRatesStrippedWithRelatedContractsQuery> => {
+): MockLink.MockedResponse<IndexRatesStrippedWithRelatedContractsQuery> => {
     const mockRates = [
         { ...strippedRateDataMock(), id: 'test-id-123', stateNumber: 3 },
         { ...strippedRateDataMock(), id: 'test-id-124', stateNumber: 2 },
@@ -141,7 +141,7 @@ const indexRatesStrippedWithRelatedContractsMockSuccess = (
 const indexRatesMockSuccess = (
     stateCode?: string,
     rates?: Rate[]
-): MockedResponse<IndexRatesQuery> => {
+): MockLink.MockedResponse<IndexRatesQuery> => {
     const mockRates = rates ?? [
         { ...rateDataMock(), id: 'test-id-123', stateNumber: 3 },
         { ...rateDataMock(), id: 'test-id-124', stateNumber: 2 },
@@ -173,7 +173,7 @@ const indexRatesMockSuccess = (
 }
 
 const indexRatesStrippedMockFailure =
-    (): MockedResponse<IndexRatesStrippedQuery> => {
+    (): MockLink.MockedResponse<IndexRatesStrippedQuery> => {
         const graphQLError = new GraphQLError('Issue finding rates stripped', {
             extensions: {
                 code: 'NOT_FOUND',
@@ -191,7 +191,7 @@ const indexRatesStrippedMockFailure =
         }
     }
 
-const indexRatesMockFailure = (): MockedResponse<IndexRatesQuery> => {
+const indexRatesMockFailure = (): MockLink.MockedResponse<IndexRatesQuery> => {
     const graphQLError = new GraphQLError('Issue finding rates with history', {
         extensions: {
             code: 'NOT_FOUND',
@@ -215,7 +215,7 @@ const fetchRateWithQuestionsMockSuccess = ({
 }: {
     rate?: Partial<Rate>
     rateRev?: Partial<RateRevision>
-}): MockedResponse<FetchRateWithQuestionsQuery> => {
+}): MockLink.MockedResponse<FetchRateWithQuestionsQuery> => {
     const rateID = rate?.id ?? rateRev?.rateID ?? 'rate-123'
     const rateData = mockRateSubmittedWithQuestions(
         { ...rate, id: rateID },

--- a/packages/mocks/src/apollo/updateUserMock.ts
+++ b/packages/mocks/src/apollo/updateUserMock.ts
@@ -1,4 +1,4 @@
-import { MockedResponse } from '@apollo/client/testing'
+import { MockLink } from '@apollo/client/testing'
 import { GraphQLError } from 'graphql'
 import {
     UpdateDivisionAssignmentDocument,
@@ -8,7 +8,7 @@ import {
 
 const updateDivisionMockSuccess = (
     updateInput: UpdateDivisionAssignmentInput
-): MockedResponse<UpdateDivisionAssignmentMutation> => {
+): MockLink.MockedResponse<UpdateDivisionAssignmentMutation> => {
     return {
         request: {
             query: UpdateDivisionAssignmentDocument,
@@ -35,7 +35,7 @@ const updateDivisionMockSuccess = (
 
 const updateDivisionMockError = (
     updateInput: UpdateDivisionAssignmentInput
-): MockedResponse<UpdateDivisionAssignmentMutation> => {
+): MockLink.MockedResponse<UpdateDivisionAssignmentMutation> => {
     const graphQLError = new GraphQLError('Error attempting to unlock.', {
         extensions: {
             code: 'NOT_FOUND',

--- a/packages/mocks/src/apollo/userGQLMock.ts
+++ b/packages/mocks/src/apollo/userGQLMock.ts
@@ -1,4 +1,4 @@
-import { MockedResponse } from '@apollo/client/testing'
+import { MockLink } from '@apollo/client/testing'
 import { ServerError } from '@apollo/client'
 import {
     CmsUser,
@@ -129,12 +129,12 @@ const fetchCurrentUserMock = ({
     user = mockValidUser(), // defaults to logged in state user, we can override though from test
     statusCode,
 }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-fetchCurrentUserMockProps): MockedResponse<Record<string, any>> => {
+fetchCurrentUserMockProps): MockLink.MockedResponse<Record<string, any>> => {
     const mockError = (message: string, statusCode?: number) => {
-        const error = new Error(message) as ServerError
-        error.statusCode = statusCode || 400
-        error.name = 'ServerError'
-        return error
+        return new ServerError(message, {
+            response: new Response('', { status: statusCode || 400 }),
+            bodyText: '',
+        })
     }
     switch (statusCode) {
         case 200:
@@ -161,7 +161,7 @@ fetchCurrentUserMockProps): MockedResponse<Record<string, any>> => {
 
 const indexUsersQueryMock = (
     users?: UserType[]
-): MockedResponse<IndexUsersQuery> => {
+): MockLink.MockedResponse<IndexUsersQuery> => {
     const indexUsers: IndexUsersPayload | undefined = users
         ? {
               totalCount: users.length,
@@ -205,7 +205,7 @@ const indexUsersQueryMock = (
     }
 }
 
-const indexUsersQueryFailMock = (): MockedResponse<GraphQLError> => {
+const indexUsersQueryFailMock = (): MockLink.MockedResponse<GraphQLError> => {
     const graphQLError = new GraphQLError(
         'Error fetching email settings data.',
         {
@@ -232,7 +232,7 @@ const indexUsersQueryFailMock = (): MockedResponse<GraphQLError> => {
 function updateStateAssignmentsMutationMockSuccess(
     stateCode: string = 'CA',
     userIDs: string[] = ['1', '2']
-): MockedResponse<
+): MockLink.MockedResponse<
     UpdateStateAssignmentsByStateMutation,
     UpdateStateAssignmentsByStateMutationVariables
 > {
@@ -276,7 +276,7 @@ function updateStateAssignmentsMutationMockSuccess(
 function updateStateAssignmentsMutationMockFailure(
     stateCode: string = 'CA',
     userIDs: string[] = ['1', '2']
-): MockedResponse<GraphQLError> {
+): MockLink.MockedResponse<GraphQLError> {
     const graphQLError = new GraphQLError(
         'Error fetching email settings data.',
         {

--- a/packages/mocks/src/apollo/withdrawContractGQLMock.ts
+++ b/packages/mocks/src/apollo/withdrawContractGQLMock.ts
@@ -1,4 +1,4 @@
-import { MockedResponse } from '@apollo/client/testing'
+import { MockLink } from '@apollo/client/testing'
 import {
     Contract,
     UndoWithdrawContractDocument,
@@ -15,7 +15,7 @@ const withdrawContractMockSuccess = (
         contractData?: Partial<Contract>
         updatedReason?: string
     } = {}
-): MockedResponse<WithdrawContractMutation> => {
+): MockLink.MockedResponse<WithdrawContractMutation> => {
     const {
         contractID = 'test-abc-123',
         contractData,
@@ -52,7 +52,7 @@ const withdrawContractMockSuccess = (
 }
 
 const withdrawContractMockFailure =
-    (): MockedResponse<WithdrawContractMutation> => {
+    (): MockLink.MockedResponse<WithdrawContractMutation> => {
         const graphQLError = new GraphQLError('Issue withdrawing submission', {
             extensions: {
                 code: 'NOT_FOUND',
@@ -83,7 +83,7 @@ const undoWithdrawContractMockSuccess = (
         contractData?: Partial<Contract>
         updatedReason?: string
     } = {}
-): MockedResponse<UndoWithdrawContractMutation> => {
+): MockLink.MockedResponse<UndoWithdrawContractMutation> => {
     const {
         contractID = 'test-abc-123',
         contractData,
@@ -121,7 +121,7 @@ const undoWithdrawContractMockSuccess = (
 }
 
 const undoWithdrawContractMockFailure =
-    (): MockedResponse<UndoWithdrawContractMutation> => {
+    (): MockLink.MockedResponse<UndoWithdrawContractMutation> => {
         const graphQLError = new GraphQLError(
             'Issue undoing submission withdraw',
             {

--- a/packages/mocks/src/apollo/withdrawRateGQLMock.ts
+++ b/packages/mocks/src/apollo/withdrawRateGQLMock.ts
@@ -5,7 +5,7 @@ import {
     WithdrawRateMutation,
     UndoWithdrawnRateMutation,
 } from '../gen/gqlClient'
-import { MockedResponse } from '@apollo/client/testing'
+import { MockLink } from '@apollo/client/testing'
 import { GraphQLError } from 'graphql/index'
 import { mockRateSubmittedWithQuestions } from './rateDataMock'
 
@@ -15,7 +15,7 @@ const withdrawRateMockSuccess = (
         rateData?: Partial<Rate>
         updatedReason?: string
     } = {}
-): MockedResponse<WithdrawRateMutation> => {
+): MockLink.MockedResponse<WithdrawRateMutation> => {
     const {
         rateID = 'test-abc-123',
         rateData,
@@ -71,7 +71,7 @@ const undoWithdrawRateMockSuccess = (
         rateData?: Partial<Rate>
         updatedReason?: string
     } = {}
-): MockedResponse<UndoWithdrawnRateMutation> => {
+): MockLink.MockedResponse<UndoWithdrawnRateMutation> => {
     const {
         rateID = 'test-abc-123',
         rateData,
@@ -136,7 +136,7 @@ const undoWithdrawRateMockSuccess = (
 }
 
 const undoWithdrawRateMockFailure =
-    (): MockedResponse<UndoWithdrawnRateMutation> => {
+    (): MockLink.MockedResponse<UndoWithdrawnRateMutation> => {
         const graphQLError = new GraphQLError(
             'Issue undoing a withdrawn rate',
             {
@@ -164,7 +164,7 @@ const undoWithdrawRateMockFailure =
         }
     }
 
-const withdrawRateMockFailure = (): MockedResponse<WithdrawRateMutation> => {
+const withdrawRateMockFailure = (): MockLink.MockedResponse<WithdrawRateMutation> => {
     const graphQLError = new GraphQLError('Issue withdrawing rate', {
         extensions: {
             code: 'NOT_FOUND',

--- a/packages/submissions/package.json
+++ b/packages/submissions/package.json
@@ -9,7 +9,8 @@
     },
     "dependencies": {
         "@mc-review/dates": "workspace:*",
-        "@apollo/client": "3.8.8",
+        "@apollo/client": "^4.1.7",
+        "rxjs": "^7.8.1",
         "@graphql-typed-document-node/core": "^3.2.0",
         "dayjs": "^1.11.19",
         "typescript": "5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
   packages/common-code:
     dependencies:
       '@apollo/client':
-        specifier: 3.8.8
-        version: 3.8.8(graphql-ws@5.16.2(graphql@16.13.2))(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(subscriptions-transport-ws@0.11.0(graphql@16.13.2))
+        specifier: ^4.1.7
+        version: 4.1.7(graphql-ws@6.0.7(graphql@16.13.2)(ws@8.20.0))(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.2)(subscriptions-transport-ws@0.11.0(graphql@16.13.2))
       '@graphql-typed-document-node/core':
         specifier: ^3.2.0
         version: 3.2.0(graphql@16.13.2)
@@ -120,6 +120,9 @@ importers:
       '@mc-review/submissions':
         specifier: workspace:*
         version: link:../submissions
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -146,11 +149,14 @@ importers:
   packages/constants:
     dependencies:
       '@apollo/client':
-        specifier: 3.8.8
-        version: 3.8.8(graphql-ws@5.16.2(graphql@16.13.2))(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(subscriptions-transport-ws@0.11.0(graphql@16.13.2))
+        specifier: ^4.1.7
+        version: 4.1.7(graphql-ws@6.0.7(graphql@16.13.2)(ws@8.20.0))(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.2)(subscriptions-transport-ws@0.11.0(graphql@16.13.2))
       '@graphql-typed-document-node/core':
         specifier: ^3.2.0
         version: 3.2.0(graphql@16.13.2)
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -180,8 +186,8 @@ importers:
   packages/helpers:
     dependencies:
       '@apollo/client':
-        specifier: 3.8.8
-        version: 3.8.8(graphql-ws@5.16.2(graphql@16.13.2))(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(subscriptions-transport-ws@0.11.0(graphql@16.13.2))
+        specifier: ^4.1.7
+        version: 4.1.7(graphql-ws@6.0.7(graphql@16.13.2)(ws@8.20.0))(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.2)(subscriptions-transport-ws@0.11.0(graphql@16.13.2))
       '@graphql-typed-document-node/core':
         specifier: ^3.2.0
         version: 3.2.0(graphql@16.13.2)
@@ -197,6 +203,12 @@ importers:
       '@mc-review/submissions':
         specifier: workspace:*
         version: link:../submissions
+      graphql:
+        specifier: ^16.13.2
+        version: 16.13.2
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -220,8 +232,8 @@ importers:
   packages/mocks:
     dependencies:
       '@apollo/client':
-        specifier: 3.8.8
-        version: 3.8.8(graphql-ws@5.16.2(graphql@16.13.2))(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(subscriptions-transport-ws@0.11.0(graphql@16.13.2))
+        specifier: ^4.1.7
+        version: 4.1.7(graphql-ws@6.0.7(graphql@16.13.2)(ws@8.20.0))(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.2)(subscriptions-transport-ws@0.11.0(graphql@16.13.2))
       '@graphql-typed-document-node/core':
         specifier: ^3.2.0
         version: 3.2.0(graphql@16.13.2)
@@ -237,6 +249,9 @@ importers:
       graphql:
         specifier: ^16.13.2
         version: 16.13.2
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -279,8 +294,8 @@ importers:
   packages/submissions:
     dependencies:
       '@apollo/client':
-        specifier: 3.8.8
-        version: 3.8.8(graphql-ws@5.16.2(graphql@16.13.2))(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(subscriptions-transport-ws@0.11.0(graphql@16.13.2))
+        specifier: ^4.1.7
+        version: 4.1.7(graphql-ws@6.0.7(graphql@16.13.2)(ws@8.20.0))(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.2)(subscriptions-transport-ws@0.11.0(graphql@16.13.2))
       '@graphql-typed-document-node/core':
         specifier: ^3.2.0
         version: 3.2.0(graphql@16.13.2)
@@ -290,6 +305,9 @@ importers:
       dayjs:
         specifier: ^1.11.19
         version: 1.11.19
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -359,14 +377,14 @@ importers:
   services/app-api:
     dependencies:
       '@apollo/client':
-        specifier: 3.8.8
-        version: 3.8.8(graphql-ws@5.16.2(graphql@16.13.2))(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(subscriptions-transport-ws@0.11.0(graphql@16.13.2))
+        specifier: ^4.1.7
+        version: 4.1.7(graphql-ws@6.0.7(graphql@16.13.2)(ws@8.20.0))(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.2)(subscriptions-transport-ws@0.11.0(graphql@16.13.2))
       '@apollo/server':
         specifier: ^5.5.0
         version: 5.5.0(graphql@16.13.2)
       '@as-integrations/aws-lambda':
-        specifier: ^3.1.0
-        version: 3.1.0(@apollo/server@5.5.0(graphql@16.13.2))
+        specifier: ^4.0.1
+        version: 4.0.1(@apollo/server@5.5.0(graphql@16.13.2))
       '@aws-sdk/client-cognito-identity-provider':
         specifier: ^3.1030.0
         version: 3.1030.0
@@ -490,6 +508,9 @@ importers:
       purify-ts:
         specifier: ^2.1.4
         version: 2.1.4
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.2
       url-parse:
         specifier: ^1.5.10
         version: 1.5.10
@@ -613,8 +634,8 @@ importers:
   services/app-web:
     dependencies:
       '@apollo/client':
-        specifier: 3.8.8
-        version: 3.8.8(graphql-ws@5.16.2(graphql@16.13.2))(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(subscriptions-transport-ws@0.11.0(graphql@16.13.2))
+        specifier: ^4.1.7
+        version: 4.1.7(graphql-ws@6.0.7(graphql@16.13.2)(ws@8.20.0))(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.2)(subscriptions-transport-ws@0.11.0(graphql@16.13.2))
       '@apollo/explorer':
         specifier: ^3.7.3
         version: 3.7.3(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-deep-compare-effect@1.8.1(react@18.3.1))
@@ -741,6 +762,9 @@ importers:
       react-select:
         specifier: ^5.10.2
         version: 5.10.2(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.2
       sass:
         specifier: ^1.49.11
         version: 1.77.2
@@ -935,8 +959,8 @@ importers:
   services/cypress:
     dependencies:
       '@apollo/client':
-        specifier: 3.8.8
-        version: 3.8.8(graphql-ws@5.16.2(graphql@16.13.2))(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(subscriptions-transport-ws@0.11.0(graphql@16.13.2))
+        specifier: ^4.1.7
+        version: 4.1.7(graphql-ws@6.0.7(graphql@16.13.2)(ws@8.20.0))(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.2)(subscriptions-transport-ws@0.11.0(graphql@16.13.2))
       '@aws-crypto/sha256-js':
         specifier: ^5.2.0
         version: 5.2.0
@@ -976,6 +1000,9 @@ importers:
       graphql:
         specifier: ^16.13.2
         version: 16.13.2
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.2
     devDependencies:
       '@bahmutov/cypress-esbuild-preprocessor':
         specifier: ^2.2.8
@@ -1244,13 +1271,14 @@ packages:
     peerDependencies:
       graphql: 14.x || 15.x || 16.x
 
-  '@apollo/client@3.8.8':
-    resolution: {integrity: sha512-omjd9ryGDkadZrKW6l5ktUAdS4SNaFOccYQ4ZST0HLW83y8kQaSZOCTNlpkoBUK8cv6qP8+AxOKwLm2ho8qQ+Q==}
+  '@apollo/client@4.1.7':
+    resolution: {integrity: sha512-CE1Pe22vszRBMGrBOovIXzTa5infy1kwF0kWX2JBLcGFXoOPBOAo9zoM++tuSRZr8PscWJyv2ka2FKoyEquEHw==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-      graphql-ws: ^5.5.5
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      graphql: ^16.0.0
+      graphql-ws: ^5.5.5 || ^6.0.3
+      react: ^17.0.0 || ^18.0.0 || >=19.0.0-rc
+      react-dom: ^17.0.0 || ^18.0.0 || >=19.0.0-rc
+      rxjs: ^7.3.0
       subscriptions-transport-ws: ^0.9.0 || ^0.11.0
     peerDependenciesMeta:
       graphql-ws:
@@ -1376,11 +1404,11 @@ packages:
     peerDependencies:
       graphql: '*'
 
-  '@as-integrations/aws-lambda@3.1.0':
-    resolution: {integrity: sha512-V7H9ICXgt5KDKfEjYSRB59lEVfQqi7oSIZEeBGzPrmfhSPIHyFCNJyHi1hXdJmRb6GHpCNmtffmqRgsB0i9k3w==}
+  '@as-integrations/aws-lambda@4.0.1':
+    resolution: {integrity: sha512-1vpz2V6MhuPhO0m5vE8NUVR+4RoM5nDO/iH+IVHovE0aOWUIoDbAqQDKCUXTV8/nJO/GBycQt/z/Mp9MX79Hkg==}
     engines: {node: '>=16.0'}
     peerDependencies:
-      '@apollo/server': ^4.0.0
+      '@apollo/server': ^5.0.0
 
   '@asamuzakjp/css-color@4.1.2':
     resolution: {integrity: sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==}
@@ -11554,10 +11582,6 @@ packages:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
 
-  response-iterator@0.2.6:
-    resolution: {integrity: sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==}
-    engines: {node: '>=0.8'}
-
   restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
@@ -12139,10 +12163,6 @@ packages:
     resolution: {integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==}
     engines: {node: '>=0.10.0'}
 
-  symbol-observable@4.0.0:
-    resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
-    engines: {node: '>=0.10'}
-
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -12351,10 +12371,6 @@ packages:
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
-
-  ts-invariant@0.10.3:
-    resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
-    engines: {node: '>=8'}
 
   ts-jest@29.4.6:
     resolution: {integrity: sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==}
@@ -13159,9 +13175,6 @@ packages:
   zen-observable-ts@1.1.0:
     resolution: {integrity: sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==}
 
-  zen-observable-ts@1.2.5:
-    resolution: {integrity: sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==}
-
   zen-observable@0.7.1:
     resolution: {integrity: sha512-OI6VMSe0yeqaouIXtedC+F55Sr6r9ppS7+wTbSexkYdHbdt4ctTuPNXP/rwm7GTVI63YBc+EBT0b0tl7YnJLRg==}
 
@@ -13205,23 +13218,19 @@ snapshots:
     dependencies:
       graphql: 16.13.2
 
-  '@apollo/client@3.8.8(graphql-ws@5.16.2(graphql@16.13.2))(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(subscriptions-transport-ws@0.11.0(graphql@16.13.2))':
+  '@apollo/client@4.1.7(graphql-ws@6.0.7(graphql@16.13.2)(ws@8.20.0))(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.2)(subscriptions-transport-ws@0.11.0(graphql@16.13.2))':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.2)
+      '@wry/caches': 1.0.1
       '@wry/equality': 0.5.7
       '@wry/trie': 0.5.0
       graphql: 16.13.2
       graphql-tag: 2.12.6(graphql@16.13.2)
-      hoist-non-react-statics: 3.3.2
       optimism: 0.18.0
-      prop-types: 15.8.1
-      response-iterator: 0.2.6
-      symbol-observable: 4.0.0
-      ts-invariant: 0.10.3
+      rxjs: 7.8.2
       tslib: 2.8.1
-      zen-observable-ts: 1.2.5
     optionalDependencies:
-      graphql-ws: 5.16.2(graphql@16.13.2)
+      graphql-ws: 6.0.7(graphql@16.13.2)(ws@8.20.0)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       subscriptions-transport-ws: 0.11.0(graphql@16.13.2)
@@ -13399,10 +13408,10 @@ snapshots:
       immutable: 5.1.5
       invariant: 2.2.4
 
-  '@as-integrations/aws-lambda@3.1.0(@apollo/server@5.5.0(graphql@16.13.2))':
+  '@as-integrations/aws-lambda@4.0.1(@apollo/server@5.5.0(graphql@16.13.2))':
     dependencies:
       '@apollo/server': 5.5.0(graphql@16.13.2)
-      '@types/aws-lambda': 8.10.152
+      '@types/aws-lambda': 8.10.159
 
   '@asamuzakjp/css-color@4.1.2':
     dependencies:
@@ -26910,8 +26919,6 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  response-iterator@0.2.6: {}
-
   restore-cursor@3.1.0:
     dependencies:
       onetime: 5.1.2
@@ -27677,8 +27684,6 @@ snapshots:
 
   symbol-observable@1.2.0: {}
 
-  symbol-observable@4.0.0: {}
-
   symbol-tree@3.2.4: {}
 
   sync-fetch@0.6.0:
@@ -27856,10 +27861,6 @@ snapshots:
       typescript: 5.9.3
 
   ts-dedent@2.2.0: {}
-
-  ts-invariant@0.10.3:
-    dependencies:
-      tslib: 2.8.1
 
   ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.29.0))(esbuild@0.25.8)(jest-util@30.2.0)(jest@30.2.0(@types/node@25.5.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
@@ -28758,10 +28759,6 @@ snapshots:
   zen-observable-ts@1.1.0:
     dependencies:
       '@types/zen-observable': 0.8.3
-      zen-observable: 0.8.15
-
-  zen-observable-ts@1.2.5:
-    dependencies:
       zen-observable: 0.8.15
 
   zen-observable@0.7.1: {}

--- a/services/app-api/package.json
+++ b/services/app-api/package.json
@@ -18,10 +18,11 @@
         "start:local": "node .local-build/local-server.js"
     },
     "dependencies": {
-        "@apollo/client": "3.8.8",
+        "@apollo/client": "^4.1.7",
         "@apollo/server": "^5.5.0",
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@as-integrations/aws-lambda": "^3.1.0",
+        "@as-integrations/aws-lambda": "^4.0.1",
+        "rxjs": "^7.8.1",
         "@aws-sdk/client-cognito-identity-provider": "^3.1030.0",
         "@aws-sdk/client-rds": "^3.1030.0",
         "@aws-sdk/client-s3": "^3.1030.0",

--- a/services/app-web/.storybook/providersDecorator.tsx
+++ b/services/app-web/.storybook/providersDecorator.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { BrowserRouter } from 'react-router-dom'
-import { MockedProvider, MockedProviderProps } from '@apollo/client/testing'
+import {
+    MockedProvider,
+    MockedProviderProps,
+} from '@apollo/client/testing/react'
 import { StoryFn } from '@storybook/react'
 
 import { AuthProvider, AuthProviderProps } from '../src/contexts/AuthContext'

--- a/services/app-web/package.json
+++ b/services/app-web/package.json
@@ -66,7 +66,8 @@
         ]
     },
     "dependencies": {
-        "@apollo/client": "3.8.8",
+        "@apollo/client": "^4.1.7",
+        "rxjs": "^7.8.1",
         "@apollo/explorer": "^3.7.3",
         "@graphql-typed-document-node/core": "^3.2.0",
         "@cypress/code-coverage": "^3.14.7",

--- a/services/app-web/src/api/fakeAmplifyFetch.ts
+++ b/services/app-web/src/api/fakeAmplifyFetch.ts
@@ -63,9 +63,10 @@ function fetchResponseFromAxios(axiosResponse: AxiosResponse): Response {
 // Apollo Link uses the ~fetch api for it's client-side middleware.
 // Amplify.API uses axios undeneath and does its own transformation of the body, so we wrap that up here.
 export async function fakeAmplifyFetch(
-    uri: string,
-    options: RequestInit
+    uri: URL | RequestInfo,
+    options?: RequestInit
 ): Promise<Response> {
+    options = options ?? {}
     if (options.method !== 'POST') {
         throw new Error('unexpected GQL request')
     }
@@ -93,8 +94,15 @@ export async function fakeAmplifyFetch(
         headers: headers,
     }
 
+    const uriString =
+        typeof uri === 'string'
+            ? uri
+            : uri instanceof URL
+              ? uri.toString()
+              : uri.url
+
     return new Promise<Response>((resolve, reject) => {
-        API.post('api', uri, apiOptions)
+        API.post('api', uriString, apiOptions)
             .then((apiResponse: AxiosResponse) => {
                 // The Apollo Link wants a fetch.Response shaped response,
                 // not the axios shaped response that Amplify.API returns

--- a/services/app-web/src/api/localGQLFetch.ts
+++ b/services/app-web/src/api/localGQLFetch.ts
@@ -5,16 +5,17 @@ import { fakeAmplifyFetch } from './fakeAmplifyFetch'
 // localGQLfetch calls Amplify fetch but puts the user in the cognito header for
 // the local Express server to map into the Lambda event
 export async function localGQLFetch(
-    uri: string,
-    options: RequestInit
+    uri: URL | RequestInfo,
+    options?: RequestInit
 ): Promise<Response> {
     const currentUser = await getLoggedInUser()
+    const opts: RequestInit = options ?? {}
 
-    options.headers = Object.assign({}, options.headers, {
+    opts.headers = Object.assign({}, opts.headers, {
         'cognito-authentication-provider': currentUser
             ? JSON.stringify(currentUser)
             : 'NO_USER',
     })
 
-    return fakeAmplifyFetch(uri, options)
+    return fakeAmplifyFetch(uri, opts)
 }

--- a/services/app-web/src/components/Modal/UnlockSubmitModal.tsx
+++ b/services/app-web/src/components/Modal/UnlockSubmitModal.tsx
@@ -9,7 +9,7 @@ import {
     FetchContractWithQuestionsDocument,
     IndexContractsStrippedDocument,
 } from '../../gen/gqlClient'
-import { useMutation } from '@apollo/client'
+import { useMutation } from '@apollo/client/react'
 import { useFormik } from 'formik'
 import { usePrevious } from '../../hooks'
 import { Modal } from './Modal'

--- a/services/app-web/src/contexts/AuthContext.tsx
+++ b/services/app-web/src/contexts/AuthContext.tsx
@@ -12,7 +12,8 @@ import { logoutLocalUser } from '../localAuth'
 import { signOut as cognitoSignOut } from '../pages/Auth/cognitoAuth'
 import { recordJSException } from '@mc-review/otel'
 import { handleApolloError } from '@mc-review/helpers'
-import { ApolloQueryResult, useQuery } from '@apollo/client'
+import type { ApolloClient } from '@apollo/client'
+import { useQuery } from '@apollo/client/react'
 
 // Constants and types
 type LoginStatusType = 'LOADING' | 'LOGGED_OUT' | 'LOGGED_IN'
@@ -31,7 +32,7 @@ const LOGOUT_PATHS: Record<LogoutType, string> = {
 type AuthContextType = {
     checkAuth: (
         failureRedirect?: string
-    ) => Promise<ApolloQueryResult<FetchCurrentUserQuery> | Error>
+    ) => Promise<ApolloClient.QueryResult<FetchCurrentUserQuery> | Error>
     refreshAuth: () => Promise<void>
     loggedInUser: UserType | undefined
     loginStatus: LoginStatusType

--- a/services/app-web/src/hooks/useContractForm.ts
+++ b/services/app-web/src/hooks/useContractForm.ts
@@ -14,9 +14,13 @@ import {
     UpdateContractDraftRevisionInput,
     ContractPackageSubmission,
 } from '../gen/gqlClient'
-import { wrapApolloResult, handleApolloError } from '@mc-review/helpers'
+import {
+    wrapApolloResult,
+    handleApolloError,
+    toGQLError,
+} from '@mc-review/helpers'
 import { recordJSException } from '@mc-review/otel'
-import { ApolloError, useMutation, useQuery } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client/react'
 import type { InterimState } from '../pages/StateSubmission/SharedSubmissionComponents'
 
 type UseContractForm = {
@@ -200,16 +204,14 @@ const useContractForm = (contractID?: string): UseContractForm => {
     // do not trip skipped as an error
     if (result.status === 'ERROR' && result.error.name !== 'SKIPPED') {
         const err = result.error
-        if (err instanceof ApolloError) {
-            handleApolloError(err, true)
-            if (err.graphQLErrors[0]?.extensions?.code === 'NOT_FOUND') {
-                interimState = 'NOT_FOUND'
-                return {
-                    interimState,
-                    createDraft,
-                    updateDraft,
-                    showPageErrorMessage,
-                }
+        handleApolloError(err, true)
+        if (toGQLError(err)?.extensions.code === 'NOT_FOUND') {
+            interimState = 'NOT_FOUND'
+            return {
+                interimState,
+                createDraft,
+                updateDraft,
+                showPageErrorMessage,
             }
         }
         if (err.name !== 'SKIPPED') {

--- a/services/app-web/src/index.tsx
+++ b/services/app-web/src/index.tsx
@@ -1,24 +1,15 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
-import {
-    ApolloClient,
-    InMemoryCache,
-    HttpLink,
-    DefaultOptions,
-} from '@apollo/client'
+import { ApolloClient, InMemoryCache, HttpLink } from '@apollo/client'
 import { Amplify } from 'aws-amplify'
-
 import './index.scss'
-
 import App from './pages/App/App'
 import reportWebVitals from './reportWebVitals'
 import { localGQLFetch, fakeAmplifyFetch } from './api'
 import { assertIsAuthMode } from '@mc-review/common-code'
 import { S3ClientT, newAmplifyS3Client, newLocalS3Client } from './s3'
 import { asyncWithLDProvider } from 'launchdarkly-react-client-sdk'
-import type { S3BucketConfigType } from './s3/s3Amplify'
-
-import schema from './gen/schema.graphql'
+import type { S3BucketConfigType } from './s3'
 
 const apiURL = import.meta.env.VITE_APP_API_URL
 if (!apiURL || apiURL === '') {
@@ -83,7 +74,7 @@ const cache = new InMemoryCache({
         },
     },
 })
-const defaultOptions: DefaultOptions = {
+const defaultOptions: ApolloClient.DefaultOptions = {
     watchQuery: {
         fetchPolicy: 'network-only',
     },
@@ -99,7 +90,6 @@ const apolloClient = new ApolloClient({
     }),
     cache,
     defaultOptions,
-    typeDefs: schema,
 })
 
 // S3 Region and LocalUrl are mutually exclusive.

--- a/services/app-web/src/pages/App/App.tsx
+++ b/services/app-web/src/pages/App/App.tsx
@@ -1,11 +1,8 @@
 import React from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import { ErrorBoundary } from 'react-error-boundary'
-import {
-    ApolloProvider,
-    ApolloClient,
-    NormalizedCacheObject,
-} from '@apollo/client'
+import { ApolloClient } from '@apollo/client'
+import { ApolloProvider } from '@apollo/client/react'
 
 import { AppBody } from './AppBody'
 import { AuthProvider } from '../../contexts/AuthContext'
@@ -39,7 +36,7 @@ export function TracingInitializer({ children }: TracingInitializerProps) {
 
 export type AppProps = {
     authMode: AuthModeType
-    apolloClient: ApolloClient<NormalizedCacheObject>
+    apolloClient: ApolloClient
     s3Client: S3ClientT
 }
 

--- a/services/app-web/src/pages/Auth/CheckAuth.tsx
+++ b/services/app-web/src/pages/Auth/CheckAuth.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { GridContainer } from '@trussworks/react-uswds'
-import { useLazyQuery } from '@apollo/client'
+import { useLazyQuery } from '@apollo/client/react'
 import { FetchCurrentUserDocument } from '../../gen/gqlClient'
 import { ButtonWithLogging } from '../../components'
 import { AccessibleAlertBanner } from '../../components/Banner/AccessibleAlertBanner/AccessibleAlertBanner'

--- a/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsDashboard.tsx
+++ b/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsDashboard.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useAuth } from '../../../contexts/AuthContext'
-import { useQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client/react'
 import { IndexRatesStrippedDocument } from '../../../gen/gqlClient'
 import { mostRecentDate } from '@mc-review/dates'
 import styles from '../../StateDashboard/StateDashboard.module.scss'

--- a/services/app-web/src/pages/CMSDashboard/SubmissionsDashboard/SubmissionsDashboard.tsx
+++ b/services/app-web/src/pages/CMSDashboard/SubmissionsDashboard/SubmissionsDashboard.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { SubmissionTypeRecord } from '@mc-review/submissions'
 import { useAuth } from '../../../contexts/AuthContext'
-import { useQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client/react'
 import { IndexContractsStrippedDocument } from '../../../gen/gqlClient'
 import { mostRecentDate } from '@mc-review/dates'
 import styles from '../../StateDashboard/StateDashboard.module.scss'

--- a/services/app-web/src/pages/Errors/ErrorFailedRequestPage.tsx
+++ b/services/app-web/src/pages/Errors/ErrorFailedRequestPage.tsx
@@ -1,15 +1,15 @@
 import React from 'react'
 import styles from './Errors.module.scss'
 
-import { PageHeading } from '../../components/PageHeading'
+import { PageHeading } from '../../components'
 import { GridContainer } from '@trussworks/react-uswds'
-import { ApolloError } from '@apollo/client'
+import type { ErrorLike } from '@apollo/client'
 import { handleApolloError, isLikelyUserAuthError } from '@mc-review/helpers'
 import { ErrorAlertFailedRequest, ErrorAlertSignIn } from '../../components'
 import { useAuth } from '../../contexts/AuthContext'
 
 /*
-    For use with an unknown ApolloError coming back from API requests
+    For use with an unknown Apollo error coming back from API requests
     - full takeover of the main app content below the header
     - specific ErrorAlert displayed at top of page
     - handles OTEL logging
@@ -19,7 +19,7 @@ export const ErrorFailedRequestPage = ({
     error,
     testID,
 }: {
-    error: ApolloError
+    error: ErrorLike | Error
     testID: string
 }): React.ReactElement => {
     const { loginStatus } = useAuth()

--- a/services/app-web/src/pages/LinkYourRates/LinkRateSelect/LinkRateSelect.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkRateSelect/LinkRateSelect.tsx
@@ -24,7 +24,8 @@ import { useField } from 'formik'
 import { convertIndexRatesGQLRateToRateForm } from '../../StateSubmission/HealthPlanSubmission/RateDetails/rateDetailsHelpers'
 import { AccessibleSelect } from '../../../components/Select'
 import { useState, useEffect } from 'react'
-import { ApolloError, useQuery } from '@apollo/client'
+import type { ErrorLike } from '@apollo/client'
+import { useQuery } from '@apollo/client/react'
 
 export interface LinkRateOptionType {
     readonly value: string
@@ -45,7 +46,7 @@ export type LinkRateSelectPropType = {
     autofill?: (
         rateForm: FormikRateForm,
         autofillLoading?: boolean,
-        autofillError?: ApolloError | undefined
+        autofillError?: ErrorLike | undefined
     ) => void // used for multi-rates, when called will FieldArray replace the existing form fields with new data
     label?: string
     stateCode?: string //used to limit rates by state

--- a/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
@@ -12,7 +12,7 @@ import {
     convertGQLRateToRateForm,
 } from '../StateSubmission/HealthPlanSubmission/RateDetails'
 import { useS3 } from '../../contexts/S3Context'
-import { ApolloError } from '@apollo/client'
+import type { ErrorLike } from '@apollo/client'
 
 export type LinkYourRatesProps = {
     fieldNamePrefix: string
@@ -21,7 +21,7 @@ export type LinkYourRatesProps = {
     autofill: (
         rateForm: FormikRateForm,
         autofillLoading?: boolean,
-        autofillError?: ApolloError
+        autofillError?: ErrorLike | undefined
     ) => void // used for multi-rates, when called will FieldArray replace the existing form fields with new data
     disableRadioBtns: boolean
 }

--- a/services/app-web/src/pages/MccrsId/MccrsId.tsx
+++ b/services/app-web/src/pages/MccrsId/MccrsId.tsx
@@ -7,6 +7,7 @@ import {
 import { Formik, FormikErrors } from 'formik'
 import { MccrsIdFormSchema } from './MccrsIdSchema'
 import { recordJSException } from '@mc-review/otel'
+import { toGQLError } from '@mc-review/helpers'
 import { useNavigate } from 'react-router-dom'
 import { usePage } from '../../contexts/PageContext'
 import {
@@ -29,7 +30,7 @@ import {
     FetchContractDocument,
     Contract,
 } from '../../gen/gqlClient'
-import { useMutation, useQuery } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client/react'
 import styles from './MccrsId.module.scss'
 import { useMemoizedStateHeader, useRouteParams } from '../../hooks'
 
@@ -101,19 +102,10 @@ export const MccrsId = (): React.ReactElement => {
         )
     } else if (fetchContractError && !fetchContractData) {
         //error handling for a state user that tries to access contracts for a different state
-        if (
-            fetchContractError?.graphQLErrors[0]?.extensions?.code ===
-            'FORBIDDEN'
-        ) {
-            return (
-                <ErrorForbiddenPage
-                    errorMsg={fetchContractError.graphQLErrors[0].message}
-                />
-            )
-        } else if (
-            fetchContractError?.graphQLErrors[0]?.extensions?.code ===
-            'NOT_FOUND'
-        ) {
+        const gqlError = toGQLError(fetchContractError)
+        if (gqlError?.extensions.code === 'FORBIDDEN') {
+            return <ErrorForbiddenPage errorMsg={gqlError.message} />
+        } else if (gqlError?.extensions.code === 'NOT_FOUND') {
             return <Error404 />
         } else {
             return <GenericErrorPage />

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/ContractQuestionResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/ContractQuestionResponse.tsx
@@ -8,7 +8,7 @@ import {
     QuestionResponseSubmitBanner,
     UserAccountWarningBanner,
 } from '../../../components/Banner'
-import { useQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client/react'
 import {
     CmsUser,
     Division,

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/RateQuestionResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/RateQuestionResponse.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect } from 'react'
 import styles from '../QuestionResponse.module.scss'
-import { useQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client/react'
 import {
     CmsUser,
     FetchRateWithQuestionsDocument,

--- a/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadContractQuestions.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadContractQuestions.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useLayoutEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import styles from '../QuestionResponse.module.scss'
-import { useMutation, useQuery } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client/react'
 import {
     ContractSubmissionType,
     CreateContractQuestionInput,

--- a/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadRateQuestions.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadRateQuestions.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useLayoutEffect } from 'react'
 import styles from '../QuestionResponse.module.scss'
 import { useNavigate, useParams } from 'react-router-dom'
-import { useMutation, useQuery } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client/react'
 import {
     CreateRateQuestionInput,
     CreateRateQuestionDocument,

--- a/services/app-web/src/pages/QuestionResponse/UploadResponse/UploadContractResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadResponse/UploadContractResponse.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { useMutation, useQuery } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client/react'
 import {
     CreateQuestionResponseInput,
     CreateContractQuestionResponseDocument,

--- a/services/app-web/src/pages/QuestionResponse/UploadResponse/UploadRateResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadResponse/UploadRateResponse.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { useMutation, useQuery } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client/react'
 import {
     CreateQuestionResponseInput,
     CreateRateQuestionResponseDocument,

--- a/services/app-web/src/pages/RateSummary/RateSummary.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.tsx
@@ -14,7 +14,7 @@ import {
     UnlockRateDocument,
     FetchRateWithQuestionsDocument,
 } from '../../gen/gqlClient'
-import { useQuery, useMutation } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client/react'
 import styles from '../SubmissionSummary/SubmissionSummary.module.scss'
 import { GenericErrorPage } from '../Errors/GenericErrorPage'
 import { ERROR_MESSAGES, RoutesRecord } from '@mc-review/constants'
@@ -31,7 +31,10 @@ import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { featureFlags } from '@mc-review/common-code'
 import { UnlockRateButton } from '../../components/SubmissionSummarySection/RateDetailsSummarySection/UnlockRateButton'
 import { recordJSException } from '@mc-review/otel'
-import { handleApolloErrorsAndAddUserFacingMessages } from '@mc-review/helpers'
+import {
+    handleApolloErrorsAndAddUserFacingMessages,
+    toGQLError,
+} from '@mc-review/helpers'
 import { StatusUpdatedBanner } from '../../components/Banner'
 import { ChildrenType } from '../../components/MultiColumnGrid/MultiColumnGrid'
 import { getSubmissionPath } from '../../routeHelpers'
@@ -122,11 +125,10 @@ export const RateSummary = (): React.ReactElement => {
             </GridContainer>
         )
     } else if (!data && error) {
-        if (error?.graphQLErrors[0]?.extensions?.code === 'FORBIDDEN') {
-            return (
-                <ErrorForbiddenPage errorMsg={error.graphQLErrors[0].message} />
-            )
-        } else if (error?.graphQLErrors[0]?.extensions?.code === 'NOT_FOUND') {
+        const gqlError = toGQLError(error)
+        if (gqlError?.extensions.code === 'FORBIDDEN') {
+            return <ErrorForbiddenPage errorMsg={gqlError.message} />
+        } else if (gqlError?.extensions.code === 'NOT_FOUND') {
             return <Error404 />
         } else {
             return <GenericErrorPage />
@@ -155,19 +157,10 @@ export const RateSummary = (): React.ReactElement => {
         )
     } else if (fetchContractError && !fetchContractData) {
         //error handling for a state user that tries to access contracts for a different state
-        if (
-            fetchContractError?.graphQLErrors[0]?.extensions?.code ===
-            'FORBIDDEN'
-        ) {
-            return (
-                <ErrorForbiddenPage
-                    errorMsg={fetchContractError.graphQLErrors[0].message}
-                />
-            )
-        } else if (
-            fetchContractError?.graphQLErrors[0]?.extensions?.code ===
-            'NOT_FOUND'
-        ) {
+        const contractGqlError = toGQLError(fetchContractError)
+        if (contractGqlError?.extensions.code === 'FORBIDDEN') {
+            return <ErrorForbiddenPage errorMsg={contractGqlError.message} />
+        } else if (contractGqlError?.extensions.code === 'NOT_FOUND') {
             return <Error404 />
         } else {
             return <GenericErrorPage />

--- a/services/app-web/src/pages/RateWithdraw/RateWithdraw.tsx
+++ b/services/app-web/src/pages/RateWithdraw/RateWithdraw.tsx
@@ -10,7 +10,7 @@ import {
 import { RoutesRecord } from '@mc-review/constants'
 import { generatePath, useNavigate, useParams } from 'react-router-dom'
 import { FetchRateDocument, WithdrawRateDocument } from '../../gen/gqlClient'
-import { useQuery, useMutation } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client/react'
 import { ErrorOrLoadingPage } from '../StateSubmission'
 import { handleAndReturnErrorState } from '../StateSubmission/SharedSubmissionComponents'
 import { ButtonGroup, Form } from '@trussworks/react-uswds'

--- a/services/app-web/src/pages/Settings/EditStateAssign/EditStateAssign.tsx
+++ b/services/app-web/src/pages/Settings/EditStateAssign/EditStateAssign.tsx
@@ -26,7 +26,7 @@ import {
     IndexUsersDocument,
     UpdateStateAssignmentsByStateDocument,
 } from '../../../gen/gqlClient'
-import { useMutation, useQuery } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client/react'
 import { RoutesRecord } from '@mc-review/constants'
 import { isValidStateCode } from '@mc-review/submissions'
 import { Error404 } from '../../Errors/Error404Page'

--- a/services/app-web/src/pages/Settings/Oauth/CreateOauthClient.tsx
+++ b/services/app-web/src/pages/Settings/Oauth/CreateOauthClient.tsx
@@ -19,7 +19,7 @@ import {
     PoliteErrorMessage,
 } from '../../../components'
 import { FormContainer } from '../../../components'
-import { useMutation, useQuery } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client/react'
 import {
     CreateOauthClientDocument,
     IndexUsersDocument,

--- a/services/app-web/src/pages/Settings/Settings.tsx
+++ b/services/app-web/src/pages/Settings/Settings.tsx
@@ -10,7 +10,7 @@ import {
     FetchMcReviewSettingsDocument,
     OauthClient,
 } from '../../gen/gqlClient'
-import { useQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client/react'
 import { StateAnalystsInDashboardType } from './SettingsTables'
 import { RoutesRecord } from '@mc-review/constants'
 import { AssignedStaffUpdateBanner } from '../../components/Banner/AssignedStaffUpdateBanner/AssignedStaffUpdateBanner'

--- a/services/app-web/src/pages/Settings/SettingsErrorAlert.tsx
+++ b/services/app-web/src/pages/Settings/SettingsErrorAlert.tsx
@@ -6,7 +6,6 @@ import {
 } from '../../components'
 import { handleApolloError } from '@mc-review/helpers'
 import { recordJSException } from '@mc-review/otel'
-import { ApolloError } from '@apollo/client'
 import styles from './Settings.module.scss'
 
 export const SettingsErrorAlert = ({
@@ -20,9 +19,7 @@ export const SettingsErrorAlert = ({
 }): React.ReactElement | null => {
     if (error) {
         recordJSException(error)
-        if (error instanceof ApolloError) {
-            handleApolloError(error, true)
-        }
+        handleApolloError(error, true)
     }
 
     if (!isAdmin) {

--- a/services/app-web/src/pages/Settings/SettingsTables/DivisionAssignmentTable.tsx
+++ b/services/app-web/src/pages/Settings/SettingsTables/DivisionAssignmentTable.tsx
@@ -16,7 +16,7 @@ import {
 
 import styles from '../Settings.module.scss'
 import { handleApolloError, updateDivisionAssignment } from '@mc-review/helpers'
-import { ApolloError, useMutation, useQuery } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client/react'
 import { useTealium } from '../../../hooks'
 import { useAuth } from '../../../contexts/AuthContext'
 import { hasAdminUserPermissions } from '@mc-review/helpers'
@@ -234,9 +234,7 @@ export const DivisionAssignmentTable = (): React.ReactElement => {
 
             if (res instanceof Error) {
                 console.error('Errored attempting to update user: ', res)
-                if (res instanceof ApolloError) {
-                    handleApolloError(res, true)
-                }
+                handleApolloError(res, true)
                 return res
             }
             return undefined

--- a/services/app-web/src/pages/Settings/SettingsTables/OauthClientsTable.tsx
+++ b/services/app-web/src/pages/Settings/SettingsTables/OauthClientsTable.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo } from 'react'
 import { OauthClient, FetchOauthClientsDocument } from '../../../gen/gqlClient'
-import { useQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client/react'
 import { Loading, NavLinkWithLogging } from '../../../components'
 import { SettingsErrorAlert } from '../SettingsErrorAlert'
 import { GenericErrorPage } from '../../Errors/GenericErrorPage'

--- a/services/app-web/src/pages/StateDashboard/StateDashboard.tsx
+++ b/services/app-web/src/pages/StateDashboard/StateDashboard.tsx
@@ -6,7 +6,7 @@ import {
     ContractSubmissionType,
     IndexContractsStrippedDocument,
 } from '../../gen/gqlClient'
-import { useQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client/react'
 import styles from './StateDashboard.module.scss'
 import { SubmissionSuccessMessage } from './SubmissionSuccessMessage'
 import { handleApolloError, isLikelyUserAuthError } from '@mc-review/helpers'

--- a/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROReviewSubmit/EQROReviewSubmit.tsx
+++ b/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROReviewSubmit/EQROReviewSubmit.tsx
@@ -17,7 +17,7 @@ import {
 import styles from './EQROReviewSubmit.module.scss'
 import { usePage } from '../../../../contexts/PageContext'
 import { useAuth } from '../../../../contexts/AuthContext'
-import { useQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client/react'
 import { FetchContractDocument } from '../../../../gen/gqlClient'
 import { ErrorForbiddenPage } from '../../../Errors/ErrorForbiddenPage'
 import { Error404 } from '../../../Errors/Error404Page'
@@ -34,6 +34,7 @@ import {
     ModalOpenButton,
     UnlockSubmitModal,
 } from '../../../../components/Modal'
+import { toGQLError } from '@mc-review/helpers'
 
 export const EQROReviewSubmit = (): React.ReactElement => {
     const { id } = useRouteParams()
@@ -76,11 +77,10 @@ export const EQROReviewSubmit = (): React.ReactElement => {
         )
     } else if (error || !contract) {
         //error handling for a state user that tries to access rates for a different state
-        if (error?.graphQLErrors[0]?.extensions?.code === 'FORBIDDEN') {
-            return (
-                <ErrorForbiddenPage errorMsg={error.graphQLErrors[0].message} />
-            )
-        } else if (error?.graphQLErrors[0]?.extensions?.code === 'NOT_FOUND') {
+        const gqlError = toGQLError(error)
+        if (gqlError?.extensions.code === 'FORBIDDEN') {
+            return <ErrorForbiddenPage errorMsg={gqlError.message} />
+        } else if (gqlError?.extensions.code === 'NOT_FOUND') {
             return <Error404 />
         } else {
             return <GenericErrorPage />

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/RateDetails/LinkedRateSummary.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/RateDetails/LinkedRateSummary.tsx
@@ -12,7 +12,7 @@ import {
     ErrorOrLoadingPage,
     handleAndReturnErrorState,
 } from '../../SharedSubmissionComponents'
-import { ApolloError } from '@apollo/client'
+import type { ErrorLike } from '@apollo/client'
 import { formattedProgramNames } from '../../../../formHelpers'
 
 export const LinkedRateSummary = ({
@@ -22,7 +22,7 @@ export const LinkedRateSummary = ({
 }: {
     rateForm: FormikRateForm
     loading: boolean | undefined
-    apiError: ApolloError | undefined
+    apiError: ErrorLike | undefined
 }): React.ReactElement | null => {
     const statePrograms = useStatePrograms()
     // Display any full page interim state resulting from the initial fetch API requests

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/RateDetails/RateDetails.tsx
@@ -54,9 +54,10 @@ import {
 import { LinkYourRates } from '../../../LinkYourRates/LinkYourRates'
 import { LinkedRateSummary } from './LinkedRateSummary'
 import { usePage } from '../../../../contexts/PageContext'
-import { InfoTag } from '../../../../components/InfoTag/InfoTag'
+import { InfoTag } from '../../../../components'
 import { useFocusOnRender } from '../../../../hooks/useFocusOnRender'
-import { ApolloError, useMutation, useQuery } from '@apollo/client'
+import type { ErrorLike } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client/react'
 
 export type FormikRateForm = {
     id?: string // no id if its a new rate
@@ -135,7 +136,7 @@ const RateDetails = ({
         boolean | undefined
     >(undefined)
     const [rateSummaryError, setRateSummaryError] = useState<
-        ApolloError | undefined
+        ErrorLike | undefined
     >(undefined)
 
     const newRateNameRef = React.useRef<HTMLElement | null>(null)
@@ -576,7 +577,7 @@ const RateDetails = ({
                                                                                 | boolean
                                                                                 | undefined,
                                                                             autoFillError?:
-                                                                                | ApolloError
+                                                                                | ErrorLike
                                                                                 | undefined
                                                                         ) => {
                                                                             if (

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ReviewSubmit/ReviewSubmit.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ReviewSubmit/ReviewSubmit.tsx
@@ -26,7 +26,7 @@ import {
     ContractDetailsSummarySection,
     SubmissionTypeSummarySection,
 } from '../../../../components/SubmissionSummarySection'
-import { useQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client/react'
 import { FetchContractDocument } from '../../../../gen/gqlClient'
 import { ErrorForbiddenPage } from '../../../Errors/ErrorForbiddenPage'
 import { Error404 } from '../../../Errors/Error404Page'
@@ -36,6 +36,7 @@ import { usePage } from '../../../../contexts/PageContext'
 import { activeFormPages } from '../../submissionUtils'
 import { featureFlags } from '@mc-review/common-code'
 import { RoutesRecord, RouteT } from '@mc-review/constants'
+import { toGQLError } from '@mc-review/helpers'
 
 export const ReviewSubmit = (): React.ReactElement => {
     const navigate = useNavigate()
@@ -84,11 +85,10 @@ export const ReviewSubmit = (): React.ReactElement => {
         )
     } else if (error || !contract) {
         //error handling for a state user that tries to access rates for a different state
-        if (error?.graphQLErrors[0]?.extensions?.code === 'FORBIDDEN') {
-            return (
-                <ErrorForbiddenPage errorMsg={error.graphQLErrors[0].message} />
-            )
-        } else if (error?.graphQLErrors[0]?.extensions?.code === 'NOT_FOUND') {
+        const gqlError = toGQLError(error)
+        if (gqlError?.extensions.code === 'FORBIDDEN') {
+            return <ErrorForbiddenPage errorMsg={gqlError.message} />
+        } else if (gqlError?.extensions.code === 'NOT_FOUND') {
             return <Error404 />
         } else {
             return <GenericErrorPage />

--- a/services/app-web/src/pages/StateSubmission/SharedSubmissionComponents/ErrorOrLoadingPage.tsx
+++ b/services/app-web/src/pages/StateSubmission/SharedSubmissionComponents/ErrorOrLoadingPage.tsx
@@ -4,9 +4,9 @@ import { GridContainer } from '@trussworks/react-uswds'
 import { Loading } from '../../../components'
 import { ErrorInvalidSubmissionStatus } from '../../Errors/ErrorInvalidSubmissionStatusPage'
 import { Error404 } from '../../Errors/Error404Page'
-import { handleApolloError } from '@mc-review/helpers'
+import { handleApolloError, toGQLError } from '@mc-review/helpers'
 import { ErrorForbiddenPage } from '../../Errors/ErrorForbiddenPage'
-import { ApolloError } from '@apollo/client'
+import type { ErrorLike } from '@apollo/client'
 
 type InterimState =
     | 'LOADING'
@@ -18,16 +18,13 @@ type ErrorOrLoadingPageProps = {
     state?: InterimState
 }
 
-const handleAndReturnErrorState = (error: Error): InterimState => {
-    if (error instanceof ApolloError) {
-        handleApolloError(error, true)
-        if (error.graphQLErrors[0]?.extensions?.code === 'NOT_FOUND') {
-            return 'NOT_FOUND'
-        } else if (
-            error.graphQLErrors[0]?.extensions?.code === 'FORBIDDEN_ERROR'
-        ) {
-            return 'FORBIDDEN'
-        }
+const handleAndReturnErrorState = (error: ErrorLike | Error): InterimState => {
+    handleApolloError(error, true)
+    const gqlError = toGQLError(error)
+    if (gqlError?.extensions.code === 'NOT_FOUND') {
+        return 'NOT_FOUND'
+    } else if (gqlError?.extensions.code === 'FORBIDDEN_ERROR') {
+        return 'FORBIDDEN'
     }
     return 'GENERIC_ERROR'
 }

--- a/services/app-web/src/pages/SubmissionReleasedToState/ReleasedToState.tsx
+++ b/services/app-web/src/pages/SubmissionReleasedToState/ReleasedToState.tsx
@@ -16,7 +16,7 @@ import {
     ApproveContractDocument,
     FetchContractDocument,
 } from '../../gen/gqlClient'
-import { useQuery, useMutation } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client/react'
 import { ErrorOrLoadingPage } from '../StateSubmission'
 import { handleAndReturnErrorState } from '../StateSubmission/SharedSubmissionComponents'
 import { GenericErrorPage } from '../Errors/GenericErrorPage'

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.tsx
@@ -13,7 +13,7 @@ import { formatToPacificTime } from '@mc-review/dates'
 import styles from './SubmissionRevisionSummary.module.scss'
 import { PreviousSubmissionBanner } from '../../components'
 import { FetchContractDocument } from '../../gen/gqlClient'
-import { useQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client/react'
 import {
     ErrorOrLoadingPage,
     handleAndReturnErrorState,

--- a/services/app-web/src/pages/SubmissionSideNav/RateSummarySideNav.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/RateSummarySideNav.tsx
@@ -11,8 +11,8 @@ import {
 import { useAuth } from '../../contexts/AuthContext'
 import { getRouteName } from '../../routeHelpers'
 import { FetchRateWithQuestionsDocument } from '../../gen/gqlClient'
-import { ApolloError, useQuery } from '@apollo/client'
-import { handleApolloError } from '@mc-review/helpers'
+import { useQuery } from '@apollo/client/react'
+import { handleApolloError, toGQLError } from '@mc-review/helpers'
 import { Error404 } from '../Errors/Error404Page'
 import { recordJSException } from '@mc-review/otel'
 import { GenericErrorPage } from '../Errors/GenericErrorPage'
@@ -79,12 +79,10 @@ export const RateSummarySideNav = () => {
     } else if (!data && error) {
         const err = error
         console.error('Error from API fetch', error)
-        if (err instanceof ApolloError) {
-            handleApolloError(err, true)
+        handleApolloError(err, true)
 
-            if (err.graphQLErrors[0]?.extensions?.code === 'NOT_FOUND') {
-                return <Error404 />
-            }
+        if (toGQLError(err)?.extensions.code === 'NOT_FOUND') {
+            return <Error404 />
         }
 
         recordJSException(err)

--- a/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.tsx
@@ -18,8 +18,8 @@ import {
     FetchContractWithQuestionsDocument,
 } from '../../gen/gqlClient'
 import { Loading, NavLinkWithLogging } from '../../components'
-import { ApolloError, useQuery } from '@apollo/client'
-import { handleApolloError } from '@mc-review/helpers'
+import { useQuery } from '@apollo/client/react'
+import { handleApolloError, toGQLError } from '@mc-review/helpers'
 import { recordJSException } from '@mc-review/otel'
 import { GenericErrorPage } from '../Errors/GenericErrorPage'
 import { Error404 } from '../Errors/Error404Page'
@@ -93,12 +93,10 @@ export const SubmissionSideNav = () => {
     } else if (!data && error) {
         const err = error
         console.error('Error from API fetch', error)
-        if (err instanceof ApolloError) {
-            handleApolloError(err, true)
+        handleApolloError(err, true)
 
-            if (err.graphQLErrors[0]?.extensions?.code === 'NOT_FOUND') {
-                return <Error404 />
-            }
+        if (toGQLError(err)?.extensions.code === 'NOT_FOUND') {
+            return <Error404 />
         }
 
         recordJSException(err)

--- a/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.tsx
@@ -4,12 +4,12 @@ import { GridContainer, Link, Grid, ModalRef } from '@trussworks/react-uswds'
 import { Navigate } from 'react-router-dom'
 import { useAuth } from '../../../contexts/AuthContext'
 import { useMemoizedStateHeader, useRouteParams } from '../../../hooks'
-import { hasCMSUserPermissions } from '@mc-review/helpers'
+import { hasCMSUserPermissions, toGQLError } from '@mc-review/helpers'
 import {
     FetchContractWithQuestionsDocument,
     UpdateInformation,
 } from '../../../gen/gqlClient'
-import { useQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client/react'
 import {
     DocumentWarningBanner,
     LinkWithLogging,
@@ -92,11 +92,10 @@ export const EQROSubmissionSummary = (): React.ReactElement => {
             </GridContainer>
         )
     } else if (!data && error) {
-        if (error?.graphQLErrors[0]?.extensions?.code === 'FORBIDDEN') {
-            return (
-                <ErrorForbiddenPage errorMsg={error.graphQLErrors[0].message} />
-            )
-        } else if (error?.graphQLErrors[0]?.extensions?.code === 'NOT_FOUND') {
+        const gqlError = toGQLError(error)
+        if (gqlError?.extensions.code === 'FORBIDDEN') {
+            return <ErrorForbiddenPage errorMsg={gqlError.message} />
+        } else if (gqlError?.extensions.code === 'NOT_FOUND') {
             return <Error404 />
         } else {
             return <GenericErrorPage />

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -29,7 +29,7 @@ import {
     UpdateInformation,
     FetchContractWithQuestionsDocument,
 } from '../../gen/gqlClient'
-import { useQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client/react'
 import { ErrorForbiddenPage } from '../Errors/ErrorForbiddenPage'
 import { Error404 } from '../Errors/Error404Page'
 import { GenericErrorPage } from '../Errors/GenericErrorPage'
@@ -42,7 +42,7 @@ import {
     getVisibleLatestRateRevisions,
 } from '@mc-review/submissions'
 import { Navigate, useNavigate, useSearchParams } from 'react-router-dom'
-import { hasCMSUserPermissions } from '@mc-review/helpers'
+import { hasCMSUserPermissions, toGQLError } from '@mc-review/helpers'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { featureFlags } from '@mc-review/common-code'
 import {
@@ -146,11 +146,10 @@ export const SubmissionSummary = (): React.ReactElement => {
             </GridContainer>
         )
     } else if (!data && error) {
-        if (error?.graphQLErrors[0]?.extensions?.code === 'FORBIDDEN') {
-            return (
-                <ErrorForbiddenPage errorMsg={error.graphQLErrors[0].message} />
-            )
-        } else if (error?.graphQLErrors[0]?.extensions?.code === 'NOT_FOUND') {
+        const gqlError = toGQLError(error)
+        if (gqlError?.extensions.code === 'FORBIDDEN') {
+            return <ErrorForbiddenPage errorMsg={gqlError.message} />
+        } else if (gqlError?.extensions.code === 'NOT_FOUND') {
             return <Error404 />
         } else {
             return <GenericErrorPage />

--- a/services/app-web/src/pages/SubmissionWithdraw/SubmissionWithdraw.tsx
+++ b/services/app-web/src/pages/SubmissionWithdraw/SubmissionWithdraw.tsx
@@ -18,7 +18,7 @@ import {
     IndexRatesStrippedWithRelatedContractsDocument,
     WithdrawContractDocument,
 } from '../../gen/gqlClient'
-import { useQuery, useMutation } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client/react'
 import { Formik, FormikErrors } from 'formik'
 import { ButtonGroup, Form } from '@trussworks/react-uswds'
 import * as Yup from 'yup'

--- a/services/app-web/src/pages/UndoRateWithdraw/UndoRateWithdraw.tsx
+++ b/services/app-web/src/pages/UndoRateWithdraw/UndoRateWithdraw.tsx
@@ -11,7 +11,7 @@ import {
     FetchRateDocument,
     UndoWithdrawnRateDocument,
 } from '../../gen/gqlClient'
-import { useQuery, useMutation } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client/react'
 import { ErrorOrLoadingPage } from '../StateSubmission'
 import { handleAndReturnErrorState } from '../StateSubmission/SharedSubmissionComponents'
 import { RoutesRecord } from '@mc-review/constants'

--- a/services/app-web/src/pages/UndoSubmissionWithdraw/UndoSubmissionWithdraw.tsx
+++ b/services/app-web/src/pages/UndoSubmissionWithdraw/UndoSubmissionWithdraw.tsx
@@ -8,7 +8,7 @@ import {
     FetchContractDocument,
     UndoWithdrawContractDocument,
 } from '../../gen/gqlClient'
-import { useQuery, useMutation } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client/react'
 import {
     ActionButton,
     Breadcrumbs,

--- a/services/app-web/src/setupTests.ts
+++ b/services/app-web/src/setupTests.ts
@@ -1,6 +1,12 @@
 import { Crypto } from '@peculiar/webcrypto'
 import { TextEncoder, TextDecoder } from 'util'
 import { cleanup } from '@testing-library/react'
+import { MockLink } from '@apollo/client/testing'
+
+// Apollo Client v4 MockedProvider introduced a 20-50ms default response
+// delay. Override globally to 0 so unit tests stay fast. Individual mocks
+// can still opt in by setting their own `delay`.
+MockLink.defaultOptions = { delay: 0 }
 
 // jest-dom adds custom jest matchers for asserting on DOM nodes.
 // allows you to do things like:

--- a/services/app-web/src/testHelpers/jestHelpers.tsx
+++ b/services/app-web/src/testHelpers/jestHelpers.tsx
@@ -1,4 +1,7 @@
-import { MockedProviderProps, MockedProvider } from '@apollo/client/testing'
+import {
+    MockedProvider,
+    MockedProviderProps,
+} from '@apollo/client/testing/react'
 import {
     Location,
     MemoryRouter,

--- a/services/cypress/package.json
+++ b/services/cypress/package.json
@@ -52,7 +52,8 @@
         "prettier": "^3.8.1"
     },
     "dependencies": {
-        "@apollo/client": "3.8.8",
+        "@apollo/client": "^4.1.7",
+        "rxjs": "^7.8.1",
         "@graphql-typed-document-node/core": "^3.2.0",
         "@mc-review/common-code": "workspace:*",
         "@mc-review/submissions": "workspace:*",

--- a/services/cypress/support/apiCommands.ts
+++ b/services/cypress/support/apiCommands.ts
@@ -31,11 +31,7 @@ import {
     eqroFromData,
     AdminUserType,
 } from '../utils/apollo-test-utils'
-import {
-    ApolloClient,
-    DocumentNode,
-    NormalizedCacheObject,
-} from '@apollo/client'
+import { ApolloClient, DocumentNode } from '@apollo/client'
 import { GraphQLError, print } from 'graphql'
 import { CMSUserLoginNames, userLoginData } from './loginCommands'
 import { calculateSHA256 } from '@mc-review/common-code'
@@ -49,7 +45,7 @@ export type ApiCreateOAuthClientResponseType = {
 }
 
 const uploadFile = async (
-    apolloClient: ApolloClient<NormalizedCacheObject>,
+    apolloClient: ApolloClient,
     fileName: string,
     fileType: UploadFileType,
     bucketName: UploadBucketName,
@@ -68,10 +64,10 @@ const uploadFile = async (
     })
 
     if (
-        uploadContractFileUrl.errors ||
+        uploadContractFileUrl.error ||
         !uploadContractFileUrl.data?.generateUploadURL
     ) {
-        const errorMsg = `generating upload url failed: ${JSON.stringify(uploadContractFileUrl.errors)}`
+        const errorMsg = `generating upload url failed: ${JSON.stringify(uploadContractFileUrl.error)}`
         throw new Error(errorMsg)
     }
 
@@ -112,7 +108,7 @@ const uploadFile = async (
 }
 
 const createAndSubmitContractOnlyPackage = async (
-    apolloClient: ApolloClient<NormalizedCacheObject>,
+    apolloClient: ApolloClient,
     documents: FixtureDocuments
 ): Promise<Contract> => {
     try {
@@ -133,12 +129,24 @@ const createAndSubmitContractOnlyPackage = async (
             },
         })
 
+        if (newContract.error || !newContract.data?.createContract.contract) {
+            throw new Error(
+                `Could not create draft contract: ${JSON.stringify(newContract.error)}`
+            )
+        }
+
         const draftContract = newContract.data.createContract.contract
         const draftRevision = draftContract.draftRevision
         const updateFormData = contractFormData({
             submissionType: 'CONTRACT_ONLY',
             contractDocuments: [contractDoc],
         })
+
+        if (!draftRevision) {
+            throw new Error(
+                `Draft contract did not contain draft revision: ${JSON.stringify(draftContract)}`
+            )
+        }
 
         const updateContractDraftRevisionInput: UpdateContractDraftRevisionInput =
             {
@@ -163,6 +171,12 @@ const createAndSubmitContractOnlyPackage = async (
             },
         })
 
+        if (submission.error || !submission.data?.submitContract.contract) {
+            throw new Error(
+                `Could not submit contract: ${JSON.stringify(submission.error)}`
+            )
+        }
+
         return submission.data.submitContract.contract
     } catch (error) {
         const errorMsg = error instanceof Error ? error.message : String(error)
@@ -173,7 +187,7 @@ const createAndSubmitContractOnlyPackage = async (
 }
 
 const createAndSubmitEQROContract = async (
-    apolloClient: ApolloClient<NormalizedCacheObject>,
+    apolloClient: ApolloClient,
     documents: FixtureDocuments
 ): Promise<Contract> => {
     try {
@@ -203,8 +217,21 @@ const createAndSubmitEQROContract = async (
             },
         })
 
+        if (newContract.error || !newContract.data?.createContract.contract) {
+            throw new Error(
+                `Could not create draft EQRO contract: ${JSON.stringify(newContract.error)}`
+            )
+        }
+
         const draftContract = newContract.data.createContract.contract
         const draftRevision = draftContract.draftRevision
+
+        if (!draftRevision) {
+            throw new Error(
+                `Draft contract did not contain draft revision: ${JSON.stringify(draftContract)}`
+            )
+        }
+
         const updateFormData = eqroFromData({
             contractDocuments: [contractDoc],
         })
@@ -232,6 +259,12 @@ const createAndSubmitEQROContract = async (
             },
         })
 
+        if (submission.error || !submission.data?.submitContract.contract) {
+            throw new Error(
+                `Could not submit EQRO contract: ${JSON.stringify(submission.error)}`
+            )
+        }
+
         return submission.data.submitContract.contract
     } catch (error) {
         const errorMsg = error instanceof Error ? error.message : String(error)
@@ -240,7 +273,7 @@ const createAndSubmitEQROContract = async (
 }
 
 const createAndSubmitContractWithRates = async (
-    apolloClient: ApolloClient<NormalizedCacheObject>,
+    apolloClient: ApolloClient,
     documents: FixtureDocuments
 ): Promise<Contract> => {
     try {
@@ -277,8 +310,21 @@ const createAndSubmitContractWithRates = async (
             },
         })
 
+        if (newContract.error || !newContract.data?.createContract.contract) {
+            throw new Error(
+                `Could not create draft contract: ${JSON.stringify(newContract.error)}`
+            )
+        }
+
         const draftContract = newContract.data.createContract.contract
         const draftRevision = draftContract.draftRevision
+
+        if (!draftRevision) {
+            throw new Error(
+                `Draft contract did not contain draft revision: ${JSON.stringify(draftContract)}`
+            )
+        }
+
         const updateFormData = contractFormData({
             submissionType: 'CONTRACT_AND_RATES',
             contractDocuments: [contractDoc],
@@ -297,6 +343,16 @@ const createAndSubmitContractWithRates = async (
                 input: updateContractDraftRevisionInput,
             },
         })
+
+        if (
+            updatedContract.error ||
+            !updatedContract.data?.updateContractDraftRevision.contract
+                .draftRevision
+        ) {
+            throw new Error(
+                `Could not update draft contract: ${JSON.stringify(updatedContract.error)}`
+            )
+        }
 
         const updatedDraftRevision =
             updatedContract.data.updateContractDraftRevision.contract
@@ -347,6 +403,12 @@ const createAndSubmitContractWithRates = async (
             },
         })
 
+        if (submission.error || !submission.data?.submitContract.contract) {
+            throw new Error(
+                `Could not submit contract: ${JSON.stringify(submission.error)}`
+            )
+        }
+
         return submission.data.submitContract.contract
     } catch (error) {
         const errorMsg = error instanceof Error ? error.message : String(error)
@@ -355,7 +417,7 @@ const createAndSubmitContractWithRates = async (
 }
 
 const assignCmsDivision = async (
-    apolloClient: ApolloClient<NormalizedCacheObject>,
+    apolloClient: ApolloClient,
     cmsUser: CmsUsersUnion,
     division: Division
 ): Promise<void> => {
@@ -363,6 +425,12 @@ const assignCmsDivision = async (
     const result = await apolloClient.query({
         query: IndexUsersDocument,
     })
+
+    if (result.error || !result.data?.indexUsers) {
+        throw new Error(
+            `Could not query indexUsers: ${JSON.stringify(result.error)}`
+        )
+    }
 
     const users = result.data.indexUsers.edges.map(
         (edge: UserEdge) => edge.node
@@ -390,16 +458,16 @@ const assignCmsDivision = async (
 }
 
 const fetchUser = async (
-    apolloClient: ApolloClient<NormalizedCacheObject>
+    apolloClient: ApolloClient
 ): Promise<User> => {
     // To seed, we just need to perform a graphql query and the api will add the user to the db
     const user = await apolloClient.query({
         query: FetchCurrentUserDocument,
     })
 
-    if (user.errors) {
+    if (user.error || !user.data?.fetchCurrentUser) {
         throw new Error(
-            `Error: Could not seed user into DB: ${JSON.stringify(user.errors)}`
+            `Error: Could not seed user into DB: ${JSON.stringify(user.error)}`
         )
     }
 
@@ -413,7 +481,7 @@ const fetchUser = async (
 }
 
 const createOAuthClient = async (
-    apolloClient: ApolloClient<NormalizedCacheObject>,
+    apolloClient: ApolloClient,
     oauthClientUser: CMSUserLoginNames,
     delegatedUser?: CMSUserLoginNames
 ): Promise<ApiCreateOAuthClientResponseType> => {
@@ -421,9 +489,9 @@ const createOAuthClient = async (
         query: IndexUsersDocument,
     })
 
-    if (indexUsersRes.errors) {
+    if (indexUsersRes.error || !indexUsersRes.data?.indexUsers) {
         throw new Error(
-            `Error: Could not retrieve index users to for createOAuthClient. ${JSON.stringify(indexUsersRes.errors)}`
+            `Error: Could not retrieve index users to for createOAuthClient. ${JSON.stringify(indexUsersRes.error)}`
         )
     }
 
@@ -480,9 +548,9 @@ const createOAuthClient = async (
         },
     })
 
-    if (oauthClientResponse.errors) {
+    if (oauthClientResponse.error || !oauthClientResponse.data) {
         throw new Error(
-            `Error: Could not create OAuth client for user: ${JSON.stringify(oauthClientResponse.errors)}`
+            `Error: Could not create OAuth client for user: ${JSON.stringify(oauthClientResponse.error)}`
         )
     }
 

--- a/services/cypress/utils/apollo-test-utils.ts
+++ b/services/cypress/utils/apollo-test-utils.ts
@@ -4,7 +4,6 @@ import {
     DocumentNode,
     HttpLink,
     InMemoryCache,
-    NormalizedCacheObject,
 } from '@apollo/client'
 import {
     RateFormDataInput,
@@ -154,7 +153,7 @@ const rateFormData = (
 
 const newSubmissionInput = (
     overrides?: Partial<CreateContractInput>
-): Partial<CreateContractInput> => {
+): CreateContractInput => {
     return Object.assign(
         {
             populationCovered: 'MEDICAID',
@@ -452,9 +451,10 @@ function fetchResponseFromAxios(axiosResponse: AxiosResponse): Response {
 // Apollo Link uses the ~fetch api for it's client-side middleware.
 // Amplify.API uses axios underneath and does its own transformation of the body, so we wrap that up here.
 async function fakeAmplifyFetch(
-    uri: string,
-    options: RequestInit
+    uri: URL | RequestInfo,
+    options?: RequestInit
 ): Promise<Response> {
+    options = options ?? {}
     if (options.method !== 'POST') {
         throw new Error('unexpected GQL request')
     }
@@ -482,8 +482,15 @@ async function fakeAmplifyFetch(
         headers: headers,
     }
 
+    const uriString =
+        typeof uri === 'string'
+            ? uri
+            : uri instanceof URL
+              ? uri.toString()
+              : uri.url
+
     return new Promise<Response>((resolve, reject) => {
-        AuthAPI.post(uri, apiOptions)
+        AuthAPI.post(uriString, apiOptions)
             .then((apiResponse: AxiosResponse) => {
                 // The Apollo Link wants a fetch.Response shaped response,
                 // not the axios shaped response that Amplify.API returns
@@ -509,7 +516,7 @@ async function fakeAmplifyFetch(
 const apolloClientWrapper = async <T>(
     schema: DocumentNode,
     authUser: StateUserType | CMSUserType | AdminUserType,
-    callback: (apolloClient: ApolloClient<NormalizedCacheObject>) => Promise<T>
+    callback: (apolloClient: ApolloClient) => Promise<T>
 ): Promise<T> => {
     const isLocalAuth = Cypress.env('AUTH_MODE') === 'LOCAL'
 
@@ -522,14 +529,13 @@ const apolloClientWrapper = async <T>(
             : undefined,
         fetch: fakeAmplifyFetch,
         fetchOptions: {
-            mode: 'no-cors',
+            mode: 'no-cors' as const,
         },
     }
 
-    const apolloClient: ApolloClient<NormalizedCacheObject> = new ApolloClient({
+    const apolloClient: ApolloClient = new ApolloClient({
         link: new HttpLink(httpLinkConfig),
         cache: new InMemoryCache(),
-        typeDefs: schema,
         defaultOptions: {
             watchQuery: {
                 fetchPolicy: 'no-cache',
@@ -564,3 +570,4 @@ export {
     eqroFromData,
     minnesotaStatePrograms,
 }
+


### PR DESCRIPTION
## Summary

Upgrades `@apollo/client` from v3.8.8 → v4.1.7 and `@as-integrations/aws-lambda` from v3.1.0 → v4.0.1 across the whole workspace. MCR-6116 previously unblocked this by swapping codegen's generated hooks for `TypedDocumentNode`, which made the upgrade path tractable.

## What changed

- Bumped `@apollo/client` to `^4.1.7` across all 8 workspace packages 
- Upgrade `@as-integrations/aws-lambda` to `^4.0.1` in app-api
- Added `rxjs` peer dep.
- Ran the Apollo v3→v4 codemod to automate some of the migration work.
- Rewrote error handling in `packages/helpers/src/gql/apolloErrors.ts` for `@apollo/client` V4
- Added `toGQLError` in `@mc-review/helpers` (with unit tests) and converted ~17 call sites that previously read `error.graphQLErrors[0]?.extensions?.code` to use it.
- Widened the `fakeAmplifyFetch` / `localGQLFetch` signatures to `(uri: URL | RequestInfo, options?: RequestInit)` to match v4's stricter `HttpLink` fetch option.
- Set `MockLink.defaultOptions = { delay: 0 }` in `setupTests.ts` so v4's new 20–50 ms default response delay doesn't slow down unit tests; per-mock overrides still work.
- Fixed the cypress harness: migrated `MutateResult.errors` → `.error`, added data guards for v4's stricter nullability, and updated the local `fakeAmplifyFetch` the same way.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

- CI should handle validating most of the issues.

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders