### PR TITLE
MCR-6076 Do not display D-SNP question for CHIP only submissions

### DIFF
--- a/services/app-api/src/domain-models/contractAndRates/dataValidatorHelpers.test.ts
+++ b/services/app-api/src/domain-models/contractAndRates/dataValidatorHelpers.test.ts
@@ -3,6 +3,7 @@ import {
     validateEQROContractDraftRevisionInput,
     parseContract,
     parseAndUpdateEqroFields,
+    parseAndUpdateChipOnlyFields,
     parseEQROContract,
 } from './dataValidatorHelpers'
 import {
@@ -787,6 +788,32 @@ describe('Health plan parsing and validation', () => {
                 )
             ).toBe(true)
         })
+
+        it('does not require dsnpContract for CHIP-only submissions when chip automation is enabled', async () => {
+            const prismaClient = await sharedTestPrismaClient()
+            const postgresStore = NewPostgresStore(prismaClient)
+            const stateCode = 'FL'
+            const contract = mockSubmittableHealthPlanContract()
+            if (!contract.draftRevision) {
+                throw new Error('Unexpected error: no draftRevision')
+            }
+            contract.draftRevision.formData.populationCovered = 'CHIP'
+            contract.draftRevision.formData.federalAuthorities = ['STATE_PLAN']
+            contract.draftRevision.formData.dsnpContract = undefined
+
+            const parsedContract = parseContract(
+                contract,
+                stateCode,
+                postgresStore,
+                {
+                    '438-attestation': true,
+                    dsnp: true,
+                    'chip-submission-automation': true,
+                }
+            )
+
+            expect(parsedContract).toEqual(contract)
+        })
         it('return error if a child rate has a deprecated rateProgramID', async () => {
             const prismaClient = await sharedTestPrismaClient()
             const postgresStore = NewPostgresStore(prismaClient)
@@ -1256,6 +1283,36 @@ describe('EQRO parsing and validation', () => {
             ALL_EQRO_FIELDS.forEach((field) => {
                 expect(result[field]).toBeNull()
             })
+        })
+    })
+
+    describe('parseAndUpdateChipOnlyFields', () => {
+        it('clears dsnpContract for CHIP-only submissions when chip automation is enabled', () => {
+            const result = parseAndUpdateChipOnlyFields(
+                {
+                    ...baseCurrentFormData({
+                        populationCovered: 'CHIP',
+                        dsnpContract: true,
+                    }),
+                },
+                { 'chip-submission-automation': true }
+            )
+
+            expect(result.dsnpContract).toBeUndefined()
+        })
+
+        it('preserves dsnpContract when chip automation is disabled', () => {
+            const result = parseAndUpdateChipOnlyFields(
+                {
+                    ...baseCurrentFormData({
+                        populationCovered: 'CHIP',
+                        dsnpContract: true,
+                    }),
+                },
+                { 'chip-submission-automation': false }
+            )
+
+            expect(result.dsnpContract).toBe(true)
         })
     })
 

--- a/services/app-api/src/domain-models/contractAndRates/dataValidatorHelpers.test.ts
+++ b/services/app-api/src/domain-models/contractAndRates/dataValidatorHelpers.test.ts
@@ -32,7 +32,7 @@ describe('Health plan parsing and validation', () => {
         it('Validates input form data and removes statutoryRegulatoryAttestationDescription', async () => {
             const prismaClient = await sharedTestPrismaClient()
             const postgresStore = NewPostgresStore(prismaClient)
-            const stateCode = 'FL'
+            const stateCode = 'KY'
             const formData = {
                 ...mockGqlContractDraftRevisionFormDataInput(stateCode),
                 contractDateStart: new Date(2025, 5, 1),
@@ -71,7 +71,7 @@ describe('Health plan parsing and validation', () => {
         it('converts fields that are null to undefined', async () => {
             const prismaClient = await sharedTestPrismaClient()
             const postgresStore = NewPostgresStore(prismaClient)
-            const stateCode = 'FL'
+            const stateCode = 'KY'
             const formData = {
                 ...mockGqlContractDraftRevisionFormDataInput(stateCode),
                 stateContacts: [
@@ -155,7 +155,7 @@ describe('Health plan parsing and validation', () => {
         it('Returns error for invalid data', async () => {
             const prismaClient = await sharedTestPrismaClient()
             const postgresStore = NewPostgresStore(prismaClient)
-            const stateCode = 'FL'
+            const stateCode = 'KY'
             const formData: ContractDraftRevisionFormDataInput = {
                 ...mockGqlContractDraftRevisionFormDataInput(stateCode),
                 contractDateStart: new Date(2025, 5, 1),
@@ -792,12 +792,13 @@ describe('Health plan parsing and validation', () => {
         it('does not require dsnpContract for CHIP-only submissions when chip automation is enabled', async () => {
             const prismaClient = await sharedTestPrismaClient()
             const postgresStore = NewPostgresStore(prismaClient)
-            const stateCode = 'FL'
+            const stateCode = 'KY'
             const contract = mockSubmittableHealthPlanContract()
             if (!contract.draftRevision) {
                 throw new Error('Unexpected error: no draftRevision')
             }
             contract.draftRevision.formData.populationCovered = 'CHIP'
+            contract.draftRevision.formData.submissionType = 'CONTRACT_ONLY'
             contract.draftRevision.formData.federalAuthorities = ['STATE_PLAN']
             contract.draftRevision.formData.dsnpContract = undefined
 

--- a/services/app-api/src/domain-models/contractAndRates/dataValidatorHelpers.ts
+++ b/services/app-api/src/domain-models/contractAndRates/dataValidatorHelpers.ts
@@ -68,6 +68,23 @@ const validatePopulationCovered = (
         }
     })
 
+const parseAndUpdateChipOnlyFields = (
+    updateFormData: UpdateDraftContractFormDataType,
+    featureFlags?: FeatureFlagSettings
+) => {
+    if (
+        featureFlags?.['chip-submission-automation'] &&
+        updateFormData.populationCovered === 'CHIP'
+    ) {
+        return {
+            ...updateFormData,
+            dsnpContract: undefined,
+        }
+    }
+
+    return updateFormData
+}
+
 const validateContractDraftRevisionInput = (
     formData: ContractDraftRevisionFormDataInput,
     stateCode: string,
@@ -203,6 +220,9 @@ const refineForFeatureFlags = (featureFlags?: FeatureFlagSettings) => {
                 }
             }
             if (featureFlags['dsnp']) {
+                const hideDsnpForChipOnly =
+                    featureFlags['chip-submission-automation'] &&
+                    contractFormData.populationCovered === 'CHIP'
                 // when the dnsp flag is on, the dsnpContract field becomes
                 // required IF the submission's federal authorities include
                 // ANY of the following: 'STATE_PLAN','WAIVER_1915B', 'WAIVER_1115', 'VOLUNTARY'
@@ -213,7 +233,7 @@ const refineForFeatureFlags = (featureFlags?: FeatureFlagSettings) => {
                 const dsnpNotAnswered =
                     contractFormData.dsnpContract === null ||
                     contractFormData.dsnpContract === undefined
-                if (dsnpIsRequired && dsnpNotAnswered) {
+                if (dsnpIsRequired && dsnpNotAnswered && !hideDsnpForChipOnly) {
                     ctx.addIssue({
                         code: 'custom',
                         message: `dsnpContract is required when any of the following Federal Authorities are present: ${dsnpTriggers.toString()}`,
@@ -378,5 +398,6 @@ export {
     parseContract,
     parseEQROContract,
     parseAndUpdateEqroFields,
+    parseAndUpdateChipOnlyFields,
     validateEQROContractDraftRevisionInput,
 }

--- a/services/app-api/src/resolvers/contract/updateContractDraftRevision.test.ts
+++ b/services/app-api/src/resolvers/contract/updateContractDraftRevision.test.ts
@@ -294,6 +294,47 @@ describe(`Tests UpdateContractDraftRevision`, () => {
             )
         })
 
+        it('clears dsnpContract when a submission is updated to CHIP-only and chip automation is enabled', async () => {
+            const mockLDService = testLDService({
+                dsnp: true,
+                'chip-submission-automation': true,
+            })
+            const server = await constructTestPostgresServer({
+                ldService: mockLDService,
+            })
+            const draftContract = await createTestContract(server)
+            const draftRevision = draftContract.draftRevision
+
+            if (!draftRevision) {
+                throw new Error(
+                    'Unexpected error: Draft contract did not contain a draft revision'
+                )
+            }
+
+            const updateFormData: ContractDraftRevisionFormDataInput = {
+                ...mockGqlContractDraftRevisionFormDataInput(
+                    draftContract.stateCode,
+                    {
+                        populationCovered: 'CHIP',
+                        dsnpContract: true,
+                        federalAuthorities: ['STATE_PLAN'],
+                    }
+                ),
+            }
+
+            const updateResult = await updateTestContractDraftRevision(
+                server,
+                draftContract.id,
+                draftRevision.updatedAt,
+                updateFormData
+            )
+
+            expect(updateResult.draftRevision?.formData.dsnpContract).toBeNull()
+            expect(updateResult.draftRevision?.formData.populationCovered).toBe(
+                'CHIP'
+            )
+        })
+
         it('errors if the Contract is already submitted', async () => {
             const server = await constructTestPostgresServer()
             const draftContract = await createTestContract(server)

--- a/services/app-api/src/resolvers/contract/updateContractDraftRevision.ts
+++ b/services/app-api/src/resolvers/contract/updateContractDraftRevision.ts
@@ -16,7 +16,10 @@ import {
     validateEQROContractDraftRevisionInput,
 } from '../../domain-models/contractAndRates'
 import { canWrite } from '../../authorization/oauthAuthorization'
-import { parseAndUpdateEqroFields } from '../../domain-models/contractAndRates/dataValidatorHelpers'
+import {
+    parseAndUpdateChipOnlyFields,
+    parseAndUpdateEqroFields,
+} from '../../domain-models/contractAndRates/dataValidatorHelpers'
 import { parseAndValidateDocuments } from '../documentHelpers'
 
 export function updateContractDraftRevision(
@@ -171,7 +174,7 @@ export function updateContractDraftRevision(
                   contractWithHistory.draftRevision.formData,
                   parsedFormData
               )
-            : parsedFormData
+            : parseAndUpdateChipOnlyFields(parsedFormData, featureFlags)
 
         // Update contract draft revision
         const updateResult = await store.updateDraftContract({

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
@@ -254,6 +254,44 @@ describe('ContractDetailsSummarySection', () => {
         ).toBeInTheDocument()
     })
 
+    it('hides the DSNP summary for CHIP-only contracts when chip automation is enabled', async () => {
+        const contract = mockContractPackageDraft()
+        if (!contract.draftRevision)
+            throw new Error('Unexpected error: no draftRevision')
+        contract.draftRevision.formData = {
+            ...contract.draftRevision.formData,
+            populationCovered: 'CHIP',
+            federalAuthorities: ['STATE_PLAN'],
+            dsnpContract: true,
+        }
+
+        renderWithProviders(
+            <ContractDetailsSummarySection
+                contract={contract}
+                isStateUser
+                editNavigateTo="contract-details"
+            />,
+            {
+                apolloProvider: defaultApolloMocks,
+                featureFlags: {
+                    dsnp: true,
+                    'chip-submission-automation': true,
+                },
+            }
+        )
+
+        await screen.findByRole('heading', {
+            level: 2,
+            name: 'Contract details',
+        })
+
+        expect(
+            screen.queryByRole('definition', {
+                name: 'Is this contract associated with a Dual-Eligible Special Needs Plan (D-SNP) that covers Medicaid benefits?',
+            })
+        ).not.toBeInTheDocument()
+    })
+
     it('displays correct effective dates text for base contract', async () => {
         const contract = mockContractPackageDraft()
         if (!contract.draftRevision)

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -98,6 +98,10 @@ export const ContractDetailsSummarySection = ({
         featureFlags.DSNP.flag,
         featureFlags.DSNP.defaultValue
     )
+    const chipSubmissionAutomation = ldClient?.variation(
+        featureFlags.CHIP_SUBMISSION_AUTOMATION.flag,
+        featureFlags.CHIP_SUBMISSION_AUTOMATION.defaultValue
+    )
 
     const contractSupportingDocuments = contractFormData?.supportingDocuments
     const contractDocs = contractFormData?.contractDocuments
@@ -161,14 +165,18 @@ export const ContractDetailsSummarySection = ({
                         explainMissingData={explainMissingData}
                     />
                 </MultiColumnGrid>
-                {contractDsnp && (
-                    <MultiColumnGrid columns={1}>
-                        <DsnpSummary
-                            contractFormData={contractFormData}
-                            explainMissingData={explainMissingData}
-                        />
-                    </MultiColumnGrid>
-                )}
+                {contractDsnp &&
+                    !(
+                        chipSubmissionAutomation &&
+                        contractFormData.populationCovered === 'CHIP'
+                    ) && (
+                        <MultiColumnGrid columns={1}>
+                            <DsnpSummary
+                                contractFormData={contractFormData}
+                                explainMissingData={explainMissingData}
+                            />
+                        </MultiColumnGrid>
+                    )}
                 {isContractWithProvisions(contract) && (
                     <MultiColumnGrid columns={2}>
                         <ModifiedProvisionSummary

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ContractDetails/ContractDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ContractDetails/ContractDetails.test.tsx
@@ -376,6 +376,58 @@ describe('ContractDetails', () => {
                 name: 'D-SNP guidance (opens in new window)',
             })
         })
+
+        it('does not render d-snp field for CHIP-only contracts when chip automation is enabled', async () => {
+            const draftContract = mockContractPackageUnlockedWithUnlockedType()
+            draftContract.draftRevision!.formData.populationCovered = 'CHIP'
+            draftContract.draftRevision!.formData.federalAuthorities = [
+                'STATE_PLAN',
+            ]
+            draftContract.draftRevision!.formData.dsnpContract = true
+
+            renderWithProviders(
+                <Routes>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_CONTRACT_DETAILS}
+                        element={<ContractDetails />}
+                    />
+                </Routes>,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({ statusCode: 200 }),
+                            fetchContractMockSuccess({
+                                contract: {
+                                    ...draftContract,
+                                    id: '15',
+                                    contractSubmissionType: 'HEALTH_PLAN',
+                                },
+                            }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: '/submissions/health-plan/15/edit/contract-details',
+                    },
+                    featureFlags: {
+                        dsnp: true,
+                        'chip-submission-automation': true,
+                    },
+                }
+            )
+
+            await screen.findByText('Contract Details')
+
+            expect(
+                screen.queryByRole('group', {
+                    name: 'Is this contract associated with a Dual-Eligible Special Needs Plan (D-SNP) that covers Medicaid benefits?',
+                })
+            ).not.toBeInTheDocument()
+            expect(
+                screen.queryByRole('link', {
+                    name: 'D-SNP guidance (opens in new window)',
+                })
+            ).not.toBeInTheDocument()
+        })
     })
 
     describe('Contract provisions - yes/nos', () => {

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ContractDetails/ContractDetails.tsx
@@ -159,6 +159,10 @@ export const ContractDetails = ({
         featureFlags.DSNP.flag,
         featureFlags.DSNP.defaultValue
     )
+    const chipSubmissionAutomation = ldClient?.variation(
+        featureFlags.CHIP_SUBMISSION_AUTOMATION.flag,
+        featureFlags.CHIP_SUBMISSION_AUTOMATION.defaultValue
+    )
 
     // Contract documents state management
     const { getKey, handleUploadFile, handleScanFile } = useS3()
@@ -209,6 +213,8 @@ export const ContractDetails = ({
     const applicableFederalAuthorities = isCHIPOnly(draftSubmission)
         ? federalAuthorityKeysForCHIP
         : federalAuthorityKeys
+    const hideDsnpForChipOnly =
+        chipSubmissionAutomation && isCHIPOnly(draftSubmission)
 
     const contractDetailsInitialValues: ContractDetailsFormValues = {
         contractDocuments: formatDocumentsForForm({
@@ -416,7 +422,7 @@ export const ContractDetails = ({
                 federalAuthorities: values.federalAuthorities,
                 // Clear dsnpContract if all dsnp trigger federalAuthorities are removed after a value was previously selected for dsnpContract
                 dsnpContract:
-                    values.dsnpContract && dsnpTrigger
+                    values.dsnpContract && dsnpTrigger && !hideDsnpForChipOnly
                         ? yesNoFormValueAsBoolean(values.dsnpContract)
                         : undefined,
                 submissionType:
@@ -1243,6 +1249,7 @@ export const ContractDetails = ({
                                                 </Fieldset>
                                             </FormGroup>
                                             {enableDSNPs &&
+                                                !hideDsnpForChipOnly &&
                                                 values.federalAuthorities.some(
                                                     (type) =>
                                                         dsnpTriggers.includes(

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ContractDetails/ContractDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ContractDetails/ContractDetailsSchema.ts
@@ -22,6 +22,10 @@ export const ContractDetailsFormSchema = (
     draftSubmission: UnlockedContract,
     activeFeatureFlags: FeatureFlagSettings = {}
 ) => {
+    const hideDsnpForChipOnly =
+        activeFeatureFlags['chip-submission-automation'] &&
+        isCHIPOnly(draftSubmission)
+
     const yesNoError = (provision: GeneralizedProvisionType) => {
         const noValidation = Yup.string().nullable()
         const provisionValidiation = Yup.string().defined(
@@ -129,7 +133,9 @@ export const ContractDetailsFormSchema = (
                         'WAIVER_1915B',
                         'STATE_PLAN',
                     ].includes(type)
-                ) && activeFeatureFlags['dsnp'],
+                ) &&
+                activeFeatureFlags['dsnp'] &&
+                !hideDsnpForChipOnly,
             then: (schema) => schema.required('You must select yes or no'),
             otherwise: (schema) => schema.notRequired(),
         }),


### PR DESCRIPTION
## Summary
Implemented CHIP-only D-SNP handling behind the existing chip-submission-automation feature flag.

On the web side, we now hide the D-SNP question on Contract Details when it's a CHIP-only submissions, along with its help text and yes/no options. The summary page was also updated to hide the D-SNP row. On submit, logic clears any existing dsnpContract value when the submission is CHIP-only so stale answers don’t persist.

On the API side, I added a server-side backstop that also clears dsnpContract for CHIP-only updates and skips D-SNP-required validation in that scenario. I added focused web and API tests for the hide/clear behavior, and the targeted app-web Vitest files are passing.

#### Related issues
https://jiraent.cms.gov/browse/MCR-6076

#### Screenshots
<img width="733" height="504" alt="image" src="https://github.com/user-attachments/assets/0535913a-3133-433b-8310-c4362551e73a" />

<img width="761" height="459" alt="image" src="https://github.com/user-attachments/assets/79bead4d-e8c9-4762-b6e8-e5524831f7fe" />

#### Test cases covered
ContractDetails.test.tsx & ContractDetailsSummarySection.test.tsx:
Verifies the D-SNP summary row is hidden for CHIP-only submissions when the flag is enabled.

dataValidatorHelpers.test.ts & updateContractDraftRevision.test.ts
Verifies the server side validations are updated and that resubmissions properly clear the dsnpContract variable

## QA guidance
- create CHIP only submission 
- verify dsnp question does not display on Contract Details
- verify dsnp question does not display on Contract Summary
- verify changing a submission that is NOT chip-only to chip-only clears the dsnp value (on resubmit)

## PR Reminders
- [NA] Updated the API Changelog (if this PR changes the API schema)
- [NA] Checked accessibility with ANDI and Wave tools as needed