### PR TITLE
Fix review decision for withdrawn EQRO submission

### DIFF
--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/EQROSubmissionTypeSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/EQROSubmissionTypeSummarySection.tsx
@@ -35,13 +35,18 @@ export type EQROSubmissionTypeSummarySection = {
 
 const calcChangeInReviewDetermination = (
     contract: Contract | UnlockedContract,
-    currentDetermination: boolean
+    currentDetermination?: boolean
 ): boolean => {
     if (
         contract.status === 'DRAFT' ||
         contract.status === 'UNLOCKED' ||
         contract.status === 'SUBMITTED'
     ) {
+        return false
+    }
+
+    // Return false if current determination is unavailable
+    if (currentDetermination === undefined) {
         return false
     }
 
@@ -88,9 +93,18 @@ export const EQROSubmissionTypeSummarySection = ({
         contract.status === 'SUBMITTED' || contract.status === 'RESUBMITTED'
     const isUnlocked = contract.status === 'UNLOCKED'
     const isDraft = contract.status === 'DRAFT'
-    const subjectToReview =
-        contract.consolidatedStatus !== 'NOT_SUBJECT_TO_REVIEW'
     const showReviewDetermination = !(isStateUser && (isUnlocked || isDraft))
+
+    const lastReviewDetermination = contract.reviewStatusActions?.find(
+        (action) =>
+            action.actionType === 'UNDER_REVIEW' ||
+            action.actionType === 'NOT_SUBJECT_TO_REVIEW'
+    )
+
+    const subjectToReview =
+        lastReviewDetermination === undefined
+            ? undefined
+            : lastReviewDetermination.actionType === 'UNDER_REVIEW'
 
     const hasReviewDeterminationChanged = calcChangeInReviewDetermination(
         contract,

--- a/services/app-web/src/components/SubmissionSummarySection/SummarySectionFields/SummarySectionFields.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SummarySectionFields/SummarySectionFields.tsx
@@ -155,20 +155,36 @@ export const ReviewDecision = ({
     label,
     newDetermination,
 }: {
-    subjectToReview: boolean
+    subjectToReview?: boolean
     label?: string
     newDetermination?: boolean
 }) => {
-    const renderReviewDetermination = subjectToReview
-        ? 'Subject to formal review and approval'
-        : 'Not subject to formal review and approval'
+    const unavailableDetermination = subjectToReview === undefined
+    let renderReviewDetermination = ''
+
+    if (unavailableDetermination) {
+        renderReviewDetermination = 'Review determination unavailable'
+    } else {
+        renderReviewDetermination = subjectToReview
+            ? 'Subject to formal review and approval'
+            : 'Not subject to formal review and approval'
+    }
 
     return (
-        <DataDetail id="reviewDecision" label={label ?? 'Review decision'}>
-            <span>
-                {newDetermination && <NewTag className={styles.tagSpacing} />}
-                {renderReviewDetermination}
-            </span>
+        <DataDetail
+            id="reviewDecision"
+            label={label ?? 'Review decision'}
+            explainMissingData={unavailableDetermination}
+            explainMissingDataMsg={renderReviewDetermination}
+        >
+            {!unavailableDetermination && (
+                <span>
+                    {newDetermination && (
+                        <NewTag className={styles.tagSpacing} />
+                    )}
+                    {renderReviewDetermination}
+                </span>
+            )}
         </DataDetail>
     )
 }

--- a/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.test.tsx
@@ -8,6 +8,8 @@ import {
     mockValidStateUser,
     mockContractPackageSubmitted,
     mockContractPackageUnlockedWithUnlockedType,
+    mockEqroContractSubmittedUnderReview,
+    mockEqroContractSubmittedNotSubjectToReview,
 } from '@mc-review/mocks'
 import { renderWithProviders } from '../../../testHelpers'
 import { EQROSubmissionSummary } from './EQROSubmissionSummary'
@@ -420,6 +422,67 @@ describe('EQROSubmissionSummary - Unlock submission button tests', () => {
             expect(screen.getByText('Review decision')).toBeInTheDocument()
         })
 
+        it('shows error UI when no decision is avaliable', async () => {
+            const contract = mockContractPackageSubmitted({
+                id: 'test-abc-123',
+                contractSubmissionType: 'EQRO',
+                status: 'SUBMITTED',
+                consolidatedStatus: 'SUBMITTED',
+            })
+
+            renderWithProviders(
+                <Routes>
+                    <Route element={<SubmissionSideNav />}>
+                        <Route
+                            path={RoutesRecord.SUBMISSIONS_SUMMARY}
+                            element={<EQROSubmissionSummary />}
+                        />
+                    </Route>
+                </Routes>,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                user: mockValidStateUser(),
+                                statusCode: 200,
+                            }),
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
+                            }),
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
+                            }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: '/submissions/eqro/test-abc-123',
+                    },
+                    featureFlags: {
+                        [featureFlags.EQRO_SUBMISSIONS.flag]: true,
+                    },
+                }
+            )
+
+            await waitFor(() => {
+                expect(
+                    screen.getByTestId('submission-summary')
+                ).toBeInTheDocument()
+            })
+
+            // Expect Review decision to be visible for state users on submitted submissions
+            expect(screen.getByText('Review decision')).toBeInTheDocument()
+
+            const reviewDecisionSection =
+                screen.getByLabelText('Review decision')
+
+            // Expect review determination unavailable
+            expect(
+                within(reviewDecisionSection).queryByText(
+                    'Review determination unavailable'
+                )
+            ).toBeInTheDocument()
+        })
+
         it('shows Review decision when EQRO submission is Resubmitted', async () => {
             const contract = mockContractPackageSubmitted({
                 id: 'test-abc-123',
@@ -690,13 +753,33 @@ describe('EQROSubmissionSummary - Unlock submission button tests', () => {
         })
 
         it('does not render the withdraw button when EQRO submission is already withdrawn', async () => {
-            const contract = mockContractPackageSubmitted({
+            const contract = mockEqroContractSubmittedUnderReview({
                 id: 'test-abc-123',
                 contractSubmissionType: 'EQRO',
                 status: 'SUBMITTED',
             })
             contract.reviewStatus = 'WITHDRAWN'
             contract.consolidatedStatus = 'WITHDRAWN'
+            contract.reviewStatusActions = [
+                {
+                    __typename: 'ContractReviewStatusActions',
+                    updatedAt: '2026-03-24T16:35:27.793Z',
+                    updatedBy: null,
+                    dateApprovalReleasedToState: null,
+                    updatedReason: null,
+                    contractID: 'test-abc-123',
+                    actionType: 'WITHDRAW',
+                },
+                {
+                    __typename: 'ContractReviewStatusActions',
+                    updatedAt: '2026-03-23T16:35:27.793Z',
+                    updatedBy: null,
+                    dateApprovalReleasedToState: null,
+                    updatedReason: null,
+                    contractID: 'test-abc-123',
+                    actionType: 'UNDER_REVIEW',
+                },
+            ]
 
             renderWithProviders(
                 <Routes>
@@ -751,12 +834,21 @@ describe('EQROSubmissionSummary - Unlock submission button tests', () => {
                     name: 'Unlock submission',
                 })
             ).not.toBeInTheDocument()
+
+            const reviewDecisionSection =
+                screen.getByLabelText('Review decision')
+
+            expect(
+                within(reviewDecisionSection).queryByText(
+                    'Subject to formal review and approval'
+                )
+            ).toBeInTheDocument()
         })
     })
 
     describe('CMS User undo withdraw submission button', () => {
         it('renders the undo withdraw button when EQRO submission is Withdrawn', async () => {
-            const contract = mockContractPackageSubmitted({
+            const contract = mockEqroContractSubmittedUnderReview({
                 id: 'test-abc-123',
                 contractSubmissionType: 'EQRO',
                 status: 'SUBMITTED',
@@ -817,6 +909,15 @@ describe('EQROSubmissionSummary - Unlock submission button tests', () => {
                     'No action can be taken on this submission in its current status.'
                 )
             ).not.toBeInTheDocument()
+
+            const reviewDecisionSection =
+                screen.getByLabelText('Review decision')
+
+            expect(
+                within(reviewDecisionSection).queryByText(
+                    'Subject to formal review and approval'
+                )
+            ).toBeInTheDocument()
         })
 
         it('does not render the undo withdraw button when EQRO submission is Submitted', async () => {
@@ -946,91 +1047,66 @@ describe('EQROSubmissionSummary - Unlock submission button tests', () => {
     })
 
     describe('NEW tag on review determination change', () => {
-        it('shows NEW tag when review determination changes on resubmission', async () => {
-            const contract = mockContractPackageSubmitted({
-                id: 'test-abc-123',
-                contractSubmissionType: 'EQRO',
-                status: 'RESUBMITTED',
-                consolidatedStatus: 'RESUBMITTED',
-            })
-            // Add a previous revision with a different determination (not subject to review)
-            // so that calcChangeInReviewDetermination detects the change.
-            contract.packageSubmissions.push({
-                ...contract.packageSubmissions[0],
-                contractRevision: {
-                    ...contract.packageSubmissions[0].contractRevision,
-                    formData: {
-                        ...contract.packageSubmissions[0].contractRevision
-                            .formData,
-                        eqroProvisionMcoEqrOrRelatedActivities: false,
-                    },
-                },
-            })
-
-            renderWithProviders(
-                <Routes>
-                    <Route element={<SubmissionSideNav />}>
-                        <Route
-                            path={RoutesRecord.SUBMISSIONS_SUMMARY}
-                            element={<EQROSubmissionSummary />}
-                        />
-                    </Route>
-                </Routes>,
-                {
-                    apolloProvider: {
-                        mocks: [
-                            fetchCurrentUserMock({
-                                user: mockValidCMSUser(),
-                                statusCode: 200,
-                            }),
-                            fetchContractWithQuestionsMockSuccess({
-                                contract,
-                            }),
-                            fetchContractWithQuestionsMockSuccess({
-                                contract,
-                            }),
-                        ],
-                    },
-                    routerProvider: {
-                        route: '/submissions/eqro/test-abc-123',
-                    },
-                    featureFlags: {
-                        [featureFlags.EQRO_SUBMISSIONS.flag]: true,
-                    },
-                }
-            )
-
-            await waitFor(() => {
-                expect(
-                    screen.getByTestId('submission-summary')
-                ).toBeInTheDocument()
-            })
-
-            // Expect NEW tag to be visible when determination changed
-            expect(screen.getByText('NEW')).toBeInTheDocument()
-        })
-
         it('does not show NEW tag when review determination is unchanged on resubmission', async () => {
-            const contract = mockContractPackageSubmitted({
+            const contract = mockEqroContractSubmittedNotSubjectToReview({
                 id: 'test-abc-123',
                 contractSubmissionType: 'EQRO',
                 status: 'RESUBMITTED',
-                consolidatedStatus: 'RESUBMITTED',
+                consolidatedStatus: 'NOT_SUBJECT_TO_REVIEW',
             })
             // Add a previous revision with the same determination (subject to review)
             contract.packageSubmissions.push({
                 ...contract.packageSubmissions[0],
                 contractRevision: {
                     ...contract.packageSubmissions[0].contractRevision,
-                    formData: {
-                        ...contract.packageSubmissions[0].contractRevision
-                            .formData,
-                        eqroProvisionMcoEqrOrRelatedActivities: true,
-                        eqroProvisionMcoNewOptionalActivity: true,
-                        eqroProvisionNewMcoEqrRelatedActivities: false,
+                    unlockInfo: {
+                        __typename: 'UpdateInformation',
+                        updatedAt: '2026-03-23T17:09:40.003Z',
+                        updatedBy: {
+                            __typename: 'UpdatedBy',
+                            email: 'zuko@example.com',
+                            role: 'CMS_USER',
+                            familyName: 'Hotman',
+                            givenName: 'Zuko',
+                        },
+                        updatedReason:
+                            'Unlocking submission to make it subject to review',
+                    },
+                    submitInfo: {
+                        __typename: 'UpdateInformation',
+                        updatedAt: '2026-03-24T17:10:31.154Z',
+                        updatedBy: {
+                            __typename: 'UpdatedBy',
+                            email: 'aang@example.com',
+                            role: 'STATE_USER',
+                            familyName: 'Avatar',
+                            givenName: 'Aang',
+                        },
+                        updatedReason:
+                            'Resubmitting to test that the contract is now subject to review',
                     },
                 },
             })
+            contract.reviewStatusActions = [
+                {
+                    __typename: 'ContractReviewStatusActions',
+                    updatedAt: '2026-03-24T16:35:27.793Z',
+                    updatedBy: null,
+                    dateApprovalReleasedToState: null,
+                    updatedReason: null,
+                    contractID: 'test-abc-123',
+                    actionType: 'NOT_SUBJECT_TO_REVIEW',
+                },
+                {
+                    __typename: 'ContractReviewStatusActions',
+                    updatedAt: '2026-03-23T16:35:27.793Z',
+                    updatedBy: null,
+                    dateApprovalReleasedToState: null,
+                    updatedReason: null,
+                    contractID: 'test-abc-123',
+                    actionType: 'NOT_SUBJECT_TO_REVIEW',
+                },
+            ]
 
             renderWithProviders(
                 <Routes>
@@ -1071,31 +1147,81 @@ describe('EQROSubmissionSummary - Unlock submission button tests', () => {
                 ).toBeInTheDocument()
             })
 
+            const reviewDecisionSection =
+                screen.getByLabelText('Review decision')
+
             // Expect NEW tag to NOT be visible when determination unchanged
-            expect(screen.queryByText('NEW')).not.toBeInTheDocument()
+            expect(
+                within(reviewDecisionSection).queryByText('NEW')
+            ).not.toBeInTheDocument()
         })
 
         it('shows NEW tag when determination changes from subject to not subject to review', async () => {
-            const contract = mockContractPackageSubmitted({
+            const contract = mockEqroContractSubmittedNotSubjectToReview({
                 id: 'test-abc-123',
                 contractSubmissionType: 'EQRO',
                 status: 'RESUBMITTED',
                 consolidatedStatus: 'NOT_SUBJECT_TO_REVIEW',
             })
             // Add a previous revision that was subject to review
-            contract.packageSubmissions.push({
-                ...contract.packageSubmissions[0],
-                contractRevision: {
-                    ...contract.packageSubmissions[0].contractRevision,
-                    formData: {
-                        ...contract.packageSubmissions[0].contractRevision
-                            .formData,
-                        eqroProvisionMcoEqrOrRelatedActivities: true,
-                        eqroProvisionMcoNewOptionalActivity: true,
-                        eqroProvisionNewMcoEqrRelatedActivities: false,
+            contract.packageSubmissions = [
+                {
+                    ...contract.packageSubmissions[0],
+                    submitInfo: {
+                        __typename: 'UpdateInformation',
+                        updatedAt: '2026-03-24T17:01:31.902Z',
+                        updatedBy: {
+                            __typename: 'UpdatedBy',
+                            email: 'aang@example.com',
+                            role: 'STATE_USER' as const,
+                            familyName: 'Avatar',
+                            givenName: 'Aang',
+                        },
+                        updatedReason: 'Resubmission',
+                    },
+                    contractRevision: {
+                        ...contract.packageSubmissions[0].contractRevision,
+                        id: 'resubmission-submission-id',
                     },
                 },
-            })
+                {
+                    ...contract.packageSubmissions[0],
+                    contractRevision: {
+                        ...contract.packageSubmissions[0].contractRevision,
+                        id: 'initial-submission-id',
+                        formData: {
+                            ...contract.packageSubmissions[0].contractRevision
+                                .formData,
+                            managedCareEntities: ['MCO'],
+                            eqroNewContractor: true,
+                            eqroProvisionMcoNewOptionalActivity: true,
+                            eqroProvisionNewMcoEqrRelatedActivities: true,
+                            eqroProvisionChipEqrRelatedActivities: true,
+                            eqroProvisionMcoEqrOrRelatedActivities: true,
+                        },
+                    },
+                },
+            ]
+            contract.reviewStatusActions = [
+                {
+                    __typename: 'ContractReviewStatusActions',
+                    updatedAt: '2026-03-24T16:35:27.793Z',
+                    updatedBy: null,
+                    dateApprovalReleasedToState: null,
+                    updatedReason: null,
+                    contractID: 'test-abc-123',
+                    actionType: 'NOT_SUBJECT_TO_REVIEW',
+                },
+                {
+                    __typename: 'ContractReviewStatusActions',
+                    updatedAt: '2026-03-23T16:35:27.793Z',
+                    updatedBy: null,
+                    dateApprovalReleasedToState: null,
+                    updatedReason: null,
+                    contractID: 'test-abc-123',
+                    actionType: 'UNDER_REVIEW',
+                },
+            ]
 
             renderWithProviders(
                 <Routes>
@@ -1136,8 +1262,13 @@ describe('EQROSubmissionSummary - Unlock submission button tests', () => {
                 ).toBeInTheDocument()
             })
 
+            const reviewDecisionSection =
+                screen.getByLabelText('Review decision')
+
             // Expect NEW tag to be visible when determination changed
-            expect(screen.getByText('NEW')).toBeInTheDocument()
+            expect(
+                within(reviewDecisionSection).queryByText('NEW')
+            ).toBeInTheDocument()
         })
     })
 })


### PR DESCRIPTION
## Summary
[MCR-5861](https://jiraent.cms.gov/browse/MCR-5861)

This is a follow up to MCR-5861 to fix the `Review decision` section on the summary page when a submission is withdrawn. The bug had the review decision change because it did not account for a `Withdrawn` status. This work adds a more robust logic to find the last review determination and handles the edge case where review determination is not available

#### Related issues

#### Screenshots

#### Test cases covered

- 'shows error UI when no decision is avaliable'
- Updated existing unit tests
   - `'does not render the withdraw button when EQRO submission is already withdrawn'`
      - Add assertion for review decision
   - `'renders the undo withdraw button when EQRO submission is Withdrawn'`
      - Add assertion for review decision
   -  Fix assertions for the new tag
      - It needed to be scoped to the `Review decision` section. It was picking up the NEW tag from documents.

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
- Make a new EQRO submission and submit. Then withdraw it to verify the review decision did not change
   - Test for both review decisions.

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed