### PR TITLE
MCR-6079: Add rotation notifier Lambda

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,6 +416,9 @@ importers:
       '@aws-sdk/client-cognito-identity-provider':
         specifier: ^3.1053.0
         version: 3.1053.0
+      '@aws-sdk/client-lambda':
+        specifier: ^3.1053.0
+        version: 3.1053.0
       '@aws-sdk/client-rds':
         specifier: ^3.1053.0
         version: 3.1053.0

--- a/services/app-api/package.json
+++ b/services/app-api/package.json
@@ -24,6 +24,7 @@
         "@as-integrations/aws-lambda": "^4.0.1",
         "rxjs": "^7.8.1",
         "@aws-sdk/client-cognito-identity-provider": "^3.1053.0",
+        "@aws-sdk/client-lambda": "^3.1053.0",
         "@aws-sdk/client-rds": "^3.1053.0",
         "@aws-sdk/client-s3": "^3.1053.0",
         "@aws-sdk/client-secrets-manager": "^3.1053.0",

--- a/services/app-api/src/handlers/rotation_notifier.ts
+++ b/services/app-api/src/handlers/rotation_notifier.ts
@@ -1,0 +1,62 @@
+import {
+    GetFunctionConfigurationCommand,
+    LambdaClient,
+    UpdateFunctionConfigurationCommand,
+} from '@aws-sdk/client-lambda'
+import type { Handler } from 'aws-lambda'
+
+type RotationSucceededEvent = {
+    detail?: {
+        additionalEventData?: {
+            SecretId?: string
+        }
+    }
+}
+
+const client = new LambdaClient({})
+
+export const main: Handler = async (
+    event: RotationSucceededEvent
+): Promise<void> => {
+    const secretId = event?.detail?.additionalEventData?.SecretId ?? ''
+    const dbSecretName = process.env.DB_SECRET_NAME
+
+    if (!dbSecretName) {
+        throw new Error('DB_SECRET_NAME is required')
+    }
+
+    if (!secretId.includes(dbSecretName)) {
+        console.info('Ignoring rotation event for unrelated secret:', secretId)
+        return
+    }
+
+    const functionNames = (process.env.LAMBDA_FUNCTION_NAMES ?? '')
+        .split(',')
+        .filter(Boolean)
+    const rotationTimestamp = new Date().toISOString()
+
+    await Promise.all(
+        functionNames.map(async (functionName) => {
+            const config = await client.send(
+                new GetFunctionConfigurationCommand({
+                    FunctionName: functionName,
+                })
+            )
+            const variables = config.Environment?.Variables ?? {}
+
+            await client.send(
+                new UpdateFunctionConfigurationCommand({
+                    FunctionName: functionName,
+                    Environment: {
+                        Variables: {
+                            ...variables,
+                            ROTATION_TIMESTAMP: rotationTimestamp,
+                        },
+                    },
+                })
+            )
+
+            console.info('Updated ROTATION_TIMESTAMP for', functionName)
+        })
+    )
+}

--- a/services/app-api/src/handlers/rotation_notifier.ts
+++ b/services/app-api/src/handlers/rotation_notifier.ts
@@ -35,28 +35,53 @@ export const main: Handler = async (
         .filter(Boolean)
     const rotationTimestamp = new Date().toISOString()
 
-    await Promise.all(
-        functionNames.map(async (functionName) => {
-            const config = await client.send(
-                new GetFunctionConfigurationCommand({
-                    FunctionName: functionName,
-                })
-            )
-            const variables = config.Environment?.Variables ?? {}
+    const results = await Promise.allSettled(
+        functionNames.map(async (functionName) =>
+            updateRotationTimestamp(functionName, rotationTimestamp)
+        )
+    )
 
-            await client.send(
-                new UpdateFunctionConfigurationCommand({
-                    FunctionName: functionName,
-                    Environment: {
-                        Variables: {
-                            ...variables,
-                            ROTATION_TIMESTAMP: rotationTimestamp,
-                        },
-                    },
-                })
-            )
+    const failedFunctionNames: string[] = []
 
-            console.info('Updated ROTATION_TIMESTAMP for', functionName)
+    results.forEach((result, index) => {
+        if (result.status === 'rejected') {
+            const functionName = functionNames[index]
+            failedFunctionNames.push(functionName)
+            console.error(
+                'Failed to update ROTATION_TIMESTAMP',
+                functionName,
+                result.reason
+            )
+        }
+    })
+
+    if (failedFunctionNames.length === functionNames.length) {
+        throw new Error('Failed to update ROTATION_TIMESTAMP on every function')
+    }
+}
+
+async function updateRotationTimestamp(
+    functionName: string,
+    rotationTimestamp: string
+): Promise<void> {
+    const config = await client.send(
+        new GetFunctionConfigurationCommand({
+            FunctionName: functionName,
         })
     )
+    const variables = config.Environment?.Variables ?? {}
+
+    await client.send(
+        new UpdateFunctionConfigurationCommand({
+            FunctionName: functionName,
+            Environment: {
+                Variables: {
+                    ...variables,
+                    ROTATION_TIMESTAMP: rotationTimestamp,
+                },
+            },
+        })
+    )
+
+    console.info('Updated ROTATION_TIMESTAMP for', functionName)
 }

--- a/services/infra-cdk/lib/stacks/app-api.ts
+++ b/services/infra-cdk/lib/stacks/app-api.ts
@@ -33,7 +33,7 @@ import { isReviewEnvironment } from '../config/environments'
 import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda'
 import { CfnWebACL, CfnWebACLAssociation } from 'aws-cdk-lib/aws-wafv2'
 import { SubnetType, Vpc, SecurityGroup } from 'aws-cdk-lib/aws-ec2'
-import { Rule, Schedule } from 'aws-cdk-lib/aws-events'
+import { Match, Rule, Schedule } from 'aws-cdk-lib/aws-events'
 import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets'
 import { ApiEndpoint } from '../constructs/api/api-endpoint'
 import path from 'path'
@@ -1113,12 +1113,18 @@ export class AppApiStack extends BaseStack {
             this.graphqlFunction,
         ]
 
-        // logicalDbManagerFunction lives in the postgres stack — reference by name
-        const logicalDbManagerFunctionName = `postgres-${this.stage}-dbManager-cdk`
-        const logicalDbManagerFunctionArn = `arn:aws:lambda:${this.region}:${this.account}:function:${logicalDbManagerFunctionName}`
         const postgresStackName = ResourceNames.stackName(
             'postgres',
             this.stage
+        )
+        const logicalDbManagerFunctionName = Fn.importValue(
+            `${postgresStackName}-LogicalDbManagerFunctionName`
+        )
+        const logicalDbManagerFunctionArn = Fn.importValue(
+            `${postgresStackName}-LogicalDbManagerFunctionArn`
+        )
+        const dbSecretName = Fn.importValue(
+            `${postgresStackName}-PostgresSecretName`
         )
 
         const allFunctionNames = [
@@ -1194,6 +1200,9 @@ exports.handler = async (event) => {
                 detail: {
                     eventSource: ['secretsmanager.amazonaws.com'],
                     eventName: ['RotationSucceeded'],
+                    additionalEventData: {
+                        SecretId: Match.wildcard(`*${dbSecretName}*`),
+                    },
                 },
             },
             targets: [new LambdaFunction(notifier)],

--- a/services/infra-cdk/lib/stacks/app-api.ts
+++ b/services/infra-cdk/lib/stacks/app-api.ts
@@ -548,6 +548,9 @@ export class AppApiStack extends BaseStack {
         // Setup cleanup function cron schedule
         this.setupCleanupSchedule()
 
+        // Force cold-start on all DB-connected Lambdas after secret rotation
+        this.setupRotationNotifier()
+
         this.createOutputs()
     }
 
@@ -1094,6 +1097,107 @@ export class AppApiStack extends BaseStack {
 
         // Grant EventBridge permission to invoke the cleanup function
         // (This is handled automatically by the LambdaFunction target)
+    }
+
+    /**
+     * Create a Lambda + EventBridge rule that bumps ROTATION_TIMESTAMP on all
+     * DB-connected VPC Lambdas whenever the Aurora secret rotation succeeds,
+     * ensuring no warmed instance retains a stale database password.
+     */
+    private setupRotationNotifier(): void {
+        const dbConnectedFunctions = [
+            this.oauthTokenFunction,
+            this.migrateFunction,
+            this.regenerateZipsFunction,
+            this.migrateS3UrlsFunction,
+            this.graphqlFunction,
+        ]
+
+        // logicalDbManagerFunction lives in the postgres stack — reference by name
+        const logicalDbManagerFunctionName = `postgres-${this.stage}-dbManager-cdk`
+        const logicalDbManagerFunctionArn = `arn:aws:lambda:${this.region}:${this.account}:function:${logicalDbManagerFunctionName}`
+        const postgresStackName = ResourceNames.stackName(
+            'postgres',
+            this.stage
+        )
+
+        const allFunctionNames = [
+            ...dbConnectedFunctions.map((fn) => fn.functionName),
+            logicalDbManagerFunctionName,
+        ]
+
+        const notifier = new CdkFunction(this, 'RotationNotifier', {
+            functionName: `${ResourceNames.apiName('app-api', this.stage)}-rotation-notifier`,
+            runtime: Runtime.NODEJS_24_X,
+            handler: 'index.handler',
+            code: Code.fromInline(`
+const { LambdaClient, GetFunctionConfigurationCommand, UpdateFunctionConfigurationCommand } = require('@aws-sdk/client-lambda');
+const client = new LambdaClient({});
+exports.handler = async (event) => {
+    const secretId = event?.detail?.additionalEventData?.SecretId ?? '';
+    const dbSecretName = process.env.DB_SECRET_NAME;
+    if (!secretId.includes(dbSecretName)) {
+        console.log('Ignoring rotation event for unrelated secret:', secretId);
+        return;
+    }
+    const names = (process.env.LAMBDA_FUNCTION_NAMES || '').split(',').filter(Boolean);
+    const ts = new Date().toISOString();
+    await Promise.all(names.map(async name => {
+        const cfg = await client.send(new GetFunctionConfigurationCommand({ FunctionName: name }));
+        const vars = cfg.Environment?.Variables ?? {};
+        await client.send(new UpdateFunctionConfigurationCommand({
+            FunctionName: name,
+            Environment: { Variables: { ...vars, ROTATION_TIMESTAMP: ts } }
+        }));
+        console.log('Updated ROTATION_TIMESTAMP for', name);
+    }));
+};`),
+            environment: {
+                LAMBDA_FUNCTION_NAMES: allFunctionNames.join(','),
+                DB_SECRET_NAME: Fn.importValue(
+                    `${postgresStackName}-PostgresSecretName`
+                ),
+            },
+            timeout: Duration.seconds(60),
+        })
+
+        // Grant permission to read and update each target function's configuration
+        dbConnectedFunctions.forEach((fn) => {
+            notifier.addToRolePolicy(
+                new PolicyStatement({
+                    effect: Effect.ALLOW,
+                    actions: [
+                        'lambda:GetFunctionConfiguration',
+                        'lambda:UpdateFunctionConfiguration',
+                    ],
+                    resources: [fn.functionArn],
+                })
+            )
+        })
+
+        notifier.addToRolePolicy(
+            new PolicyStatement({
+                effect: Effect.ALLOW,
+                actions: [
+                    'lambda:GetFunctionConfiguration',
+                    'lambda:UpdateFunctionConfiguration',
+                ],
+                resources: [logicalDbManagerFunctionArn],
+            })
+        )
+
+        // Fire whenever Secrets Manager reports a successful rotation
+        new Rule(this, 'SecretRotationSucceededRule', {
+            eventPattern: {
+                source: ['aws.secretsmanager'],
+                detailType: ['AWS Service Event via CloudTrail'],
+                detail: {
+                    eventSource: ['secretsmanager.amazonaws.com'],
+                    eventName: ['RotationSucceeded'],
+                },
+            },
+            targets: [new LambdaFunction(notifier)],
+        })
     }
 
     private createOutputs(): void {

--- a/services/infra-cdk/lib/stacks/app-api.ts
+++ b/services/infra-cdk/lib/stacks/app-api.ts
@@ -1132,40 +1132,18 @@ export class AppApiStack extends BaseStack {
             logicalDbManagerFunctionName,
         ]
 
-        const notifier = new CdkFunction(this, 'RotationNotifier', {
-            functionName: `${ResourceNames.apiName('app-api', this.stage)}-rotation-notifier`,
-            runtime: Runtime.NODEJS_24_X,
-            handler: 'index.handler',
-            code: Code.fromInline(`
-const { LambdaClient, GetFunctionConfigurationCommand, UpdateFunctionConfigurationCommand } = require('@aws-sdk/client-lambda');
-const client = new LambdaClient({});
-exports.handler = async (event) => {
-    const secretId = event?.detail?.additionalEventData?.SecretId ?? '';
-    const dbSecretName = process.env.DB_SECRET_NAME;
-    if (!secretId.includes(dbSecretName)) {
-        console.log('Ignoring rotation event for unrelated secret:', secretId);
-        return;
-    }
-    const names = (process.env.LAMBDA_FUNCTION_NAMES || '').split(',').filter(Boolean);
-    const ts = new Date().toISOString();
-    await Promise.all(names.map(async name => {
-        const cfg = await client.send(new GetFunctionConfigurationCommand({ FunctionName: name }));
-        const vars = cfg.Environment?.Variables ?? {};
-        await client.send(new UpdateFunctionConfigurationCommand({
-            FunctionName: name,
-            Environment: { Variables: { ...vars, ROTATION_TIMESTAMP: ts } }
-        }));
-        console.log('Updated ROTATION_TIMESTAMP for', name);
-    }));
-};`),
-            environment: {
-                LAMBDA_FUNCTION_NAMES: allFunctionNames.join(','),
-                DB_SECRET_NAME: Fn.importValue(
-                    `${postgresStackName}-PostgresSecretName`
-                ),
-            },
-            timeout: Duration.seconds(60),
-        })
+        const notifier = this.createLambdaFunction(
+            'rotation-notifier',
+            'rotation_notifier',
+            'main',
+            {
+                timeout: Duration.seconds(60),
+                environment: {
+                    LAMBDA_FUNCTION_NAMES: allFunctionNames.join(','),
+                    DB_SECRET_NAME: dbSecretName,
+                },
+            }
+        )
 
         // Grant permission to read and update each target function's configuration
         dbConnectedFunctions.forEach((fn) => {


### PR DESCRIPTION
* Added notifier lambda for resetting running lambda environments when db password is rotated
  *  Updates the ROTATION_TIMESTAMP env var on all DB connected lambdas, resetting warm lambda environments
* Added event bridge rule for secret manager secret rotation, used to trigger notifier lambda
