### PR TITLE
MCR-6265: fix the submission type page to work if the SDP flag is on independently

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -52,7 +52,7 @@ export IAM_PATH='/'
 export CLOUDFRONT_CERT_ARN='local'
 export CLOUDFRONT_SB_DOMAIN_NAME='local'
 export CLOUDFRONT_DOMAIN_NAME='local'
-export SECRETS_MANAGER_SECRET='local-secrets-manager' // pragma: allowlist secret
+export SECRETS_MANAGER_SECRET='local-secrets-manager' # pragma: allowlist secret
 export stage='local'
 export REGION='us-east-1'
 

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/SubmissionType/SubmissionType.tsx
@@ -176,9 +176,8 @@ export const SubmissionType = ({
         if (options.type === 'SAVE_AS_DRAFT' && draftSaved) {
             setDraftSaved(false)
         }
-        console.warn('PPPPPPPPPPPP')
+
         if (isNewSubmission) {
-            console.warn('HIIIIIIIII')
             const input: CreateContractInput = {
                 populationCovered: values.populationCovered!,
                 programIDs: values.programIDs,

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/SubmissionType/SubmissionType.tsx
@@ -110,14 +110,19 @@ export const SubmissionType = ({
         featureFlags.EQRO_SUBMISSIONS.flag,
         featureFlags.EQRO_SUBMISSIONS.defaultValue
     )
+    const showSDPSubmissions: boolean = ldClient?.variation(
+        featureFlags.SDP.flag,
+        featureFlags.SDP.defaultValue
+    )
 
-    //Toggle isNewSubmission condition based on EQRO feature flag
-    const isNewSubmission = showEqroSubmissions
-        ? matchPath(
-              RoutesRecord.SUBMISSIONS_NEW_SUBMISSION_FORM,
-              location.pathname
-          )
-        : location.pathname === '/submissions/new'
+    //Toggle isNewSubmission condition based if either EQRO or SDP feature flags are on
+    const isNewSubmission =
+        showEqroSubmissions || showSDPSubmissions
+            ? matchPath(
+                  RoutesRecord.SUBMISSIONS_NEW_SUBMISSION_FORM,
+                  location.pathname
+              )
+            : location.pathname === '/submissions/new'
 
     const {
         draftSubmission,
@@ -171,7 +176,9 @@ export const SubmissionType = ({
         if (options.type === 'SAVE_AS_DRAFT' && draftSaved) {
             setDraftSaved(false)
         }
+        console.warn('PPPPPPPPPPPP')
         if (isNewSubmission) {
+            console.warn('HIIIIIIIII')
             const input: CreateContractInput = {
                 populationCovered: values.populationCovered!,
                 programIDs: values.programIDs,


### PR DESCRIPTION
## Summary

Bryan ran into an issue on Val where he hit a submission error when trying to progress pass the Submission Type page. On Val the SDP flag was on and the EQRO flag is off. Previously the code only called createContract if the new submission form was detected based on the EQRO flag. This PR updates the logic to call createContract (and not updateContract) when the either the EQRO or the SDP flag is on (since these flags should be fully independent of each other)

#### Related issues

https://jiraent.cms.gov/browse/MCR-6265

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

1. Turn the SDP flag on and the EQRO flag off. 
2. Select to create a new Health plan submission
3. Fill in the submission type page and click continue
4. you should be able to progress pass the Submission Type page without error


## PR Reminders
- [x ] Updated the API Changelog (if this PR changes the API schema)
- [ x] Checked accessibility with ANDI and Wave tools as needed