### PR TITLE
MCR-5858 & MCR-5861: allow CMS user to withdraw and undo withdraw EQRO submission

### DIFF
--- a/services/app-api/src/resolvers/contract/undoWithdrawContract.test.ts
+++ b/services/app-api/src/resolvers/contract/undoWithdrawContract.test.ts
@@ -16,6 +16,7 @@ import {
     unlockTestContract,
     errorUndoWithdrawTestContract,
     createAndSubmitTestContractWithRate,
+    createAndUpdateTestEQROContract,
 } from '../../testHelpers/gqlContractHelpers'
 import { fetchTestRateById, must } from '../../testHelpers'
 import {
@@ -690,6 +691,105 @@ describe('undoWithdrawContract', () => {
             expect.objectContaining({
                 bodyHTML: expect.stringContaining(contractName),
             })
+        )
+    })
+
+    it('can undo withdraw EQRO contract', async () => {
+        const stateServer = await constructTestPostgresServer({
+            context: {
+                user: stateUser,
+            },
+        })
+
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+        })
+
+        // At least one EQRO provision field true -> UNDER_REVIEW / SUBMITTED
+        const draft = await createAndUpdateTestEQROContract(
+            stateServer,
+            undefined,
+            {
+                eqroNewContractor: true,
+                eqroProvisionMcoNewOptionalActivity: true,
+                eqroProvisionNewMcoEqrRelatedActivities: true,
+                eqroProvisionChipEqrRelatedActivities: true,
+                eqroProvisionMcoEqrOrRelatedActivities: null,
+            }
+        )
+
+        const submittedContract = await submitTestContract(
+            stateServer,
+            draft.id
+        )
+        expect(submittedContract.consolidatedStatus).toBe('SUBMITTED')
+
+        const withdrawnContract = await withdrawTestContract(
+            cmsServer,
+            submittedContract.id,
+            'withdraw EQRO submission'
+        )
+
+        expect(withdrawnContract.consolidatedStatus).toBe('WITHDRAWN')
+
+        const contractHistory = contractHistoryToDescriptions(withdrawnContract)
+        expect(contractHistory).toStrictEqual(
+            expect.arrayContaining([
+                'Initial submission',
+                'Withdraw submission. withdraw EQRO submission',
+                'CMS withdrew the submission from review. withdraw EQRO submission',
+            ])
+        )
+
+        const undoneContract = await undoWithdrawTestContract(
+            cmsServer,
+            withdrawnContract.id,
+            'undo withdraw EQRO submission'
+        )
+
+        expect(undoneContract.consolidatedStatus).toBe('RESUBMITTED')
+
+        const undoneHistory = contractHistoryToDescriptions(undoneContract)
+        expect(undoneHistory).toStrictEqual(
+            expect.arrayContaining([
+                'Initial submission',
+                'Withdraw submission. withdraw EQRO submission',
+                'CMS withdrew the submission from review. withdraw EQRO submission',
+                'CMS undoing submission withdrawal. undo withdraw EQRO submission',
+                'CMS undid submission withdrawal. undo withdraw EQRO submission',
+            ])
+        )
+
+        must(
+            await unlockTestContract(
+                cmsServer,
+                undoneContract.id,
+                'unlock EQRO after undo'
+            )
+        )
+        const resubmittedAfterUndo = must(
+            await submitTestContract(
+                stateServer,
+                undoneContract.id,
+                'resubmit EQRO after undo'
+            )
+        )
+        expect(resubmittedAfterUndo.consolidatedStatus).toBe('RESUBMITTED')
+
+        const afterUndoHistory =
+            contractHistoryToDescriptions(resubmittedAfterUndo)
+        expect(afterUndoHistory).toStrictEqual(
+            expect.arrayContaining([
+                'Initial submission',
+                'Withdraw submission. withdraw EQRO submission',
+                'CMS withdrew the submission from review. withdraw EQRO submission',
+                'CMS undoing submission withdrawal. undo withdraw EQRO submission',
+                'CMS undid submission withdrawal. undo withdraw EQRO submission',
+                'unlock EQRO after undo',
+                'resubmit EQRO after undo',
+            ])
         )
     })
 })

--- a/services/app-api/src/resolvers/contract/undoWithdrawContract.ts
+++ b/services/app-api/src/resolvers/contract/undoWithdrawContract.ts
@@ -1,9 +1,9 @@
 import type { Store } from '../../postgres'
 import type { MutationResolvers } from '../../gen/gqlServer'
 import {
-    setErrorAttributesOnActiveSpan,
-    setResolverDetailsOnActiveSpan,
-    setSuccessAttributesOnActiveSpan,
+    withResolverSpan,
+    setResolverDetails,
+    recordResolverError,
 } from '../attributeHelper'
 import { NotFoundError } from '../../postgres'
 import { logError, logSuccess } from '../../logger'
@@ -21,175 +21,176 @@ export function undoWithdrawContract(
     documentZip: DocumentZipService
 ): MutationResolvers['undoWithdrawContract'] {
     return async (_parent, { input }, context) => {
-        const { user, ctx, tracer } = context
-        const span = tracer?.startSpan('undoWithdrawContract', {}, ctx)
-        setResolverDetailsOnActiveSpan('undoWithdrawContract', user, span)
-
+        const { user } = context
         const { contractID, updatedReason } = input
-        span?.setAttribute('mcreview.package_id', contractID)
 
-        // Check OAuth client read permissions
-        if (!canOauthWrite(context)) {
-            const errMessage = `OAuth client does not have write permissions`
-            logError('undoWithdrawContract', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
+        return withResolverSpan(
+            context,
+            'undoWithdrawContract',
+            { 'mcreview.contract_id': contractID },
+            async (span) => {
+                setResolverDetails(span, user)
 
-            throw new GraphQLError(errMessage, {
-                extensions: {
-                    code: 'FORBIDDEN',
-                    cause: 'INSUFFICIENT_OAUTH_GRANTS',
-                },
-            })
-        }
+                // Check OAuth client read permissions
+                if (!canOauthWrite(context)) {
+                    const errMessage = `OAuth client does not have write permissions`
+                    logError('undoWithdrawContract', errMessage)
 
-        if (!hasCMSPermissions(user)) {
-            const message =
-                'user not authorized to undo a submission withdrawal'
-            logError('undoWithdrawContract', message)
-            setErrorAttributesOnActiveSpan(message, span)
-            throw createForbiddenError(message)
-        }
+                    throw new GraphQLError(errMessage, {
+                        extensions: {
+                            code: 'FORBIDDEN',
+                            cause: 'INSUFFICIENT_OAUTH_GRANTS',
+                        },
+                    })
+                }
 
-        const contractWithHistory =
-            await store.findContractWithHistory(contractID)
+                if (!hasCMSPermissions(user)) {
+                    const message =
+                        'user not authorized to undo a submission withdrawal'
+                    logError('undoWithdrawContract', message)
+                    throw createForbiddenError(message)
+                }
 
-        if (contractWithHistory instanceof Error) {
-            if (contractWithHistory instanceof NotFoundError) {
-                const errMessage = `A contract must exist to undo a submission withdrawal: ${contractID}`
-                logError('undoWithdrawContract', errMessage)
-                setErrorAttributesOnActiveSpan(errMessage, span)
-                throw createUserInputError(errMessage, 'contractID')
-            }
+                const contractWithHistory =
+                    await store.findContractWithHistory(contractID)
 
-            const errMessage = `Issue finding a contract. Message: ${contractWithHistory.message}`
-            logError('undoWithdrawContract', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-            throw new GraphQLError(errMessage, {
-                extensions: {
-                    code: 'INTERNAL_SERVER_ERROR',
-                    cause: 'DB_ERROR',
-                },
-            })
-        }
+                if (contractWithHistory instanceof Error) {
+                    if (contractWithHistory instanceof NotFoundError) {
+                        const errMessage = `A contract must exist to undo a submission withdrawal: ${contractID}`
+                        logError('undoWithdrawContract', errMessage)
+                        throw createUserInputError(errMessage, 'contractID')
+                    }
 
-        if (contractWithHistory.consolidatedStatus !== 'WITHDRAWN') {
-            const errMessage = `Attempted to undo a submission withdrawal with invalid contract status of ${contractWithHistory.consolidatedStatus}`
-            logError('undoWithdrawContract', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-            throw createUserInputError(errMessage, 'contractID')
-        }
+                    const errMessage = `Issue finding a contract. Message: ${contractWithHistory.message}`
+                    logError('undoWithdrawContract', errMessage)
+                    throw new GraphQLError(errMessage, {
+                        extensions: {
+                            code: 'INTERNAL_SERVER_ERROR',
+                            cause: 'DB_ERROR',
+                        },
+                    })
+                }
 
-        const undoWithdrawResult = await store.undoWithdrawContract({
-            contract: contractWithHistory,
-            updatedByID: user.id,
-            updatedReason,
-        })
+                if (contractWithHistory.consolidatedStatus !== 'WITHDRAWN') {
+                    const errMessage = `Attempted to undo a submission withdrawal with invalid contract status of ${contractWithHistory.consolidatedStatus}`
+                    logError('undoWithdrawContract', errMessage)
+                    throw createUserInputError(errMessage, 'contractID')
+                }
 
-        if (undoWithdrawResult instanceof Error) {
-            const errMessage = `Failed to undo a submission withdrawal. ${undoWithdrawResult.message}`
-            logError('undoWithdrawContract', errMessage)
-
-            if (undoWithdrawResult instanceof NotFoundError) {
-                throw new GraphQLError(errMessage, {
-                    extensions: {
-                        code: 'NOT_FOUND',
-                        cause: 'DB_ERROR',
-                    },
+                const undoWithdrawResult = await store.undoWithdrawContract({
+                    contract: contractWithHistory,
+                    updatedByID: user.id,
+                    updatedReason,
                 })
-            }
 
-            throw new GraphQLError(errMessage, {
-                extensions: {
-                    code: 'INTERNAL_SERVER_ERROR',
-                    cause: 'DB_ERROR',
-                },
-            })
-        }
+                if (undoWithdrawResult instanceof Error) {
+                    const errMessage = `Failed to undo a submission withdrawal. ${undoWithdrawResult.message}`
+                    logError('undoWithdrawContract', errMessage)
 
-        const { contract, ratesForDisplay } = undoWithdrawResult
-        // Generate zips!
-        const contractZipRes = await documentZip.createContractZips(
-            contract,
-            span
-        )
-        if (contractZipRes instanceof Error) {
-            const errMessage = `Failed to zip files for contract revision with ID: ${contract.id}: ${contractZipRes.message}`
-            logError('submitContract', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-        }
-        const rateZipRes = await documentZip.createRateZips(contract, span)
-        if (rateZipRes instanceof Array) {
-            const errorMessage = `Failed to zip files for ${rateZipRes.length} rate revision(s) on contract ${contract.id}`
-            logError('submitContract', errorMessage)
-            setErrorAttributesOnActiveSpan(errorMessage, span)
+                    if (undoWithdrawResult instanceof NotFoundError) {
+                        throw new GraphQLError(errMessage, {
+                            extensions: {
+                                code: 'NOT_FOUND',
+                                cause: 'DB_ERROR',
+                            },
+                        })
+                    }
 
-            rateZipRes.forEach((error, index) => {
-                logError(
-                    'submitContract',
-                    `Rate zip error ${index + 1}: ${error.message}`
+                    throw new GraphQLError(errMessage, {
+                        extensions: {
+                            code: 'INTERNAL_SERVER_ERROR',
+                            cause: 'DB_ERROR',
+                        },
+                    })
+                }
+
+                const { contract, ratesForDisplay } = undoWithdrawResult
+                // Generate zips!
+                const contractZipRes = await documentZip.createContractZips(
+                    contract,
+                    span
                 )
-            })
-        }
-        let stateAnalystsEmails: string[] = []
-        const stateAnalystsEmailsResult = await store.findStateAssignedUsers(
-            contract.stateCode as StateCodeType
+                if (contractZipRes instanceof Error) {
+                    const errMessage = `Failed to zip files for contract revision with ID: ${contract.id}: ${contractZipRes.message}`
+                    logError('undoWithdrawContract', errMessage)
+                    recordResolverError(span, errMessage)
+                }
+                const rateZipRes = await documentZip.createRateZips(
+                    contract,
+                    span
+                )
+                if (rateZipRes instanceof Array) {
+                    const errorMessage = `Failed to zip files for ${rateZipRes.length} rate revision(s) on contract ${contract.id}`
+                    logError('undoWithdrawContract', errorMessage)
+                    recordResolverError(span, errorMessage)
+
+                    rateZipRes.forEach((error, index) => {
+                        logError(
+                            'undoWithdrawContract',
+                            `Rate zip error ${index + 1}: ${error.message}`
+                        )
+                    })
+                }
+                let stateAnalystsEmails: string[] = []
+                const stateAnalystsEmailsResult =
+                    await store.findStateAssignedUsers(
+                        contract.stateCode as StateCodeType
+                    )
+
+                if (stateAnalystsEmailsResult instanceof Error) {
+                    logError(
+                        'getStateAnalystsEmails',
+                        stateAnalystsEmailsResult.message
+                    )
+                    recordResolverError(span, stateAnalystsEmailsResult)
+                } else {
+                    stateAnalystsEmails = stateAnalystsEmailsResult.map(
+                        (u) => u.email
+                    )
+                }
+
+                const sendUndoWithdrawCMSEmail =
+                    await emailer.sendUndoWithdrawnSubmissionCMSEmail(
+                        contract,
+                        ratesForDisplay,
+                        stateAnalystsEmails
+                    )
+
+                const sendUndoWithdrawStateEmail =
+                    await emailer.sendUndoWithdrawnSubmissionStateEmail(
+                        contract,
+                        ratesForDisplay
+                    )
+
+                if (
+                    sendUndoWithdrawCMSEmail instanceof Error ||
+                    sendUndoWithdrawStateEmail instanceof Error
+                ) {
+                    let errMessage = ''
+
+                    if (sendUndoWithdrawCMSEmail instanceof Error) {
+                        errMessage = `CMS Email failed: ${sendUndoWithdrawCMSEmail.message}`
+                    }
+
+                    if (sendUndoWithdrawStateEmail instanceof Error) {
+                        errMessage = `State Email failed: ${sendUndoWithdrawStateEmail.message}`
+                    }
+
+                    logError('undoWithdrawContract', errMessage)
+                    throw new GraphQLError(errMessage, {
+                        extensions: {
+                            code: 'INTERNAL_SERVER_ERROR',
+                            cause: 'EMAIL_ERROR',
+                        },
+                    })
+                }
+
+                logSuccess('undoWithdrawContract')
+
+                return {
+                    contract: contract,
+                }
+            }
         )
-
-        if (stateAnalystsEmailsResult instanceof Error) {
-            logError(
-                'getStateAnalystsEmails',
-                stateAnalystsEmailsResult.message
-            )
-            setErrorAttributesOnActiveSpan(
-                stateAnalystsEmailsResult.message,
-                span
-            )
-        } else {
-            stateAnalystsEmails = stateAnalystsEmailsResult.map((u) => u.email)
-        }
-
-        const sendUndoWithdrawCMSEmail =
-            await emailer.sendUndoWithdrawnSubmissionCMSEmail(
-                contract,
-                ratesForDisplay,
-                stateAnalystsEmails
-            )
-
-        const sendUndoWithdrawStateEmail =
-            await emailer.sendUndoWithdrawnSubmissionStateEmail(
-                contract,
-                ratesForDisplay
-            )
-
-        if (
-            sendUndoWithdrawCMSEmail instanceof Error ||
-            sendUndoWithdrawStateEmail instanceof Error
-        ) {
-            let errMessage = ''
-
-            if (sendUndoWithdrawCMSEmail instanceof Error) {
-                errMessage = `CMS Email failed: ${sendUndoWithdrawCMSEmail.message}`
-            }
-
-            if (sendUndoWithdrawStateEmail instanceof Error) {
-                errMessage = `State Email failed: ${sendUndoWithdrawStateEmail.message}`
-            }
-
-            logError('undoWithdrawContract', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-            throw new GraphQLError(errMessage, {
-                extensions: {
-                    code: 'INTERNAL_SERVER_ERROR',
-                    cause: 'EMAIL_ERROR',
-                },
-            })
-        }
-
-        logSuccess('undoWithdrawContract')
-        setSuccessAttributesOnActiveSpan(span)
-
-        return {
-            contract: contract,
-        }
     }
 }

--- a/services/app-api/src/resolvers/contract/withdrawContract.test.ts
+++ b/services/app-api/src/resolvers/contract/withdrawContract.test.ts
@@ -33,6 +33,7 @@ import {
 import { testEmailConfig, testEmailer } from '../../testHelpers/emailerHelpers'
 import { sharedTestPrismaClient } from '../../testHelpers/storeHelpers'
 import { NewPostgresStore } from '../../postgres'
+import { testLDService } from '../../testHelpers/launchDarklyHelpers'
 
 const testRateFormInputData = (): RateFormDataInput => ({
     rateType: 'AMENDMENT',
@@ -1224,21 +1225,19 @@ describe('withdrawContract', () => {
         )
     })
 
-    it('cannot withdraw EQRO contract with NOT_SUBJECT_TO_REVIEW status', async () => {
+    it('cannot withdraw EQRO or CHIP-only HEALTH_PLAN contract with NOT_SUBJECT_TO_REVIEW status', async () => {
         const stateServer = await constructTestPostgresServer({
-            context: {
-                user: stateUser,
-            },
+            context: { user: stateUser },
+            ldService: testLDService({
+                'chip-submission-automation': true,
+            }),
         })
-
         const cmsServer = await constructTestPostgresServer({
-            context: {
-                user: cmsUser,
-            },
+            context: { user: cmsUser },
         })
 
-        // All-false EQRO provision fields trigger NOT_SUBJECT_TO_REVIEW on submit
-        const draft = await createAndUpdateTestEQROContract(
+        // EQRO: all-false provision fields trigger NOT_SUBJECT_TO_REVIEW on submit
+        const eqroDraft = await createAndUpdateTestEQROContract(
             stateServer,
             undefined,
             {
@@ -1249,27 +1248,54 @@ describe('withdrawContract', () => {
                 eqroProvisionMcoEqrOrRelatedActivities: null,
             }
         )
-
-        const submittedContract = await submitTestContract(
+        const eqroSubmitted = await submitTestContract(
             stateServer,
-            draft.id
+            eqroDraft.id
         )
-        expect(submittedContract.consolidatedStatus).toBe(
-            'NOT_SUBJECT_TO_REVIEW'
-        )
+        expect(eqroSubmitted.contractSubmissionType).toBe('EQRO')
+        expect(eqroSubmitted.consolidatedStatus).toBe('NOT_SUBJECT_TO_REVIEW')
 
-        const withdrawResult = await executeGraphQLOperation(cmsServer, {
+        const chipDraft = await createAndUpdateTestContractWithoutRates(
+            stateServer,
+            undefined,
+            {
+                submissionType: 'CONTRACT_ONLY',
+                populationCovered: 'CHIP',
+                federalAuthorities: ['TITLE_XXI'],
+            }
+        )
+        const chipSubmitted = await submitTestContract(
+            stateServer,
+            chipDraft.id
+        )
+        expect(chipSubmitted.contractSubmissionType).toBe('HEALTH_PLAN')
+        expect(chipSubmitted.consolidatedStatus).toBe('NOT_SUBJECT_TO_REVIEW')
+
+        const eqroWithdrawResult = await executeGraphQLOperation(cmsServer, {
             query: WithdrawContractDocument,
             variables: {
                 input: {
-                    contractID: submittedContract.id,
+                    contractID: eqroSubmitted.id,
                     updatedReason: 'withdraw submission',
                 },
             },
         })
+        expect(eqroWithdrawResult.errors).toBeDefined()
+        expect(eqroWithdrawResult.errors?.[0].message).toBe(
+            'Attempted to withdraw submission with invalid contract status of NOT_SUBJECT_TO_REVIEW'
+        )
 
-        expect(withdrawResult.errors).toBeDefined()
-        expect(withdrawResult.errors?.[0].message).toBe(
+        const chipWithdrawResult = await executeGraphQLOperation(cmsServer, {
+            query: WithdrawContractDocument,
+            variables: {
+                input: {
+                    contractID: chipSubmitted.id,
+                    updatedReason: 'withdraw submission',
+                },
+            },
+        })
+        expect(chipWithdrawResult.errors).toBeDefined()
+        expect(chipWithdrawResult.errors?.[0].message).toBe(
             'Attempted to withdraw submission with invalid contract status of NOT_SUBJECT_TO_REVIEW'
         )
     })

--- a/services/app-api/src/resolvers/contract/withdrawContract.test.ts
+++ b/services/app-api/src/resolvers/contract/withdrawContract.test.ts
@@ -12,6 +12,7 @@ import {
     approveTestContract,
     createAndUpdateTestContractWithoutRates,
     createAndUpdateTestContractWithRate,
+    createAndUpdateTestEQROContract,
     submitTestContract,
     unlockTestContract,
     withdrawTestContract,
@@ -23,6 +24,7 @@ import type { RateFormDataInput, RateStrippedEdge } from '../../gen/gqlClient'
 import {
     SubmitContractDocument,
     UpdateDraftContractRatesDocument,
+    WithdrawContractDocument,
 } from '../../gen/gqlClient'
 import {
     addNewRateToTestContract,
@@ -1219,6 +1221,124 @@ describe('withdrawContract', () => {
                     })
                 )
             )
+        )
+    })
+
+    it('cannot withdraw EQRO contract with NOT_SUBJECT_TO_REVIEW status', async () => {
+        const stateServer = await constructTestPostgresServer({
+            context: {
+                user: stateUser,
+            },
+        })
+
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+        })
+
+        // All-false EQRO provision fields trigger NOT_SUBJECT_TO_REVIEW on submit
+        const draft = await createAndUpdateTestEQROContract(
+            stateServer,
+            undefined,
+            {
+                eqroNewContractor: false,
+                eqroProvisionMcoNewOptionalActivity: false,
+                eqroProvisionNewMcoEqrRelatedActivities: false,
+                eqroProvisionChipEqrRelatedActivities: false,
+                eqroProvisionMcoEqrOrRelatedActivities: null,
+            }
+        )
+
+        const submittedContract = await submitTestContract(
+            stateServer,
+            draft.id
+        )
+        expect(submittedContract.consolidatedStatus).toBe(
+            'NOT_SUBJECT_TO_REVIEW'
+        )
+
+        const withdrawResult = await executeGraphQLOperation(cmsServer, {
+            query: WithdrawContractDocument,
+            variables: {
+                input: {
+                    contractID: submittedContract.id,
+                    updatedReason: 'withdraw submission',
+                },
+            },
+        })
+
+        expect(withdrawResult.errors).toBeDefined()
+        expect(withdrawResult.errors?.[0].message).toBe(
+            'Attempted to withdraw submission with invalid contract status of NOT_SUBJECT_TO_REVIEW'
+        )
+    })
+
+    it('can withdraw EQRO contract with SUBMITTED status', async () => {
+        const stateServer = await constructTestPostgresServer({
+            context: {
+                user: stateUser,
+            },
+        })
+
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+        })
+
+        // At least one EQRO provision field true -> UNDER_REVIEW / SUBMITTED
+        const draft = await createAndUpdateTestEQROContract(
+            stateServer,
+            undefined,
+            {
+                eqroNewContractor: true,
+                eqroProvisionMcoNewOptionalActivity: true,
+                eqroProvisionNewMcoEqrRelatedActivities: true,
+                eqroProvisionChipEqrRelatedActivities: true,
+                eqroProvisionMcoEqrOrRelatedActivities: null,
+            }
+        )
+
+        const submittedContract = await submitTestContract(
+            stateServer,
+            draft.id
+        )
+        expect(submittedContract.consolidatedStatus).toBe('SUBMITTED')
+
+        must(
+            await unlockTestContract(
+                cmsServer,
+                submittedContract.id,
+                'unlock EQRO submission'
+            )
+        )
+        const resubmittedContract = must(
+            await submitTestContract(
+                stateServer,
+                submittedContract.id,
+                'resubmit EQRO'
+            )
+        )
+        expect(resubmittedContract.consolidatedStatus).toBe('RESUBMITTED')
+
+        const withdrawnContract = await withdrawTestContract(
+            cmsServer,
+            resubmittedContract.id,
+            'withdraw EQRO submission'
+        )
+
+        expect(withdrawnContract.consolidatedStatus).toBe('WITHDRAWN')
+
+        const contractHistory = contractHistoryToDescriptions(withdrawnContract)
+        expect(contractHistory).toStrictEqual(
+            expect.arrayContaining([
+                'Initial submission',
+                'unlock EQRO submission',
+                'resubmit EQRO',
+                'Withdraw submission. withdraw EQRO submission',
+                'CMS withdrew the submission from review. withdraw EQRO submission',
+            ])
         )
     })
 })

--- a/services/app-api/src/resolvers/contract/withdrawContract.ts
+++ b/services/app-api/src/resolvers/contract/withdrawContract.ts
@@ -2,8 +2,9 @@ import type { Store } from '../../postgres'
 import { NotFoundError } from '../../postgres'
 import type { MutationResolvers } from '../../gen/gqlServer'
 import {
-    setErrorAttributesOnActiveSpan,
-    setResolverDetailsOnActiveSpan,
+    withResolverSpan,
+    setResolverDetails,
+    recordResolverError,
 } from '../attributeHelper'
 import { hasCMSPermissions } from '../../domain-models'
 import { logError } from '../../logger'
@@ -20,179 +21,178 @@ export function withdrawContract(
     documentZip: DocumentZipService
 ): MutationResolvers['withdrawContract'] {
     return async (_parent, { input }, context) => {
-        const { user, ctx, tracer } = context
-        const span = tracer?.startSpan('withdrawContract', {}, ctx)
-        setResolverDetailsOnActiveSpan('withdrawContract', user, span)
-
-        // Check OAuth client read permissions
-        if (!canOauthWrite(context)) {
-            const errMessage = `OAuth client does not have write permissions`
-            logError('withdrawContract', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-
-            throw new GraphQLError(errMessage, {
-                extensions: {
-                    code: 'FORBIDDEN',
-                    cause: 'INSUFFICIENT_OAUTH_GRANTS',
-                },
-            })
-        }
-
+        const { user } = context
         const { contractID, updatedReason } = input
-        span?.setAttribute('mcreview.package_id', contractID)
 
-        if (!hasCMSPermissions(user)) {
-            const message = 'user not authorized to withdraw a contract'
-            logError('withdrawContract', message)
-            setErrorAttributesOnActiveSpan(message, span)
-            throw createForbiddenError(message)
-        }
+        return withResolverSpan(
+            context,
+            'withdrawContract',
+            { 'mcreview.contract_id': contractID },
+            async (span) => {
+                setResolverDetails(span, user)
 
-        const contractWithHistory =
-            await store.findContractWithHistory(contractID)
+                // Check OAuth client read permissions
+                if (!canOauthWrite(context)) {
+                    const errMessage = `OAuth client does not have write permissions`
+                    logError('withdrawContract', errMessage)
 
-        if (contractWithHistory instanceof Error) {
-            if (contractWithHistory instanceof NotFoundError) {
-                const errMessage = `A contract must exist to be withdrawn: ${contractID}`
-                logError('withdrawContract', errMessage)
-                setErrorAttributesOnActiveSpan(errMessage, span)
-                throw createUserInputError(errMessage, 'contractID')
-            }
+                    throw new GraphQLError(errMessage, {
+                        extensions: {
+                            code: 'FORBIDDEN',
+                            cause: 'INSUFFICIENT_OAUTH_GRANTS',
+                        },
+                    })
+                }
 
-            const errMessage = `Issue finding a contract. Message: ${contractWithHistory.message}`
-            logError('withdrawContract', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-            throw new GraphQLError(errMessage, {
-                extensions: {
-                    code: 'INTERNAL_SERVER_ERROR',
-                    cause: 'DB_ERROR',
-                },
-            })
-        }
+                if (!hasCMSPermissions(user)) {
+                    const message = 'user not authorized to withdraw a contract'
+                    logError('withdrawContract', message)
+                    throw createForbiddenError(message)
+                }
 
-        if (
-            !['SUBMITTED', 'RESUBMITTED'].includes(
-                contractWithHistory.consolidatedStatus
-            )
-        ) {
-            const errMessage = `Attempted to withdraw submission with invalid contract status of ${contractWithHistory.consolidatedStatus}`
-            logError('withdrawContract', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-            throw createUserInputError(errMessage, 'contractID')
-        }
+                const contractWithHistory =
+                    await store.findContractWithHistory(contractID)
 
-        const withdrawResult = await store.withdrawContract({
-            contract: contractWithHistory,
-            updatedByID: user.id,
-            updatedReason,
-        })
+                if (contractWithHistory instanceof Error) {
+                    if (contractWithHistory instanceof NotFoundError) {
+                        const errMessage = `A contract must exist to be withdrawn: ${contractID}`
+                        logError('withdrawContract', errMessage)
+                        throw createUserInputError(errMessage, 'contractID')
+                    }
 
-        if (withdrawResult instanceof Error) {
-            const errMessage = `Failed to withdraw contract. ${withdrawResult.message}`
-            logError('withdrawSubmission', errMessage)
+                    const errMessage = `Issue finding a contract. Message: ${contractWithHistory.message}`
+                    logError('withdrawContract', errMessage)
+                    throw new GraphQLError(errMessage, {
+                        extensions: {
+                            code: 'INTERNAL_SERVER_ERROR',
+                            cause: 'DB_ERROR',
+                        },
+                    })
+                }
 
-            if (withdrawResult instanceof NotFoundError) {
-                throw new GraphQLError(errMessage, {
-                    extensions: {
-                        code: 'NOT_FOUND',
-                        cause: 'DB_ERROR',
-                    },
+                if (
+                    !['SUBMITTED', 'RESUBMITTED'].includes(
+                        contractWithHistory.consolidatedStatus
+                    )
+                ) {
+                    const errMessage = `Attempted to withdraw submission with invalid contract status of ${contractWithHistory.consolidatedStatus}`
+                    logError('withdrawContract', errMessage)
+                    throw createUserInputError(errMessage, 'contractID')
+                }
+
+                const withdrawResult = await store.withdrawContract({
+                    contract: contractWithHistory,
+                    updatedByID: user.id,
+                    updatedReason,
                 })
-            }
 
-            throw new GraphQLError(errMessage, {
-                extensions: {
-                    code: 'INTERNAL_SERVER_ERROR',
-                    cause: 'DB_ERROR',
-                },
-            })
-        }
+                if (withdrawResult instanceof Error) {
+                    const errMessage = `Failed to withdraw contract. ${withdrawResult.message}`
+                    logError('withdrawContract', errMessage)
 
-        const { withdrawnContract, ratesForDisplay } = withdrawResult
+                    if (withdrawResult instanceof NotFoundError) {
+                        throw new GraphQLError(errMessage, {
+                            extensions: {
+                                code: 'NOT_FOUND',
+                                cause: 'DB_ERROR',
+                            },
+                        })
+                    }
 
-        // Generate zips!
-        const contractZipRes = await documentZip.createContractZips(
-            withdrawnContract,
-            span
-        )
-        if (contractZipRes instanceof Error) {
-            const errMessage = `Failed to zip files for contract revision with ID: ${withdrawnContract.id}: ${contractZipRes.message}`
-            logError('submitContract', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-        }
-        const rateZipRes = await documentZip.createRateZips(
-            withdrawnContract,
-            span
-        )
-        if (rateZipRes instanceof Array) {
-            const errorMessage = `Failed to zip files for ${rateZipRes.length} rate revision(s) on contract ${withdrawnContract.id}`
-            logError('submitContract', errorMessage)
-            setErrorAttributesOnActiveSpan(errorMessage, span)
+                    throw new GraphQLError(errMessage, {
+                        extensions: {
+                            code: 'INTERNAL_SERVER_ERROR',
+                            cause: 'DB_ERROR',
+                        },
+                    })
+                }
 
-            rateZipRes.forEach((error, index) => {
-                logError(
-                    'submitContract',
-                    `Rate zip error ${index + 1}: ${error.message}`
+                const { withdrawnContract, ratesForDisplay } = withdrawResult
+
+                // Generate zips!
+                const contractZipRes = await documentZip.createContractZips(
+                    withdrawnContract,
+                    span
                 )
-            })
-        }
-        let stateAnalystsEmails: string[] = []
-        const stateAnalystsEmailsResult = await store.findStateAssignedUsers(
-            withdrawnContract.stateCode as StateCodeType
+                if (contractZipRes instanceof Error) {
+                    const errMessage = `Failed to zip files for contract revision with ID: ${withdrawnContract.id}: ${contractZipRes.message}`
+                    logError('withdrawContract', errMessage)
+                    recordResolverError(span, errMessage)
+                }
+                const rateZipRes = await documentZip.createRateZips(
+                    withdrawnContract,
+                    span
+                )
+                if (rateZipRes instanceof Array) {
+                    const errorMessage = `Failed to zip files for ${rateZipRes.length} rate revision(s) on contract ${withdrawnContract.id}`
+                    logError('withdrawContract', errorMessage)
+                    recordResolverError(span, errorMessage)
+
+                    rateZipRes.forEach((error, index) => {
+                        logError(
+                            'withdrawContract',
+                            `Rate zip error ${index + 1}: ${error.message}`
+                        )
+                    })
+                }
+                let stateAnalystsEmails: string[] = []
+                const stateAnalystsEmailsResult =
+                    await store.findStateAssignedUsers(
+                        withdrawnContract.stateCode as StateCodeType
+                    )
+
+                if (stateAnalystsEmailsResult instanceof Error) {
+                    logError(
+                        'getStateAnalystsEmails',
+                        stateAnalystsEmailsResult.message
+                    )
+                    recordResolverError(span, stateAnalystsEmailsResult)
+                } else {
+                    stateAnalystsEmails = stateAnalystsEmailsResult.map(
+                        (u) => u.email
+                    )
+                }
+
+                const sendWithdrawCMSEmail =
+                    await emailer.sendWithdrawnSubmissionCMSEmail(
+                        withdrawnContract,
+                        ratesForDisplay,
+                        stateAnalystsEmails
+                    )
+
+                const sendWithdrawStateEmail =
+                    await emailer.sendWithdrawnSubmissionStateEmail(
+                        withdrawnContract,
+                        ratesForDisplay
+                    )
+
+                if (
+                    sendWithdrawCMSEmail instanceof Error ||
+                    sendWithdrawStateEmail instanceof Error
+                ) {
+                    let errMessage = ''
+
+                    if (sendWithdrawCMSEmail instanceof Error) {
+                        errMessage = `CMS Email failed: ${sendWithdrawCMSEmail.message}`
+                    }
+
+                    if (sendWithdrawStateEmail instanceof Error) {
+                        errMessage = `State Email failed: ${sendWithdrawStateEmail.message}`
+                    }
+
+                    logError('withdrawContract', errMessage)
+                    throw new GraphQLError(errMessage, {
+                        extensions: {
+                            code: 'INTERNAL_SERVER_ERROR',
+                            cause: 'EMAIL_ERROR',
+                        },
+                    })
+                }
+
+                return {
+                    contract: withdrawnContract,
+                }
+            }
         )
-
-        if (stateAnalystsEmailsResult instanceof Error) {
-            logError(
-                'getStateAnalystsEmails',
-                stateAnalystsEmailsResult.message
-            )
-            setErrorAttributesOnActiveSpan(
-                stateAnalystsEmailsResult.message,
-                span
-            )
-        } else {
-            stateAnalystsEmails = stateAnalystsEmailsResult.map((u) => u.email)
-        }
-
-        const sendWithdrawCMSEmail =
-            await emailer.sendWithdrawnSubmissionCMSEmail(
-                withdrawnContract,
-                ratesForDisplay,
-                stateAnalystsEmails
-            )
-
-        const sendWithdrawStateEmail =
-            await emailer.sendWithdrawnSubmissionStateEmail(
-                withdrawnContract,
-                ratesForDisplay
-            )
-
-        if (
-            sendWithdrawCMSEmail instanceof Error ||
-            sendWithdrawStateEmail instanceof Error
-        ) {
-            let errMessage = ''
-
-            if (sendWithdrawCMSEmail instanceof Error) {
-                errMessage = `CMS Email failed: ${sendWithdrawCMSEmail.message}`
-            }
-
-            if (sendWithdrawStateEmail instanceof Error) {
-                errMessage = `State Email failed: ${sendWithdrawStateEmail.message}`
-            }
-
-            logError('withdrawContract', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-            throw new GraphQLError(errMessage, {
-                extensions: {
-                    code: 'INTERNAL_SERVER_ERROR',
-                    cause: 'EMAIL_ERROR',
-                },
-            })
-        }
-
-        return {
-            contract: withdrawnContract,
-        }
     }
 }

--- a/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.test.tsx
@@ -562,6 +562,390 @@ describe('EQROSubmissionSummary - Unlock submission button tests', () => {
         })
     })
 
+    describe('CMS User withdraw submission button', () => {
+        it('renders the withdraw button when EQRO submission is Submitted', async () => {
+            const contract = mockContractPackageSubmitted({
+                id: 'test-abc-123',
+                contractSubmissionType: 'EQRO',
+                status: 'SUBMITTED',
+                consolidatedStatus: 'SUBMITTED',
+            })
+
+            renderWithProviders(
+                <Routes>
+                    <Route element={<SubmissionSideNav />}>
+                        <Route
+                            path={RoutesRecord.SUBMISSIONS_SUMMARY}
+                            element={<EQROSubmissionSummary />}
+                        />
+                    </Route>
+                </Routes>,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                user: mockValidCMSUser(),
+                                statusCode: 200,
+                            }),
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
+                            }),
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
+                            }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: '/submissions/eqro/test-abc-123',
+                    },
+                    featureFlags: {
+                        [featureFlags.EQRO_SUBMISSIONS.flag]: true,
+                        [featureFlags.WITHDRAW_SUBMISSION.flag]: true,
+                        [featureFlags.UNDO_WITHDRAW_SUBMISSION.flag]: true,
+                    },
+                }
+            )
+
+            await waitFor(() => {
+                expect(
+                    screen.getByTestId('submission-summary')
+                ).toBeInTheDocument()
+            })
+
+            expect(
+                screen.getByRole('button', {
+                    name: 'Withdraw submission',
+                })
+            ).toHaveClass('usa-button')
+
+            // Undo withdraw should NOT be present on a submitted package
+            expect(
+                screen.queryByRole('button', {
+                    name: 'Undo submission withdraw',
+                })
+            ).not.toBeInTheDocument()
+        })
+
+        it('does not render the withdraw button when EQRO submission is not subject to review', async () => {
+            const contract = mockContractPackageSubmitted({
+                id: 'test-abc-123',
+                contractSubmissionType: 'EQRO',
+                status: 'SUBMITTED',
+                consolidatedStatus: 'NOT_SUBJECT_TO_REVIEW',
+            })
+
+            renderWithProviders(
+                <Routes>
+                    <Route element={<SubmissionSideNav />}>
+                        <Route
+                            path={RoutesRecord.SUBMISSIONS_SUMMARY}
+                            element={<EQROSubmissionSummary />}
+                        />
+                    </Route>
+                </Routes>,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                user: mockValidCMSUser(),
+                                statusCode: 200,
+                            }),
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
+                            }),
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
+                            }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: '/submissions/eqro/test-abc-123',
+                    },
+                    featureFlags: {
+                        [featureFlags.EQRO_SUBMISSIONS.flag]: true,
+                        [featureFlags.WITHDRAW_SUBMISSION.flag]: true,
+                        [featureFlags.UNDO_WITHDRAW_SUBMISSION.flag]: true,
+                    },
+                }
+            )
+
+            await waitFor(() => {
+                expect(
+                    screen.getByTestId('submission-summary')
+                ).toBeInTheDocument()
+            })
+
+            // Withdraw button is gated on SUBMITTED/RESUBMITTED consolidatedStatus
+            expect(
+                screen.queryByRole('button', {
+                    name: 'Withdraw submission',
+                })
+            ).not.toBeInTheDocument()
+
+            // Unlock is still allowed for NOT_SUBJECT_TO_REVIEW
+            expect(
+                screen.getByRole('button', {
+                    name: 'Unlock submission',
+                })
+            ).toBeInTheDocument()
+        })
+
+        it('does not render the withdraw button when EQRO submission is already withdrawn', async () => {
+            const contract = mockContractPackageSubmitted({
+                id: 'test-abc-123',
+                contractSubmissionType: 'EQRO',
+                status: 'SUBMITTED',
+            })
+            contract.reviewStatus = 'WITHDRAWN'
+            contract.consolidatedStatus = 'WITHDRAWN'
+
+            renderWithProviders(
+                <Routes>
+                    <Route element={<SubmissionSideNav />}>
+                        <Route
+                            path={RoutesRecord.SUBMISSIONS_SUMMARY}
+                            element={<EQROSubmissionSummary />}
+                        />
+                    </Route>
+                </Routes>,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                user: mockValidCMSUser(),
+                                statusCode: 200,
+                            }),
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
+                            }),
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
+                            }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: '/submissions/eqro/test-abc-123',
+                    },
+                    featureFlags: {
+                        [featureFlags.EQRO_SUBMISSIONS.flag]: true,
+                        [featureFlags.WITHDRAW_SUBMISSION.flag]: true,
+                        [featureFlags.UNDO_WITHDRAW_SUBMISSION.flag]: true,
+                    },
+                }
+            )
+
+            await waitFor(() => {
+                expect(
+                    screen.getByTestId('submission-summary')
+                ).toBeInTheDocument()
+            })
+
+            expect(
+                screen.queryByRole('button', {
+                    name: 'Withdraw submission',
+                })
+            ).not.toBeInTheDocument()
+
+            // Unlock is not allowed on a withdrawn submission either
+            expect(
+                screen.queryByRole('button', {
+                    name: 'Unlock submission',
+                })
+            ).not.toBeInTheDocument()
+        })
+    })
+
+    describe('CMS User undo withdraw submission button', () => {
+        it('renders the undo withdraw button when EQRO submission is Withdrawn', async () => {
+            const contract = mockContractPackageSubmitted({
+                id: 'test-abc-123',
+                contractSubmissionType: 'EQRO',
+                status: 'SUBMITTED',
+            })
+            contract.reviewStatus = 'WITHDRAWN'
+            contract.consolidatedStatus = 'WITHDRAWN'
+
+            renderWithProviders(
+                <Routes>
+                    <Route element={<SubmissionSideNav />}>
+                        <Route
+                            path={RoutesRecord.SUBMISSIONS_SUMMARY}
+                            element={<EQROSubmissionSummary />}
+                        />
+                    </Route>
+                </Routes>,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                user: mockValidCMSUser(),
+                                statusCode: 200,
+                            }),
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
+                            }),
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
+                            }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: '/submissions/eqro/test-abc-123',
+                    },
+                    featureFlags: {
+                        [featureFlags.EQRO_SUBMISSIONS.flag]: true,
+                        [featureFlags.WITHDRAW_SUBMISSION.flag]: true,
+                        [featureFlags.UNDO_WITHDRAW_SUBMISSION.flag]: true,
+                    },
+                }
+            )
+
+            await waitFor(() => {
+                expect(
+                    screen.getByTestId('submission-summary')
+                ).toBeInTheDocument()
+            })
+
+            expect(
+                screen.getByRole('button', {
+                    name: 'Undo submission withdraw',
+                })
+            ).toHaveClass('usa-button')
+
+            // "No action" message should not render when the undo button is available
+            expect(
+                screen.queryByText(
+                    'No action can be taken on this submission in its current status.'
+                )
+            ).not.toBeInTheDocument()
+        })
+
+        it('does not render the undo withdraw button when EQRO submission is Submitted', async () => {
+            const contract = mockContractPackageSubmitted({
+                id: 'test-abc-123',
+                contractSubmissionType: 'EQRO',
+                status: 'SUBMITTED',
+                consolidatedStatus: 'SUBMITTED',
+            })
+
+            renderWithProviders(
+                <Routes>
+                    <Route element={<SubmissionSideNav />}>
+                        <Route
+                            path={RoutesRecord.SUBMISSIONS_SUMMARY}
+                            element={<EQROSubmissionSummary />}
+                        />
+                    </Route>
+                </Routes>,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                user: mockValidCMSUser(),
+                                statusCode: 200,
+                            }),
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
+                            }),
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
+                            }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: '/submissions/eqro/test-abc-123',
+                    },
+                    featureFlags: {
+                        [featureFlags.EQRO_SUBMISSIONS.flag]: true,
+                        [featureFlags.WITHDRAW_SUBMISSION.flag]: true,
+                        [featureFlags.UNDO_WITHDRAW_SUBMISSION.flag]: true,
+                    },
+                }
+            )
+
+            await waitFor(() => {
+                expect(
+                    screen.getByTestId('submission-summary')
+                ).toBeInTheDocument()
+            })
+
+            expect(
+                screen.queryByRole('button', {
+                    name: 'Undo submission withdraw',
+                })
+            ).not.toBeInTheDocument()
+        })
+
+        it('renders withdraw and unlock but not undo withdraw after the withdraw has been undone', async () => {
+            const contract = mockContractPackageSubmitted({
+                id: 'test-abc-123',
+                contractSubmissionType: 'EQRO',
+                status: 'RESUBMITTED',
+            })
+            contract.reviewStatus = 'UNDER_REVIEW'
+            contract.consolidatedStatus = 'RESUBMITTED'
+
+            renderWithProviders(
+                <Routes>
+                    <Route element={<SubmissionSideNav />}>
+                        <Route
+                            path={RoutesRecord.SUBMISSIONS_SUMMARY}
+                            element={<EQROSubmissionSummary />}
+                        />
+                    </Route>
+                </Routes>,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                user: mockValidCMSUser(),
+                                statusCode: 200,
+                            }),
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
+                            }),
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
+                            }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: '/submissions/eqro/test-abc-123',
+                    },
+                    featureFlags: {
+                        [featureFlags.EQRO_SUBMISSIONS.flag]: true,
+                        [featureFlags.WITHDRAW_SUBMISSION.flag]: true,
+                        [featureFlags.UNDO_WITHDRAW_SUBMISSION.flag]: true,
+                    },
+                }
+            )
+
+            await waitFor(() => {
+                expect(
+                    screen.getByTestId('submission-summary')
+                ).toBeInTheDocument()
+            })
+
+            expect(
+                screen.getByRole('button', {
+                    name: 'Withdraw submission',
+                })
+            ).toHaveClass('usa-button')
+
+            expect(
+                screen.getByRole('button', {
+                    name: 'Unlock submission',
+                })
+            ).toHaveClass('usa-button')
+
+            expect(
+                screen.queryByRole('button', {
+                    name: 'Undo submission withdraw',
+                })
+            ).not.toBeInTheDocument()
+        })
+    })
+
     describe('NEW tag on review determination change', () => {
         it('shows NEW tag when review determination changes on resubmission', async () => {
             const contract = mockContractPackageSubmitted({

--- a/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.tsx
@@ -1,16 +1,19 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { usePage } from '../../../contexts/PageContext'
 import { GridContainer, Link, Grid, ModalRef } from '@trussworks/react-uswds'
-import { Navigate } from 'react-router-dom'
+import { Navigate, useNavigate, useSearchParams } from 'react-router-dom'
 import { useAuth } from '../../../contexts/AuthContext'
 import { useMemoizedStateHeader, useRouteParams } from '../../../hooks'
 import { hasCMSUserPermissions, toGQLError } from '@mc-review/helpers'
+import { useLDClient } from 'launchdarkly-react-client-sdk'
+import { featureFlags } from '@mc-review/common-code'
 import {
     FetchContractWithQuestionsDocument,
     UpdateInformation,
 } from '../../../gen/gqlClient'
 import { useQuery } from '@apollo/client/react'
 import {
+    ButtonWithLogging,
     DocumentWarningBanner,
     LinkWithLogging,
     Loading,
@@ -19,7 +22,9 @@ import {
 } from '../../../components'
 import {
     EqroReviewDeterminationBanners,
+    StatusUpdatedBanner,
     SubmissionUnlockedBanner,
+    SubmissionWithdrawnBanner,
 } from '../../../components/Banner'
 import { ModalOpenButton, UnlockSubmitModal } from '../../../components/Modal'
 import { ErrorForbiddenPage } from '../../Errors/ErrorForbiddenPage'
@@ -40,11 +45,26 @@ export const EQROSubmissionSummary = (): React.ReactElement => {
     // Page level state
     const { updateHeading, updateActiveMainContent } = usePage()
     const [documentError, setDocumentError] = useState(false)
+    const [showTempUndoWithdrawBanner, setShowTempUndoWithdrawBanner] =
+        useState<boolean>(false)
+    const [searchParams, setSearchParams] = useSearchParams()
     const { loggedInUser } = useAuth()
     const { id } = useRouteParams()
     const hasCMSPermissions = hasCMSUserPermissions(loggedInUser)
     const isStateUser = loggedInUser?.role === 'STATE_USER'
     const isHelpDeskUser = loggedInUser?.role === 'HELPDESK_USER'
+    const navigate = useNavigate()
+    const ldClient = useLDClient()
+
+    const withdrawSubmissionFlag = ldClient?.variation(
+        featureFlags.WITHDRAW_SUBMISSION.flag,
+        featureFlags.WITHDRAW_SUBMISSION.defaultValue
+    )
+
+    const undoWithdrawSubmissionFlag = ldClient?.variation(
+        featureFlags.UNDO_WITHDRAW_SUBMISSION.flag,
+        featureFlags.UNDO_WITHDRAW_SUBMISSION.defaultValue
+    )
 
     const modalRef = useRef<ModalRef>(null)
 
@@ -73,6 +93,16 @@ export const EQROSubmissionSummary = (): React.ReactElement => {
         stateName: contract?.state.name,
         contractType: contract?.contractSubmissionType,
     })
+
+    useEffect(() => {
+        if (searchParams.get('showTempUndoWithdrawBanner') === 'true') {
+            setShowTempUndoWithdrawBanner(true)
+
+            //This ensures the banner goes away upon refresh or navigation
+            searchParams.delete('showTempUndoWithdrawBanner')
+            setSearchParams(searchParams, { replace: true })
+        }
+    }, [searchParams, setSearchParams])
 
     // Setting app wide variables
     useLayoutEffect(() => {
@@ -137,12 +167,32 @@ export const EQROSubmissionSummary = (): React.ReactElement => {
         }
     }
 
+    const latestContractAction = contract.reviewStatusActions?.[0]
+
     const showUnlockBtn =
         hasCMSPermissions &&
         ['SUBMITTED', 'RESUBMITTED', 'NOT_SUBJECT_TO_REVIEW'].includes(
             consolidatedStatus
         )
-    const showNoActionsMsg = !showUnlockBtn
+    const showWithdrawBtn =
+        hasCMSPermissions &&
+        withdrawSubmissionFlag &&
+        ['SUBMITTED', 'RESUBMITTED'].includes(consolidatedStatus)
+    const showUndoWithdrawBtn =
+        hasCMSPermissions &&
+        undoWithdrawSubmissionFlag &&
+        consolidatedStatus === 'WITHDRAWN'
+    const showNoActionsMsg =
+        !showUnlockBtn && !showWithdrawBtn && !showUndoWithdrawBtn
+    const showWithdrawnBanner =
+        withdrawSubmissionFlag &&
+        consolidatedStatus === 'WITHDRAWN' &&
+        latestContractAction
+    const undoWithdrawAction =
+        latestContractAction?.actionType === 'UNDER_REVIEW' &&
+        contract.reviewStatusActions?.[1]?.actionType === 'WITHDRAW'
+    const showPermUndoWithdrawBanner =
+        undoWithdrawAction && undoWithdrawSubmissionFlag && isStateUser
 
     // Get the correct update info depending on the submission status
     let updateInfo: UpdateInformation | undefined = undefined
@@ -177,6 +227,28 @@ export const EQROSubmissionSummary = (): React.ReactElement => {
     }
 
     const renderStatusAlerts = () => {
+        if (showTempUndoWithdrawBanner) {
+            return <StatusUpdatedBanner className={styles.banner} />
+        }
+
+        if (showWithdrawnBanner && latestContractAction.updatedBy) {
+            return (
+                <SubmissionWithdrawnBanner
+                    className={styles.banner}
+                    withdrawInfo={{
+                        updatedReason:
+                            latestContractAction?.updatedReason ?? '',
+                        updatedAt: latestContractAction.updatedAt,
+                        updatedBy: latestContractAction.updatedBy,
+                    }}
+                />
+            )
+        }
+
+        if (showPermUndoWithdrawBanner) {
+            return <StatusUpdatedBanner className={styles.banner} />
+        }
+
         if (isUnlocked && updateInfo) {
             return (
                 <SubmissionUnlockedBanner
@@ -249,6 +321,53 @@ export const EQROSubmissionSummary = (): React.ReactElement => {
                                     >
                                         Unlock submission
                                     </ModalOpenButton>
+                                )}
+                                {showWithdrawBtn && (
+                                    <ButtonWithLogging
+                                        type="button"
+                                        outline
+                                        className="usa-button"
+                                        onClick={() =>
+                                            navigate(
+                                                getSubmissionPath(
+                                                    'SUBMISSION_WITHDRAW',
+                                                    contractSubmissionType,
+                                                    contract.id
+                                                )
+                                            )
+                                        }
+                                        link_url={getSubmissionPath(
+                                            'SUBMISSION_WITHDRAW',
+                                            contractSubmissionType,
+                                            contract.id
+                                        )}
+                                    >
+                                        Withdraw submission
+                                    </ButtonWithLogging>
+                                )}
+                                {showUndoWithdrawBtn && (
+                                    <ButtonWithLogging
+                                        className="usa-button usa-button--outline"
+                                        type="button"
+                                        outline
+                                        onClick={() =>
+                                            navigate(
+                                                getSubmissionPath(
+                                                    'UNDO_SUBMISSION_WITHDRAW',
+                                                    contractSubmissionType,
+                                                    contract.id
+                                                )
+                                            )
+                                        }
+                                        link_url={getSubmissionPath(
+                                            'UNDO_SUBMISSION_WITHDRAW',
+                                            contractSubmissionType,
+                                            contract.id
+                                        )}
+                                        style={{ width: '16rem' }}
+                                    >
+                                        Undo submission withdraw
+                                    </ButtonWithLogging>
                                 )}
                             </MultiColumnGrid>
                         )}


### PR DESCRIPTION
## Summary
Add withdraw and undo withdraw UI for EQRO submissions. The API was already capable of doing this, I just added unit tests.

I also refactored the otel logging to use the wrapper function in withdraw and undo withdraw resolvers.

[MCR-5858](https://jiraent.cms.gov/browse/MCR-5858)
- AC:
   - Withdraw submission button appears in the "Actions" section of the Submission Summary on submissions which are in the status of "Submitted"
   - Clicking "Withdraw submission" button routes the user to the "Withdraw submission" page
   - "Withdraw submission" page will display and function for EQROs in the same manner as it currently does for Health Plans
      - Error state occurs when no reason is provided but the user clicks the "Withdraw submission" button
      - When clicked, the "Cancel" button returns user to the submission summary page and does not change the submission status
      - When reason for withdrawing is included and the "Withdraw submission" button is clicked then the user is returned to the submission summary page for the submission and:
          - The "Status Updated" banner will be displayed
          - The "Undo submission withdraw" button will be available in the actions section of the page
- This functionality should be behind the [eqro-submissions] feature flag until all EQRO work is ready to be used in production.

[MCR-5861](https://jiraent.cms.gov/browse/MCR-5861)
- AC:
   - "Undo submission withdraw" button appears in the "Actions" section of the Submission Summary on submissions which are in the status of "Withdrawn"
   - Clicking "Undo submission withdraw" button routes the user to the "Undo submission withdraw" page
   - "Undo submission withdraw" page will display and function for EQROs in the same manner as it currently does for Health Plans
      - Error state occurs when no reason is provided but the user clicks the "Undo withdraw" button
      - When clicked, the "Cancel" button returns user to the submission summary page and does not change the submission status
      - When reason for undoing the submission withdraw is included and the "Undo withdraw" button is clicked then the user is returned to the submission summary page for the submission and:
          - The "Status Updated" banner will be displayed
          - The submission status will be updated to "Submitted"
          - The "Withdraw submission" button will be available in the actions section of the page
- This functionality should remain behind the [eqro-submissions] feature flag until EQROs are ready to be submitted in production

#### Related issues

#### Screenshots

#### Test cases covered

- `withdrawContract.test.ts` - resolver
   - `'can undo withdraw EQRO contract'`
   -  `'cannot withdraw EQRO or CHIP-only HEALTH_PLAN contract with NOT_SUBJECT_TO_REVIEW status'` 
- `undoWithdrawContract.test.ts` - resolver
   - `'can undo withdraw EQRO contract'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
- Go the workflows and test out permutations of what can be done. IE: the submit -> unlock -> resubmit -withdraw -undo withdraw - unlock - resubmit - withdraw - approve

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed