### PR TITLE
MCR-5863 & MCR-6066 EQRO Undo Withdraw Email

### DIFF
--- a/services/app-api/src/emailer/emails/__snapshots__/sendUndoWithdrawnSubmissionCMSEmail.test.ts.snap
+++ b/services/app-api/src/emailer/emails/__snapshots__/sendUndoWithdrawnSubmissionCMSEmail.test.ts.snap
@@ -1,5 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`sendUndoWithdrawnSubmissionCMSEmail > renders EQRO email when undo withdraw returns to not subject to review 1`] = `
+"<h1 style="font-weight: normal;">Submission MCR-MN-0004-SNBC status was updated to 'Not subject to review' by CMS</h1>
+<b>Withdraw reversed by:</b> <a href="mailto:zuko@example.com">zuko@example.com</a><br />
+<b>Status:</b> Not subject to review<br />
+<b>Review decision:</b> Not subject to formal review and approval<br />
+<b>Reason for withdrawal reversal:</b> Test Undo Withdraw<br />
+<br />
+<a href="http://localhost/submissions/eqro/test-contract-123">View submission</a><br />
+"
+`;
+
+exports[`sendUndoWithdrawnSubmissionCMSEmail > renders EQRO email when undo withdraw returns to subject to review 1`] = `
+"<h1 style="font-weight: normal;">Submission MCR-MN-0004-SNBC status was updated to 'Submitted' by CMS</h1>
+<b>Withdraw reversed by:</b> <a href="mailto:zuko@example.com">zuko@example.com</a><br />
+<b>Status:</b> Submitted<br />
+<b>Review decision:</b> Subject to formal review and approval<br />
+<b>Reason for withdrawal reversal:</b> Test Undo Withdraw<br />
+<br />
+<a href="http://localhost/submissions/eqro/test-contract-123">View submission</a><br />
+"
+`;
+
 exports[`sendUndoWithdrawnSubmissionCMSEmail > renders overall email for undo withdraw contract as expected 1`] = `
 "<h1 style="font-weight: normal;">Submission MCR-MN-0004-SNBC status was updated to 'Submitted' by CMS</h1>
 <b>Updated by:</b> zuko@example.com<br />

--- a/services/app-api/src/emailer/emails/__snapshots__/sendUndoWithdrawnSubmissionStateEmail.test.ts.snap
+++ b/services/app-api/src/emailer/emails/__snapshots__/sendUndoWithdrawnSubmissionStateEmail.test.ts.snap
@@ -1,5 +1,39 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`sendUndoWithdrawnSubmissionStateEmail > renders EQRO email when undo withdraw returns to not subject to review 1`] = `
+"<h1 style="font-weight: normal;">Submission MCR-MN-0004-SNBC status was updated to 'Not subject to review' by CMS</h1>
+<b>Withdraw reversed by:</b> <a href="mailto:zuko@example.com">zuko@example.com</a><br />
+<b>Status:</b> Not subject to review<br />
+<b>Review decision:</b> Not subject to formal review and approval<br />
+<b>Reason for withdrawal reversal:</b> Test Undo Withdraw<br />
+<br />
+<a href="http://localhost/submissions/eqro/test-contract-123">View submission</a><br />
+<br />
+If you need assistance or have any questions:
+<ul>
+  <li>For assistance with programmatic, contractual, or operational issues, please reach out to <a href="mailto:MCGDMCOactions@cms.hhs.gov">MCGDMCOactions@cms.hhs.gov</a> and/or your CMS primary contact.</li>
+  <li>For issues related to MC-Review or all other inquiries, please reach out to <a href="mailto:MC_Review_HelpDesk@cms.hhs.gov">MC_Review_HelpDesk@cms.hhs.gov</a>.</li>
+</ul>
+"
+`;
+
+exports[`sendUndoWithdrawnSubmissionStateEmail > renders EQRO email when undo withdraw returns to subject to review 1`] = `
+"<h1 style="font-weight: normal;">Submission MCR-MN-0004-SNBC status was updated to 'Submitted' by CMS</h1>
+<b>Withdraw reversed by:</b> <a href="mailto:zuko@example.com">zuko@example.com</a><br />
+<b>Status:</b> Submitted<br />
+<b>Review decision:</b> Subject to formal review and approval<br />
+<b>Reason for withdrawal reversal:</b> Test Undo Withdraw<br />
+<br />
+<a href="http://localhost/submissions/eqro/test-contract-123">View submission</a><br />
+<br />
+If you need assistance or have any questions:
+<ul>
+  <li>For assistance with programmatic, contractual, or operational issues, please reach out to <a href="mailto:MCGDMCOactions@cms.hhs.gov">MCGDMCOactions@cms.hhs.gov</a> and/or your CMS primary contact.</li>
+  <li>For issues related to MC-Review or all other inquiries, please reach out to <a href="mailto:MC_Review_HelpDesk@cms.hhs.gov">MC_Review_HelpDesk@cms.hhs.gov</a>.</li>
+</ul>
+"
+`;
+
 exports[`sendUndoWithdrawnSubmissionStateEmail > renders overall email for undo withdraw contract as expected 1`] = `
 "<h1 style="font-weight: normal;">Submission MCR-MN-0004-SNBC status was updated to 'Submitted' by CMS</h1>
 <b>Updated by:</b> zuko@example.com<br />

--- a/services/app-api/src/emailer/emails/sendUndoWithdrawnSubmissionCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/sendUndoWithdrawnSubmissionCMSEmail.test.ts
@@ -1,5 +1,6 @@
 import {
     mockContract,
+    mockEQROContract,
     testEmailConfig,
     testStateAnalystsEmails,
 } from '../../testHelpers/emailerHelpers'
@@ -50,6 +51,87 @@ const testRatesForDisplay = [
 ]
 const stateAnalystEmails = () => [...testStateAnalystsEmails]
 
+const undoWithdrawReviewStatusActions = (
+    actionType: 'UNDER_REVIEW' | 'NOT_SUBJECT_TO_REVIEW'
+) => [
+    {
+        updatedAt: new Date('2025-05-10'),
+        updatedBy: {
+            role: 'CMS_USER' as const,
+            email: 'zuko@example.com',
+            givenName: 'Zuko',
+            familyName: 'Hotman',
+        },
+        updatedReason: 'Test Undo Withdraw',
+        dateApprovalReleasedToState: undefined,
+        actionType,
+        contractID: 'test-contract-123',
+    },
+    {
+        updatedAt: new Date('2025-04-10'),
+        updatedBy: {
+            role: 'CMS_USER' as const,
+            email: 'zuko@example.com',
+            givenName: 'Zuko',
+            familyName: 'Hotman',
+        },
+        updatedReason: 'Test Withdraw',
+        dateApprovalReleasedToState: undefined,
+        actionType: 'WITHDRAW' as const,
+        contractID: 'test-contract-123',
+    },
+]
+
+const mockEQROUndoWithdrawContract = (subjectToReview: boolean) => {
+    const baseContract = mockEQROContract()
+    const latestSubmission = baseContract.packageSubmissions[0]
+
+    return mockEQROContract({
+        id: 'test-contract-123',
+        consolidatedStatus: subjectToReview
+            ? 'RESUBMITTED'
+            : 'NOT_SUBJECT_TO_REVIEW',
+        reviewStatusActions: undoWithdrawReviewStatusActions(
+            subjectToReview ? 'UNDER_REVIEW' : 'NOT_SUBJECT_TO_REVIEW'
+        ),
+        packageSubmissions: [
+            {
+                ...latestSubmission,
+                contractRevision: {
+                    ...latestSubmission.contractRevision,
+                    formData: {
+                        ...latestSubmission.contractRevision.formData,
+                        eqroProvisionMcoEqrOrRelatedActivities: subjectToReview,
+                        eqroProvisionMcoNewOptionalActivity: subjectToReview,
+                        eqroProvisionNewMcoEqrRelatedActivities: false,
+                    },
+                },
+            },
+        ],
+    })
+}
+
+const expectEQROUndoWithdrawContent = (
+    bodyHTML: string | undefined,
+    status: string,
+    reviewDecision: string
+) => {
+    expect(bodyHTML).toContain(
+        `Submission MCR-MN-0004-SNBC status was updated to '${status}' by CMS`
+    )
+    expect(bodyHTML).toContain(
+        '<b>Withdraw reversed by:</b> <a href="mailto:zuko@example.com">zuko@example.com</a>'
+    )
+    expect(bodyHTML).toContain(`<b>Status:</b> ${status}`)
+    expect(bodyHTML).toContain(`<b>Review decision:</b> ${reviewDecision}`)
+    expect(bodyHTML).toContain(
+        '<b>Reason for withdrawal reversal:</b> Test Undo Withdraw'
+    )
+    expect(bodyHTML).toContain(
+        '<a href="http://localhost/submissions/eqro/test-contract-123">View submission</a>'
+    )
+}
+
 describe('sendUndoWithdrawnSubmissionCMSEmail', () => {
     it('CMS email contains correct toAddresses', async () => {
         const template = await sendUndoWithdrawnSubmissionCMSEmail(
@@ -84,6 +166,62 @@ describe('sendUndoWithdrawnSubmissionCMSEmail', () => {
             throw template
         }
 
+        expect(template.bodyHTML).toMatchSnapshot()
+    })
+
+    it('renders EQRO email when undo withdraw returns to subject to review', async () => {
+        const emailConfig = testEmailConfig()
+        const template = await sendUndoWithdrawnSubmissionCMSEmail(
+            mockEQROUndoWithdrawContract(true),
+            [],
+            stateAnalystEmails(),
+            emailConfig
+        )
+
+        if (template instanceof Error) {
+            throw template
+        }
+
+        expect(template.toAddresses).toEqual([
+            ...emailConfig.dmcoEmails,
+            ...emailConfig.devReviewTeamEmails,
+        ])
+        expect(template.subject).toBe(
+            "[LOCAL] MCR-MN-0004-SNBC status was updated to 'Submitted' by CMS"
+        )
+        expectEQROUndoWithdrawContent(
+            template.bodyHTML,
+            'Submitted',
+            'Subject to formal review and approval'
+        )
+        expect(template.bodyHTML).toMatchSnapshot()
+    })
+
+    it('renders EQRO email when undo withdraw returns to not subject to review', async () => {
+        const emailConfig = testEmailConfig()
+        const template = await sendUndoWithdrawnSubmissionCMSEmail(
+            mockEQROUndoWithdrawContract(false),
+            [],
+            stateAnalystEmails(),
+            emailConfig
+        )
+
+        if (template instanceof Error) {
+            throw template
+        }
+
+        expect(template.toAddresses).toEqual([
+            ...emailConfig.dmcoEmails,
+            ...emailConfig.devReviewTeamEmails,
+        ])
+        expect(template.subject).toBe(
+            "[LOCAL] MCR-MN-0004-SNBC status was updated to 'Not subject to review' by CMS"
+        )
+        expectEQROUndoWithdrawContent(
+            template.bodyHTML,
+            'Not subject to review',
+            'Not subject to formal review and approval'
+        )
         expect(template.bodyHTML).toMatchSnapshot()
     })
 })

--- a/services/app-api/src/emailer/emails/sendUndoWithdrawnSubmissionCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/sendUndoWithdrawnSubmissionCMSEmail.ts
@@ -9,6 +9,7 @@ import {
     renderTemplate,
     stripHTMLFromTemplate,
     parseEmailDataWithdrawSubmission,
+    parseEmailDataUndoWithdrawEQROSubmission,
     type RateForDisplayType,
 } from '../templateHelpers'
 
@@ -18,41 +19,79 @@ export const sendUndoWithdrawnSubmissionCMSEmail = async (
     stateAnalystsEmails: StateAnalystsEmails,
     config: EmailConfiguration
 ): Promise<EmailData | Error> => {
-    const toAddresses = pruneDuplicateEmails([
-        ...stateAnalystsEmails,
-        ...config.dmcpSubmissionEmails,
-        ...config.oactEmails,
-        ...config.dmcoEmails,
-        ...config.devReviewTeamEmails,
-    ])
+    if (contract.contractSubmissionType === 'EQRO') {
+        const toAddresses = pruneDuplicateEmails([
+            ...config.dmcoEmails,
+            ...config.devReviewTeamEmails,
+        ])
 
-    const etaData = parseEmailDataWithdrawSubmission(
-        contract,
-        ratesForDisplay,
-        config,
-        'UNDO_WITHDRAW'
-    )
-    if (etaData instanceof Error) {
-        return etaData
-    }
+        const etaData = parseEmailDataUndoWithdrawEQROSubmission(
+            contract,
+            ratesForDisplay,
+            config
+        )
+        if (etaData instanceof Error) {
+            return etaData
+        }
 
-    const template = await renderTemplate(
-        'sendUndoWithdrawnSubmissionCMSEmail',
-        etaData
-    )
+        const template = await renderTemplate(
+            'sendUndoWithdrawnEQROSubmissionCMSEmail',
+            etaData
+        )
 
-    if (template instanceof Error) {
-        return template
+        if (template instanceof Error) {
+            return template
+        } else {
+            return {
+                toAddresses,
+                replyToAddresses: [],
+                sourceEmail: config.emailSource,
+                subject: `${
+                    config.stage !== 'prod' ? `[${config.stage}] ` : ''
+                }${etaData.contractName} status was updated to '${
+                    etaData.status
+                }' by CMS`,
+                bodyText: stripHTMLFromTemplate(template),
+                bodyHTML: template,
+            }
+        }
     } else {
-        return {
-            toAddresses,
-            replyToAddresses: [],
-            sourceEmail: config.emailSource,
-            subject: `${
-                config.stage !== 'prod' ? `[${config.stage}] ` : ''
-            }${etaData.contractName} status update`,
-            bodyText: stripHTMLFromTemplate(template),
-            bodyHTML: template,
+        const toAddresses = pruneDuplicateEmails([
+            ...stateAnalystsEmails,
+            ...config.dmcpSubmissionEmails,
+            ...config.oactEmails,
+            ...config.dmcoEmails,
+            ...config.devReviewTeamEmails,
+        ])
+
+        const etaData = parseEmailDataWithdrawSubmission(
+            contract,
+            ratesForDisplay,
+            config,
+            'UNDO_WITHDRAW'
+        )
+        if (etaData instanceof Error) {
+            return etaData
+        }
+
+        const template = await renderTemplate(
+            'sendUndoWithdrawnSubmissionCMSEmail',
+            etaData
+        )
+
+        if (template instanceof Error) {
+            return template
+        } else {
+            return {
+                toAddresses,
+                replyToAddresses: [],
+                sourceEmail: config.emailSource,
+                subject: `${
+                    config.stage !== 'prod' ? `[${config.stage}] ` : ''
+                }${etaData.contractName} status update`,
+                bodyText: stripHTMLFromTemplate(template),
+                bodyHTML: template,
+            }
         }
     }
 }

--- a/services/app-api/src/emailer/emails/sendUndoWithdrawnSubmissionStateEmail.test.ts
+++ b/services/app-api/src/emailer/emails/sendUndoWithdrawnSubmissionStateEmail.test.ts
@@ -1,4 +1,8 @@
-import { mockContract, testEmailConfig } from '../../testHelpers/emailerHelpers'
+import {
+    mockContract,
+    mockEQROContract,
+    testEmailConfig,
+} from '../../testHelpers/emailerHelpers'
 import { sendUndoWithdrawnSubmissionStateEmail } from './sendUndoWithdrawnSubmissionStateEmail'
 
 const testContract = mockContract({
@@ -45,6 +49,96 @@ const testRatesForDisplay = [
     },
 ]
 
+const undoWithdrawReviewStatusActions = (
+    actionType: 'UNDER_REVIEW' | 'NOT_SUBJECT_TO_REVIEW'
+) => [
+    {
+        updatedAt: new Date('2025-05-10'),
+        updatedBy: {
+            role: 'CMS_USER' as const,
+            email: 'zuko@example.com',
+            givenName: 'Zuko',
+            familyName: 'Hotman',
+        },
+        updatedReason: 'Test Undo Withdraw',
+        dateApprovalReleasedToState: undefined,
+        actionType,
+        contractID: 'test-contract-123',
+    },
+    {
+        updatedAt: new Date('2025-04-10'),
+        updatedBy: {
+            role: 'CMS_USER' as const,
+            email: 'zuko@example.com',
+            givenName: 'Zuko',
+            familyName: 'Hotman',
+        },
+        updatedReason: 'Test Withdraw',
+        dateApprovalReleasedToState: undefined,
+        actionType: 'WITHDRAW' as const,
+        contractID: 'test-contract-123',
+    },
+]
+
+const mockEQROUndoWithdrawContract = (subjectToReview: boolean) => {
+    const baseContract = mockEQROContract()
+    const latestSubmission = baseContract.packageSubmissions[0]
+
+    return mockEQROContract({
+        id: 'test-contract-123',
+        consolidatedStatus: subjectToReview
+            ? 'RESUBMITTED'
+            : 'NOT_SUBJECT_TO_REVIEW',
+        reviewStatusActions: undoWithdrawReviewStatusActions(
+            subjectToReview ? 'UNDER_REVIEW' : 'NOT_SUBJECT_TO_REVIEW'
+        ),
+        packageSubmissions: [
+            {
+                ...latestSubmission,
+                contractRevision: {
+                    ...latestSubmission.contractRevision,
+                    formData: {
+                        ...latestSubmission.contractRevision.formData,
+                        eqroProvisionMcoEqrOrRelatedActivities: subjectToReview,
+                        eqroProvisionMcoNewOptionalActivity: subjectToReview,
+                        eqroProvisionNewMcoEqrRelatedActivities: false,
+                    },
+                },
+            },
+        ],
+    })
+}
+
+const expectEQROUndoWithdrawContent = (
+    bodyHTML: string | undefined,
+    status: string,
+    reviewDecision: string
+) => {
+    expect(bodyHTML).toContain(
+        `Submission MCR-MN-0004-SNBC status was updated to '${status}' by CMS`
+    )
+    expect(bodyHTML).toContain(
+        '<b>Withdraw reversed by:</b> <a href="mailto:zuko@example.com">zuko@example.com</a>'
+    )
+    expect(bodyHTML).toContain(`<b>Status:</b> ${status}`)
+    expect(bodyHTML).toContain(`<b>Review decision:</b> ${reviewDecision}`)
+    expect(bodyHTML).toContain(
+        '<b>Reason for withdrawal reversal:</b> Test Undo Withdraw'
+    )
+    expect(bodyHTML).toContain(
+        '<a href="http://localhost/submissions/eqro/test-contract-123">View submission</a>'
+    )
+    expect(bodyHTML).toContain('If you need assistance or have any questions:')
+    expect(bodyHTML).toContain(
+        'For assistance with programmatic, contractual, or operational issues'
+    )
+    expect(bodyHTML).toContain('MCGDMCOactions@cms.hhs.gov')
+    expect(bodyHTML).toContain(
+        'For issues related to MC-Review or all other inquiries'
+    )
+    expect(bodyHTML).toContain('MC_Review_HelpDesk@cms.hhs.gov')
+}
+
 describe('sendUndoWithdrawnSubmissionStateEmail', () => {
     it('State email contains correct toAddresses', async () => {
         const template = await sendUndoWithdrawnSubmissionStateEmail(
@@ -76,6 +170,60 @@ describe('sendUndoWithdrawnSubmissionStateEmail', () => {
             throw template
         }
 
+        expect(template.bodyHTML).toMatchSnapshot()
+    })
+
+    it('renders EQRO email when undo withdraw returns to subject to review', async () => {
+        const emailConfig = testEmailConfig()
+        const template = await sendUndoWithdrawnSubmissionStateEmail(
+            mockEQROUndoWithdrawContract(true),
+            [],
+            emailConfig
+        )
+
+        if (template instanceof Error) {
+            throw template
+        }
+
+        expect(template.toAddresses).toEqual([
+            'contract-state-contact@example.com',
+            ...emailConfig.devReviewTeamEmails,
+        ])
+        expect(template.subject).toBe(
+            "[LOCAL] MCR-MN-0004-SNBC status was updated to 'Submitted' by CMS"
+        )
+        expectEQROUndoWithdrawContent(
+            template.bodyHTML,
+            'Submitted',
+            'Subject to formal review and approval'
+        )
+        expect(template.bodyHTML).toMatchSnapshot()
+    })
+
+    it('renders EQRO email when undo withdraw returns to not subject to review', async () => {
+        const emailConfig = testEmailConfig()
+        const template = await sendUndoWithdrawnSubmissionStateEmail(
+            mockEQROUndoWithdrawContract(false),
+            [],
+            emailConfig
+        )
+
+        if (template instanceof Error) {
+            throw template
+        }
+
+        expect(template.toAddresses).toEqual([
+            'contract-state-contact@example.com',
+            ...emailConfig.devReviewTeamEmails,
+        ])
+        expect(template.subject).toBe(
+            "[LOCAL] MCR-MN-0004-SNBC status was updated to 'Not subject to review' by CMS"
+        )
+        expectEQROUndoWithdrawContent(
+            template.bodyHTML,
+            'Not subject to review',
+            'Not subject to formal review and approval'
+        )
         expect(template.bodyHTML).toMatchSnapshot()
     })
 })

--- a/services/app-api/src/emailer/emails/sendUndoWithdrawnSubmissionStateEmail.ts
+++ b/services/app-api/src/emailer/emails/sendUndoWithdrawnSubmissionStateEmail.ts
@@ -5,52 +5,99 @@ import {
     renderTemplate,
     stripHTMLFromTemplate,
     parseEmailDataWithdrawSubmission,
+    parseEmailDataUndoWithdrawEQROSubmission,
     type RateForDisplayType,
 } from '../templateHelpers'
 
-export const sendUndoWithdrawnSubmissionStateEmail = async (
-    contract: ContractType,
-    ratesForDisplay: RateForDisplayType[],
-    config: EmailConfiguration
-): Promise<EmailData | Error> => {
+const stateContactEmailsForContract = (contract: ContractType): string[] => {
     const stateContactEmails: string[] = []
     const contractRev = contract.packageSubmissions[0].contractRevision
     contractRev.formData.stateContacts.forEach((contact) => {
         if (contact.email) stateContactEmails.push(contact.email)
     })
 
-    const toAddresses = pruneDuplicateEmails([
-        ...stateContactEmails,
-        ...config.devReviewTeamEmails,
-    ])
+    return stateContactEmails
+}
 
-    const etaData = parseEmailDataWithdrawSubmission(
-        contract,
-        ratesForDisplay,
-        config,
-        'UNDO_WITHDRAW'
-    )
-    if (etaData instanceof Error) {
-        return etaData
-    }
+export const sendUndoWithdrawnSubmissionStateEmail = async (
+    contract: ContractType,
+    ratesForDisplay: RateForDisplayType[],
+    config: EmailConfiguration
+): Promise<EmailData | Error> => {
+    if (contract.contractSubmissionType === 'EQRO') {
+        const toAddresses = pruneDuplicateEmails([
+            ...stateContactEmailsForContract(contract),
+            ...config.devReviewTeamEmails,
+        ])
 
-    const template = await renderTemplate(
-        'sendUndoWithdrawnSubmissionStateEmail',
-        etaData
-    )
+        const etaData = parseEmailDataUndoWithdrawEQROSubmission(
+            contract,
+            ratesForDisplay,
+            config
+        )
+        if (etaData instanceof Error) {
+            return etaData
+        }
 
-    if (template instanceof Error) {
-        return template
+        const template = await renderTemplate(
+            'sendUndoWithdrawnEQROSubmissionStateEmail',
+            {
+                ...etaData,
+                MCGDMCOContactEmail: 'MCGDMCOactions@cms.hhs.gov',
+                CMSContactEmail: 'MC_Review_HelpDesk@cms.hhs.gov',
+            }
+        )
+
+        if (template instanceof Error) {
+            return template
+        } else {
+            return {
+                toAddresses,
+                replyToAddresses: [],
+                sourceEmail: config.emailSource,
+                subject: `${
+                    config.stage !== 'prod' ? `[${config.stage}] ` : ''
+                }${etaData.contractName} status was updated to '${
+                    etaData.status
+                }' by CMS`,
+                bodyText: stripHTMLFromTemplate(template),
+                bodyHTML: template,
+            }
+        }
     } else {
-        return {
-            toAddresses,
-            replyToAddresses: [],
-            sourceEmail: config.emailSource,
-            subject: `${
-                config.stage !== 'prod' ? `[${config.stage}] ` : ''
-            }${etaData.contractName} status update`,
-            bodyText: stripHTMLFromTemplate(template),
-            bodyHTML: template,
+        const toAddresses = pruneDuplicateEmails([
+            ...stateContactEmailsForContract(contract),
+            ...config.devReviewTeamEmails,
+        ])
+
+        const etaData = parseEmailDataWithdrawSubmission(
+            contract,
+            ratesForDisplay,
+            config,
+            'UNDO_WITHDRAW'
+        )
+        if (etaData instanceof Error) {
+            return etaData
+        }
+
+        const template = await renderTemplate(
+            'sendUndoWithdrawnSubmissionStateEmail',
+            etaData
+        )
+
+        if (template instanceof Error) {
+            return template
+        } else {
+            return {
+                toAddresses,
+                replyToAddresses: [],
+                sourceEmail: config.emailSource,
+                subject: `${
+                    config.stage !== 'prod' ? `[${config.stage}] ` : ''
+                }${etaData.contractName} status update`,
+                bodyText: stripHTMLFromTemplate(template),
+                bodyHTML: template,
+            }
         }
     }
 }

--- a/services/app-api/src/emailer/etaTemplates/sendUndoWithdrawnEQROSubmissionCMSEmail.eta
+++ b/services/app-api/src/emailer/etaTemplates/sendUndoWithdrawnEQROSubmissionCMSEmail.eta
@@ -1,0 +1,7 @@
+<h1 style=<%~'"font-weight: normal;"'%>>Submission <%= it.contractName %> status was updated to '<%= it.status %>' by CMS</h1>
+<b>Withdraw reversed by:</b> <a href="mailto:<%= it.updatedBy %>"><%= it.updatedBy %></a><br />
+<b>Status:</b> <%= it.status %><br />
+<b>Review decision:</b> <%= it.reviewDecision %><br />
+<b>Reason for withdrawal reversal:</b> <%= it.reason %><br />
+<br />
+<a href="<%= it.contractSummaryURL %>">View submission</a><br />

--- a/services/app-api/src/emailer/etaTemplates/sendUndoWithdrawnEQROSubmissionStateEmail.eta
+++ b/services/app-api/src/emailer/etaTemplates/sendUndoWithdrawnEQROSubmissionStateEmail.eta
@@ -1,0 +1,13 @@
+<h1 style=<%~'"font-weight: normal;"'%>>Submission <%= it.contractName %> status was updated to '<%= it.status %>' by CMS</h1>
+<b>Withdraw reversed by:</b> <a href="mailto:<%= it.updatedBy %>"><%= it.updatedBy %></a><br />
+<b>Status:</b> <%= it.status %><br />
+<b>Review decision:</b> <%= it.reviewDecision %><br />
+<b>Reason for withdrawal reversal:</b> <%= it.reason %><br />
+<br />
+<a href="<%= it.contractSummaryURL %>">View submission</a><br />
+<br />
+If you need assistance or have any questions:
+<ul>
+  <li>For assistance with programmatic, contractual, or operational issues, please reach out to <a href="mailto:<%= it.MCGDMCOContactEmail %>"><%= it.MCGDMCOContactEmail %></a> and/or your CMS primary contact.</li>
+  <li>For issues related to MC-Review or all other inquiries, please reach out to <a href="mailto:<%= it.CMSContactEmail %>"><%= it.CMSContactEmail %></a>.</li>
+</ul>

--- a/services/app-api/src/emailer/templateHelpers.ts
+++ b/services/app-api/src/emailer/templateHelpers.ts
@@ -14,7 +14,11 @@ import type {
 import { logError } from '../logger'
 import { parseErrorToError } from '@mc-review/helpers'
 import { pruneDuplicateEmails } from './formatters'
-import { findStatePrograms, packageName } from '@mc-review/submissions'
+import {
+    eqroValidationAndReviewDetermination,
+    findStatePrograms,
+    packageName,
+} from '@mc-review/submissions'
 import { rateSummaryURL, submissionSummaryURL } from './generateURLs'
 import { formatCalendarDate } from '@mc-review/dates'
 import type { SubmissionType } from '../gen/gqlServer'
@@ -385,6 +389,14 @@ export type WithdrawContractEtaDataType = {
     formattedRates: RateEtaDataType[]
 }
 
+export type UndoWithdrawEQROContractEtaDataType =
+    WithdrawContractEtaDataType & {
+        status: string
+        reviewDecision: string
+        MCGDMCOContactEmail?: string
+        CMSContactEmail?: string
+    }
+
 // Function to format ETA template data for both withdraw and undo withdraw submission
 const parseEmailDataWithdrawSubmission = (
     contract: ContractType,
@@ -465,6 +477,51 @@ const parseEmailDataWithdrawSubmission = (
     }
 }
 
+const parseEmailDataUndoWithdrawEQROSubmission = (
+    contract: ContractType,
+    rates: RateForDisplayType[],
+    config: EmailConfiguration
+): UndoWithdrawEQROContractEtaDataType | Error => {
+    if (contract.contractSubmissionType !== 'EQRO') {
+        return new Error(
+            'Cannot parse EQRO undo withdraw email data for non-EQRO contract'
+        )
+    }
+
+    const etaData = parseEmailDataWithdrawSubmission(
+        contract,
+        rates,
+        config,
+        'UNDO_WITHDRAW'
+    )
+    if (etaData instanceof Error) {
+        return etaData
+    }
+
+    const latestSubmission = contract.packageSubmissions[0]
+    if (!latestSubmission) {
+        return new Error(
+            'Cannot parse EQRO undo withdraw email data: contract has no submitted revision'
+        )
+    }
+
+    const subjectToReview = eqroValidationAndReviewDetermination(
+        contract.id,
+        latestSubmission.contractRevision.formData
+    )
+    if (subjectToReview instanceof Error) {
+        return subjectToReview
+    }
+
+    return {
+        ...etaData,
+        status: subjectToReview ? 'Submitted' : 'Not subject to review',
+        reviewDecision: subjectToReview
+            ? 'Subject to formal review and approval'
+            : 'Not subject to formal review and approval',
+    }
+}
+
 type FieldYesNoUserValue = 'Yes' | 'No' | undefined // Use for user facing display
 const booleanAsYesNoUserValue = (bool?: boolean | null): FieldYesNoUserValue =>
     bool ? 'Yes' : bool === false ? 'No' : undefined
@@ -484,5 +541,6 @@ export {
     getRateSubmitterEmails,
     getRateStateContactEmails,
     parseEmailDataWithdrawSubmission,
+    parseEmailDataUndoWithdrawEQROSubmission,
     booleanAsYesNoUserValue,
 }


### PR DESCRIPTION
## Summary
For EQRO Undo Withdraw emails, since they have different fields from Health Plan Undo Withdraw emails, I created two new eta templates. The status is also dynamic - depending on the previous contract status, undo withdraw could return a submission to 'Submitted' or 'Not subject to review'. 
In the email service, updated the logic so EQRO undo withdraw emails use a different template from Health Plan. For CMS, included the logic to only send to DMCO (and Dev Team review inbox). For State, used the same logic as Health Plan - all the contacts on the submission as well as Dev Team review inbox. Created a helper method here so EQRO and Health Plan are using same logic for 'To' field. 
Added template helpers to extract the needed information from EQRO contracts for the email - including the review decision status and the contract status.
Added tests.

Email Designs: https://docs.google.com/document/d/1tU_cjlmAClO4yJqk95IAEmjdTw9880kItkX1qPDumeA/edit?tab=t.74lcnidwj65g#heading=h.hxdd5cs9zqma 

#### Related issues
https://jiraent.cms.gov/browse/MCR-5863
https://jiraent.cms.gov/browse/MCR-6066

#### Screenshots
Note: I don't have access to the Dev Team review inbox for the CMS versions, I confirmed them locally though.
State User when EQRO was previously 'Not subject to review':
<img width="1061" height="529" alt="image" src="https://github.com/user-attachments/assets/7a77996c-0f88-4a1e-838e-fd5dc1c3b168" />

State User when EQRO was previously 'Subject to review':
<img width="1053" height="535" alt="image" src="https://github.com/user-attachments/assets/f1d65e88-b923-4158-8e93-9a6b06cdf400" />

#### Test cases covered
- test CMS email when status should be Submitted, including 'To' field and email content
- test CMS email when status should be Not subject to review, including 'To' field and email content
- test State email when status should be Submitted, including 'To' field and email content
- test State email when status should be Not subject to review, including 'To' field and email content

## QA guidance
- As State user, submit an EQRO that is 'Subject to review' and include your email as a State Contact
- Log in as CMS user and Withdraw the submission, then Undo the Withdraw
- Verify the email State and CMS receives matches the email design and the 'status' in the email is "Submitted"

- As State user, submit an EQRO that is 'Not subject to review' and include your email as a State Contact
- Log in as CMS user and withdraw the submission, then Undo the Withdraw
- Verify the email State and CMS receives matches the email design and the 'status' in the email is "Not subject to review"

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed