### PR TITLE
MCR-6247: Fix CHIP amendment provision cleanup on submit

### DIFF
--- a/services/app-api/src/resolvers/contract/submitContract.test.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.test.ts
@@ -203,6 +203,66 @@ describe('submitContract', () => {
             expect(sub.rateRevisions).toHaveLength(1)
         })
 
+        it('preserves CHIP amendment provision answers on submit', async () => {
+            const stateServer = await constructTestPostgresServer({
+                ldService: testLDService({
+                    'chip-submission-automation': true,
+                }),
+                s3Client: mockS3,
+            })
+
+            const draft = await createTestContract(stateServer)
+
+            await updateTestContractDraftRevision(
+                stateServer,
+                draft.id,
+                undefined,
+                {
+                    populationCovered: 'CHIP',
+                    contractType: 'AMENDMENT',
+                    federalAuthorities: ['TITLE_XXI'],
+                    inLieuServicesAndSettings: true,
+                    modifiedBenefitsProvided: true,
+                    modifiedGeoAreaServed: false,
+                    modifiedMedicaidBeneficiaries: true,
+                    modifiedRiskSharingStrategy: true,
+                    modifiedEnrollmentProcess: false,
+                    modifiedMedicalLossRatioStandards: true,
+                    modifiedGrevienceAndAppeal: false,
+                    modifiedNetworkAdequacyStandards: true,
+                    modifiedLengthOfContract: false,
+                    modifiedNonRiskPaymentArrangements: true,
+                }
+            )
+
+            const submittedContract = await submitTestContract(
+                stateServer,
+                draft.id
+            )
+            const submittedFormData =
+                submittedContract.packageSubmissions[0].contractRevision
+                    .formData
+
+            expect(submittedFormData.modifiedBenefitsProvided).toBe(true)
+            expect(submittedFormData.modifiedGeoAreaServed).toBe(false)
+            expect(submittedFormData.modifiedMedicaidBeneficiaries).toBe(true)
+            expect(submittedFormData.modifiedEnrollmentProcess).toBe(false)
+            expect(submittedFormData.modifiedMedicalLossRatioStandards).toBe(
+                true
+            )
+            expect(submittedFormData.modifiedGrevienceAndAppeal).toBe(false)
+            expect(submittedFormData.modifiedNetworkAdequacyStandards).toBe(
+                true
+            )
+            expect(submittedFormData.modifiedLengthOfContract).toBe(false)
+            expect(submittedFormData.modifiedNonRiskPaymentArrangements).toBe(
+                true
+            )
+
+            expect(submittedFormData.inLieuServicesAndSettings).toBeNull()
+            expect(submittedFormData.modifiedRiskSharingStrategy).toBeNull()
+        })
+
         it('can submit a contract with a rate linked to a still unsubmitted contract (MCR-4245 bug)', async () => {
             const stateServer = await constructTestPostgresServer({
                 s3Client: mockS3,

--- a/services/app-api/src/resolvers/contract/submitContract.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.ts
@@ -7,6 +7,9 @@ import { isStateUser, contractSubmitters } from '../../domain-models'
 import {
     type CHIPFederalAuthority,
     federalAuthorityKeysForCHIP,
+    modifiedProvisionMedicaidAmendmentKeys,
+    modifiedProvisionMedicaidBaseKeys,
+    provisionCHIPKeys,
 } from '@mc-review/submissions'
 import { createForbiddenError, createUserInputError } from '../errorUtils'
 import { GraphQLError } from 'graphql'
@@ -28,7 +31,7 @@ import {
     isContractWithProvisions,
     generateApplicableProvisionsList,
 } from '../../domain-models/contractAndRates'
-import type { GeneralizedModifiedProvisions } from '@mc-review/submissions'
+import type { GeneralizedProvisionType } from '@mc-review/submissions'
 import { canWrite } from '../../authorization/oauthAuthorization'
 import type { DocumentZipService } from '../../zip/generateZip'
 
@@ -161,8 +164,9 @@ export function submitContract(
                     )
                 }
 
-                const initialFormData =
-                    contractWithHistory.draftRevision.formData
+                const initialFormData = {
+                    ...contractWithHistory.draftRevision.formData,
+                }
                 const contractRevisionID = contractWithHistory.draftRevision.id
                 const draftRatesWithoutLinkedRates =
                     contractWithHistory.draftRates?.filter((rate) => {
@@ -176,35 +180,44 @@ export function submitContract(
                 if (isCHIPOnly(contractWithHistory)) {
                     // remove invalid provisions
                     if (isContractWithProvisions(contractWithHistory)) {
-                        const validProvisionsKeys =
-                            generateApplicableProvisionsList(
-                                contractWithHistory
-                            )
-                        const validProvisionsData: Partial<GeneralizedModifiedProvisions> =
-                            {}
-                        validProvisionsKeys.forEach((provision) => {
-                            contractWithHistory.draftRevision!.formData[
-                                provision
-                            ] = validProvisionsData[provision]
+                        const validProvisionsKeys: GeneralizedProvisionType[] =
+                            [
+                                ...generateApplicableProvisionsList(
+                                    contractWithHistory
+                                ),
+                            ]
+
+                        const allProvisionKeys: GeneralizedProvisionType[] = [
+                            ...provisionCHIPKeys,
+                            ...modifiedProvisionMedicaidBaseKeys,
+                            ...modifiedProvisionMedicaidAmendmentKeys,
+                        ]
+
+                        allProvisionKeys.forEach((provision) => {
+                            if (!validProvisionsKeys.includes(provision)) {
+                                initialFormData[provision] = undefined
+                            }
                         })
                     }
 
-                    contractWithHistory.draftRevision.formData.federalAuthorities =
-                        contractWithHistory.draftRevision.formData.federalAuthorities.filter(
-                            (authority) =>
-                                federalAuthorityKeysForCHIP.includes(
-                                    authority as CHIPFederalAuthority
-                                )
+                    initialFormData.federalAuthorities =
+                        initialFormData.federalAuthorities.filter((authority) =>
+                            federalAuthorityKeysForCHIP.includes(
+                                authority as CHIPFederalAuthority
+                            )
                         )
                 }
 
                 const contractToParse = Object.assign({}, contractWithHistory)
+                contractToParse.draftRevision = {
+                    ...contractWithHistory.draftRevision,
+                    formData: initialFormData,
+                }
 
                 contractToParse.draftRates = draftRatesWithoutLinkedRates
 
                 // MCR-5970 if user changes DSNP, ensure rate medicaidPopulations is cleared out
-                const isDsnp =
-                    contractWithHistory.draftRevision.formData.dsnpContract
+                const isDsnp = initialFormData.dsnpContract
 
                 const parsedContract = isEQRO
                     ? parseEQROContract(


### PR DESCRIPTION
## Summary

Fixes a submit time bug for CHIP-only health plan amendments where valid provision responses could be cleared and later appear as null in fetchContract and thus on the Submission Summary.

**What changed**

- updated CHIP-only submit cleanup to clear only non-applicable provision fields
- stopped mutating the live draft form data object during submit
- ensured submit validation and persistence use the same cleaned form data
- added regression coverage for CHIP amendment provision preservation on submit

#### Related issues
https://jiraent.cms.gov/browse/MCR-6247 

#### Screenshots

#### Test cases covered

submitContract.test -> 'preserves CHIP amendment provision answers on submit'

## QA guidance

Steps To Reproduce

1. Create or use a HEALTH_PLAN contract.
2. Set it up as a CHIP-only amendment:
   - `populationCovered = CHIP`
   - `contractType = AMENDMENT`
3. Go to Contract Details.
4. Answer the provision yes/no questions under:
   - `Does this contract action include new or modified provisions related to any of the following`
5. Submit the package.
6. Open Submission Summary or call `fetchContract` for the submitted contract.
7. Observe that the provision fields come back as boolean values and not null.


## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed