### PR TITLE
Add query to support rate arrays

### DIFF
--- a/API_Changelog.md
+++ b/API_Changelog.md
@@ -1,6 +1,13 @@
 # Managed Care Review - API Changelog
 ## This document highlights API changes that have been introduced since May 2025. See the full [GraphQL schema](services/app-graphql/src/schema.graphql).
 
+### April 20, 2026
+#### Updated
+- **`indexRates`** endpoint updated to accept an optional `rateIDs` parameter (via `IndexRatesInput`):
+    - **`rateIDs`**: an optional array of rate ID strings. When provided, only rates matching those IDs are returned. Useful for batch-fetching a known set of rates in a single request.
+    - When omitted, behavior is unchanged — all submitted rates are returned (filtered by state for state users).
+    - Draft rates are excluded from results regardless of whether their ID is in the list.
+
 ### April 1, 2026
 #### Added
 - `isDeprecated` and `deprecatedByProgramId` added to the `Program` GraphQL type.

--- a/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.test.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.test.ts
@@ -182,7 +182,7 @@ describe('findAllRatesWithHistoryBySubmittedInfo', () => {
                 mockInsertRateArgs({ rateCertificationName: 'rate two' })
             )
         )
-        const rateThree = must(
+        must(
             await insertDraftRate(
                 client,
                 contractA.id,
@@ -204,15 +204,11 @@ describe('findAllRatesWithHistoryBySubmittedInfo', () => {
             })
         )
 
+        expect(rates).toHaveLength(2)
         expect(rates).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({ rateID: rateOne.id }),
                 expect.objectContaining({ rateID: rateTwo.id }),
-            ])
-        )
-        expect(rates).not.toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({ rateID: rateThree.id }),
             ])
         )
     })

--- a/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.test.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.test.ts
@@ -146,6 +146,77 @@ describe('findAllRatesWithHistoryBySubmittedInfo', () => {
         )
     })
 
+    it('returns only rates matching the provided rateIDs', async () => {
+        const client = await sharedTestPrismaClient()
+        const stateUser = await client.user.create({
+            data: {
+                id: uuidv4(),
+                givenName: 'Aang',
+                familyName: 'Avatar',
+                email: 'aang@example.com',
+                role: 'STATE_USER',
+                stateCode: 'NM',
+            },
+        })
+
+        const contractA = must(
+            await insertDraftContract(
+                client,
+                mockInsertContractArgs({
+                    submissionDescription: 'one contract',
+                })
+            )
+        )
+
+        const rateOne = must(
+            await insertDraftRate(
+                client,
+                contractA.id,
+                mockInsertRateArgs({ rateCertificationName: 'rate one' })
+            )
+        )
+        const rateTwo = must(
+            await insertDraftRate(
+                client,
+                contractA.id,
+                mockInsertRateArgs({ rateCertificationName: 'rate two' })
+            )
+        )
+        const rateThree = must(
+            await insertDraftRate(
+                client,
+                contractA.id,
+                mockInsertRateArgs({ rateCertificationName: 'rate three' })
+            )
+        )
+
+        must(
+            await submitContract(client, {
+                contractID: contractA.id,
+                submittedByUserID: stateUser.id,
+                submittedReason: 'Submitting rates',
+            })
+        )
+
+        const rates = must(
+            await findAllRatesWithHistoryBySubmitInfo(client, {
+                rateIDs: [rateOne.id, rateTwo.id],
+            })
+        )
+
+        expect(rates).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ rateID: rateOne.id }),
+                expect.objectContaining({ rateID: rateTwo.id }),
+            ])
+        )
+        expect(rates).not.toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ rateID: rateThree.id }),
+            ])
+        )
+    })
+
     it('can return rates only for a specific state if stateCode passed in', async () => {
         const client = await sharedTestPrismaClient()
         const stateUser = await client.user.create({

--- a/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.ts
@@ -13,6 +13,7 @@ type RateOrErrorArrayType = RateOrErrorType[]
 
 type FindAllRatesWithHistoryBySubmitType = {
     stateCode?: string
+    rateIDs?: string[]
     useZod?: boolean
 }
 
@@ -23,6 +24,7 @@ async function findAllRatesWithHistoryBySubmitInfo(
     try {
         const rates = await client.rateTable.findMany({
             where: {
+                id: args?.rateIDs ? { in: args.rateIDs } : undefined,
                 revisions: {
                     some: {
                         submitInfoID: {

--- a/services/app-api/src/resolvers/rate/indexRates.test.ts
+++ b/services/app-api/src/resolvers/rate/indexRates.test.ts
@@ -218,6 +218,46 @@ describe('indexRates', () => {
                 expect(testRates).toHaveLength(0)
             })
 
+            it('returns only rates matching the provided rateIDs', async () => {
+                const cmsUser = mockUser()
+                const stateServer = await constructTestPostgresServer({
+                    ldService,
+                    s3Client: mockS3,
+                })
+                const cmsServer = await constructTestPostgresServer({
+                    context: { user: cmsUser },
+                    ldService,
+                    s3Client: mockS3,
+                })
+
+                const contract1 =
+                    await createAndSubmitTestContractWithRate(stateServer)
+                const contract2 =
+                    await createAndSubmitTestContractWithRate(stateServer)
+                const contract3 =
+                    await createAndSubmitTestContractWithRate(stateServer)
+
+                const rate1ID =
+                    contract1.packageSubmissions[0].rateRevisions[0].rateID
+                const rate2ID =
+                    contract2.packageSubmissions[0].rateRevisions[0].rateID
+                const rate3ID =
+                    contract3.packageSubmissions[0].rateRevisions[0].rateID
+
+                const result = await executeGraphQLOperation(cmsServer, {
+                    query: IndexRatesDocument,
+                    variables: { input: { rateIDs: [rate1ID, rate2ID] } },
+                })
+
+                expect(result.errors).toBeUndefined()
+                const returnedIDs = result.data?.indexRates.edges.map(
+                    (edge: RateEdge) => edge.node.id
+                )
+                expect(returnedIDs).toContain(rate1ID)
+                expect(returnedIDs).toContain(rate2ID)
+                expect(returnedIDs).not.toContain(rate3ID)
+            })
+
             it('return a list of submitted rates from multiple states', async () => {
                 const cmsUser = mockUser()
                 const stateServer = await constructTestPostgresServer({

--- a/services/app-api/src/resolvers/rate/indexRates.test.ts
+++ b/services/app-api/src/resolvers/rate/indexRates.test.ts
@@ -234,15 +234,12 @@ describe('indexRates', () => {
                     await createAndSubmitTestContractWithRate(stateServer)
                 const contract2 =
                     await createAndSubmitTestContractWithRate(stateServer)
-                const contract3 =
-                    await createAndSubmitTestContractWithRate(stateServer)
+                await createAndSubmitTestContractWithRate(stateServer)
 
                 const rate1ID =
                     contract1.packageSubmissions[0].rateRevisions[0].rateID
                 const rate2ID =
                     contract2.packageSubmissions[0].rateRevisions[0].rateID
-                const rate3ID =
-                    contract3.packageSubmissions[0].rateRevisions[0].rateID
 
                 const result = await executeGraphQLOperation(cmsServer, {
                     query: IndexRatesDocument,
@@ -253,9 +250,10 @@ describe('indexRates', () => {
                 const returnedIDs = result.data?.indexRates.edges.map(
                     (edge: RateEdge) => edge.node.id
                 )
-                expect(returnedIDs).toContain(rate1ID)
-                expect(returnedIDs).toContain(rate2ID)
-                expect(returnedIDs).not.toContain(rate3ID)
+                expect(returnedIDs).toHaveLength(2)
+                expect(returnedIDs).toEqual(
+                    expect.arrayContaining([rate1ID, rate2ID])
+                )
             })
 
             it('return a list of submitted rates from multiple states', async () => {

--- a/services/app-api/src/resolvers/rate/indexRates.ts
+++ b/services/app-api/src/resolvers/rate/indexRates.ts
@@ -70,17 +70,20 @@ export function indexRatesResolver(store: Store): QueryResolvers['indexRates'] {
                 ratesWithHistory =
                     await store.findAllRatesWithHistoryBySubmitInfo({
                         stateCode: user.stateCode,
+                        rateIDs: input?.rateIDs ?? undefined,
                         useZod: true,
                     })
             } else if (input && input.stateCode) {
                 ratesWithHistory =
                     await store.findAllRatesWithHistoryBySubmitInfo({
                         stateCode: input.stateCode,
+                        rateIDs: input?.rateIDs ?? undefined,
                         useZod: true,
                     })
             } else {
                 ratesWithHistory =
                     await store.findAllRatesWithHistoryBySubmitInfo({
+                        rateIDs: input?.rateIDs ?? undefined,
                         useZod: false,
                     })
             }


### PR DESCRIPTION
## Summary

ARMS let us know that it'd make their lives easier if they could query rates by a list of rate IDs. We actually already had some of the types, we just didn't have the Prisma piece to support it. This adds it.

#### Related Issues
https://jiraent.cms.gov/browse/MCR-6202
