### PR TITLE
MCR-6216: Fix react 19 upgrade UI regressions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -878,8 +878,8 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
       '@vitest/ui':
-        specifier: ^4.1.5
-        version: 4.1.5(vitest@3.2.4)
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4)
       classnames:
         specifier: ^2.2.6
         version: 2.5.1
@@ -951,7 +951,7 @@ importers:
         version: 5.2.0(rollup@4.60.1)(typescript@5.9.3)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(sass@1.77.2)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@25.5.0)(@vitest/ui@4.1.5)(jiti@2.6.1)(jsdom@28.0.0)(sass@1.77.2)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@25.5.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.0.0)(sass@1.77.2)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   services/cypress:
     dependencies:
@@ -6758,9 +6758,6 @@ packages:
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
-  '@vitest/pretty-format@4.1.5':
-    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
-
   '@vitest/runner@3.2.4':
     resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
@@ -6775,16 +6772,8 @@ packages:
     peerDependencies:
       vitest: 3.2.4
 
-  '@vitest/ui@4.1.5':
-    resolution: {integrity: sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==}
-    peerDependencies:
-      vitest: 4.1.5
-
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
-
-  '@vitest/utils@4.1.5':
-    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -12234,10 +12223,6 @@ packages:
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyrainbow@3.1.0:
-    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
@@ -20923,10 +20908,6 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/pretty-format@4.1.5':
-    dependencies:
-      tinyrainbow: 3.1.0
-
   '@vitest/runner@3.2.4':
     dependencies:
       '@vitest/utils': 3.2.4
@@ -20953,30 +20934,12 @@ snapshots:
       tinyglobby: 0.2.16
       tinyrainbow: 2.0.0
       vitest: 3.2.4(@types/node@25.5.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.0.0)(sass@1.77.2)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-    optional: true
-
-  '@vitest/ui@4.1.5(vitest@3.2.4)':
-    dependencies:
-      '@vitest/utils': 4.1.5
-      fflate: 0.8.2
-      flatted: 3.4.2
-      pathe: 2.0.3
-      sirv: 3.0.2
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vitest: 3.2.4(@types/node@25.5.0)(@vitest/ui@4.1.5)(jiti@2.6.1)(jsdom@28.0.0)(sass@1.77.2)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
-
-  '@vitest/utils@4.1.5':
-    dependencies:
-      '@vitest/pretty-format': 4.1.5
-      convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -27686,8 +27649,6 @@ snapshots:
 
   tinyrainbow@2.0.0: {}
 
-  tinyrainbow@3.1.0: {}
-
   tinyspy@4.0.4: {}
 
   title-case@3.0.3:
@@ -28249,49 +28210,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
       '@vitest/ui': 3.2.4(vitest@3.2.4)
-      jsdom: 28.0.0
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vitest@3.2.4(@types/node@25.5.0)(@vitest/ui@4.1.5)(jiti@2.6.1)(jsdom@28.0.0)(sass@1.77.2)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.2.7(@types/node@25.5.0)(jiti@2.6.1)(sass@1.77.2)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3(supports-color@5.5.0)
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.2.7(@types/node@25.5.0)(jiti@2.6.1)(sass@1.77.2)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(sass@1.77.2)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 25.5.0
-      '@vitest/ui': 4.1.5(vitest@3.2.4)
       jsdom: 28.0.0
     transitivePeerDependencies:
       - jiti

--- a/services/app-web/.storybook/providersDecorator.tsx
+++ b/services/app-web/.storybook/providersDecorator.tsx
@@ -9,7 +9,7 @@ import { Decorator } from '@storybook/react'
 import { AuthProvider, AuthProviderProps } from '../src/contexts/AuthContext'
 import { PageProvider } from '../src/contexts/PageContext'
 import { S3Provider } from '../src/contexts/S3Context'
-import { testS3Client } from '../src/testHelpers'
+import { testS3Client } from '../src/testHelpers/s3Helpers'
 import { MockTraceProvider } from '../src/contexts/TraceContext'
 
 type StoryRenderer = Parameters<Decorator>[0]

--- a/services/app-web/package.json
+++ b/services/app-web/package.json
@@ -149,7 +149,7 @@
         "@typescript-eslint/eslint-plugin": "^8.58.1",
         "@typescript-eslint/parser": "^8.58.1",
         "@vitest/coverage-v8": "^3.2.4",
-        "@vitest/ui": "^4.1.5",
+        "@vitest/ui": "^3.2.4",
         "classnames": "^2.2.6",
         "cypress": "^15.8.2",
         "eslint": "^10.2.0",

--- a/services/app-web/src/components/Banner/AccessibleAlertBanner/AccessibleAlertBanner.module.scss
+++ b/services/app-web/src/components/Banner/AccessibleAlertBanner/AccessibleAlertBanner.module.scss
@@ -18,4 +18,10 @@
     [class*='usa-alert__text'] {
         font-size: 1rem;
     }
+
+    [class*='usa-alert__body'] {
+        margin-left: 0;
+        margin-right: 0;
+        font-size: 1rem;
+    }
 }

--- a/services/app-web/src/components/Header/Header.module.scss
+++ b/services/app-web/src/components/Header/Header.module.scss
@@ -61,6 +61,7 @@
         right: 0 !important;
         margin-top: 1.5rem !important;
         width: fit-content;
+        padding: 1rem;
         background-color: custom.$mcr-cmsblue-base !important;
 
         > li {
@@ -114,7 +115,6 @@
     .subMenuContainer {
         ul {
             margin-top: 0.5rem !important;
-            padding: 1rem;
             li {
                 margin: 0;
             }
@@ -131,7 +131,7 @@
         display: flex;
         flex-flow: column;
         text-align: center;
-        margin: 0;       
+        margin: 0;
     }
     & h1 {
         margin-bottom: 10px;

--- a/services/app-web/src/components/Header/UserLoginInfo/UserLoginInfo.tsx
+++ b/services/app-web/src/components/Header/UserLoginInfo/UserLoginInfo.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-
 import { LoginStatusType, useAuth } from '../../../contexts/AuthContext'
 import { User } from '../../../gen/gqlClient'
 import { idmRedirectURL } from '../../../pages/Auth/cognitoAuth'

--- a/services/app-web/src/components/Select/PackageSelect/PackageSelect.stories.tsx
+++ b/services/app-web/src/components/Select/PackageSelect/PackageSelect.stories.tsx
@@ -1,4 +1,5 @@
 import { StoryFn } from '@storybook/react'
+import { Formik } from 'formik'
 import { PackageSelect, PackageSelectPropType } from '../index'
 import { mockContractPackageDraft, mockMNState } from '@mc-review/mocks'
 import React from 'react'
@@ -23,7 +24,14 @@ export default {
 }
 
 const Template: StoryFn<PackageSelectPropType> = (args) => (
-    <PackageSelect {...args} />
+    <Formik
+        initialValues={{ [args.name]: args.initialValues }}
+        onSubmit={() => undefined}
+    >
+        <form>
+            <PackageSelect {...args} />
+        </form>
+    </Formik>
 )
 
 export const Default = Template.bind({})

--- a/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROSubmissionDetails/EQROSubmissionDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROSubmissionDetails/EQROSubmissionDetails.tsx
@@ -554,6 +554,7 @@ export const EQROSubmissionDetails = (): React.ReactElement => {
                                                     hash: '#submission-description',
                                                 }}
                                                 target="_blank"
+                                                className="display-inline-block"
                                             >
                                                 View description examples
                                             </ReactRouterLinkWithLogging>

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/SubmissionType/SubmissionType.tsx
@@ -738,6 +738,7 @@ export const SubmissionType = ({
                                                         hash: '#submission-description',
                                                     }}
                                                     target="_blank"
+                                                    className="display-inline-block"
                                                 >
                                                     View description examples
                                                 </ReactRouterLinkWithLogging>

--- a/services/app-web/src/styles/overrides.scss
+++ b/services/app-web/src/styles/overrides.scss
@@ -35,7 +35,7 @@ html {
     background-color: #f0fafd;
 }
 
-.usa-hint:not(.usa-character-count__message--invalid) {
+.usa-hint:not(.usa-character-count__status--invalid) {
     color: $mcr-foundation-hint;
 }
 


### PR DESCRIPTION
## Summary
MCR-6216

Fix regressions in UI from React 19 upgrade

- [x] Fix UI regressions
   - [x] `Your account` dropdown padding issues
      - <img width="250" alt="Screenshot 2026-04-23 at 5 07 02 PM" src="https://github.com/user-attachments/assets/0183c7ae-d13f-4d72-b5b2-818f4b7cb501" />
   - [x] - Step indicator grey bars are darker than it should( No fix needed)
      - USWDS Change: This was done for a11y contrast ratio. [See 3.4.0 release notes](https://github.com/uswds/uswds/releases/tag/v3.4.0)
   - [x] - Light gray buttons now show as grey ( No fix needed )
      - USWDS Change: This was done to align disabled UI across USWDS. [See 3.5.6 release notes](https://github.com/uswds/uswds/releases/tag/v3.5.0)
   - [x] Submission description text area input character count error color is not red
    - [x] Submission description on submission type page
       - `View description examples` link should all be in a new line
       - <img width="839" alt="Screenshot 2026-04-23 at 3 55 49 PM" src="https://github.com/user-attachments/assets/268f3e69-308e-45ea-af49-e139428c67d9" />
    - [x] New submission banner has excess left and right padding.
       - <img width="500" alt="Screenshot 2026-04-23 at 3 46 48 PM" src="https://github.com/user-attachments/assets/230561d0-b446-463a-a967-4f02b7e0c5cb" />

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [x] Updated the API Changelog (if this PR changes the API schema)
- [x] Checked accessibility with ANDI and Wave tools as needed