### PR TITLE
MCR-6115: update ma programs nickname and add storybook components

### DIFF
--- a/packages/submissions/src/statePrograms/statePrograms.json
+++ b/packages/submissions/src/statePrograms/statePrograms.json
@@ -674,7 +674,7 @@
                 {
                     "id": "1076bd88-69c7-470f-839c-481c0ad13b97",
                     "fullName": "MassHealth Managed Care Organization Program",
-                    "name": "MCO",
+                    "name": "MCO Program",
                     "isRateProgram": false,
                     "isDeprecated": false
                 },

--- a/services/app-web/src/components/Select/ProgramSelect/ProgramSelect.stories.tsx
+++ b/services/app-web/src/components/Select/ProgramSelect/ProgramSelect.stories.tsx
@@ -2,54 +2,71 @@ import { StoryFn } from '@storybook/react'
 import { Formik } from 'formik'
 import {
     fetchCurrentUserMock,
-    mockMNState,
+    mockStateData,
     mockValidStateUser,
 } from '@mc-review/mocks'
+import { typedStatePrograms } from '@mc-review/submissions'
 import { ProgramSelect, type ProgramSelectPropType } from './ProgramSelect'
 import ProvidersDecorator from '../../../../.storybook/providersDecorator'
 import { useStatePrograms } from '../../../hooks'
 
+type StoryArgs = ProgramSelectPropType & { stateCode: string }
+
+// Only offer states that actually have program data in statePrograms.json.
+const stateCodesWithPrograms = typedStatePrograms.states
+    .filter((s) => s.programs.length > 0)
+    .map((s) => s.code)
+    .sort()
+
 export default {
     title: 'Components/Select/ProgramSelect',
     component: ProgramSelect,
-}
-
-const deprecatedProgram = {
-    id: 'deprecated-program-id',
-    name: 'Legacy Program',
-    fullName: 'Legacy Program Full Name',
-    isRateProgram: false,
-    isDeprecated: true,
-    deprecatedByProgramId: null,
-}
-
-const mnState = mockMNState()
-const firstProgramId = mnState.programs[0].id
-
-const stateUserWithDeprecatedProgram = mockValidStateUser({
-    state: {
-        ...mnState,
-        programs: [...mnState.programs, deprecatedProgram],
+    argTypes: {
+        stateCode: {
+            control: 'select',
+            options: stateCodesWithPrograms,
+            description:
+                'State whose programs are loaded into the mocked user context',
+        },
+        contractProgramsOnly: {
+            name: 'Contract programs only',
+            control: 'boolean',
+            description:
+                'Toggle true for contract programs only, false for all programs. Rate details page display all programs.',
+        },
     },
-})
+}
+
+const buildStateUser = (stateCode: string) => {
+    const state = mockStateData(stateCode)
+    if (!stateCode) {
+        throw new Error(`${stateCode} not found in state programs data.`)
+    }
+    return mockValidStateUser({ state })
+}
 
 // Wait for the user (and thus state programs) to load before rendering
 // ProgramSelect, because react-select captures defaultValue at mount time.
-const ProgramSelectWithReadyState = (args: ProgramSelectPropType) => {
+// Re-key on stateCode so switching states forces a remount with fresh options.
+const ProgramSelectWithReadyState = ({ stateCode, ...args }: StoryArgs) => {
     const programs = useStatePrograms()
     const isLoading = programs.length === 0
 
     return (
         <ProgramSelect
-            key={isLoading ? 'loading' : 'ready'}
+            key={`${stateCode}-${isLoading ? 'loading' : 'ready'}`}
             {...args}
             isLoading={isLoading}
         />
     )
 }
 
-const Template: StoryFn<ProgramSelectPropType> = (args) => (
+const Template: StoryFn<StoryArgs> = (args) => (
     <div style={{ width: '600px', height: '300px', padding: '2rem' }}>
+        <h2>
+            {typedStatePrograms.states.find((s) => s.code === args.stateCode)
+                ?.name ?? args.stateCode}
+        </h2>
         <Formik
             initialValues={{ programSelect: args.programIDs }}
             onSubmit={() => undefined}
@@ -66,19 +83,25 @@ Default.args = {
     name: 'programSelect',
     inputId: 'programSelect',
     'aria-label': 'Programs (required)',
-    programIDs: [firstProgramId, deprecatedProgram.id],
-    contractProgramsOnly: true,
+    programIDs: [],
+    contractProgramsOnly: false,
+    stateCode: 'KY',
 }
 Default.decorators = [
-    (StoryFn) =>
-        ProvidersDecorator(StoryFn, {
-            apolloProvider: {
-                mocks: [
-                    fetchCurrentUserMock({
-                        user: stateUserWithDeprecatedProgram,
-                        statusCode: 200,
-                    }),
-                ],
-            },
-        }),
+    (StoryFn, context) => (
+        // Keying on stateCode remounts MockedProvider with fresh mocks when
+        // the user picks a different state from the Storybook control.
+        <div key={context.args.stateCode}>
+            {ProvidersDecorator(StoryFn, {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: buildStateUser(context.args.stateCode),
+                            statusCode: 200,
+                        }),
+                    ],
+                },
+            })}
+        </div>
+    ),
 ]


### PR DESCRIPTION
## Summary
[MCR-6115](https://jiraent.cms.gov/browse/MCR-6115)

This work changes Abbreviated MA Program Name "MCO" to "MCO Program". I also add a storybook component so PM and Designers can quickly validate program changes.

Storybook: https://d1vo2dd6x51urg.cloudfront.net/

#### Related issues

#### Screenshots

<img width="1298" height="1117" alt="Screenshot 2026-04-20 at 11 23 06 AM" src="https://github.com/user-attachments/assets/fc4a8ae7-dbed-4f93-9336-6821a8cfbe5b" />

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders