### PR TITLE
adjust homepage headings when EQRO flag is off

### DIFF
--- a/services/app-web/src/pages/Landing/Landing.tsx
+++ b/services/app-web/src/pages/Landing/Landing.tsx
@@ -194,7 +194,9 @@ export const Landing = (): React.ReactElement => {
                         <Grid row gap className="margin-top-2">
                             <Grid tablet={{ col: 6 }}>
                                 <div className={styles.detailsSteps}>
-                                    <h2>How it works</h2>
+                                    <h2 className="mcr-homepage-h2-bold">
+                                        How it works
+                                    </h2>
                                     <ul>
                                         <li className={styles.login}>
                                             <span>Sign in with IDM</span>
@@ -228,7 +230,7 @@ export const Landing = (): React.ReactElement => {
                                 </div>
                             </Grid>
                             <Grid tablet={{ col: 6 }}>
-                                <h2 className="margin-top-0">
+                                <h2 className="margin-top-0 mcr-homepage-h2-bold">
                                     Submit your managed care health plans to CMS
                                     for review
                                 </h2>
@@ -261,7 +263,9 @@ export const Landing = (): React.ReactElement => {
                                     </li>
                                 </ul>
 
-                                <h3>Not accepted by MC-Review at this time:</h3>
+                                <h5 className="margin-bottom-0">
+                                    Not accepted by MC-Review at this time:
+                                </h5>
                                 <ul className={styles.detailsList}>
                                     <li>State directed preprints</li>
                                     <li>


### PR DESCRIPTION
## Summary
As part of the EQRO work the homepage content and stylings were updated. Since those changes are behind a feature flag, the present day homepage has some wonkyness. This is quick-fix PR that adjusts the headings on the non feature flagged version to be more inline with upcoming changes

#### Related issues
[convo with design](https://cmsgov.slack.com/archives/C014CRU197U/p1777469637501379)
#### Screenshots
<img width="1264" height="667" alt="Screenshot 2026-04-30 at 8 59 40 AM" src="https://github.com/user-attachments/assets/eaff131e-a01e-4e10-96ca-ad729f53e606" />

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

View the homepage with the EQRO submission flagged turned off

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed