### PR TITLE
Check prisma generated directory before generating

### DIFF
--- a/dev_tool/src/local/postgres.ts
+++ b/dev_tool/src/local/postgres.ts
@@ -1,9 +1,17 @@
+import fs from 'node:fs'
+import path from 'node:path'
 import LabeledProcessRunner from '../runner.js'
 import { checkDockerInstalledAndRunning } from '../deps.js'
 import { commandMustSucceedSync } from '../localProcess.js'
 
 // prisma generate creates the prisma client based on the current prisma schema
+// Prisma 7+ throws an error if the output directory already exists, so we remove it first
 export async function installPrismaDeps(runner: LabeledProcessRunner) {
+    const generatedDir = path.resolve('services/app-api/src/generated')
+    if (fs.existsSync(generatedDir)) {
+        fs.rmSync(generatedDir, { recursive: true, force: true })
+    }
+
     await runner.runCommandAndOutput(
         'api prisma',
         ['pnpm', 'generate'],

--- a/dev_tool/tsconfig.json
+++ b/dev_tool/tsconfig.json
@@ -4,6 +4,7 @@
         "target": "ESNext",
         "module": "ESNext",
         "lib": ["ES2021", "DOM"],
+        "types": ["node"],
         "moduleResolution": "bundler",
 
         "baseUrl": "/",


### PR DESCRIPTION
## Summary

Jason hit an issue where the `dev` tool errored because he already had a local `generated` dir for prisma output. This just checks to see if it already exists and clears it if so.

#### Related issues
https://jiraent.cms.gov/browse/MCR-6064
