### PR TITLE
Refactor new submission form page and feature flags

### DIFF
--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -145,6 +145,10 @@ const StateUserRoutes = ({
         featureFlags.EQRO_SUBMISSIONS.flag,
         featureFlags.EQRO_SUBMISSIONS.defaultValue
     )
+    const showSdpSubmissions: boolean = ldClient?.variation(
+        featureFlags.SDP.flag,
+        featureFlags.SDP.defaultValue
+    )
 
     return (
         <AuthenticatedRouteWrapper>
@@ -169,7 +173,7 @@ const StateUserRoutes = ({
                     path={RoutesRecord.SUBMISSIONS}
                     element={<StateDashboard />}
                 />
-                {showEqroSubmissions ? (
+                {showEqroSubmissions || showSdpSubmissions ? (
                     <>
                         <Route
                             path={RoutesRecord.SUBMISSIONS_NEW}

--- a/services/app-web/src/pages/StateSubmission/SharedSubmissionComponents/NewSubmissionForm/NewSubmissionForm.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/SharedSubmissionComponents/NewSubmissionForm/NewSubmissionForm.test.tsx
@@ -78,6 +78,9 @@ it('routes to new EQRO url', async () => {
                 route: `/submissions/new`,
             },
             location: (location) => (testLocation = location),
+            featureFlags: {
+                ['eqro-submissions']: true,
+            },
         }
     )
 
@@ -218,6 +221,9 @@ it('renders inline errors', async () => {
         {
             routerProvider: {
                 route: `/submissions/new`,
+            },
+            featureFlags: {
+                ['eqro-submissions']: true,
             },
         }
     )

--- a/services/app-web/src/pages/StateSubmission/SharedSubmissionComponents/NewSubmissionForm/NewSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmission/SharedSubmissionComponents/NewSubmissionForm/NewSubmissionForm.tsx
@@ -49,6 +49,10 @@ export const NewSubmission = () => {
     const navigate = useNavigate()
     const [shouldValidate, setShouldValidate] = React.useState(false)
     const ldClient = useLDClient()
+    const isEQROenabled = ldClient?.variation(
+        featureFlags.EQRO_SUBMISSIONS.flag,
+        featureFlags.EQRO_SUBMISSIONS.defaultValue
+    )
     const isSDPEnabled = ldClient?.variation(
         featureFlags.SDP.flag,
         featureFlags.SDP.defaultValue
@@ -68,7 +72,7 @@ export const NewSubmission = () => {
             values.contractSubmissionType ===
                 ContractSubmissionTypeRecord['SDP']
         ) {
-            //TODO: add new env urls to parameter store for val and prod once available
+            //TODO: add new env urls to prod once available
             window.location.href = import.meta.env.VITE_APP_SDP_PORTAL_URL
         } else {
             navigate(
@@ -151,20 +155,22 @@ export const NewSubmission = () => {
                                         labelDescription="Submit your Medicaid and CHIP managed care plans. This includes base contracts, amendments to base contracts, and rate certifications."
                                         tile
                                     />
-                                    <FieldRadio
-                                        id="eqro"
-                                        name="contractSubmissionType"
-                                        label="External Quality Review Organization (EQRO)"
-                                        data-testid="eqro"
-                                        aria-required
-                                        value="eqro"
-                                        list_position={2}
-                                        list_options={2}
-                                        parent_component_heading="Submission type"
-                                        radio_button_title="External Quality Review Organization (EQRO)"
-                                        labelDescription="Submit base contracts and amendments to base contracts between your state and an EQRO."
-                                        tile
-                                    />
+                                    {isEQROenabled && (
+                                        <FieldRadio
+                                            id="eqro"
+                                            name="contractSubmissionType"
+                                            label="External Quality Review Organization (EQRO)"
+                                            data-testid="eqro"
+                                            aria-required
+                                            value="eqro"
+                                            list_position={2}
+                                            list_options={isSDPEnabled ? 3 : 2} // adjust options if SDP is enabled
+                                            parent_component_heading="Submission type"
+                                            radio_button_title="External Quality Review Organization (EQRO)"
+                                            labelDescription="Submit base contracts and amendments to base contracts between your state and an EQRO."
+                                            tile
+                                        />
+                                    )}
                                     {isSDPEnabled && (
                                         <FieldRadio
                                             id="sdp"
@@ -173,8 +179,10 @@ export const NewSubmission = () => {
                                             data-testid="sdp"
                                             aria-required
                                             value="sdp"
-                                            list_position={3}
-                                            list_options={2}
+                                            list_position={
+                                                isEQROenabled ? 3 : 2 // adjust position if EQRO is enabled
+                                            }
+                                            list_options={isEQROenabled ? 3 : 2} // adjust options if EQRO is enabled
                                             parent_component_heading="Submission type"
                                             radio_button_title="State Directed Payment Preprint (SDP)"
                                             labelDescription="Submit preprints to get prior approval for state directed payments"


### PR DESCRIPTION
## Summary

The link to SDP submission is on the new submission page, which is behind the EQRO flag. SDP should not be reliant on the EQRO flag.

This work refactors the logic so the new submission page shows if either SDP or EQRO submission flag is on and submission type options are toggled by the flags.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

- Turn SPD flag `ON` and EQRO `OFF`
   - New submission button takes you to new submission page
   - You should only see 2 options `Health plan` and `SDP`
- Turn SPD flag `OFF` and EQRO `ON`
   - New submission button takes you to new submission page
   - You should only see 2 options `Health plan` and `EQRO`
- Turn SPD flag `ON` and EQRO `ON`
   - New submission button takes you to new submission page
   - You should only see 3 options `Health plan`, `EQRO`, and `SDP`
- Turn SPD flag `OFF` and EQRO `OFF`
   - New submission button takes you to the Health plan submission type form page.

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed