### PR TITLE
Add query for rates updated since given date

### DIFF
--- a/API_Changelog.md
+++ b/API_Changelog.md
@@ -1,31 +1,38 @@
 # Managed Care Review - API Changelog
+
 ## This document highlights API changes that have been introduced since May 2025. See the full [GraphQL schema](services/app-graphql/src/schema.graphql).
 
 ### April 20, 2026
+
 #### Updated
-- **`indexRates`** endpoint updated to accept an optional `rateIDs` parameter (via `IndexRatesInput`):
-    - **`rateIDs`**: an optional array of rate ID strings. When provided, only rates matching those IDs are returned. Useful for batch-fetching a known set of rates in a single request.
-    - When omitted, behavior is unchanged — all submitted rates are returned (filtered by state for state users).
-    - Draft rates are excluded from results regardless of whether their ID is in the list.
+
+- **`indexRates`** endpoint updated to accept two new optional parameters (via `IndexRatesInput`):
+    - **`rateIDs`**: an optional array of rate ID strings. When provided, only rates matching those IDs are returned. Useful for batch-fetching a known set of rates in a single request. Draft rates are excluded regardless of whether their ID is in the list.
+    - **`updatedSince`**: an optional `DateTime`. When provided, only rates with an `updatedAt` at or after this timestamp are returned. Designed for incremental pulls — pass your last-run timestamp to receive only rates that are new or have changed since then.
+    - When both are omitted, behavior is unchanged — all submitted rates are returned.
 
 ### April 1, 2026
+
 #### Added
+
 - `isDeprecated` and `deprecatedByProgramId` added to the `Program` GraphQL type.
-   - `isDeprecated` required `Boolean`, indicates whether the program has been retired from new selection.
-   - `deprecatedByProgramId` nullable `String`, optionally identifies the replacement program when one exists.
-   - Affected endpoints:
-     - `fetchCurrentUser`
-     - `fetchContract`
-     - `fetchRate`
-     - `fetchMcReviewSettings`
-     - `indexContracts`
-     - `indexContractsStripped`
-     - `indexRates`
-     - `indexRatesStripped`
-     - `indexUsers`
+    - `isDeprecated` required `Boolean`, indicates whether the program has been retired from new selection.
+    - `deprecatedByProgramId` nullable `String`, optionally identifies the replacement program when one exists.
+    - Affected endpoints:
+        - `fetchCurrentUser`
+        - `fetchContract`
+        - `fetchRate`
+        - `fetchMcReviewSettings`
+        - `indexContracts`
+        - `indexContractsStripped`
+        - `indexRates`
+        - `indexRatesStripped`
+        - `indexUsers`
 
 ### March 16, 2026
+
 #### Added
+
 - New mutation `reverseApproveContract` added to the API
     - Reverses a previously approved contract. CMS users only.
     - Parameters (via `ReverseApproveContractInput`)
@@ -39,13 +46,15 @@
         - `INTERNAL_SERVER_ERROR`: DB_ERROR — a contract cannot be found by id
 
 ### March 12, 2026
+
 #### Added
+
 - New endpoint `generateUploadURL` added to the API
     - Parameters
         - `fileName`: required String, the full name of the file including extension
         - `fileType`: required enum, corresponds to the file's extension, possible values: `[PDF, DOC, DOCX, XLS, XLSX, XLSM, CSV]`
         - `bucketName`: required enum, corresponds to the bucket the file should be uploaded to, possible values: `[HEALTH_PLAN_DOCS, QUESTION_ANSWER_DOCS]`
-    - Returns 
+    - Returns
         - bucket: String
         - expiresIn: Int
         - s3Key: String
@@ -53,18 +62,23 @@
         - uploadURL: String
 
 ### January 29, 2026
+
 #### Added
+
 - New submission status of `NOT_SUBJECT_TO_REVIEW`. For EQRO submissions that do not require CMS review.
-   - `NOT_SUBJECT_TO_REVIEW` to the enum `ContractReviewStatus` in GraphQL.
-   - `NOT_SUBJECT_TO_REVIEW` to the enum `ConsolidatedContractStatus` in GraphQL.
-   - `NOT_SUBJECT_TO_REVIEW` to the enum `ContractActionType` in GraphQL.
+    - `NOT_SUBJECT_TO_REVIEW` to the enum `ContractReviewStatus` in GraphQL.
+    - `NOT_SUBJECT_TO_REVIEW` to the enum `ConsolidatedContractStatus` in GraphQL.
+    - `NOT_SUBJECT_TO_REVIEW` to the enum `ContractActionType` in GraphQL.
 
 #### Updated
+
 - `ContractReviewStatusActions` GraphQL type.
-   - `updatedBy` field is now optional.
+    - `updatedBy` field is now optional.
 
 ### November 13, 2025
+
 #### Added
+
 - `EQRO` contract submission type fields to `ContractFormData` GraphQL type.
     ```graphql
         type ContractFormData {
@@ -81,36 +95,37 @@
             eqroProvisionMcoEqrOrRelatedActivities: Boolean
         }
     ```
-  - These new fields on the `ContractFormData` are `EQRO` contract submission form fields. They are questions asked for `EQRO` contract submissions only in the MC-Review state portal app.
-  - Affected endpoints:
-    - `fetchContract`
-    - `indexContracts`
-    - `fetchRate`
-    - `indexRates`
+
+    - These new fields on the `ContractFormData` are `EQRO` contract submission form fields. They are questions asked for `EQRO` contract submissions only in the MC-Review state portal app.
+    - Affected endpoints:
+        - `fetchContract`
+        - `indexContracts`
+        - `fetchRate`
+        - `indexRates`
 
 ### October 30, 2025
+
 #### Added
+
 - `contractSubmissionType` to the `Contract` and `UnlockedContract` GraphQL type.
-   - `contractSubmissionType` label the contract type of the submission. At this time there are two types a contract can be `HEALTH_PLAN` and `EQRO`.
-   - Affected endpoints:
-     - `fetchContract`
-     - `indexContracts`
+    - `contractSubmissionType` label the contract type of the submission. At this time there are two types a contract can be `HEALTH_PLAN` and `EQRO`.
+    - Affected endpoints:
+        - `fetchContract`
+        - `indexContracts`
 
 ### October 16, 2025
+
 #### Updated
+
 - **IndexContracts** endpoint updated to accept 2 optional parameters:
-    - **updatedWithin**: an integer, representing seconds. Only submissions that have been updated within the specified timeframe will be returned 
-    - **statusesToExclude**: An array of statuses to exclude in the filtered results. 
-        Valid statuses include:
-            - DRAFT
-            - SUBMITTED
-            - UNLOCKED
-            - RESUBMITTED
-            - APPROVED
-            - WITHDRAWN
+    - **updatedWithin**: an integer, representing seconds. Only submissions that have been updated within the specified timeframe will be returned
+    - **statusesToExclude**: An array of statuses to exclude in the filtered results.
+      Valid statuses include: - DRAFT - SUBMITTED - UNLOCKED - RESUBMITTED - APPROVED - WITHDRAWN
 
 ### September 4, 2025
+
 #### Added
+
 - **ID** field added to `Document` GraphQL type (optional)
     - The Document type is used for Q&A document responses
     - API endpoints that return Document data will now include the document ID when available
@@ -118,12 +133,15 @@
         - `fetchContract`
         - `fetchRate`
         - `fetchDocument`
+
 ### August 25, 2025
+
 #### Added
+
 - New endpoint `fetchDocument` added to the API
     - Parameters
         - `documentID`: the `id` of the document to be retrieved
-        - `documentType`: optional field that represents the type of document to be retrieved. Can be one of:  CONTRACT_DOC, CONTRACT_SUPPORTING_DOC, RATE_DOC, RATE_SUPPORTING_DOC, CONTRACT_QUESTION_DOC, CONTRACT_QUESTION_RESPONSE_DOC, RATE_QUESTION_DOC, RATE_QUESTION_RESPONSE_DOC. Using this parameter gives a performance boost
+        - `documentType`: optional field that represents the type of document to be retrieved. Can be one of: CONTRACT_DOC, CONTRACT_SUPPORTING_DOC, RATE_DOC, RATE_SUPPORTING_DOC, CONTRACT_QUESTION_DOC, CONTRACT_QUESTION_RESPONSE_DOC, RATE_QUESTION_DOC, RATE_QUESTION_RESPONSE_DOC. Using this parameter gives a performance boost
         - `expiresIn`: represents times in seconds until the downloadURL's expiration. Valid range from 1 second to 604,800 seconds (1 week). Defaults to 3600 seconds (1 hour)
     - Returns a SharedDocument type
         - id: String
@@ -131,28 +149,40 @@
         - s3URL: String
         - sha256: String
         - downloadURL: String
+
 ### July 9, 2025
+
 #### Added
+
 - `rateMedicaidPopulations` optional array field, possible values: `["MEDICARE_MEDICAID_WITH_DSNP", "MEDICAID_ONLY", "MEDICARE_MEDICAID_WITHOUT_DSNP"]`, added to `formData` on `RateRevision`. This change affects all queries and mutations that include `RateFormData`
 
 ### June 27, 2025
+
 #### Added
+
 - `dsnpContract` optional field (`boolean` type) added to `formData` on `ContractRevision`. This change affects all queries and mutations that include `ContractFormData`
 
 ### June 20, 2025
+
 #### Added
+
 - `round` field (`int` type) added to `RateQuestion`
 
 ### June 9, 2025
+
 #### Added
+
 - `id` field added to `GenericDocument`
 
 ### May 9, 2025
+
 #### Deleted
+
 - `withdrawInfo` field was removed from `Rate`
 - `withdrawInfo` field was removed from `RateStripped`
 
 ### May 2, 2025
-#### Deleted
-- `withdrawAndReplaceRedundantRate` endpoint deleted. It was an Admin only action that was used to address bookkeeping errors with rates
 
+#### Deleted
+
+- `withdrawAndReplaceRedundantRate` endpoint deleted. It was an Admin only action that was used to address bookkeeping errors with rates

--- a/API_Changelog.md
+++ b/API_Changelog.md
@@ -6,9 +6,9 @@
 
 #### Updated
 
-- **`indexRates`** endpoint updated to accept two new optional parameters (via `IndexRatesInput`):
+- **`indexRates`** and **`indexRatesStripped`** endpoints updated to accept two new optional parameters (via `IndexRatesInput`):
     - **`rateIDs`**: an optional array of rate ID strings. When provided, only rates matching those IDs are returned. Useful for batch-fetching a known set of rates in a single request. Draft rates are excluded regardless of whether their ID is in the list.
-    - **`updatedSince`**: an optional `DateTime`. When provided, only rates with an `updatedAt` at or after this timestamp are returned. Designed for incremental pulls — pass your last-run timestamp to receive only rates that are new or have changed since then.
+    - **`updatedSince`**: an optional `DateTime`. When provided, only rates where the rate row, any submitted revision, or the revision's submit record has an `updatedAt` at or after this timestamp are returned. Designed for incremental pulls — pass your last-run timestamp to receive only rates that are new or have changed since then.
     - When both are omitted, behavior is unchanged — all submitted rates are returned.
 
 ### April 1, 2026
@@ -80,6 +80,7 @@
 #### Added
 
 - `EQRO` contract submission type fields to `ContractFormData` GraphQL type.
+
     ```graphql
         type ContractFormData {
             ...existing fields,

--- a/services/app-api/src/postgres/contractAndRates/findAllRatesStripped.test.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesStripped.test.ts
@@ -206,3 +206,64 @@ it('returns all rates with stripped down data', async () => {
     // ID should not exist so we expect no results
     expect(notRealRateSelectedOrError).toHaveLength(0)
 })
+
+it('returns no stripped rates when updatedSince is in the future', async () => {
+    const client = await sharedTestPrismaClient()
+    const stateServer = await constructTestPostgresServer({
+        context: { user: testStateUser() },
+    })
+
+    const submitted = await createAndSubmitTestContractWithRate(stateServer)
+    const rateID = submitted.packageSubmissions[0].rateRevisions[0].rateID
+
+    const farFuture = new Date('2099-01-01')
+    const results = must(
+        await findAllRatesStripped(client, { updatedSince: farFuture })
+    )
+
+    const found = results.find((r) => r.rateID === rateID)
+    expect(found).toBeUndefined()
+})
+
+it('returns stripped rates when updatedSince is in the past', async () => {
+    const client = await sharedTestPrismaClient()
+    const stateServer = await constructTestPostgresServer({
+        context: { user: testStateUser() },
+    })
+
+    const submitted = await createAndSubmitTestContractWithRate(stateServer)
+    const rateID = submitted.packageSubmissions[0].rateRevisions[0].rateID
+
+    const farPast = new Date('2000-01-01')
+    const results = must(
+        await findAllRatesStripped(client, { updatedSince: farPast })
+    )
+
+    const found = results.find((r) => r.rateID === rateID)
+    expect(found).toBeDefined()
+})
+
+it('returns stripped rate after unlock and resubmit when updatedSince is set between the two submissions', async () => {
+    const client = await sharedTestPrismaClient()
+    const stateServer = await constructTestPostgresServer({
+        context: { user: testStateUser() },
+    })
+    const cmsServer = await constructTestPostgresServer({
+        context: { user: testCMSUser() },
+    })
+
+    const submitted = await createAndSubmitTestContractWithRate(stateServer)
+    const rateID = submitted.packageSubmissions[0].rateRevisions[0].rateID
+
+    const cutoff = new Date()
+
+    await unlockTestContract(cmsServer, submitted.id, 'Making a change')
+    await submitTestContract(stateServer, submitted.id, 'Resubmission')
+
+    const results = must(
+        await findAllRatesStripped(client, { updatedSince: cutoff })
+    )
+
+    const found = results.find((r) => r.rateID === rateID)
+    expect(found).toBeDefined()
+})

--- a/services/app-api/src/postgres/contractAndRates/findAllRatesStripped.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesStripped.ts
@@ -15,6 +15,7 @@ type StrippedRateOrErrorArrayType = StrippedRateOrErrorType[]
 type FindAllRatesStrippedType = {
     stateCode?: string
     rateIDs?: string[]
+    updatedSince?: Date
 }
 
 async function findAllRatesStrippedInTransaction(
@@ -23,6 +24,7 @@ async function findAllRatesStrippedInTransaction(
 ): Promise<StrippedRateOrErrorArrayType | Error> {
     const stateCode = args?.stateCode
     const rateIDs = args?.rateIDs
+    const updatedSince = args?.updatedSince
     const rates = await tx.rateTable.findMany({
         where: {
             revisions: {
@@ -43,6 +45,33 @@ async function findAllRatesStrippedInTransaction(
                 ? {
                       in: rateIDs,
                   }
+                : undefined,
+            AND: updatedSince
+                ? [
+                      {
+                          OR: [
+                              { updatedAt: { gte: updatedSince } },
+                              {
+                                  revisions: {
+                                      some: {
+                                          submitInfoID: { not: null },
+                                          updatedAt: { gte: updatedSince },
+                                      },
+                                  },
+                              },
+                              {
+                                  revisions: {
+                                      some: {
+                                          submitInfoID: { not: null },
+                                          submitInfo: {
+                                              updatedAt: { gte: updatedSince },
+                                          },
+                                      },
+                                  },
+                              },
+                          ],
+                      },
+                  ]
                 : undefined,
         },
         include: includeStrippedRate,

--- a/services/app-api/src/postgres/contractAndRates/findAllRatesStripped.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesStripped.ts
@@ -67,6 +67,13 @@ async function findAllRatesStrippedInTransaction(
                               },
                           },
                       },
+                      {
+                          reviewStatusActions: {
+                              some: {
+                                  updatedAt: { gte: updatedSince },
+                              },
+                          },
+                      },
                   ]
                 : undefined,
         },

--- a/services/app-api/src/postgres/contractAndRates/findAllRatesStripped.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesStripped.ts
@@ -46,30 +46,26 @@ async function findAllRatesStrippedInTransaction(
                       in: rateIDs,
                   }
                 : undefined,
-            AND: updatedSince
+            OR: updatedSince
                 ? [
+                      { updatedAt: { gte: updatedSince } },
                       {
-                          OR: [
-                              { updatedAt: { gte: updatedSince } },
-                              {
-                                  revisions: {
-                                      some: {
-                                          submitInfoID: { not: null },
-                                          updatedAt: { gte: updatedSince },
-                                      },
+                          revisions: {
+                              some: {
+                                  submitInfoID: { not: null },
+                                  updatedAt: { gte: updatedSince },
+                              },
+                          },
+                      },
+                      {
+                          revisions: {
+                              some: {
+                                  submitInfoID: { not: null },
+                                  submitInfo: {
+                                      updatedAt: { gte: updatedSince },
                                   },
                               },
-                              {
-                                  revisions: {
-                                      some: {
-                                          submitInfoID: { not: null },
-                                          submitInfo: {
-                                              updatedAt: { gte: updatedSince },
-                                          },
-                                      },
-                                  },
-                              },
-                          ],
+                          },
                       },
                   ]
                 : undefined,

--- a/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.test.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.test.ts
@@ -213,6 +213,102 @@ describe('findAllRatesWithHistoryBySubmittedInfo', () => {
         )
     })
 
+    it('returns no rates when updatedSince is in the future', async () => {
+        const client = await sharedTestPrismaClient()
+        const stateUser = await client.user.create({
+            data: {
+                id: uuidv4(),
+                givenName: 'Aang',
+                familyName: 'Avatar',
+                email: 'aang@example.com',
+                role: 'STATE_USER',
+                stateCode: 'NM',
+            },
+        })
+
+        const contractA = must(
+            await insertDraftContract(
+                client,
+                mockInsertContractArgs({
+                    submissionDescription: 'one contract',
+                })
+            )
+        )
+        must(
+            await insertDraftRate(
+                client,
+                contractA.id,
+                mockInsertRateArgs({ rateCertificationName: 'a rate' })
+            )
+        )
+        must(
+            await submitContract(client, {
+                contractID: contractA.id,
+                submittedByUserID: stateUser.id,
+                submittedReason: 'Submitting',
+            })
+        )
+
+        const farFuture = new Date('2099-01-01')
+        const rates = must(
+            await findAllRatesWithHistoryBySubmitInfo(client, {
+                updatedSince: farFuture,
+            })
+        )
+
+        expect(rates).toHaveLength(0)
+    })
+
+    it('returns submitted rates when updatedSince is in the past', async () => {
+        const client = await sharedTestPrismaClient()
+        const stateUser = await client.user.create({
+            data: {
+                id: uuidv4(),
+                givenName: 'Aang',
+                familyName: 'Avatar',
+                email: 'aang@example.com',
+                role: 'STATE_USER',
+                stateCode: 'NM',
+            },
+        })
+
+        const contractA = must(
+            await insertDraftContract(
+                client,
+                mockInsertContractArgs({
+                    submissionDescription: 'one contract',
+                })
+            )
+        )
+        const rate = must(
+            await insertDraftRate(
+                client,
+                contractA.id,
+                mockInsertRateArgs({ rateCertificationName: 'a rate' })
+            )
+        )
+        must(
+            await submitContract(client, {
+                contractID: contractA.id,
+                submittedByUserID: stateUser.id,
+                submittedReason: 'Submitting',
+            })
+        )
+
+        const farPast = new Date('2000-01-01')
+        const rates = must(
+            await findAllRatesWithHistoryBySubmitInfo(client, {
+                updatedSince: farPast,
+            })
+        )
+
+        expect(rates).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ rateID: rate.id }),
+            ])
+        )
+    })
+
     it('can return rates only for a specific state if stateCode passed in', async () => {
         const client = await sharedTestPrismaClient()
         const stateUser = await client.user.create({

--- a/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.test.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.test.ts
@@ -309,6 +309,78 @@ describe('findAllRatesWithHistoryBySubmittedInfo', () => {
         )
     })
 
+    it('returns a rate after unlock and resubmit when updatedSince is set between the two submissions', async () => {
+        const client = await sharedTestPrismaClient()
+        const stateUser = await client.user.create({
+            data: {
+                id: uuidv4(),
+                givenName: 'Aang',
+                familyName: 'Avatar',
+                email: 'aang@example.com',
+                role: 'STATE_USER',
+                stateCode: 'NM',
+            },
+        })
+
+        const contractA = must(
+            await insertDraftContract(
+                client,
+                mockInsertContractArgs({
+                    submissionDescription: 'one contract',
+                })
+            )
+        )
+        const rate = must(
+            await insertDraftRate(
+                client,
+                contractA.id,
+                mockInsertRateArgs({ rateCertificationName: 'a rate' })
+            )
+        )
+
+        // First submission
+        must(
+            await submitContract(client, {
+                contractID: contractA.id,
+                submittedByUserID: stateUser.id,
+                submittedReason: 'Initial submission',
+            })
+        )
+
+        // Set cutoff timestamp between the two submissions
+        const cutoff = new Date()
+
+        // Unlock and resubmit — this creates a new revision and submitInfo row,
+        // but does NOT touch RateTable.updatedAt, so the OR filter on revisions
+        // is what catches it
+        must(
+            await unlockContract(client, {
+                contractID: contractA.id,
+                unlockedByUserID: stateUser.id,
+                unlockReason: 'Making a change',
+            })
+        )
+        must(
+            await submitContract(client, {
+                contractID: contractA.id,
+                submittedByUserID: stateUser.id,
+                submittedReason: 'Resubmission after unlock',
+            })
+        )
+
+        const rates = must(
+            await findAllRatesWithHistoryBySubmitInfo(client, {
+                updatedSince: cutoff,
+            })
+        )
+
+        expect(rates).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ rateID: rate.id }),
+            ])
+        )
+    })
+
     it('can return rates only for a specific state if stateCode passed in', async () => {
         const client = await sharedTestPrismaClient()
         const stateUser = await client.user.create({

--- a/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.test.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.test.ts
@@ -309,6 +309,70 @@ describe('findAllRatesWithHistoryBySubmittedInfo', () => {
         )
     })
 
+    it('returns a rate when a review status action occurs after updatedSince', async () => {
+        const client = await sharedTestPrismaClient()
+        const stateUser = await client.user.create({
+            data: {
+                id: uuidv4(),
+                givenName: 'Aang',
+                familyName: 'Avatar',
+                email: 'aang@example.com',
+                role: 'STATE_USER',
+                stateCode: 'NM',
+            },
+        })
+
+        const contractA = must(
+            await insertDraftContract(
+                client,
+                mockInsertContractArgs({
+                    submissionDescription: 'one contract',
+                })
+            )
+        )
+        const rate = must(
+            await insertDraftRate(
+                client,
+                contractA.id,
+                mockInsertRateArgs({ rateCertificationName: 'a rate' })
+            )
+        )
+        must(
+            await submitContract(client, {
+                contractID: contractA.id,
+                submittedByUserID: stateUser.id,
+                submittedReason: 'Initial submission',
+            })
+        )
+
+        // Set cutoff after submission
+        const cutoff = new Date()
+
+        // Directly insert a review status action after the cutoff — this does NOT
+        // touch RateTable.updatedAt or any revision row, so only the
+        // reviewStatusActions OR branch should catch it
+        await client.rateActionTable.create({
+            data: {
+                rateID: rate.id,
+                updatedByID: stateUser.id,
+                updatedReason: 'Withdrawing rate',
+                actionType: 'WITHDRAW',
+            },
+        })
+
+        const rates = must(
+            await findAllRatesWithHistoryBySubmitInfo(client, {
+                updatedSince: cutoff,
+            })
+        )
+
+        expect(rates).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ rateID: rate.id }),
+            ])
+        )
+    })
+
     it('returns a rate after unlock and resubmit when updatedSince is set between the two submissions', async () => {
         const client = await sharedTestPrismaClient()
         const stateUser = await client.user.create({

--- a/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.ts
@@ -40,34 +40,26 @@ async function findAllRatesWithHistoryBySubmitInfo(
                     : {
                           not: 'AS', // exclude test state as per ADR 019
                       },
-                AND: args?.updatedSince
+                OR: args?.updatedSince
                     ? [
+                          { updatedAt: { gte: args.updatedSince } },
                           {
-                              OR: [
-                                  { updatedAt: { gte: args.updatedSince } },
-                                  {
-                                      revisions: {
-                                          some: {
-                                              submitInfoID: { not: null },
-                                              updatedAt: {
-                                                  gte: args.updatedSince,
-                                              },
-                                          },
+                              revisions: {
+                                  some: {
+                                      submitInfoID: { not: null },
+                                      updatedAt: { gte: args.updatedSince },
+                                  },
+                              },
+                          },
+                          {
+                              revisions: {
+                                  some: {
+                                      submitInfoID: { not: null },
+                                      submitInfo: {
+                                          updatedAt: { gte: args.updatedSince },
                                       },
                                   },
-                                  {
-                                      revisions: {
-                                          some: {
-                                              submitInfoID: { not: null },
-                                              submitInfo: {
-                                                  updatedAt: {
-                                                      gte: args.updatedSince,
-                                                  },
-                                              },
-                                          },
-                                      },
-                                  },
-                              ],
+                              },
                           },
                       ]
                     : undefined,

--- a/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.ts
@@ -40,8 +40,36 @@ async function findAllRatesWithHistoryBySubmitInfo(
                     : {
                           not: 'AS', // exclude test state as per ADR 019
                       },
-                updatedAt: args?.updatedSince
-                    ? { gte: args.updatedSince }
+                AND: args?.updatedSince
+                    ? [
+                          {
+                              OR: [
+                                  { updatedAt: { gte: args.updatedSince } },
+                                  {
+                                      revisions: {
+                                          some: {
+                                              submitInfoID: { not: null },
+                                              updatedAt: {
+                                                  gte: args.updatedSince,
+                                              },
+                                          },
+                                      },
+                                  },
+                                  {
+                                      revisions: {
+                                          some: {
+                                              submitInfoID: { not: null },
+                                              submitInfo: {
+                                                  updatedAt: {
+                                                      gte: args.updatedSince,
+                                                  },
+                                              },
+                                          },
+                                      },
+                                  },
+                              ],
+                          },
+                      ]
                     : undefined,
             },
             include: {

--- a/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.ts
@@ -61,6 +61,13 @@ async function findAllRatesWithHistoryBySubmitInfo(
                                   },
                               },
                           },
+                          {
+                              reviewStatusActions: {
+                                  some: {
+                                      updatedAt: { gte: args.updatedSince },
+                                  },
+                              },
+                          },
                       ]
                     : undefined,
             },

--- a/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.ts
+++ b/services/app-api/src/postgres/contractAndRates/findAllRatesWithHistoryBySubmitInfo.ts
@@ -14,6 +14,7 @@ type RateOrErrorArrayType = RateOrErrorType[]
 type FindAllRatesWithHistoryBySubmitType = {
     stateCode?: string
     rateIDs?: string[]
+    updatedSince?: Date
     useZod?: boolean
 }
 
@@ -39,6 +40,9 @@ async function findAllRatesWithHistoryBySubmitInfo(
                     : {
                           not: 'AS', // exclude test state as per ADR 019
                       },
+                updatedAt: args?.updatedSince
+                    ? { gte: args.updatedSince }
+                    : undefined,
             },
             include: {
                 ...includeFullRate,

--- a/services/app-api/src/resolvers/rate/indexRates.test.ts
+++ b/services/app-api/src/resolvers/rate/indexRates.test.ts
@@ -256,6 +256,63 @@ describe('indexRates', () => {
                 )
             })
 
+            it('returns no rates when updatedSince is in the future', async () => {
+                const cmsUser = mockUser()
+                const stateServer = await constructTestPostgresServer({
+                    ldService,
+                    s3Client: mockS3,
+                })
+                const cmsServer = await constructTestPostgresServer({
+                    context: { user: cmsUser },
+                    ldService,
+                    s3Client: mockS3,
+                })
+
+                await createAndSubmitTestContractWithRate(stateServer)
+
+                const result = await executeGraphQLOperation(cmsServer, {
+                    query: IndexRatesDocument,
+                    variables: {
+                        input: { updatedSince: new Date('2099-01-01') },
+                    },
+                })
+
+                expect(result.errors).toBeUndefined()
+                expect(result.data?.indexRates.totalCount).toBe(0)
+                expect(result.data?.indexRates.edges).toHaveLength(0)
+            })
+
+            it('returns submitted rates when updatedSince is in the past', async () => {
+                const cmsUser = mockUser()
+                const stateServer = await constructTestPostgresServer({
+                    ldService,
+                    s3Client: mockS3,
+                })
+                const cmsServer = await constructTestPostgresServer({
+                    context: { user: cmsUser },
+                    ldService,
+                    s3Client: mockS3,
+                })
+
+                const contract =
+                    await createAndSubmitTestContractWithRate(stateServer)
+                const rateID =
+                    contract.packageSubmissions[0].rateRevisions[0].rateID
+
+                const result = await executeGraphQLOperation(cmsServer, {
+                    query: IndexRatesDocument,
+                    variables: {
+                        input: { updatedSince: new Date('2000-01-01') },
+                    },
+                })
+
+                expect(result.errors).toBeUndefined()
+                const returnedIDs = result.data?.indexRates.edges.map(
+                    (edge: RateEdge) => edge.node.id
+                )
+                expect(returnedIDs).toContain(rateID)
+            })
+
             it('return a list of submitted rates from multiple states', async () => {
                 const cmsUser = mockUser()
                 const stateServer = await constructTestPostgresServer({

--- a/services/app-api/src/resolvers/rate/indexRates.ts
+++ b/services/app-api/src/resolvers/rate/indexRates.ts
@@ -66,11 +66,15 @@ export function indexRatesResolver(store: Store): QueryResolvers['indexRates'] {
 
         if (adminPermissions || cmsUser || stateUser) {
             let ratesWithHistory
+            const updatedSince = input?.updatedSince
+                ? new Date(input.updatedSince)
+                : undefined
             if (stateUser) {
                 ratesWithHistory =
                     await store.findAllRatesWithHistoryBySubmitInfo({
                         stateCode: user.stateCode,
                         rateIDs: input?.rateIDs ?? undefined,
+                        updatedSince,
                         useZod: true,
                     })
             } else if (input && input.stateCode) {
@@ -78,12 +82,14 @@ export function indexRatesResolver(store: Store): QueryResolvers['indexRates'] {
                     await store.findAllRatesWithHistoryBySubmitInfo({
                         stateCode: input.stateCode,
                         rateIDs: input?.rateIDs ?? undefined,
+                        updatedSince,
                         useZod: true,
                     })
             } else {
                 ratesWithHistory =
                     await store.findAllRatesWithHistoryBySubmitInfo({
                         rateIDs: input?.rateIDs ?? undefined,
+                        updatedSince,
                         useZod: false,
                     })
             }

--- a/services/app-api/src/resolvers/rate/indexRates.ts
+++ b/services/app-api/src/resolvers/rate/indexRates.ts
@@ -66,9 +66,7 @@ export function indexRatesResolver(store: Store): QueryResolvers['indexRates'] {
 
         if (adminPermissions || cmsUser || stateUser) {
             let ratesWithHistory
-            const updatedSince = input?.updatedSince
-                ? new Date(input.updatedSince)
-                : undefined
+            const updatedSince = input?.updatedSince ?? undefined
             if (stateUser) {
                 ratesWithHistory =
                     await store.findAllRatesWithHistoryBySubmitInfo({

--- a/services/app-api/src/resolvers/rate/indexRatesStripped.test.ts
+++ b/services/app-api/src/resolvers/rate/indexRatesStripped.test.ts
@@ -17,6 +17,7 @@ import {
 import {
     createAndSubmitTestContractWithRate,
     submitTestContract,
+    unlockTestContract,
     createAndUpdateTestContractWithRate,
 } from '../../testHelpers/gqlContractHelpers'
 import { testS3Client } from '../../testHelpers'
@@ -341,5 +342,73 @@ describe('indexRatesStripped', () => {
         )
 
         expect(virginiaRateStateCodes.every((code) => code === 'VA')).toBe(true)
+    })
+
+    it('returns no rates when updatedSince is in the future', async () => {
+        const stateServer = await constructTestPostgresServer({ ldService })
+        const cmsServer = await constructTestPostgresServer({
+            context: { user: testCMSUser() },
+            ldService,
+        })
+
+        const contract = await createAndSubmitTestContractWithRate(stateServer)
+        const rateID = contract.packageSubmissions[0].rateRevisions[0].rateID
+
+        const result = await executeGraphQLOperation(cmsServer, {
+            query: IndexRatesStrippedDocument,
+            variables: { input: { updatedSince: new Date('2099-01-01') } },
+        })
+
+        expect(result.errors).toBeUndefined()
+        const edges = result.data?.indexRatesStripped.edges ?? []
+        const found = edges.find((e: RateStrippedEdge) => e.node.id === rateID)
+        expect(found).toBeUndefined()
+    })
+
+    it('returns submitted rates when updatedSince is in the past', async () => {
+        const stateServer = await constructTestPostgresServer({ ldService })
+        const cmsServer = await constructTestPostgresServer({
+            context: { user: testCMSUser() },
+            ldService,
+        })
+
+        const contract = await createAndSubmitTestContractWithRate(stateServer)
+        const rateID = contract.packageSubmissions[0].rateRevisions[0].rateID
+
+        const result = await executeGraphQLOperation(cmsServer, {
+            query: IndexRatesStrippedDocument,
+            variables: { input: { updatedSince: new Date('2000-01-01') } },
+        })
+
+        expect(result.errors).toBeUndefined()
+        const edges = result.data?.indexRatesStripped.edges ?? []
+        const found = edges.find((e: RateStrippedEdge) => e.node.id === rateID)
+        expect(found).toBeDefined()
+    })
+
+    it('returns a rate after unlock and resubmit when updatedSince is set between the two submissions', async () => {
+        const stateServer = await constructTestPostgresServer({ ldService })
+        const cmsServer = await constructTestPostgresServer({
+            context: { user: testCMSUser() },
+            ldService,
+        })
+
+        const contract = await createAndSubmitTestContractWithRate(stateServer)
+        const rateID = contract.packageSubmissions[0].rateRevisions[0].rateID
+
+        const cutoff = new Date()
+
+        await unlockTestContract(cmsServer, contract.id, 'Making a change')
+        await submitTestContract(stateServer, contract.id, 'Resubmission')
+
+        const result = await executeGraphQLOperation(cmsServer, {
+            query: IndexRatesStrippedDocument,
+            variables: { input: { updatedSince: cutoff } },
+        })
+
+        expect(result.errors).toBeUndefined()
+        const edges = result.data?.indexRatesStripped.edges ?? []
+        const found = edges.find((e: RateStrippedEdge) => e.node.id === rateID)
+        expect(found).toBeDefined()
     })
 })

--- a/services/app-api/src/resolvers/rate/indexRatesStripped.ts
+++ b/services/app-api/src/resolvers/rate/indexRatesStripped.ts
@@ -58,9 +58,7 @@ export function indexRatesStripped(
 
         if (adminPermissions || cmsUser || stateUser) {
             let ratesWithHistory
-            const updatedSince = input?.updatedSince
-                ? new Date(input.updatedSince)
-                : undefined
+            const updatedSince = input?.updatedSince ?? undefined
             if (stateUser) {
                 ratesWithHistory = await store.findAllRatesStripped({
                     stateCode: user.stateCode,

--- a/services/app-api/src/resolvers/rate/indexRatesStripped.ts
+++ b/services/app-api/src/resolvers/rate/indexRatesStripped.ts
@@ -58,15 +58,20 @@ export function indexRatesStripped(
 
         if (adminPermissions || cmsUser || stateUser) {
             let ratesWithHistory
+            const updatedSince = input?.updatedSince
+                ? new Date(input.updatedSince)
+                : undefined
             if (stateUser) {
                 ratesWithHistory = await store.findAllRatesStripped({
                     stateCode: user.stateCode,
                     rateIDs: input?.rateIDs ?? undefined,
+                    updatedSince,
                 })
             } else {
                 ratesWithHistory = await store.findAllRatesStripped({
                     stateCode: input?.stateCode ?? undefined,
                     rateIDs: input?.rateIDs ?? undefined,
+                    updatedSince,
                 })
             }
             if (ratesWithHistory instanceof Error) {

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -2281,6 +2281,8 @@ type RateEdge {
 input IndexRatesInput {
     stateCode: String
     rateIDs: [String!]
+    "Return only rates updated at or after this datetime. Useful for incremental pulls — pass your last-run timestamp to get only new or changed rates."
+    updatedSince: DateTime
 }
 
 type IndexRatesPayload {


### PR DESCRIPTION
## Summary

Another major quality of life improvement that would decrease the query load for ARMS is providing a date since last updated. This adds the ability to provide an optional `updatedSince` field that will only return rates that have seen a change since that provided date.

#### Related issues
