### PR TITLE
Add status updated banner for approved eqro submission

### DIFF
--- a/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.test.tsx
@@ -1374,4 +1374,72 @@ describe('EQROSubmissionSummary - Unlock submission button tests', () => {
             ).toBeInTheDocument()
         })
     })
+
+    describe('Submission approval banner', () => {
+        it('renders the approval banner on an approved EQRO submission', async () => {
+            const contract = mockContractPackageSubmitted({
+                id: 'test-abc-123',
+                contractSubmissionType: 'EQRO',
+                status: 'RESUBMITTED',
+                reviewStatus: 'APPROVED',
+                consolidatedStatus: 'APPROVED',
+                reviewStatusActions: [
+                    {
+                        actionType: 'MARK_AS_APPROVED',
+                        contractID: 'test-abc-123',
+                        updatedAt: new Date(),
+                        updatedBy: {
+                            email: 'cmsapprover@example.com',
+                            familyName: 'Smith',
+                            givenName: 'John',
+                            role: 'CMS_APPROVER_USER',
+                        },
+                        updatedReason: 'Some approval reason',
+                    },
+                ],
+            })
+
+            renderWithProviders(
+                <Routes>
+                    <Route element={<SubmissionSideNav />}>
+                        <Route
+                            path={RoutesRecord.SUBMISSIONS_SUMMARY}
+                            element={<EQROSubmissionSummary />}
+                        />
+                    </Route>
+                </Routes>,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({
+                                user: mockValidCMSUser(),
+                                statusCode: 200,
+                            }),
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
+                            }),
+                            fetchContractWithQuestionsMockSuccess({
+                                contract,
+                            }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: '/submissions/eqro/test-abc-123',
+                    },
+                    featureFlags: {
+                        [featureFlags.EQRO_SUBMISSIONS.flag]: true,
+                    },
+                }
+            )
+
+            await waitFor(() => {
+                expect(
+                    screen.getByTestId('submission-summary')
+                ).toBeInTheDocument()
+                expect(
+                    screen.getByTestId('submissionApprovedBanner')
+                ).toBeInTheDocument()
+            })
+        })
+    })
 })

--- a/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/EQROSubmissionSummary/EQROSubmissionSummary.tsx
@@ -24,6 +24,7 @@ import {
 import {
     EqroReviewDeterminationBanners,
     StatusUpdatedBanner,
+    SubmissionApprovedBanner,
     SubmissionUnlockedBanner,
     SubmissionWithdrawnBanner,
 } from '../../../components/Banner'
@@ -201,6 +202,8 @@ export const EQROSubmissionSummary = (): React.ReactElement => {
         withdrawSubmissionFlag &&
         consolidatedStatus === 'WITHDRAWN' &&
         latestContractAction
+    const showApprovalBanner =
+        consolidatedStatus === 'APPROVED' && latestContractAction
 
     // Get the correct update info depending on the submission status
     let updateInfo: UpdateInformation | undefined = undefined
@@ -235,6 +238,19 @@ export const EQROSubmissionSummary = (): React.ReactElement => {
     }
 
     const renderStatusAlerts = () => {
+        if (showApprovalBanner && latestContractAction.updatedBy) {
+            return (
+                <SubmissionApprovedBanner
+                    className={styles.banner}
+                    updatedBy={latestContractAction.updatedBy}
+                    updatedAt={latestContractAction.updatedAt}
+                    dateReleasedToState={
+                        latestContractAction.dateApprovalReleasedToState
+                    }
+                />
+            )
+        }
+
         if (showTempUndoWithdrawBanner) {
             const status = isSubjectToReview
                 ? 'Submitted'


### PR DESCRIPTION
## Summary

This work adds the status updated banner for approved EQRO submissions on the summary page.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

- `Release to state` a EQRO submission
- Validate status updated banner appears.

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed