### PR TITLE
added testing for eqro Q&A state emails

### DIFF
--- a/services/app-api/src/emailer/emails/__snapshots__/sendQuestionStateEmail.test.ts.snap
+++ b/services/app-api/src/emailer/emails/__snapshots__/sendQuestionStateEmail.test.ts.snap
@@ -1,5 +1,18 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`renders correctly for an EQRO submission 1`] = `
+"CMS asked questions about MCR-MN-0004-SNBC<br />
+<b>Sent by:</b> Ronald McDonald (DMCO) <a href="cms@email.com">cms@email.com</a>
+<br />
+<b>Date:</b> 12/31/2023<br />
+<br />
+You must respond to the questions before CMS can continue their review. Responses should be submitted in DOC or DOCX format.<br />
+<br />
+<a href="http://localhost/submissions/eqro/test-abc-123/question-and-answers">Open the submission in MC-Review to answer questions</a>
+
+"
+`;
+
 exports[`renders overall email for a new question as expected 1`] = `
 "CMS asked questions about MCR-MN-0003-SNBC<br />
 <b>Sent by:</b> Ronald McDonald (DMCO) <a href="cms@email.com">cms@email.com</a>

--- a/services/app-api/src/emailer/emails/sendQuestionStateEmail.test.ts
+++ b/services/app-api/src/emailer/emails/sendQuestionStateEmail.test.ts
@@ -1,6 +1,7 @@
 import {
     testEmailConfig,
     mockContractRev,
+    mockEQROContract,
     mockMNState,
 } from '../../testHelpers/emailerHelpers'
 import type {
@@ -327,4 +328,44 @@ test('renders overall email for a new question as expected', async () => {
     }
 
     expect(result.bodyHTML).toMatchSnapshot()
+})
+
+test('renders correctly for an EQRO submission', async () => {
+    const eqroContract = mockEQROContract()
+    const sub = eqroContract.packageSubmissions[0].contractRevision
+    const defaultStatePrograms = mockMNState().programs
+    const name = packageName(
+        sub.contract.stateCode,
+        sub.contract.stateNumber,
+        sub.formData.programIDs,
+        defaultStatePrograms
+    )
+
+    const template = await sendQuestionStateEmail(
+        sub,
+        'EQRO',
+        defaultSubmitters,
+        testEmailConfig(),
+        defaultStatePrograms,
+        currentQuestion
+    )
+
+    if (template instanceof Error) {
+        throw template
+    }
+
+    expect(template).toEqual(
+        expect.objectContaining({
+            toAddresses: expect.arrayContaining([
+                ...sub.formData.stateContacts.map((c) => c.email),
+                ...defaultSubmitters,
+                ...testEmailConfig().devReviewTeamEmails,
+            ]),
+            subject: expect.stringContaining(`New questions about ${name}`),
+            bodyHTML: expect.stringContaining(
+                `http://localhost/submissions/eqro/${sub.contract.id}/question-and-answers`
+            ),
+        })
+    )
+    expect(template.bodyHTML).toMatchSnapshot()
 })

--- a/services/app-api/src/resolvers/questionResponse/createContractQuestion.test.ts
+++ b/services/app-api/src/resolvers/questionResponse/createContractQuestion.test.ts
@@ -20,6 +20,7 @@ import { testEmailConfig, testEmailer } from '../../testHelpers/emailerHelpers'
 import {
     approveTestContract,
     createAndSubmitTestContractWithRate,
+    createAndUpdateTestEQROContract,
     submitTestContract,
     unlockTestContract,
 } from '../../testHelpers/gqlContractHelpers'
@@ -386,6 +387,50 @@ describe('createQuestion', () => {
                 ),
                 bodyHTML: expect.stringContaining(
                     `http://localhost/submissions/health-plan/${contract.id}/question-and-answers`
+                ),
+            })
+        )
+    })
+
+    it('send state email with EQRO question-and-answers URL when question is created on an EQRO submission', async () => {
+        const config = testEmailConfig()
+        const mockEmailer = testEmailer(config)
+        const stateServer = await constructTestPostgresServer()
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+            emailer: mockEmailer,
+        })
+
+        const draft = await createAndUpdateTestEQROContract(stateServer)
+        const contract = await submitTestContract(stateServer, draft.id)
+        expect(contract.contractSubmissionType).toBe('EQRO')
+
+        await createTestQuestion(cmsServer, contract.id)
+
+        const formData =
+            contract.packageSubmissions[0].contractRevision.formData
+        const contractName =
+            contract.packageSubmissions[0].contractRevision.contractName
+
+        const stateReceiverEmails = formData.stateContacts.map(
+            (contact) => contact.email
+        )
+
+        expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({
+                subject: expect.stringContaining(
+                    `[LOCAL] New questions about ${contractName}`
+                ),
+                sourceEmail: config.emailSource,
+                toAddresses: expect.arrayContaining(stateReceiverEmails),
+                bodyText: expect.stringContaining(
+                    `CMS asked questions about ${contractName}`
+                ),
+                bodyHTML: expect.stringContaining(
+                    `http://localhost/submissions/eqro/${contract.id}/question-and-answers`
                 ),
             })
         )


### PR DESCRIPTION
## Summary
> [!NOTE]
> Looks like some previous EQRO work I had completed already took care of this so this PR only adds testing.

As a State user I want to receive an email notification when questions related to my EQRO submission have been sent by CMS so that I am aware of the questions and can prepare a response.

**Acceptance Criteria:**
- Email is sent to State user(s) when a question is created on an EQRO submission
- Established patterns for emails will be followed

**Eng Note:** We should try to use the emailer function as what currently exists for Health Plans, as these emails should function in the same manner and have no design differences.
#### Related issues
[MCR-6031](https://jiraent.cms.gov/browse/MCR-6031)