### PR TITLE
MCR-5859 & 6067: EQRO submission withdraw emails

### DIFF
--- a/services/app-api/src/emailer/emails/sendWithdrawnSubmissionCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/sendWithdrawnSubmissionCMSEmail.test.ts
@@ -1,5 +1,6 @@
 import {
     mockContract,
+    mockEQROContract,
     testEmailConfig,
     testStateAnalystsEmails,
 } from '../../testHelpers/emailerHelpers'
@@ -73,6 +74,69 @@ describe('sendWithdrawnSubmissionCMSEmail', () => {
 
         expect(template.bodyHTML).toMatchSnapshot()
     })
+
+    const withdrawReviewStatusActions = [
+        {
+            updatedAt: new Date('2025-04-10'),
+            updatedBy: {
+                role: 'CMS_USER' as const,
+                email: 'zuko@example.com',
+                givenName: 'Zuko',
+                familyName: 'Hotman',
+            },
+            updatedReason: 'Test Withdraw',
+            dateApprovalReleasedToState: undefined,
+            actionType: 'WITHDRAW' as const,
+            contractID: 'test-contract-123',
+        },
+    ]
+
+    it.each([
+        {
+            submissionType: 'HEALTH_PLAN' as const,
+            contract: mockContract({
+                id: 'test-contract-123',
+                consolidatedStatus: 'WITHDRAWN',
+                reviewStatusActions: withdrawReviewStatusActions,
+            }),
+            expectedPath: '/submissions/health-plan/test-contract-123',
+            excludedPath: '/submissions/eqro/',
+        },
+        {
+            submissionType: 'EQRO' as const,
+            contract: mockEQROContract({
+                id: 'test-contract-123',
+
+                consolidatedStatus: 'WITHDRAWN',
+                reviewStatusActions: withdrawReviewStatusActions,
+            }),
+            expectedPath: '/submissions/eqro/test-contract-123',
+            excludedPath: '/submissions/health-plan/',
+        },
+    ])(
+        'CMS email contains correct submission summary URL for $submissionType contract',
+        async ({ contract, expectedPath, excludedPath }) => {
+            const template = await sendWithdrawnSubmissionCMSEmail(
+                contract,
+                testRatesForDisplay,
+                stateAnalystEmails(),
+                testEmailConfig()
+            )
+
+            if (template instanceof Error) {
+                throw template
+            }
+
+            expect(template.bodyHTML).toEqual(
+                expect.stringContaining(
+                    `${testEmailConfig().baseUrl}${expectedPath}`
+                )
+            )
+            expect(template.bodyHTML).toEqual(
+                expect.not.stringContaining(excludedPath)
+            )
+        }
+    )
 })
 
 describe('sendWithdrawnSubmissionCMSEmail error handling', () => {

--- a/services/app-api/src/emailer/emails/sendWithdrawnSubmissionCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/sendWithdrawnSubmissionCMSEmail.ts
@@ -18,13 +18,18 @@ export const sendWithdrawnSubmissionCMSEmail = async (
     stateAnalystsEmails: StateAnalystsEmails,
     config: EmailConfiguration
 ): Promise<EmailData | Error> => {
-    const toAddresses = pruneDuplicateEmails([
-        ...stateAnalystsEmails,
-        ...config.dmcpSubmissionEmails,
-        ...config.oactEmails,
-        ...config.dmcoEmails,
-        ...config.devReviewTeamEmails,
-    ])
+    const receiverEmails = [...config.dmcoEmails, ...config.devReviewTeamEmails]
+
+    // Non-EQRO contracts also notify state analysts, DMCP, and OACT
+    if (withdrawnContract.contractSubmissionType !== 'EQRO') {
+        receiverEmails.push(
+            ...stateAnalystsEmails,
+            ...config.dmcpSubmissionEmails,
+            ...config.oactEmails
+        )
+    }
+
+    const toAddresses = pruneDuplicateEmails(receiverEmails)
 
     const etaData = parseEmailDataWithdrawSubmission(
         withdrawnContract,

--- a/services/app-api/src/emailer/emails/sendWithdrawnSubmissionStateEmail.test.ts
+++ b/services/app-api/src/emailer/emails/sendWithdrawnSubmissionStateEmail.test.ts
@@ -1,4 +1,8 @@
-import { mockContract, testEmailConfig } from '../../testHelpers/emailerHelpers'
+import {
+    mockContract,
+    mockEQROContract,
+    testEmailConfig,
+} from '../../testHelpers/emailerHelpers'
 import { sendWithdrawnSubmissionStateEmail } from './sendWithdrawnSubmissionStateEmail'
 
 const testContract = mockContract({
@@ -65,4 +69,65 @@ describe('sendWithdrawnSubmissionStateEmail', () => {
 
         expect(template.bodyHTML).toMatchSnapshot()
     })
+
+    const withdrawReviewStatusActions = [
+        {
+            updatedAt: new Date('2025-04-10'),
+            updatedBy: {
+                role: 'CMS_USER' as const,
+                email: 'zuko@example.com',
+                givenName: 'Zuko',
+                familyName: 'Hotman',
+            },
+            updatedReason: 'Test Withdraw',
+            dateApprovalReleasedToState: undefined,
+            actionType: 'WITHDRAW' as const,
+            contractID: 'test-contract-123',
+        },
+    ]
+
+    it.each([
+        {
+            submissionType: 'HEALTH_PLAN' as const,
+            contract: mockContract({
+                id: 'test-contract-123',
+                consolidatedStatus: 'WITHDRAWN',
+                reviewStatusActions: withdrawReviewStatusActions,
+            }),
+            expectedPath: '/submissions/health-plan/test-contract-123',
+            excludedPath: '/submissions/eqro/',
+        },
+        {
+            submissionType: 'EQRO' as const,
+            contract: mockEQROContract({
+                id: 'test-contract-123',
+                consolidatedStatus: 'WITHDRAWN',
+                reviewStatusActions: withdrawReviewStatusActions,
+            }),
+            expectedPath: '/submissions/eqro/test-contract-123',
+            excludedPath: '/submissions/health-plan/',
+        },
+    ])(
+        'State email contains correct submission summary URL for $submissionType contract',
+        async ({ contract, expectedPath, excludedPath }) => {
+            const template = await sendWithdrawnSubmissionStateEmail(
+                contract,
+                testRatesForDisplay,
+                testEmailConfig()
+            )
+
+            if (template instanceof Error) {
+                throw template
+            }
+
+            expect(template.bodyHTML).toEqual(
+                expect.stringContaining(
+                    `${testEmailConfig().baseUrl}${expectedPath}`
+                )
+            )
+            expect(template.bodyHTML).toEqual(
+                expect.not.stringContaining(excludedPath)
+            )
+        }
+    )
 })

--- a/services/app-api/src/resolvers/contract/withdrawContract.test.ts
+++ b/services/app-api/src/resolvers/contract/withdrawContract.test.ts
@@ -1059,6 +1059,102 @@ describe('withdrawContract', () => {
         )
     })
 
+    it('sends emails only to DMCO and dev review team when an EQRO submission is withdrawn', async () => {
+        const emailConfig = testEmailConfig()
+        const mockEmailer = testEmailer()
+        const stateUser = testStateUser()
+        const cmsUser = testCMSUser()
+        const stateServer = await constructTestPostgresServer({
+            context: {
+                user: stateUser,
+            },
+        })
+
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+            emailer: mockEmailer,
+        })
+
+        const draft = await createAndUpdateTestEQROContract(
+            stateServer,
+            undefined,
+            {
+                eqroNewContractor: true,
+                eqroProvisionMcoNewOptionalActivity: true,
+                eqroProvisionNewMcoEqrRelatedActivities: true,
+                eqroProvisionChipEqrRelatedActivities: true,
+                eqroProvisionMcoEqrOrRelatedActivities: null,
+            }
+        )
+
+        const submittedContract = await submitTestContract(
+            stateServer,
+            draft.id
+        )
+        expect(submittedContract.contractSubmissionType).toBe('EQRO')
+        expect(submittedContract.consolidatedStatus).toBe('SUBMITTED')
+
+        const withdrawnContract = await withdrawTestContract(
+            cmsServer,
+            submittedContract.id,
+            'withdraw EQRO submission'
+        )
+
+        const contractName =
+            withdrawnContract.packageSubmissions[0].contractRevision
+                .contractName
+
+        // CMS email (first call): only DMCO + dev review team
+        expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({
+                subject: expect.stringContaining(
+                    `${contractName} was withdrawn by CMS`
+                ),
+                sourceEmail: emailConfig.emailSource,
+                toAddresses: expect.arrayContaining([
+                    ...emailConfig.dmcoEmails,
+                    ...emailConfig.devReviewTeamEmails,
+                ]),
+                bodyHTML: expect.stringContaining(contractName),
+            })
+        )
+
+        // Confirm EQRO-excluded recipients are not included
+        expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({
+                toAddresses: expect.not.arrayContaining([
+                    ...emailConfig.dmcpSubmissionEmails,
+                    ...emailConfig.oactEmails,
+                ]),
+            })
+        )
+
+        // State email (second call): includes state contacts + dev review team
+        const stateReceiverEmails =
+            withdrawnContract.packageSubmissions[0].contractRevision.formData.stateContacts.map(
+                (contact) => contact.email
+            )
+
+        expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                subject: expect.stringContaining(
+                    `${contractName} was withdrawn by CMS`
+                ),
+                sourceEmail: emailConfig.emailSource,
+                toAddresses: expect.arrayContaining([
+                    ...stateReceiverEmails,
+                    ...emailConfig.devReviewTeamEmails,
+                ]),
+                bodyHTML: expect.stringContaining(contractName),
+            })
+        )
+    })
+
     it('can withdraw and undo withdraw contract and rate submission with rate overrides', async () => {
         const prismaClient = await sharedTestPrismaClient()
         const store = NewPostgresStore(prismaClient)


### PR DESCRIPTION
## Summary
[MCR-5859](https://jiraent.cms.gov/browse/MCR-5859)
[MCR-6067](https://jiraent.cms.gov/browse/MCR-6067)

CMS Email AC:
- CMS user receives email reflecting that the EQRO submission was withdrawn
- Email will include:
   - Withdrawn by [user]
   - Withdrawn on [date]
   - Reason for withdrawal: [as entered by user in modal]
   - Link to allow the user to View submission in MC-Review
- The CMS users will be limited to DMCO (i.e. the DMCO email (MCGDMCOActions@cms.hhs.gov) and the assigned DMCO users

State Email AC:
- State user receives email reflecting that the EQRO submission was withdrawn
- Email will include:
   - Withdrawn by [user]
   - Withdrawn on [date]
   - Reason for withdrawal: [as entered by user in modal]
   - Statement, "If you have any questions, please reach out to your CMS point of contact."
   - Link to allow the user to View submission in MC-Review

#### Related issues

#### Screenshots

State email
<img width="600" alt="Screenshot 2026-04-22 at 11 52 07 PM" src="https://github.com/user-attachments/assets/e05ffc99-cc5f-4f40-8395-77052bcc65a5" />

CMS email
<img width="600" alt="Screenshot 2026-04-22 at 11 52 44 PM" src="https://github.com/user-attachments/assets/5e1f870e-75d7-4f90-8b55-f2d184d4732d" />

<img width="600" alt="Screenshot 2026-04-22 at 11 52 52 PM" src="https://github.com/user-attachments/assets/b196f208-d62a-4cef-a57c-e848359b931d" />


#### Test cases covered

- `sendWithdrawnSubmissionStateEmaik.test.ts`
   - `'State email contains correct submission summary URL for $submissionType contract'`
      - Runs a test on an array of data, this allows upcoming EB submissions to be added to it.
- `sendWithdrawnSubmissionCMSEmail.test.ts`
   - `'CMS email contains correct submission summary URL for $submissionType contract'`
      - Runs a test on an array of data, this allows upcoming EB submissions to be added to it.
- `withdrawContract.test.ts` - resolver
   - `'sends emails only to DMCO and dev review team when an EQRO submission is withdrawn'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
- Withdraw a EQRO submission and review the emails

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders