### PR TITLE
MCR-5861: Allow not subject to review to be withdrawn

### DIFF
--- a/API_Changelog.md
+++ b/API_Changelog.md
@@ -1,6 +1,11 @@
 # Managed Care Review - API Changelog
 ## This document highlights API changes that have been introduced since May 2025. See the full [GraphQL schema](services/app-graphql/src/schema.graphql).
 
+### April 24, 2026
+#### Updated
+- **`withdrawContract`** endpoint now accepts contracts with a consolidated status of `NOT_SUBJECT_TO_REVIEW` in addition to `SUBMITTED` and `RESUBMITTED`. Applies to EQRO submissions with no review-triggering provisions and CHIP-only `HEALTH_PLAN` submissions.
+- **`undoWithdrawContract`** endpoint re-runs review determination after undoing a withdrawal. Submissions that qualify as `NOT_SUBJECT_TO_REVIEW` (EQRO with no review-triggering provisions, CHIP-only `HEALTH_PLAN`) are restored to `NOT_SUBJECT_TO_REVIEW` rather than `UNDER_REVIEW`.
+
 ### April 20, 2026
 #### Updated
 - **`indexRates`** endpoint updated to accept an optional `rateIDs` parameter (via `IndexRatesInput`):

--- a/packages/submissions/src/contract/healthPlanFormDataValidtions.ts
+++ b/packages/submissions/src/contract/healthPlanFormDataValidtions.ts
@@ -1,4 +1,9 @@
-import { Contract, ContractRevision, UnlockedContract } from '../gen/gqlClient'
+import {
+    Contract,
+    ContractFormData,
+    ContractRevision,
+    UnlockedContract,
+} from '../gen/gqlClient'
 import { getLastContractSubmission } from './contractHelpers'
 import {
     CHIPProvisionType,
@@ -220,6 +225,18 @@ const isMissingProvisions = (
     )
 }
 
+/**
+ * Returns a review determination for a HEALTH_PLAN submission based on form data.
+ *
+ * @param formData - formData of the HEALTH_PLAN submission
+ * @returns {true} - HEALTH_PLAN submission is subject to review
+ * @returns {false} - HEALTH_PLAN submission is not subject to review (CHIP-only)
+ */
+const healthPlanReviewDetermination = (formData: ContractFormData): boolean => {
+    const isChipOnly = formData.populationCovered === 'CHIP'
+    return !isChipOnly
+}
+
 /*
     Returns lang string dictionary for variant
 */
@@ -254,4 +271,5 @@ export {
     generateApplicableProvisionsList,
     generateProvisionLabel,
     isMissingProvisions,
+    healthPlanReviewDetermination,
 }

--- a/services/app-api/src/domain-models/contractAndRates/contractReviewActionType.ts
+++ b/services/app-api/src/domain-models/contractAndRates/contractReviewActionType.ts
@@ -20,7 +20,8 @@ const contractReviewActionSchema = z.object({
 
 type ContractReviewActionType = z.infer<typeof contractReviewActionSchema>
 type PackageStatusType = z.infer<typeof contractSchema.shape.status>
+type ReviewActionTypes = z.infer<typeof contractReviewActionTypeSchema>
 
-export type { PackageStatusType, ContractReviewActionType }
+export type { PackageStatusType, ContractReviewActionType, ReviewActionTypes }
 
 export { contractReviewActionSchema }

--- a/services/app-api/src/emailer/emails/sendUndoWithdrawnSubmissionCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/sendUndoWithdrawnSubmissionCMSEmail.test.ts
@@ -104,7 +104,7 @@ describe('sendUndoWithdrawnSubmissionCMSEmail error handling', () => {
 
         expect(template).toBeInstanceOf(Error)
         expect((template as Error).message).toBe(
-            'Contract consolidated status should be RESUBMITTED'
+            'Contract consolidated status is incorrect for UNDO_WITHDRAW email. Consolidated status: WITHDRAWN'
         )
     })
 
@@ -123,7 +123,7 @@ describe('sendUndoWithdrawnSubmissionCMSEmail error handling', () => {
 
         expect(template).toBeInstanceOf(Error)
         expect((template as Error).message).toBe(
-            'Latest contract review action is not UNDER_REVIEW'
+            'Latest contract review action is incorrect for UNDO_WITHDRAW email. Contract action: undefined'
         )
     })
 
@@ -156,7 +156,7 @@ describe('sendUndoWithdrawnSubmissionCMSEmail error handling', () => {
 
         expect(template).toBeInstanceOf(Error)
         expect((template as Error).message).toBe(
-            'Latest contract review action is not UNDER_REVIEW'
+            'Latest contract review action is incorrect for UNDO_WITHDRAW email. Contract action: WITHDRAW'
         )
     })
 })

--- a/services/app-api/src/emailer/emails/sendWithdrawnSubmissionCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/sendWithdrawnSubmissionCMSEmail.test.ts
@@ -155,7 +155,7 @@ describe('sendWithdrawnSubmissionCMSEmail error handling', () => {
 
         expect(template).toBeInstanceOf(Error)
         expect((template as Error).message).toBe(
-            'Contract consolidated status should be WITHDRAWN'
+            'Contract consolidated status is incorrect for WITHDRAW email. Consolidated status: RESUBMITTED'
         )
     })
 
@@ -174,7 +174,7 @@ describe('sendWithdrawnSubmissionCMSEmail error handling', () => {
 
         expect(template).toBeInstanceOf(Error)
         expect((template as Error).message).toBe(
-            'Latest contract review action is not WITHDRAW'
+            'Latest contract review action is incorrect for WITHDRAW email. Contract action: undefined'
         )
     })
 
@@ -207,7 +207,7 @@ describe('sendWithdrawnSubmissionCMSEmail error handling', () => {
 
         expect(template).toBeInstanceOf(Error)
         expect((template as Error).message).toBe(
-            'Latest contract review action is not WITHDRAW'
+            'Latest contract review action is incorrect for WITHDRAW email. Contract action: UNDER_REVIEW'
         )
     })
 })

--- a/services/app-api/src/emailer/templateHelpers.ts
+++ b/services/app-api/src/emailer/templateHelpers.ts
@@ -18,6 +18,8 @@ import { findStatePrograms, packageName } from '@mc-review/submissions'
 import { rateSummaryURL, submissionSummaryURL } from './generateURLs'
 import { formatCalendarDate } from '@mc-review/dates'
 import type { SubmissionType } from '../gen/gqlServer'
+import type { ConsolidatedContractStatusType } from '../domain-models/contractAndRates'
+import type { ReviewActionTypes } from '../domain-models/contractAndRates/contractReviewActionType'
 
 // ETA SETUP
 Eta.configure({
@@ -390,22 +392,31 @@ const parseEmailDataWithdrawSubmission = (
     config: EmailConfiguration,
     type: 'WITHDRAW' | 'UNDO_WITHDRAW'
 ): WithdrawContractEtaDataType | Error => {
-    const validConsolidatedStatus =
-        type === 'WITHDRAW' ? 'WITHDRAWN' : 'RESUBMITTED'
-    const validReviewAction = type === 'WITHDRAW' ? type : 'UNDER_REVIEW'
+    const validConsolidatedStatus: ConsolidatedContractStatusType[] =
+        type === 'WITHDRAW'
+            ? ['WITHDRAWN'] //If withdrawing, expect only this status
+            : ['RESUBMITTED', 'NOT_SUBJECT_TO_REVIEW']
 
-    if (contract.consolidatedStatus !== validConsolidatedStatus) {
+    const validReviewAction: ReviewActionTypes[] =
+        type === 'WITHDRAW'
+            ? ['WITHDRAW'] //If withdrawing, expect only this status
+            : ['UNDER_REVIEW', 'NOT_SUBJECT_TO_REVIEW']
+
+    if (!validConsolidatedStatus.includes(contract.consolidatedStatus)) {
         return new Error(
             `Contract consolidated status should be ${validConsolidatedStatus}`
         )
     }
 
-    // Latest review action should be UNDER_REVIEW
     const latestStatusAction = contract.reviewStatusActions?.sort(
         (a, b) =>
             new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
     )[0]
-    if (latestStatusAction?.actionType !== validReviewAction) {
+
+    if (
+        !latestStatusAction?.actionType ||
+        !validReviewAction.includes(latestStatusAction.actionType)
+    ) {
         return new Error(
             `Latest contract review action is not ${validReviewAction}`
         )

--- a/services/app-api/src/emailer/templateHelpers.ts
+++ b/services/app-api/src/emailer/templateHelpers.ts
@@ -404,7 +404,7 @@ const parseEmailDataWithdrawSubmission = (
 
     if (!validConsolidatedStatus.includes(contract.consolidatedStatus)) {
         return new Error(
-            `Contract consolidated status should be ${validConsolidatedStatus}`
+            `Contract consolidated status is incorrect for ${type} email. Consolidated status: ${contract.consolidatedStatus}`
         )
     }
 
@@ -418,7 +418,7 @@ const parseEmailDataWithdrawSubmission = (
         !validReviewAction.includes(latestStatusAction.actionType)
     ) {
         return new Error(
-            `Latest contract review action is not ${validReviewAction}`
+            `Latest contract review action is incorrect for ${type} email. Contract action: ${latestStatusAction?.actionType}`
         )
     }
 

--- a/services/app-api/src/postgres/contractAndRates/submitContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/submitContract.ts
@@ -4,7 +4,10 @@ import type { UpdateInfoType, ContractType } from '../../domain-models'
 import type { PrismaTransactionType } from '../prismaTypes'
 import { submitContractAndOrRates } from './submitContractAndOrRates'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import { eqroValidationAndReviewDetermination } from '@mc-review/submissions'
+import {
+    eqroValidationAndReviewDetermination,
+    healthPlanReviewDetermination,
+} from '@mc-review/submissions'
 import { parseErrorToError } from '@mc-review/helpers'
 
 async function submitContractInsideTransaction(
@@ -165,13 +168,16 @@ async function healthPlanContractReviewDeterminationAction(
         )
     }
 
-    const isChipOnly =
-        latestSubmission.contractRevision.formData.populationCovered === 'CHIP'
+    const subjectToReview = healthPlanReviewDetermination(
+        latestSubmission.contractRevision.formData
+    )
 
     await tx.contractActionTable.create({
         data: {
             updatedByID: undefined,
-            actionType: isChipOnly ? 'NOT_SUBJECT_TO_REVIEW' : 'UNDER_REVIEW',
+            actionType: subjectToReview
+                ? 'UNDER_REVIEW'
+                : 'NOT_SUBJECT_TO_REVIEW',
             contractID: contract.id,
         },
     })

--- a/services/app-api/src/postgres/contractAndRates/undoWithdrawContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/undoWithdrawContract.ts
@@ -6,6 +6,10 @@ import { unlockContractInsideTransaction } from './unlockContract'
 import { submitContractInsideTransaction } from './submitContract'
 import { findContractWithHistory } from './findContractWithHistory'
 import { parseErrorToError } from '@mc-review/helpers'
+import {
+    eqroValidationAndReviewDetermination,
+    healthPlanReviewDetermination,
+} from '@mc-review/submissions'
 
 export type UndoWithdrawContractArgsType = {
     contract: ContractType
@@ -97,7 +101,7 @@ const undoWithdrawContractInsideTransaction = async (
         }
     })
 
-    // Resubmit contact and child rates
+    // Resubmit contract and child rates
     const resubmitContract = await submitContractInsideTransaction(tx, {
         contractID: contract.id,
         submittedByUserID: updatedByID,
@@ -110,7 +114,39 @@ const undoWithdrawContractInsideTransaction = async (
         )
     }
 
-    // Add UNDER_REVIEW action to contract
+    // Determine restored review status — mirrors submitContract logic so that
+    // NOT_SUBJECT_TO_REVIEW submissions (EQRO with no review-triggering
+    // provisions, CHIP-only HEALTH_PLAN) return to NOT_SUBJECT_TO_REVIEW
+    // rather than flipping to UNDER_REVIEW.
+    let restoredActionType: 'UNDER_REVIEW' | 'NOT_SUBJECT_TO_REVIEW' =
+        'UNDER_REVIEW'
+    const latestSubmission = resubmitContract.packageSubmissions[0]
+    if (!latestSubmission) {
+        throw new Error(
+            'Cannot determine review on undo-withdraw: contract has no submitted revision'
+        )
+    }
+
+    if (resubmitContract.contractSubmissionType === 'EQRO') {
+        const reviewDetermination = eqroValidationAndReviewDetermination(
+            resubmitContract.id,
+            latestSubmission.contractRevision.formData
+        )
+        if (reviewDetermination instanceof Error) {
+            throw reviewDetermination
+        }
+        restoredActionType = reviewDetermination
+            ? 'UNDER_REVIEW'
+            : 'NOT_SUBJECT_TO_REVIEW'
+    } else if (resubmitContract.contractSubmissionType === 'HEALTH_PLAN') {
+        const subjectToReview = healthPlanReviewDetermination(
+            latestSubmission.contractRevision.formData
+        )
+        restoredActionType = subjectToReview
+            ? 'UNDER_REVIEW'
+            : 'NOT_SUBJECT_TO_REVIEW'
+    }
+
     await tx.contractTable.update({
         where: {
             id: contract.id,
@@ -120,7 +156,7 @@ const undoWithdrawContractInsideTransaction = async (
                 create: {
                     updatedByID,
                     updatedReason,
-                    actionType: 'UNDER_REVIEW',
+                    actionType: restoredActionType,
                 },
             },
         },
@@ -152,7 +188,11 @@ const undoWithdrawContractInsideTransaction = async (
         throw new Error(undoWithdrawnContract.message)
     }
 
-    if (undoWithdrawnContract.consolidatedStatus !== 'RESUBMITTED') {
+    if (
+        !['RESUBMITTED', 'NOT_SUBJECT_TO_REVIEW'].includes(
+            undoWithdrawnContract.consolidatedStatus
+        )
+    ) {
         throw new Error('Contract failed to withdraw')
     }
 

--- a/services/app-api/src/postgres/contractAndRates/undoWithdrawContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/undoWithdrawContract.ts
@@ -208,7 +208,10 @@ const undoWithdrawContract = async (
 ): Promise<UndoWithdrawContractReturnType | Error> => {
     try {
         return await client.$transaction(
-            async (tx) => await undoWithdrawContractInsideTransaction(tx, args)
+            async (tx) => await undoWithdrawContractInsideTransaction(tx, args),
+            {
+                timeout: 30000,
+            }
         )
     } catch (err) {
         const parsedError = parseErrorToError(err)

--- a/services/app-api/src/resolvers/contract/undoWithdrawContract.test.ts
+++ b/services/app-api/src/resolvers/contract/undoWithdrawContract.test.ts
@@ -28,6 +28,7 @@ import {
     UpdateDraftContractRatesDocument,
 } from '../../gen/gqlClient'
 import { testEmailConfig, testEmailer } from '../../testHelpers/emailerHelpers'
+import { testLDService } from '../../testHelpers/launchDarklyHelpers'
 
 const testRateFormInputData = (): RateFormDataInput => ({
     rateType: 'AMENDMENT',
@@ -791,6 +792,81 @@ describe('undoWithdrawContract', () => {
                 'resubmit EQRO after undo',
             ])
         )
+    })
+
+    it('can undo withdraw EQRO or CHIP-only HEALTH_PLAN contract with NOT_SUBJECT_TO_REVIEW status', async () => {
+        const stateServer = await constructTestPostgresServer({
+            context: { user: stateUser },
+            ldService: testLDService({
+                'chip-submission-automation': true,
+            }),
+        })
+        const cmsServer = await constructTestPostgresServer({
+            context: { user: cmsUser },
+        })
+
+        // EQRO: all-false provision fields trigger NOT_SUBJECT_TO_REVIEW on submit
+        const eqroDraft = await createAndUpdateTestEQROContract(
+            stateServer,
+            undefined,
+            {
+                eqroNewContractor: false,
+                eqroProvisionMcoNewOptionalActivity: false,
+                eqroProvisionNewMcoEqrRelatedActivities: false,
+                eqroProvisionChipEqrRelatedActivities: false,
+                eqroProvisionMcoEqrOrRelatedActivities: null,
+            }
+        )
+        const eqroSubmitted = await submitTestContract(
+            stateServer,
+            eqroDraft.id
+        )
+        expect(eqroSubmitted.contractSubmissionType).toBe('EQRO')
+        expect(eqroSubmitted.consolidatedStatus).toBe('NOT_SUBJECT_TO_REVIEW')
+
+        const chipDraft = await createAndUpdateTestContractWithoutRates(
+            stateServer,
+            undefined,
+            {
+                submissionType: 'CONTRACT_ONLY',
+                populationCovered: 'CHIP',
+                federalAuthorities: ['TITLE_XXI'],
+            }
+        )
+        const chipSubmitted = await submitTestContract(
+            stateServer,
+            chipDraft.id
+        )
+        expect(chipSubmitted.contractSubmissionType).toBe('HEALTH_PLAN')
+        expect(chipSubmitted.consolidatedStatus).toBe('NOT_SUBJECT_TO_REVIEW')
+
+        const eqroWithdrawn = await withdrawTestContract(
+            cmsServer,
+            eqroSubmitted.id,
+            'withdraw EQRO submission'
+        )
+        expect(eqroWithdrawn.consolidatedStatus).toBe('WITHDRAWN')
+
+        const chipWithdrawn = await withdrawTestContract(
+            cmsServer,
+            chipSubmitted.id,
+            'withdraw CHIP submission'
+        )
+        expect(chipWithdrawn.consolidatedStatus).toBe('WITHDRAWN')
+
+        const eqroUndone = await undoWithdrawTestContract(
+            cmsServer,
+            eqroWithdrawn.id,
+            'undo withdraw EQRO submission'
+        )
+        expect(eqroUndone.consolidatedStatus).toBe('NOT_SUBJECT_TO_REVIEW')
+
+        const chipUndone = await undoWithdrawTestContract(
+            cmsServer,
+            chipWithdrawn.id,
+            'undo withdraw CHIP submission'
+        )
+        expect(chipUndone.consolidatedStatus).toBe('NOT_SUBJECT_TO_REVIEW')
     })
 })
 

--- a/services/app-api/src/resolvers/contract/withdrawContract.test.ts
+++ b/services/app-api/src/resolvers/contract/withdrawContract.test.ts
@@ -24,7 +24,6 @@ import type { RateFormDataInput, RateStrippedEdge } from '../../gen/gqlClient'
 import {
     SubmitContractDocument,
     UpdateDraftContractRatesDocument,
-    WithdrawContractDocument,
 } from '../../gen/gqlClient'
 import {
     addNewRateToTestContract,
@@ -1321,7 +1320,7 @@ describe('withdrawContract', () => {
         )
     })
 
-    it('cannot withdraw EQRO or CHIP-only HEALTH_PLAN contract with NOT_SUBJECT_TO_REVIEW status', async () => {
+    it('can withdraw EQRO or CHIP-only HEALTH_PLAN contract with NOT_SUBJECT_TO_REVIEW status', async () => {
         const stateServer = await constructTestPostgresServer({
             context: { user: stateUser },
             ldService: testLDService({
@@ -1367,33 +1366,19 @@ describe('withdrawContract', () => {
         expect(chipSubmitted.contractSubmissionType).toBe('HEALTH_PLAN')
         expect(chipSubmitted.consolidatedStatus).toBe('NOT_SUBJECT_TO_REVIEW')
 
-        const eqroWithdrawResult = await executeGraphQLOperation(cmsServer, {
-            query: WithdrawContractDocument,
-            variables: {
-                input: {
-                    contractID: eqroSubmitted.id,
-                    updatedReason: 'withdraw submission',
-                },
-            },
-        })
-        expect(eqroWithdrawResult.errors).toBeDefined()
-        expect(eqroWithdrawResult.errors?.[0].message).toBe(
-            'Attempted to withdraw submission with invalid contract status of NOT_SUBJECT_TO_REVIEW'
+        const eqroWithdrawn = await withdrawTestContract(
+            cmsServer,
+            eqroSubmitted.id,
+            'withdraw EQRO submission'
         )
+        expect(eqroWithdrawn.consolidatedStatus).toBe('WITHDRAWN')
 
-        const chipWithdrawResult = await executeGraphQLOperation(cmsServer, {
-            query: WithdrawContractDocument,
-            variables: {
-                input: {
-                    contractID: chipSubmitted.id,
-                    updatedReason: 'withdraw submission',
-                },
-            },
-        })
-        expect(chipWithdrawResult.errors).toBeDefined()
-        expect(chipWithdrawResult.errors?.[0].message).toBe(
-            'Attempted to withdraw submission with invalid contract status of NOT_SUBJECT_TO_REVIEW'
+        const chipWithdrawn = await withdrawTestContract(
+            cmsServer,
+            chipSubmitted.id,
+            'withdraw CHIP submission'
         )
+        expect(chipWithdrawn.consolidatedStatus).toBe('WITHDRAWN')
     })
 
     it('can withdraw EQRO contract with SUBMITTED status', async () => {

--- a/services/app-api/src/resolvers/contract/withdrawContract.ts
+++ b/services/app-api/src/resolvers/contract/withdrawContract.ts
@@ -71,9 +71,11 @@ export function withdrawContract(
                 }
 
                 if (
-                    !['SUBMITTED', 'RESUBMITTED'].includes(
-                        contractWithHistory.consolidatedStatus
-                    )
+                    ![
+                        'SUBMITTED',
+                        'RESUBMITTED',
+                        'NOT_SUBJECT_TO_REVIEW',
+                    ].includes(contractWithHistory.consolidatedStatus)
                 ) {
                     const errMessage = `Attempted to withdraw submission with invalid contract status of ${contractWithHistory.consolidatedStatus}`
                     logError('withdrawContract', errMessage)

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -478,14 +478,13 @@ type Mutation {
     undoWithdrawRate(input: UndoWithdrawRateInput!): UndoWithdrawRatePayload
 
     """
-    withdrawSubmission is a CMS user only action to withdraw an entire submission package, which includes contract and child rates
+    withdrawSubmission is a CMS user only action to withdraw an entire submission package, which includes contract and child rates.
 
     Errors:
     - ForbiddenError:
     - A non CMS/CMS Approver user called this
     - UserInputError:
-    - A contract is not in the correct submission status: SUBMITTED or RESUBMITTED
-    - A contract is not in the correct review status: UNDER_REVIEW
+    - A contract is not in the correct consolidated status: SUBMITTED, RESUBMITTED, or NOT_SUBJECT_TO_REVIEW
     - INTERNAL_SERVER_ERROR
     - DB_ERROR
     - A contract cannot be found by id
@@ -493,7 +492,8 @@ type Mutation {
     withdrawContract(input: WithdrawContractInput!): WithdrawContractPayload!
 
     """
-    unoWithdrawSubmission is a CMS user only action to undo a submission widthdrawal, which includes contract and and child rates withdrawn together.
+    undoWithdrawSubmission is a CMS user only action to undo a submission withdrawal, which includes contract and child rates withdrawn together.
+    Review determination is re-run on undo, so the restored review status reflects current rules rather than the pre-withdrawal status.
     """
     undoWithdrawContract(
         input: UndoWithdrawContractInput!

--- a/services/app-web/src/components/Banner/StatusUpdatedBanner/StatusUpdatedBanner.tsx
+++ b/services/app-web/src/components/Banner/StatusUpdatedBanner/StatusUpdatedBanner.tsx
@@ -3,7 +3,10 @@ import { AccessibleAlertBanner } from '../AccessibleAlertBanner/AccessibleAlertB
 
 export const StatusUpdatedBanner = ({
     className,
-}: React.HTMLAttributes<HTMLDivElement>) => {
+    message = 'Submission status updated to "Submitted".',
+}: {
+    message?: string
+} & React.HTMLAttributes<HTMLDivElement>) => {
     return (
         <AccessibleAlertBanner
             role="status"
@@ -13,7 +16,7 @@ export const StatusUpdatedBanner = ({
             data-testid="statusUpdatedBanner"
             className={className}
         >
-            Submission status updated to "Submitted".
+            {message}
         </AccessibleAlertBanner>
     )
 }

--- a/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.test.tsx
@@ -626,7 +626,7 @@ describe('EQROSubmissionSummary - Unlock submission button tests', () => {
             ).not.toBeInTheDocument()
         })
 
-        it('does not render the withdraw button when EQRO submission is not subject to review', async () => {
+        it('render the withdraw button when EQRO submission is not subject to review', async () => {
             const contract = mockContractPackageSubmitted({
                 id: 'test-abc-123',
                 contractSubmissionType: 'EQRO',
@@ -675,12 +675,11 @@ describe('EQROSubmissionSummary - Unlock submission button tests', () => {
                 ).toBeInTheDocument()
             })
 
-            // Withdraw button is gated on SUBMITTED/RESUBMITTED consolidatedStatus
             expect(
-                screen.queryByRole('button', {
+                screen.getByRole('button', {
                     name: 'Withdraw submission',
                 })
-            ).not.toBeInTheDocument()
+            ).toBeInTheDocument()
 
             // Unlock is still allowed for NOT_SUBJECT_TO_REVIEW
             expect(

--- a/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.tsx
@@ -227,7 +227,7 @@ export const EQROSubmissionSummary = (): React.ReactElement => {
     const renderStatusAlerts = () => {
         if (showTempUndoWithdrawBanner) {
             const status = isSubjectToReview
-                ? ReviewDecisionRecord['UNDER_REVIEW']
+                ? 'Submitted'
                 : ReviewDecisionRecord['NOT_SUBJECT_TO_REVIEW']
             return (
                 <StatusUpdatedBanner

--- a/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.tsx
@@ -177,7 +177,9 @@ export const EQROSubmissionSummary = (): React.ReactElement => {
     const showWithdrawBtn =
         hasCMSPermissions &&
         withdrawSubmissionFlag &&
-        ['SUBMITTED', 'RESUBMITTED'].includes(consolidatedStatus)
+        ['SUBMITTED', 'RESUBMITTED', 'NOT_SUBJECT_TO_REVIEW'].includes(
+            consolidatedStatus
+        )
     const showUndoWithdrawBtn =
         hasCMSPermissions &&
         undoWithdrawSubmissionFlag &&

--- a/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.tsx
@@ -230,7 +230,14 @@ export const EQROSubmissionSummary = (): React.ReactElement => {
 
     const renderStatusAlerts = () => {
         if (showTempUndoWithdrawBanner) {
-            return <StatusUpdatedBanner className={styles.banner} />
+            return (
+                <StatusUpdatedBanner
+                    className={styles.banner}
+                    message={
+                        'Submission status updated to "Not subject to review".'
+                    }
+                />
+            )
         }
 
         if (showWithdrawnBanner && latestContractAction.updatedBy) {

--- a/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.tsx
@@ -40,6 +40,7 @@ import {
 import { getSubmissionPath } from '../../../routeHelpers'
 import { StatusTag } from '../../../components/ContractTable'
 import { ChangeHistory } from '../../../components/ChangeHistory'
+import { ReviewDecisionRecord } from '@mc-review/constants'
 
 export const EQROSubmissionSummary = (): React.ReactElement => {
     // Page level state
@@ -190,11 +191,6 @@ export const EQROSubmissionSummary = (): React.ReactElement => {
         withdrawSubmissionFlag &&
         consolidatedStatus === 'WITHDRAWN' &&
         latestContractAction
-    const undoWithdrawAction =
-        latestContractAction?.actionType === 'UNDER_REVIEW' &&
-        contract.reviewStatusActions?.[1]?.actionType === 'WITHDRAW'
-    const showPermUndoWithdrawBanner =
-        undoWithdrawAction && undoWithdrawSubmissionFlag && isStateUser
 
     // Get the correct update info depending on the submission status
     let updateInfo: UpdateInformation | undefined = undefined
@@ -230,12 +226,13 @@ export const EQROSubmissionSummary = (): React.ReactElement => {
 
     const renderStatusAlerts = () => {
         if (showTempUndoWithdrawBanner) {
+            const status = isSubjectToReview
+                ? ReviewDecisionRecord['UNDER_REVIEW']
+                : ReviewDecisionRecord['NOT_SUBJECT_TO_REVIEW']
             return (
                 <StatusUpdatedBanner
                     className={styles.banner}
-                    message={
-                        'Submission status updated to "Not subject to review".'
-                    }
+                    message={`Submission status updated to "${status}".`}
                 />
             )
         }
@@ -252,10 +249,6 @@ export const EQROSubmissionSummary = (): React.ReactElement => {
                     }}
                 />
             )
-        }
-
-        if (showPermUndoWithdrawBanner) {
-            return <StatusUpdatedBanner className={styles.banner} />
         }
 
         if (isUnlocked && updateInfo) {

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -251,7 +251,9 @@ export const SubmissionSummary = (): React.ReactElement => {
     const showWithdrawBtn =
         hasCMSPermissions &&
         withdrawSubmissionFlag &&
-        ['SUBMITTED', 'RESUBMITTED'].includes(consolidatedStatus)
+        ['SUBMITTED', 'RESUBMITTED', 'NOT_SUBJECT_TO_REVIEW'].includes(
+            consolidatedStatus
+        )
     const showUndoWithdrawBtn =
         hasCMSPermissions &&
         undoWithdrawSubmissionFlag &&

--- a/services/local-launch-darkly/src/server/server.ts
+++ b/services/local-launch-darkly/src/server/server.ts
@@ -163,7 +163,7 @@ const indexRateLimiter = rateLimit({
     limit: 100, // limit each IP to 100 index requests per windowMs
 })
 
-app.get('*', indexRateLimiter as unknown as express.RequestHandler, (_req, res) => {
+app.get('/*splat', indexRateLimiter as unknown as express.RequestHandler, (_req, res) => {
     res.sendFile(join(distDir, 'index.html'))
 })
 


### PR DESCRIPTION
## Summary
[MCR-5861](https://jiraent.cms.gov/browse/MCR-5861)

Follow up to https://jiraent.cms.gov/browse/MCR-5861 work to enable withdrawing `NOT_SUBJECT_TO_REVIEW` submissions and update undo withdraw for this.

APP-API:
- Added healthPlanReviewDetermination(formData)
   - Abstracted out the logic for health plan review determination so it can be reused and extended only in one place if needed.
- Updated `services/app-api/src/resolvers/contract/withdrawContract.ts` to allow `NOT_SUBJECT_TO_REVIEW` to be withdrawn.
- Updated `services/app-api/src/postgres/contractAndRates/undoWithdrawContract.ts` for doing withdraw for a `NOT_SUBJECT_TO_REVIEW` submission.
   - Updated code to reapply review determinations when undoing a contract withdraw
- Updated API change log and GraphQL Schema comments
  
APP-WEB:
- Add `Withdraw` and `Undo withdraw` button to EQRO and Health Plan submission summary pages
- Add unit tests

#### Related issues

#### Screenshots

#### Test cases covered
- services/app-api/src/resolvers/contract/withdrawContract.test.ts
    - Renamed + inverted: cannot withdraw EQRO or CHIP-only HEALTH_PLAN contract with NOT_SUBJECT_TO_REVIEW status → can withdraw EQRO or CHIP-only HEALTH_PLAN contract with NOT_SUBJECT_TO_REVIEW status
- services/app-api/src/resolvers/contract/undoWithdrawContract.test.ts
    - Added: can undo withdraw EQRO or CHIP-only HEALTH_PLAN contract with NOT_SUBJECT_TO_REVIEW status
- services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.test.tsx
    - Renamed + flipped: does not render the withdraw button when EQRO submission is not subject to review → render the withdraw button when EQRO submission is not subject to review
   
<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
Go through the withdraw and undo withdraw for:
- EQRO Submissions 'NOT_SUBJECT_TO_REVIEW`
- CHIP only health plan submissions 'NOT_SUBJECT_TO_REVIEW`

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [x] Updated the API Changelog (if this PR changes the API schema)
- [x] Checked accessibility with ANDI and Wave tools as needed