### PR TITLE
MCR-6209: Enable mulesoft to call createContractQuestion

### DIFF
--- a/services/app-api/src/authn/thirdPartyAuthn.test.ts
+++ b/services/app-api/src/authn/thirdPartyAuthn.test.ts
@@ -1,0 +1,52 @@
+import { userFromThirdPartyAuthorizer } from './thirdPartyAuthn'
+import { lookupUserAurora } from './cognitoAuthn'
+import type { Store } from '../postgres'
+import type { CMSUserType } from '../domain-models'
+
+vi.mock('./cognitoAuthn', () => ({
+    lookupUserAurora: vi.fn(),
+}))
+
+vi.mock('../otel/otel_handler', () => ({
+    initTracer: vi.fn(),
+    recordException: vi.fn(),
+}))
+
+const mockLookupUserAurora = vi.mocked(lookupUserAurora)
+
+const mockStore = {} as Store
+
+const cmsUser = (overrides: Partial<CMSUserType> = {}): CMSUserType => ({
+    id: 'cms-user-1',
+    role: 'CMS_USER',
+    email: 'cms@example.com',
+    givenName: 'CMS',
+    familyName: 'User',
+    stateAssignments: [],
+    ...overrides,
+})
+
+describe('userFromThirdPartyAuthorizer', () => {
+    it('returns the delegated CMS user and defaults divisionAssignment to DMCO', async () => {
+        const delegatedUser = cmsUser({
+            id: 'delegated-cms-user',
+            divisionAssignment: undefined,
+        })
+        mockLookupUserAurora.mockResolvedValue(delegatedUser)
+
+        const result = await userFromThirdPartyAuthorizer(
+            mockStore,
+            'oauth-test',
+            delegatedUser.id
+        )
+
+        expect(mockLookupUserAurora).toHaveBeenCalledWith(
+            mockStore,
+            delegatedUser.id
+        )
+        expect(result).toEqual({
+            ...delegatedUser,
+            divisionAssignment: 'DMCO',
+        })
+    })
+})

--- a/services/app-api/src/authn/thirdPartyAuthn.ts
+++ b/services/app-api/src/authn/thirdPartyAuthn.ts
@@ -44,7 +44,9 @@ export async function userFromThirdPartyAuthorizer(
                     `Fetch delegated user error. Delegated user not authorized. Role: ${delegatedUser.role}`
                 )
             }
-
+            if (!delegatedUser.divisionAssignment) {
+                delegatedUser.divisionAssignment = 'DMCO'
+            }
             return delegatedUser
         } else {
             // Lookup user from postgres - validates for non-delegated user

--- a/services/app-api/src/resolvers/questionResponse/createContractQuestion.ts
+++ b/services/app-api/src/resolvers/questionResponse/createContractQuestion.ts
@@ -22,7 +22,7 @@ export function createContractQuestionResolver(
         const { user, ctx, tracer } = context
         const span = tracer?.startSpan('createContractQuestion', {}, ctx)
 
-        // Check OAuth client read permissions
+        // Check OAuth client write permissions
         if (!canOauthWrite(context)) {
             const errMessage = `OAuth client does not have write permissions`
             logError('createContractQuestion', errMessage)
@@ -41,6 +41,12 @@ export function createContractQuestionResolver(
             logError('createContractQuestion', msg)
             setErrorAttributesOnActiveSpan(msg, span)
             throw createForbiddenError(msg)
+        }
+
+        // Default to setting DMCO as the division when the
+        // request comes through Oauth
+        if (!user.divisionAssignment && canOauthWrite(context)) {
+            user.divisionAssignment = 'DMCO'
         }
 
         if (
@@ -134,6 +140,7 @@ export function createContractQuestionResolver(
             ...input,
             documents: docs,
         }
+
         const questionResult = await store.insertContractQuestion(
             inputFormatted,
             user

--- a/services/app-api/src/resolvers/questionResponse/createContractQuestion.ts
+++ b/services/app-api/src/resolvers/questionResponse/createContractQuestion.ts
@@ -43,12 +43,6 @@ export function createContractQuestionResolver(
             throw createForbiddenError(msg)
         }
 
-        // Default to setting DMCO as the division when the
-        // request comes through Oauth
-        // if (!user.divisionAssignment && canOauthWrite(context)) {
-        //     user.divisionAssignment = 'DMCO'
-        // }
-
         if (
             !user.divisionAssignment ||
             (user.divisionAssignment &&

--- a/services/app-api/src/resolvers/questionResponse/createContractQuestion.ts
+++ b/services/app-api/src/resolvers/questionResponse/createContractQuestion.ts
@@ -45,9 +45,9 @@ export function createContractQuestionResolver(
 
         // Default to setting DMCO as the division when the
         // request comes through Oauth
-        if (!user.divisionAssignment && canOauthWrite(context)) {
-            user.divisionAssignment = 'DMCO'
-        }
+        // if (!user.divisionAssignment && canOauthWrite(context)) {
+        //     user.divisionAssignment = 'DMCO'
+        // }
 
         if (
             !user.divisionAssignment ||


### PR DESCRIPTION
## Summary

CMS users who will be creating contract questions via mulesoft may not always have a division set on their user. This approach, updates the delegatedUser to use DMCO for their divisionAssignment, when:

- A request is coming via oAuth
- The user doesn’t currently have a division set (prevents unintentional overrides)

[Discovery doc](https://www.notion.so/mc-review/Enable-Mulesoft-to-Call-CreateContractQuestion-endpoint-3504f9e180fa80b8b1c2d8ca432a2684)
#### Related issues
https://jiraent.cms.gov/browse/MCR-6209

#### Screenshots

#### Test cases covered

Defaults to DMCO when the delegated user doesn't have a division set

## QA guidance

Can be tested manually with a delegated oauth client and the `createContractQuestion` enpoint

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed