### PR TITLE
mcr-6237: add workflow for deploying to dev environment

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -51,9 +51,9 @@ jobs:
         name: Create GitHub deployment
         id: ghdeployment
         with:
-          token: "${{ github.token }}"
+          token: '${{ github.token }}'
           environment: dev-cdk
-          description: "Manual CDK dev deployment from branch: ${{ inputs.branch }}"
+          description: 'Manual CDK dev deployment from branch: ${{ inputs.branch }}'
           initial-status: in_progress
 
   web-unit-tests:
@@ -98,12 +98,6 @@ jobs:
         with:
           name: cypress-gen
           path: ./services/cypress/gen
-
-      - name: upload unit test coverage
-        uses: actions/upload-artifact@v7
-        with:
-          name: unit-test-coverage
-          path: ./services/app-web/coverage/coverage-final.json
 
   api-unit-tests:
     name: test - api unit tests
@@ -221,8 +215,8 @@ jobs:
           region: ${{ vars.AWS_DEFAULT_REGION }}
           account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
           stage-name: dev
-          changed-services: "github-oidc"
-          use-cdk-role: "true"
+          changed-services: 'github-oidc'
+          use-cdk-role: 'true'
 
       - name: deploy github-oidc with CDK
         id: deploy-github-oidc-cdk
@@ -268,7 +262,7 @@ jobs:
           region: ${{ vars.AWS_DEFAULT_REGION }}
           account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
           stage-name: dev
-          use-cdk-role: "true"
+          use-cdk-role: 'true'
 
       - name: Deploy Network stack
         working-directory: services/infra-cdk
@@ -356,14 +350,7 @@ jobs:
             --require-approval never
 
   deploy-cdk-app-dev:
-    needs:
-      [
-        begin-deployment,
-        deploy-cdk-infrastructure-dev,
-        web-unit-tests,
-        api-unit-tests,
-        packages-unit-tests,
-      ]
+    needs: [begin-deployment, deploy-cdk-infrastructure-dev, web-unit-tests, api-unit-tests, packages-unit-tests]
     if: |
       always() &&
       needs.deploy-cdk-infrastructure-dev.result == 'success' &&
@@ -396,7 +383,7 @@ jobs:
           region: ${{ vars.AWS_DEFAULT_REGION }}
           account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
           stage-name: dev
-          use-cdk-role: "true"
+          use-cdk-role: 'true'
 
       - name: Deploy AppApi stack
         working-directory: services/infra-cdk
@@ -471,7 +458,7 @@ jobs:
           region: ${{ vars.AWS_DEFAULT_REGION }}
           account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
           stage-name: dev
-          use-cdk-role: "true"
+          use-cdk-role: 'true'
 
       - name: Get CDK configuration for app-web build
         env:
@@ -528,14 +515,14 @@ jobs:
         if: needs.deploy-cdk-app-dev.result != 'success' || needs.deploy-frontend-app-dev.result != 'success'
         uses: chrnorm/deployment-status@v2
         with:
-          token: "${{ github.token }}"
-          state: "failure"
+          token: '${{ github.token }}'
+          state: 'failure'
           deployment-id: ${{ needs.begin-deployment.outputs.deploy-id }}
 
       - name: Update deployment status (success)
         if: needs.deploy-cdk-app-dev.result == 'success' && needs.deploy-frontend-app-dev.result == 'success'
         uses: chrnorm/deployment-status@v2
         with:
-          token: "${{ github.token }}"
-          state: "success"
+          token: '${{ github.token }}'
+          state: 'success'
           deployment-id: ${{ needs.begin-deployment.outputs.deploy-id }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,541 @@
+name: Deploy to Dev Environment (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to deploy to the dev environment
+        required: true
+        default: main
+        type: string
+
+# Use same concurrency group as promote-cdk.yml so they don't race
+concurrency:
+  group: deploy-cdk-dev
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+  deployments: write
+
+jobs:
+  begin-deployment:
+    name: Begin CDK Deployment
+    runs-on: ubuntu-24.04
+    environment:
+      name: dev
+    permissions:
+      deployments: write
+    outputs:
+      deploy-id: ${{ steps.ghdeployment.outputs.deployment_id }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Check for secrets
+        uses: ./.github/actions/check_secrets
+        with:
+          expected-secret: ${{ secrets.VITE_APP_AUTH_MODE }}
+
+      - name: Setup env
+        uses: ./.github/actions/setup_env
+
+      - name: build scripts
+        shell: bash
+        run: pnpm -r build:ci-scripts
+
+      - uses: chrnorm/deployment-action@v2
+        name: Create GitHub deployment
+        id: ghdeployment
+        with:
+          token: "${{ github.token }}"
+          environment: dev-cdk
+          description: "Manual CDK dev deployment from branch: ${{ inputs.branch }}"
+          initial-status: in_progress
+
+  web-unit-tests:
+    name: test - web unit tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup env
+        uses: ./.github/actions/setup_env
+
+      - name: Generate Code
+        run: pnpm -r generate
+
+      - name: Build packages
+        shell: bash
+        run: pnpm build:packages
+
+      - name: Web Unit Tests
+        id: web-unit-tests
+        env:
+          NODE_OPTIONS: --max_old_space_size=6000
+          VITE_APP_AUTH_MODE: IDM
+          DATABASE_URL: postgresql://postgres:shhhsecret@localhost:5432/postgres?schema=public&connection_limit=5 #pragma: allowlist secret
+        working-directory: services/app-web
+        run: |
+          set -e
+          pnpm test:coverage
+          exit $?
+
+      - name: upload app web gen directory
+        uses: actions/upload-artifact@v7
+        with:
+          name: app-web-gen
+          path: ./services/app-web/src/gen
+
+      - name: upload cypress gen directory
+        uses: actions/upload-artifact@v7
+        with:
+          name: cypress-gen
+          path: ./services/cypress/gen
+
+      - name: upload unit test coverage
+        uses: actions/upload-artifact@v7
+        with:
+          name: unit-test-coverage
+          path: ./services/app-web/coverage/coverage-final.json
+
+  api-unit-tests:
+    name: test - api unit tests
+    runs-on: ubuntu-24.04
+    services:
+      postgres:
+        image: postgres:16.6
+        env:
+          VITE_APP_AUTH_MODE: IDM
+          POSTGRES_PASSWORD: shhhsecret #pragma: allowlist secret
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup env
+        uses: ./.github/actions/setup_env
+
+      - name: Generate code
+        run: pnpm -r generate
+
+      - name: Reset test database
+        env:
+          NODE_OPTIONS: --max_old_space_size=6000
+          VITE_APP_AUTH_MODE: IDM
+          DATABASE_URL: postgresql://postgres:shhhsecret@localhost:5432/postgres?schema=public&connection_limit=5 #pragma: allowlist secret
+        working-directory: services/app-api
+        run: npx prisma migrate reset --force --config ../../prisma.config.ts
+
+      - name: Build packages
+        shell: bash
+        run: pnpm build:packages
+
+      - name: API Unit Tests
+        id: api-unit-tests
+        env:
+          NODE_OPTIONS: --max_old_space_size=6000
+          VITE_APP_OTEL_COLLECTOR_URL: ${{vars.VITE_APP_OTEL_COLLECTOR_URL}}
+          VITE_APP_AUTH_MODE: IDM
+          DATABASE_URL: postgresql://postgres:shhhsecret@localhost:5432/postgres?schema=public&connection_limit=5 #pragma: allowlist secret
+        working-directory: services/app-api
+        run: |
+          set -e
+          pnpm test:coverage
+          exit $?
+
+      - name: upload api test coverage
+        uses: actions/upload-artifact@v7
+        with:
+          name: api-test-coverage
+          path: ./services/app-api/coverage/coverage-final.json
+
+  packages-unit-tests:
+    name: test - packages unit tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup env
+        uses: ./.github/actions/setup_env
+
+      - name: Generate Code
+        run: pnpm -r generate
+
+      - name: Build packages
+        shell: bash
+        run: pnpm build:packages
+
+      - name: Packages Unit Tests
+        id: packages-unit-tests
+        env:
+          NODE_OPTIONS: --max_old_space_size=6000
+        run: |
+          set -e
+          pnpm --filter "./packages/**" test:coverage
+          exit $?
+
+  deploy-github-oidc-dev:
+    needs: [begin-deployment]
+    name: deploy - GitHub OIDC service (dev)
+    runs-on: ubuntu-24.04
+    environment:
+      name: dev
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup env
+        uses: ./.github/actions/setup_env
+
+      - name: Generate Code
+        run: pnpm -r generate
+
+      - name: Build packages
+        shell: bash
+        run: pnpm build:packages
+
+      - name: Get AWS credentials (bootstrap with dev CDK OIDC role)
+        uses: ./.github/actions/get_aws_credentials
+        with:
+          region: ${{ vars.AWS_DEFAULT_REGION }}
+          account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
+          stage-name: dev
+          changed-services: "github-oidc"
+          use-cdk-role: "true"
+
+      - name: deploy github-oidc with CDK
+        id: deploy-github-oidc-cdk
+        working-directory: services/infra-cdk
+        env:
+          STAGE_NAME: dev
+        run: |
+          echo "Starting CDK OIDC deployment for stage: dev"
+          echo "Stack name will be: github-oidc-dev-cdk"
+
+          echo "=== Deploying OIDC stack ==="
+          pnpm cdk deploy github-oidc-dev-cdk \
+            --app 'pnpm tsx bin/oidc.ts' \
+            --context stage=dev \
+            --require-approval never
+
+          echo "=== CDK OIDC deployment completed ==="
+
+  deploy-cdk-infrastructure-dev:
+    needs: [begin-deployment, deploy-github-oidc-dev]
+    name: deploy - CDK infrastructure stacks (dev)
+    runs-on: ubuntu-24.04
+    environment: dev
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup env
+        uses: ./.github/actions/setup_env
+
+      - name: Generate Code
+        run: pnpm -r generate
+
+      - name: Build packages
+        shell: bash
+        run: pnpm build:packages
+
+      - name: Get AWS credentials
+        uses: ./.github/actions/get_aws_credentials
+        with:
+          region: ${{ vars.AWS_DEFAULT_REGION }}
+          account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
+          stage-name: dev
+          use-cdk-role: "true"
+
+      - name: Deploy Network stack
+        working-directory: services/infra-cdk
+        env:
+          STAGE_NAME: dev
+          VPC_ID: ${{ secrets.DEV_VPC_ID }}
+          SUBNET_PRIVATE_A_ID: ${{ secrets.DEV_SUBNET_PRIVATE_A_ID }}
+          SUBNET_PRIVATE_B_ID: ${{ secrets.DEV_SUBNET_PRIVATE_B_ID }}
+          SUBNET_PRIVATE_C_ID: ${{ secrets.DEV_SUBNET_PRIVATE_C_ID }}
+        run: |
+          echo "=== Deploying Network stack ==="
+          pnpm cdk deploy network-dev-cdk \
+            --app 'pnpm tsx bin/network.ts' \
+            --context stage=dev \
+            --require-approval never
+
+      - name: Deploy Uploads stack
+        working-directory: services/infra-cdk
+        env:
+          STAGE_NAME: dev
+        run: |
+          echo "=== Deploying Uploads stack ==="
+          pnpm cdk deploy uploads-dev-cdk \
+            --app 'pnpm tsx bin/uploads.ts' \
+            --context stage=dev \
+            --require-approval never
+
+      - name: Deploy Virus Scanning stack
+        working-directory: services/infra-cdk
+        env:
+          STAGE_NAME: dev
+          VPC_ID: ${{ secrets.DEV_VPC_ID }}
+          SUBNET_PRIVATE_A_ID: ${{ secrets.DEV_SUBNET_PRIVATE_A_ID }}
+          SUBNET_PRIVATE_B_ID: ${{ secrets.DEV_SUBNET_PRIVATE_B_ID }}
+          SUBNET_PRIVATE_C_ID: ${{ secrets.DEV_SUBNET_PRIVATE_C_ID }}
+          SUBNET_PUBLIC_A_ID: ${{ secrets.DEV_SUBNET_PUBLIC_A_ID }}
+          NR_LICENSE_KEY: ${{ secrets.NR_LICENSE_KEY }}
+          VITE_APP_OTEL_COLLECTOR_URL: ${{vars.VITE_APP_OTEL_COLLECTOR_URL}}
+          GUARDDUTY_DETECTOR_ID: ${{ secrets.DEV_GUARDDUTY_DETECTOR_ID }}
+        run: |
+          echo "=== Deploying Virus Scanning stack ==="
+          pnpm cdk deploy virus-scanning-dev-cdk \
+            --app 'pnpm tsx bin/virus-scanning.ts' \
+            --context stage=dev \
+            --require-approval never
+
+      - name: Deploy Postgres stack
+        working-directory: services/infra-cdk
+        env:
+          STAGE_NAME: dev
+          VPC_ID: ${{ secrets.DEV_VPC_ID }}
+          SUBNET_PRIVATE_A_ID: ${{ secrets.DEV_SUBNET_PRIVATE_A_ID }}
+          SUBNET_PRIVATE_B_ID: ${{ secrets.DEV_SUBNET_PRIVATE_B_ID }}
+          SUBNET_PRIVATE_C_ID: ${{ secrets.DEV_SUBNET_PRIVATE_C_ID }}
+        run: |
+          echo "=== Deploying Postgres stack ==="
+          pnpm cdk deploy postgres-dev-cdk \
+            --app 'pnpm tsx bin/postgres.ts' \
+            --context stage=dev \
+            --require-approval never
+
+      - name: Deploy Frontend Infrastructure stack
+        working-directory: services/infra-cdk
+        env:
+          STAGE_NAME: dev
+          CLOUDFRONT_CERT_ARN: ${{ secrets.DEV_CERTIFICATE_ARN }}
+          CLOUDFRONT_DOMAIN_NAME: ${{ secrets.DEV_CLOUDFRONT_DOMAIN_NAME }}
+          CLOUDFRONT_SB_DOMAIN_NAME: ${{ secrets.DEV_CLOUDFRONT_SB_DOMAIN_NAME }}
+        run: |
+          echo "=== Deploying Frontend Infrastructure stack ==="
+          pnpm cdk deploy frontend-infra-dev-cdk \
+            --app 'pnpm tsx bin/frontend-infra.ts' \
+            --context stage=dev \
+            --require-approval never
+
+      - name: Deploy Cognito stack
+        working-directory: services/infra-cdk
+        env:
+          STAGE_NAME: dev
+        run: |
+          echo "=== Deploying Cognito stack ==="
+          pnpm cdk deploy cognito-dev-cdk \
+            --app 'pnpm tsx bin/cognito.ts' \
+            --context stage=dev \
+            --require-approval never
+
+  deploy-cdk-app-dev:
+    needs:
+      [
+        begin-deployment,
+        deploy-cdk-infrastructure-dev,
+        web-unit-tests,
+        api-unit-tests,
+        packages-unit-tests,
+      ]
+    if: |
+      always() &&
+      needs.deploy-cdk-infrastructure-dev.result == 'success' &&
+      needs.web-unit-tests.result == 'success' &&
+      needs.api-unit-tests.result == 'success' &&
+      needs.packages-unit-tests.result == 'success' &&
+      needs.begin-deployment.result == 'success'
+    name: deploy - CDK application stacks (dev)
+    runs-on: ubuntu-24.04
+    environment: dev
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup env
+        uses: ./.github/actions/setup_env
+
+      - name: Generate Code
+        run: pnpm -r generate
+
+      - name: Build packages
+        shell: bash
+        run: pnpm build:packages
+
+      - name: Get AWS credentials
+        uses: ./.github/actions/get_aws_credentials
+        with:
+          region: ${{ vars.AWS_DEFAULT_REGION }}
+          account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
+          stage-name: dev
+          use-cdk-role: "true"
+
+      - name: Deploy AppApi stack
+        working-directory: services/infra-cdk
+        env:
+          STAGE_NAME: dev
+          VPC_ID: ${{ secrets.DEV_VPC_ID }}
+          INTERNAL_ALLOWED_ORIGINS: ${{ secrets.DEV_INTERNAL_ALLOWED_ORIGINS }}
+        run: |
+          echo "=== Deploying AppApi stack ==="
+          pnpm cdk deploy app-api-dev-cdk \
+            --app 'pnpm tsx bin/app-api.ts' \
+            --context stage=dev \
+            --require-approval never
+
+      - name: Create Test Users
+        env:
+          STAGE_NAME: dev
+          TEST_USERS_PASS: ${{ secrets.TEST_USERS_PASS }}
+        run: |
+          cd scripts
+          pnpm tsc
+          node ./add_cypress_test_users_cdk.js dev $TEST_USERS_PASS
+
+      - name: Run database migrations
+        env:
+          STAGE_NAME: dev
+        run: |
+          echo "=== Running database migrations ==="
+          cd services/app-api
+          ./scripts/invoke-migrate-lambda.sh app-api-dev-cdk-migrate
+
+  deploy-frontend-app-dev:
+    needs:
+      [
+        begin-deployment,
+        deploy-cdk-infrastructure-dev,
+        deploy-cdk-app-dev,
+        web-unit-tests,
+        api-unit-tests,
+        packages-unit-tests,
+      ]
+    if: |
+      always() &&
+      needs.deploy-cdk-infrastructure-dev.result == 'success' &&
+      needs.deploy-cdk-app-dev.result == 'success' &&
+      needs.web-unit-tests.result == 'success' &&
+      needs.api-unit-tests.result == 'success' &&
+      needs.packages-unit-tests.result == 'success' &&
+      needs.begin-deployment.result == 'success'
+    name: deploy - Frontend app with built assets (dev)
+    runs-on: ubuntu-24.04
+    environment: dev
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup env
+        uses: ./.github/actions/setup_env
+
+      - name: Generate Code
+        run: pnpm -r generate
+
+      - name: Build packages
+        shell: bash
+        run: pnpm build:packages
+
+      - name: Get AWS credentials
+        uses: ./.github/actions/get_aws_credentials
+        with:
+          region: ${{ vars.AWS_DEFAULT_REGION }}
+          account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
+          stage-name: dev
+          use-cdk-role: "true"
+
+      - name: Get CDK configuration for app-web build
+        env:
+          STAGE_NAME: dev
+          VITE_APP_AUTH_MODE: IDM
+        run: |
+          echo "=== Fetching CDK stack outputs for app-web build ==="
+          ./scripts/get-cdk-config.sh dev
+
+          echo "Sourcing configuration for build..."
+          source "/tmp/cdk-config-dev.env"
+
+          cat "/tmp/cdk-config-dev.env" >> $GITHUB_ENV
+
+      - name: Build app-web with CDK configuration
+        working-directory: services/app-web
+        run: |
+          echo "=== Building React app and Storybook with CDK configuration ==="
+
+          source "/tmp/cdk-config-dev.env"
+
+          echo "Using VITE_APP_API_URL: $VITE_APP_API_URL"
+          echo "Using VITE_APP_COGNITO_USER_POOL_ID: $VITE_APP_COGNITO_USER_POOL_ID"
+          echo "Using VITE_APP_S3_DOCUMENTS_BUCKET: $VITE_APP_S3_DOCUMENTS_BUCKET"
+          echo "Using VITE_APP_AUTH_MODE: $VITE_APP_AUTH_MODE"
+
+          pnpm build
+          pnpm storybook:build
+
+      - name: Deploy Frontend App stack
+        working-directory: services/infra-cdk
+        env:
+          STAGE_NAME: dev
+        run: |
+          echo "=== Deploying Frontend App stack with built assets ==="
+          pnpm cdk deploy frontend-app-dev-cdk \
+            --app 'pnpm tsx bin/frontend-app.ts' \
+            --context stage=dev \
+            --require-approval never
+
+  end-deployment-dev:
+    needs: [begin-deployment, deploy-cdk-app-dev, deploy-frontend-app-dev]
+    if: always() && needs.begin-deployment.result == 'success'
+    name: End CDK Dev Deployment
+    runs-on: ubuntu-24.04
+    permissions:
+      deployments: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Update deployment status (failure)
+        if: needs.deploy-cdk-app-dev.result != 'success' || needs.deploy-frontend-app-dev.result != 'success'
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: "${{ github.token }}"
+          state: "failure"
+          deployment-id: ${{ needs.begin-deployment.outputs.deploy-id }}
+
+      - name: Update deployment status (success)
+        if: needs.deploy-cdk-app-dev.result == 'success' && needs.deploy-frontend-app-dev.result == 'success'
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: "${{ github.token }}"
+          state: "success"
+          deployment-id: ${{ needs.begin-deployment.outputs.deploy-id }}


### PR DESCRIPTION
- Adds a manually triggered GitHub Actions workflow (`.github/workflows/deploy-dev.yml`) that deploys a specified branch to the **dev environment** (stage `dev`)
- Intended for cases where you need to redeploy dev outside of the normal `main`-push promotion — e.g., recovering from a broken dev, or deploying infrastructure changes that need to land in dev before a PR merges
- Runs the exact same deployment sequence as the dev portion of `promote-cdk.yml` (unit tests → OIDC → infra stacks → app-api → frontend), with `VITE_APP_AUTH_MODE: IDM` and dev-specific secrets