### PR TITLE
MCR-6036 Display All Question Documents for State User Response page

### DIFF
--- a/services/app-web/src/pages/QuestionResponse/QATable/QuestionDisplayTable.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/QuestionDisplayTable.tsx
@@ -14,12 +14,13 @@ type QuestionDisplayTablePropType = {
 export const QuestionDisplayTable = ({
     documents,
     user,
-    onlyDisplayInitial, // used when we only care about initial question
+    onlyDisplayInitial, // used when we only care about initial question documents
     ...rest
 }: QuestionDisplayTablePropType) => {
     const displayDocuments = onlyDisplayInitial
-        ? [documents[documents.length - 1]]
+        ? documents.filter((doc) => doc.addedBy.__typename !== 'StateUser')
         : documents
+
     return (
         <table
             className={`borderTopLinearGradient ${styles.qaDocumentTable}`}


### PR DESCRIPTION
## Summary
When a state user is responding to a question, only 1 document was showing on the Upload response page. There was already a filter in place `onlyDisplayInitial`, which was filtering to the last document uploaded or showing all documents. To make as minimal changes as possible, I just changed that filter to filter down to all documents added by CMS users or show all documents. Both contract and rates uses this method, so one change fixes both places. There was not test class for this component, so I did not add any test cases - but I can if the team wants.

#### Related issues
https://jiraent.cms.gov/browse/MCR-6036

#### Screenshots
All docs still display on Q&A page:
<img width="754" height="693" alt="image" src="https://github.com/user-attachments/assets/5fdc6c0b-37a6-4735-99da-806285f47ba4" />

All question docs display on Upload Response:
<img width="684" height="659" alt="image" src="https://github.com/user-attachments/assets/0480f102-1bc9-4bf9-95fd-5140864cbb03" />

All docs on Rate Review Upload Response:
<img width="684" height="558" alt="image" src="https://github.com/user-attachments/assets/7c5976f1-7ea2-4157-83c6-ea3fb1d25692" />


#### Test cases covered
Changes were isolated to QuestionDisplayTable but that component does not have a test file.

## QA guidance
- As CMS user, upload multiple documents on a Question 
- As State User, click Upload Response and verify that all documents display

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed