### PR TITLE
regression fixes

### DIFF
--- a/services/app-web/src/components/DynamicStepIndicator/DynamicStepIndicator.module.scss
+++ b/services/app-web/src/components/DynamicStepIndicator/DynamicStepIndicator.module.scss
@@ -19,6 +19,13 @@
     [class^='usa-step-indicator__header'] {
         display: inline;
     }
+
+    [class^='usa-step-indicator__current-step'] {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+    }
+
     @media (min-width: 40em) {
         [class^='usa-step-indicator__segment-label'] {
             padding-right: 1rem;

--- a/services/app-web/src/components/Form/FieldYesNo/FieldYesNo.module.scss
+++ b/services/app-web/src/components/Form/FieldYesNo/FieldYesNo.module.scss
@@ -16,6 +16,7 @@
 
 .yesnofieldsecondary legend {
     font-weight: normal;
+    max-width: none;
 }
 
 .no {

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponse.module.scss
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponse.module.scss
@@ -27,6 +27,7 @@
 }
 .tableHeader {
     h2 {
+        margin-top: 34px;
         margin-bottom: 0;
     }
 }


### PR DESCRIPTION
## Summary
While review regressions from the React 19 upgrade we found some UI regressions that existed before the upgrade.

#### Here is the list:
- State user's Rate Q&A page top spacing for Rate Q&A header is not sufficient 
- Health plan contract details page word wrapping
  - The (2) and (3) is on a new line, this is in existing UI. We might need to figure out how to break point this.
  - Incentive arrangements in accordance with 42 CFR § 438.6(b)(2)
  - Withhold arrangements in accordance with 42 CFR § 438.6(b)(3)
- Step indicator number # of # pages, the first number is not aligned correctly with the blue circle behind it.

#### AC:
- All listed regressions are fixed
#### Related issues
[MCR-6217](https://jiraent.cms.gov/browse/MCR-6217)
#### Screenshots
##### Q&A page top margin:
<img width="1105" height="444" alt="image" src="https://github.com/user-attachments/assets/acc8a058-ccbc-409b-aec5-345d6e92cc60" />

##### Contract details word wrapping:
<img width="639" height="851" alt="image" src="https://github.com/user-attachments/assets/fa8d6ae6-ab00-467f-a5b3-dd2e3331ccc1" />

##### Step indicator alignment:
<img width="321" height="61" alt="image" src="https://github.com/user-attachments/assets/2b49e946-6de0-49b8-ad20-0fd0f79db082" />

## QA guidance
- On `/submissions/health-plan/{contract id}/rates/{rate id}/question-and-answers` check the header has appropriate top margin
- On the contract details page; ensure `Withhold arrangements in accordance with 42 CFR § 438.6(b)(3)` does not have `(3)` on a new line
- On the contract details page; ensure `Incentive arrangements in accordance with 42 CFR § 438.6(b)(2)` does not have `(2)` on a new line
- Move through the form flow and ensure all the dynamic step numbers are centered inside the blue circle
<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed