### PR TITLE
MCR-6223: Handle race conditions for mutations

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/approveContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/approveContract.ts
@@ -21,13 +21,25 @@ async function approveContractInsideTransaction(
             id: contractID,
         },
         include: {
-            reviewStatusActions: true,
+            reviewStatusActions: {
+                orderBy: {
+                    updatedAt: 'desc',
+                },
+                take: 1,
+            },
         },
     })
 
     if (!contract) {
         return new NotFoundError(
             `PRISMA ERROR: Cannot find contract with id: ${contractID}`
+        )
+    }
+
+    const latestReviewStatusAction = contract.reviewStatusActions[0]
+    if (latestReviewStatusAction?.actionType === 'MARK_AS_APPROVED') {
+        return new Error(
+            'Cannot approve contract: contract is already approved'
         )
     }
 

--- a/services/app-api/src/postgres/contractAndRates/approveContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/approveContract.ts
@@ -3,10 +3,7 @@ import { NotFoundError } from '../postgresErrors'
 import type { ContractType } from '../../domain-models'
 import type { PrismaTransactionType } from '../prismaTypes'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import {
-    lockContractRowForUpdate,
-    runTransactionWithRowLock,
-} from '../prismaHelpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
 
 async function approveContractInsideTransaction(
     tx: PrismaTransactionType,
@@ -73,7 +70,8 @@ async function approveContract(
     return runTransactionWithRowLock({
         client,
         operationName: 'approveContract',
-        lock: async (tx) => await lockContractRowForUpdate(tx, args.contractID),
+        table: 'ContractTable',
+        id: args.contractID,
         transaction: async (tx) =>
             await approveContractInsideTransaction(tx, args),
     })

--- a/services/app-api/src/postgres/contractAndRates/approveContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/approveContract.ts
@@ -3,7 +3,10 @@ import { NotFoundError } from '../postgresErrors'
 import type { ContractType } from '../../domain-models'
 import type { PrismaTransactionType } from '../prismaTypes'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import { parseErrorToError } from '@mc-review/helpers'
+import {
+    lockContractRowForUpdate,
+    runTransactionWithRowLock,
+} from '../prismaHelpers'
 
 async function approveContractInsideTransaction(
     tx: PrismaTransactionType,
@@ -15,49 +18,45 @@ async function approveContractInsideTransaction(
         dateApprovalReleasedToState,
         updatedReason,
     } = args
-    try {
-        const contract = await tx.contractTable.findFirst({
-            where: {
-                id: contractID,
-            },
-            include: {
-                reviewStatusActions: true,
-            },
-        })
 
-        if (!contract) {
-            const err = `PRISMA ERROR: Cannot find contract with id: ${contractID}`
-            console.error(err)
-            return new NotFoundError(err)
-        }
+    const contract = await tx.contractTable.findFirst({
+        where: {
+            id: contractID,
+        },
+        include: {
+            reviewStatusActions: true,
+        },
+    })
 
-        // generate approval notice info and update contract
-        const approvalNotice = await tx.contractActionTable.create({
-            data: {
-                updatedByID: updatedByID,
-                dateApprovalReleasedToState: dateApprovalReleasedToState,
-                updatedReason,
-                actionType: 'MARK_AS_APPROVED',
-                contractID: contractID,
-            },
-        })
-
-        await tx.contractTable.update({
-            where: {
-                id: contractID,
-            },
-            data: {
-                reviewStatusActions: {
-                    connect: { id: approvalNotice.id },
-                },
-            },
-        })
-
-        return findContractWithHistory(tx, contractID)
-    } catch (err) {
-        console.error('Prisma error finding contract to approve', err)
-        return parseErrorToError(err)
+    if (!contract) {
+        return new NotFoundError(
+            `PRISMA ERROR: Cannot find contract with id: ${contractID}`
+        )
     }
+
+    // generate approval notice info and update contract
+    const approvalNotice = await tx.contractActionTable.create({
+        data: {
+            updatedByID: updatedByID,
+            dateApprovalReleasedToState: dateApprovalReleasedToState,
+            updatedReason,
+            actionType: 'MARK_AS_APPROVED',
+            contractID: contractID,
+        },
+    })
+
+    await tx.contractTable.update({
+        where: {
+            id: contractID,
+        },
+        data: {
+            reviewStatusActions: {
+                connect: { id: approvalNotice.id },
+            },
+        },
+    })
+
+    return findContractWithHistory(tx, contractID)
 }
 
 type ApproveContractArgsType = {
@@ -71,18 +70,13 @@ async function approveContract(
     client: ExtendedPrismaClient,
     args: ApproveContractArgsType
 ): Promise<ContractType | NotFoundError | Error> {
-    try {
-        return await client.$transaction(async (tx) => {
-            const result = await approveContractInsideTransaction(tx, args)
-            if (result instanceof Error) {
-                throw result
-            }
-            return result
-        })
-    } catch (err) {
-        console.error('Prisma error approving contract', err)
-        return parseErrorToError(err)
-    }
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'approveContract',
+        lock: async (tx) => await lockContractRowForUpdate(tx, args.contractID),
+        transaction: async (tx) =>
+            await approveContractInsideTransaction(tx, args),
+    })
 }
 
 export { approveContract }

--- a/services/app-api/src/postgres/contractAndRates/approveContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/approveContract.ts
@@ -31,16 +31,14 @@ async function approveContractInsideTransaction(
     })
 
     if (!contract) {
-        return new NotFoundError(
+        throw new NotFoundError(
             `PRISMA ERROR: Cannot find contract with id: ${contractID}`
         )
     }
 
     const latestReviewStatusAction = contract.reviewStatusActions[0]
     if (latestReviewStatusAction?.actionType === 'MARK_AS_APPROVED') {
-        return new Error(
-            'Cannot approve contract: contract is already approved'
-        )
+        throw new Error('Cannot approve contract: contract is already approved')
     }
 
     // generate approval notice info and update contract

--- a/services/app-api/src/postgres/contractAndRates/overrideRateData.ts
+++ b/services/app-api/src/postgres/contractAndRates/overrideRateData.ts
@@ -2,10 +2,7 @@ import type { PrismaTransactionType } from '../prismaTypes'
 import type { RateType } from '../../domain-models'
 import type { ExtendedPrismaClient } from '../prismaClient'
 import { findRateWithHistory } from './findRateWithHistory'
-import {
-    lockRateRowForUpdate,
-    runTransactionWithRowLock,
-} from '../prismaHelpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
 
 type OverrideRateDataArgsType = {
     rateID: string
@@ -117,7 +114,8 @@ const overrideRateData = async (
     return runTransactionWithRowLock({
         client,
         operationName: 'overrideRateData',
-        lock: async (tx) => await lockRateRowForUpdate(tx, args.rateID),
+        table: 'RateTable',
+        id: args.rateID,
         transaction: async (tx) =>
             await overrideRateDataInsideTransaction(tx, args),
     })

--- a/services/app-api/src/postgres/contractAndRates/overrideRateData.ts
+++ b/services/app-api/src/postgres/contractAndRates/overrideRateData.ts
@@ -2,7 +2,10 @@ import type { PrismaTransactionType } from '../prismaTypes'
 import type { RateType } from '../../domain-models'
 import type { ExtendedPrismaClient } from '../prismaClient'
 import { findRateWithHistory } from './findRateWithHistory'
-import { parseErrorToError } from '@mc-review/helpers'
+import {
+    lockRateRowForUpdate,
+    runTransactionWithRowLock,
+} from '../prismaHelpers'
 
 type OverrideRateDataArgsType = {
     rateID: string
@@ -111,14 +114,13 @@ const overrideRateData = async (
     client: ExtendedPrismaClient,
     args: OverrideRateDataArgsType
 ): Promise<RateType | Error> => {
-    try {
-        return await client.$transaction(
-            async (tx) => await overrideRateDataInsideTransaction(tx, args)
-        )
-    } catch (err) {
-        console.error('PRISMA ERROR: Error overriding rate data', err)
-        return parseErrorToError(err)
-    }
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'overrideRateData',
+        lock: async (tx) => await lockRateRowForUpdate(tx, args.rateID),
+        transaction: async (tx) =>
+            await overrideRateDataInsideTransaction(tx, args),
+    })
 }
 
 export {

--- a/services/app-api/src/postgres/contractAndRates/reverseApproveContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/reverseApproveContract.ts
@@ -1,9 +1,12 @@
 import { findContractWithHistory } from './findContractWithHistory'
 import { NotFoundError } from '../postgresErrors'
-import type { ContractType } from '../../domain-models/contractAndRates'
+import type { ContractType } from '../../domain-models'
 import type { PrismaTransactionType } from '../prismaTypes'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import { parseErrorToError } from '@mc-review/helpers'
+import {
+    lockContractRowForUpdate,
+    runTransactionWithRowLock,
+} from '../prismaHelpers'
 
 async function reverseApproveContractInsideTransaction(
     tx: PrismaTransactionType,
@@ -24,9 +27,9 @@ async function reverseApproveContractInsideTransaction(
     })
 
     if (!contract) {
-        const err = `PRISMA ERROR: Cannot find contract with id: ${contractID}`
-        console.error(err)
-        return new NotFoundError(err)
+        return new NotFoundError(
+            `PRISMA ERROR: Cannot find contract with id: ${contractID}`
+        )
     }
 
     const latestAction = contract.reviewStatusActions[0]
@@ -58,21 +61,13 @@ async function reverseApproveContract(
     client: ExtendedPrismaClient,
     args: ReverseApproveContractArgsType
 ): Promise<ContractType | NotFoundError | Error> {
-    try {
-        return await client.$transaction(async (tx) => {
-            const result = await reverseApproveContractInsideTransaction(
-                tx,
-                args
-            )
-            if (result instanceof Error) {
-                throw result
-            }
-            return result
-        })
-    } catch (err) {
-        console.error('Prisma error reversing contract approval', err)
-        return parseErrorToError(err)
-    }
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'reverseApproveContract',
+        lock: async (tx) => await lockContractRowForUpdate(tx, args.contractID),
+        transaction: async (tx) =>
+            await reverseApproveContractInsideTransaction(tx, args),
+    })
 }
 
 export { reverseApproveContract }

--- a/services/app-api/src/postgres/contractAndRates/reverseApproveContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/reverseApproveContract.ts
@@ -3,10 +3,7 @@ import { NotFoundError } from '../postgresErrors'
 import type { ContractType } from '../../domain-models'
 import type { PrismaTransactionType } from '../prismaTypes'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import {
-    lockContractRowForUpdate,
-    runTransactionWithRowLock,
-} from '../prismaHelpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
 
 async function reverseApproveContractInsideTransaction(
     tx: PrismaTransactionType,
@@ -64,7 +61,8 @@ async function reverseApproveContract(
     return runTransactionWithRowLock({
         client,
         operationName: 'reverseApproveContract',
-        lock: async (tx) => await lockContractRowForUpdate(tx, args.contractID),
+        table: 'ContractTable',
+        id: args.contractID,
         transaction: async (tx) =>
             await reverseApproveContractInsideTransaction(tx, args),
     })

--- a/services/app-api/src/postgres/contractAndRates/submitContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/submitContract.ts
@@ -8,10 +8,7 @@ import {
     eqroValidationAndReviewDetermination,
     healthPlanReviewDetermination,
 } from '@mc-review/submissions'
-import {
-    lockContractRowForUpdate,
-    runTransactionWithRowLock,
-} from '../prismaHelpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
 
 async function submitContractInsideTransaction(
     tx: PrismaTransactionType,
@@ -221,7 +218,8 @@ async function submitContract(
     return runTransactionWithRowLock({
         client,
         operationName: 'submitContract',
-        lock: async (tx) => await lockContractRowForUpdate(tx, contractID),
+        table: 'ContractTable',
+        id: contractID,
         transaction: async (tx) => {
             const result = await submitContractInsideTransaction(tx, {
                 contractID,

--- a/services/app-api/src/postgres/contractAndRates/submitContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/submitContract.ts
@@ -8,7 +8,10 @@ import {
     eqroValidationAndReviewDetermination,
     healthPlanReviewDetermination,
 } from '@mc-review/submissions'
-import { parseErrorToError } from '@mc-review/helpers'
+import {
+    lockContractRowForUpdate,
+    runTransactionWithRowLock,
+} from '../prismaHelpers'
 
 async function submitContractInsideTransaction(
     tx: PrismaTransactionType,
@@ -37,9 +40,9 @@ async function submitContractInsideTransaction(
     })
 
     if (!currentRev) {
-        const err = `PRISMA ERROR: Cannot find the current rev to submit with contract id: ${contractID}`
-        console.error(err)
-        return new NotFoundError(err)
+        return new NotFoundError(
+            `PRISMA ERROR: Cannot find the current rev to submit with contract id: ${contractID}`
+        )
     }
 
     const unsubmittedChildRevs = []
@@ -54,8 +57,9 @@ async function submitContractInsideTransaction(
                 )
                 const latestSubmittedRate = rate.revisions[0]
                 if (!latestSubmittedRate) {
-                    const msg = `Attempted to submit a contract connected to an unsubmitted child-rate. ContractID: ${contractID}`
-                    return new Error(msg)
+                    return new Error(
+                        `Attempted to submit a contract connected to an unsubmitted child-rate. ContractID: ${contractID}`
+                    )
                 }
                 linkedRateRevs.push(latestSubmittedRate)
             }
@@ -63,8 +67,9 @@ async function submitContractInsideTransaction(
             // non-child rate
             const latestSubmittedRate = rate.revisions[0]
             if (!latestSubmittedRate) {
-                const msg = `Attempted to submit a contract connected to an unsubmitted non-child-rate. ContractID: ${contractID}`
-                return new Error(msg)
+                return new Error(
+                    `Attempted to submit a contract connected to an unsubmitted non-child-rate. ContractID: ${contractID}`
+                )
             }
             linkedRateRevs.push(latestSubmittedRate)
         }
@@ -78,7 +83,7 @@ async function submitContractInsideTransaction(
         submittedReason
     )
     if (submissionResult instanceof Error) {
-        return submissionResult
+        throw submissionResult
     }
 
     return await findContractWithHistory(tx, contractID)
@@ -213,8 +218,11 @@ async function submitContract(
         chipSubmissionAutomationFlag,
     } = args
 
-    try {
-        return await client.$transaction(async (tx) => {
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'submitContract',
+        lock: async (tx) => await lockContractRowForUpdate(tx, contractID),
+        transaction: async (tx) => {
             const result = await submitContractInsideTransaction(tx, {
                 contractID,
                 submittedByUserID,
@@ -260,11 +268,8 @@ async function submitContract(
             }
 
             return result
-        })
-    } catch (err) {
-        console.error('Submit Prisma Error: ', err)
-        return parseErrorToError(err)
-    }
+        },
+    })
 }
 
 export {

--- a/services/app-api/src/postgres/contractAndRates/submitRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/submitRate.ts
@@ -9,10 +9,7 @@ import { NotFoundError } from '../postgresErrors'
 import type { PrismaTransactionType } from '../prismaTypes'
 import { submitContractAndOrRates } from './submitContractAndOrRates'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import {
-    lockRateRowForUpdate,
-    runTransactionWithRowLock,
-} from '../prismaHelpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
 
 async function submitRateInsideTransaction(
     tx: PrismaTransactionType,
@@ -108,7 +105,8 @@ async function submitRate(
     return runTransactionWithRowLock({
         client,
         operationName: 'submitRate',
-        lock: async (tx) => await lockRateRowForUpdate(tx, args.rateID),
+        table: 'RateTable',
+        id: args.rateID,
         transaction: async (tx) => await submitRateInsideTransaction(tx, args),
     })
 }

--- a/services/app-api/src/postgres/contractAndRates/submitRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/submitRate.ts
@@ -9,7 +9,10 @@ import { NotFoundError } from '../postgresErrors'
 import type { PrismaTransactionType } from '../prismaTypes'
 import { submitContractAndOrRates } from './submitContractAndOrRates'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import { parseErrorToError } from '@mc-review/helpers'
+import {
+    lockRateRowForUpdate,
+    runTransactionWithRowLock,
+} from '../prismaHelpers'
 
 async function submitRateInsideTransaction(
     tx: PrismaTransactionType,
@@ -102,18 +105,12 @@ async function submitRate(
     client: ExtendedPrismaClient,
     args: SubmitRateArgsType
 ): Promise<RateType | NotFoundError | Error> {
-    try {
-        return await client.$transaction(async (tx) => {
-            const result = await submitRateInsideTransaction(tx, args)
-            if (result instanceof Error) {
-                throw result
-            }
-            return result
-        })
-    } catch (err) {
-        console.error('Prisma error submitting rate', err)
-        return parseErrorToError(err)
-    }
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'submitRate',
+        lock: async (tx) => await lockRateRowForUpdate(tx, args.rateID),
+        transaction: async (tx) => await submitRateInsideTransaction(tx, args),
+    })
 }
 
 export { submitRate, submitRateInsideTransaction }

--- a/services/app-api/src/postgres/contractAndRates/undoUnlockContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/undoUnlockContract.ts
@@ -1,17 +1,17 @@
 import { findContractWithHistory } from './findContractWithHistory'
 import { type NotFoundError, UserInputPostgresError } from '../postgresErrors'
-import type { ContractType } from '../../domain-models/contractAndRates'
+import type { ContractType } from '../../domain-models'
 import type { PrismaTransactionType } from '../prismaTypes'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import { parseErrorToError } from '@mc-review/helpers'
-import { Prisma } from '../../generated/client'
 import {
     getLatestActiveRevision,
     isSubmittedRevision,
     isUnlockedRevision,
 } from './prismaSharedContractRateHelpers'
-
-const MAX_SERIALIZATION_RETRIES = 2
+import {
+    lockContractRowForUpdate,
+    runTransactionWithRowLock,
+} from '../prismaHelpers'
 
 async function undoUnlockContractInsideTransaction(
     tx: PrismaTransactionType,
@@ -193,43 +193,13 @@ async function undoUnlockContract(
     client: ExtendedPrismaClient,
     args: UndoUnlockContractArgsType
 ): Promise<ContractType | NotFoundError | Error> {
-    let attempt = 0
-    while (true) {
-        try {
-            return await client.$transaction(
-                async (tx) => {
-                    const result = await undoUnlockContractInsideTransaction(
-                        tx,
-                        args
-                    )
-                    if (result instanceof Error) {
-                        throw result
-                    }
-                    return result
-                },
-                {
-                    isolationLevel:
-                        Prisma.TransactionIsolationLevel.Serializable,
-                }
-            )
-        } catch (err) {
-            const code = (err as { code?: string }).code
-            const cause = (err as { cause?: { kind?: string } }).cause
-            const isWriteConflict =
-                code === 'P2034' || cause?.kind === 'TransactionWriteConflict'
-
-            if (isWriteConflict && attempt < MAX_SERIALIZATION_RETRIES - 1) {
-                console.warn(
-                    `undoUnlockContract: serialization conflict, retrying. contractID=${args.contractID} attempt=${attempt + 1}`
-                )
-                attempt++
-                continue
-            }
-
-            console.error('Prisma error undoing contract unlock', err)
-            return parseErrorToError(err)
-        }
-    }
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'undoUnlockContract',
+        lock: async (tx) => await lockContractRowForUpdate(tx, args.contractID),
+        transaction: async (tx) =>
+            await undoUnlockContractInsideTransaction(tx, args),
+    })
 }
 
 export { undoUnlockContract, undoUnlockContractInsideTransaction }

--- a/services/app-api/src/postgres/contractAndRates/undoUnlockContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/undoUnlockContract.ts
@@ -1,5 +1,6 @@
 import { findContractWithHistory } from './findContractWithHistory'
-import { type NotFoundError, UserInputPostgresError } from '../postgresErrors'
+import { UserInputPostgresError } from '../postgresErrors'
+import type { NotFoundError } from '../postgresErrors'
 import type { ContractType } from '../../domain-models'
 import type { PrismaTransactionType } from '../prismaTypes'
 import type { ExtendedPrismaClient } from '../prismaClient'
@@ -8,10 +9,7 @@ import {
     isSubmittedRevision,
     isUnlockedRevision,
 } from './prismaSharedContractRateHelpers'
-import {
-    lockContractRowForUpdate,
-    runTransactionWithRowLock,
-} from '../prismaHelpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
 
 async function undoUnlockContractInsideTransaction(
     tx: PrismaTransactionType,
@@ -196,7 +194,8 @@ async function undoUnlockContract(
     return runTransactionWithRowLock({
         client,
         operationName: 'undoUnlockContract',
-        lock: async (tx) => await lockContractRowForUpdate(tx, args.contractID),
+        table: 'ContractTable',
+        id: args.contractID,
         transaction: async (tx) =>
             await undoUnlockContractInsideTransaction(tx, args),
     })

--- a/services/app-api/src/postgres/contractAndRates/undoWithdrawContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/undoWithdrawContract.ts
@@ -5,11 +5,14 @@ import type { ExtendedPrismaClient } from '../prismaClient'
 import { unlockContractInsideTransaction } from './unlockContract'
 import { submitContractInsideTransaction } from './submitContract'
 import { findContractWithHistory } from './findContractWithHistory'
-import { parseErrorToError } from '@mc-review/helpers'
 import {
     eqroValidationAndReviewDetermination,
     healthPlanReviewDetermination,
 } from '@mc-review/submissions'
+import {
+    lockContractRowForUpdate,
+    runTransactionWithRowLock,
+} from '../prismaHelpers'
 
 export type UndoWithdrawContractArgsType = {
     contract: ContractType
@@ -206,19 +209,17 @@ const undoWithdrawContract = async (
     client: ExtendedPrismaClient,
     args: UndoWithdrawContractArgsType
 ): Promise<UndoWithdrawContractReturnType | Error> => {
-    try {
-        return await client.$transaction(
-            async (tx) => await undoWithdrawContractInsideTransaction(tx, args),
-            {
-                timeout: 30000,
-            }
-        )
-    } catch (err) {
-        const parsedError = parseErrorToError(err)
-        const msg = `PRISMA ERROR: Error undo withdraw contract: ${parsedError.message}`
-        console.error(msg)
-        return parsedError
-    }
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'undoWithdrawContract',
+        lock: async (tx) =>
+            await lockContractRowForUpdate(tx, args.contract.id),
+        transaction: async (tx) =>
+            await undoWithdrawContractInsideTransaction(tx, args),
+        transactionOptions: {
+            timeout: 30000,
+        },
+    })
 }
 
 export { undoWithdrawContract }

--- a/services/app-api/src/postgres/contractAndRates/undoWithdrawContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/undoWithdrawContract.ts
@@ -9,10 +9,7 @@ import {
     eqroValidationAndReviewDetermination,
     healthPlanReviewDetermination,
 } from '@mc-review/submissions'
-import {
-    lockContractRowForUpdate,
-    runTransactionWithRowLock,
-} from '../prismaHelpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
 
 export type UndoWithdrawContractArgsType = {
     contract: ContractType
@@ -212,8 +209,8 @@ const undoWithdrawContract = async (
     return runTransactionWithRowLock({
         client,
         operationName: 'undoWithdrawContract',
-        lock: async (tx) =>
-            await lockContractRowForUpdate(tx, args.contract.id),
+        table: 'ContractTable',
+        id: args.contract.id,
         transaction: async (tx) =>
             await undoWithdrawContractInsideTransaction(tx, args),
         transactionOptions: {

--- a/services/app-api/src/postgres/contractAndRates/undoWithdrawRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/undoWithdrawRate.ts
@@ -8,7 +8,10 @@ import type { UpdateDraftContractRatesArgsType } from './updateDraftContractRate
 import { updateDraftContractRatesInsideTransaction } from './updateDraftContractRates'
 import type { SubmitContractArgsType } from './submitContract'
 import { submitContractInsideTransaction } from './submitContract'
-import { parseErrorToError } from '@mc-review/helpers'
+import {
+    lockRateRowForUpdate,
+    runTransactionWithRowLock,
+} from '../prismaHelpers'
 
 type UndoWithdrawRateArgsType = {
     rateID: string
@@ -231,17 +234,16 @@ const undoWithdrawRate = async (
     client: ExtendedPrismaClient,
     args: UndoWithdrawRateArgsType
 ): Promise<RateType | Error> => {
-    try {
-        return await client.$transaction(
-            async (tx) => await undoWithdrawRateInsideTransaction(tx, args),
-            {
-                timeout: 30000,
-            }
-        )
-    } catch (err) {
-        console.error('PRISMA ERROR: Error undoing rate withdrawal', err)
-        return parseErrorToError(err)
-    }
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'undoWithdrawRate',
+        lock: async (tx) => await lockRateRowForUpdate(tx, args.rateID),
+        transaction: async (tx) =>
+            await undoWithdrawRateInsideTransaction(tx, args),
+        transactionOptions: {
+            timeout: 30000,
+        },
+    })
 }
 
 export {

--- a/services/app-api/src/postgres/contractAndRates/undoWithdrawRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/undoWithdrawRate.ts
@@ -8,10 +8,7 @@ import type { UpdateDraftContractRatesArgsType } from './updateDraftContractRate
 import { updateDraftContractRatesInsideTransaction } from './updateDraftContractRates'
 import type { SubmitContractArgsType } from './submitContract'
 import { submitContractInsideTransaction } from './submitContract'
-import {
-    lockRateRowForUpdate,
-    runTransactionWithRowLock,
-} from '../prismaHelpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
 
 type UndoWithdrawRateArgsType = {
     rateID: string
@@ -237,7 +234,8 @@ const undoWithdrawRate = async (
     return runTransactionWithRowLock({
         client,
         operationName: 'undoWithdrawRate',
-        lock: async (tx) => await lockRateRowForUpdate(tx, args.rateID),
+        table: 'RateTable',
+        id: args.rateID,
         transaction: async (tx) =>
             await undoWithdrawRateInsideTransaction(tx, args),
         transactionOptions: {

--- a/services/app-api/src/postgres/contractAndRates/undoWithdrawRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/undoWithdrawRate.ts
@@ -61,6 +61,10 @@ const undoWithdrawRateInsideTransaction = async (
     const latestRateRev = withdrawnRate.packageSubmissions[0].rateRevision
     const parentContractID = withdrawnRate.parentContractID
 
+    if (withdrawnRate.reviewStatusActions?.[0]?.actionType !== 'WITHDRAW') {
+        throw new Error('Rate to undo withdrawal is not currently withdrawn')
+    }
+
     if (
         !withdrawnRate.withdrawnFromContracts ||
         withdrawnRate.withdrawnFromContracts.length === 0

--- a/services/app-api/src/postgres/contractAndRates/unlockContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/unlockContract.ts
@@ -4,10 +4,7 @@ import { NotFoundError } from '../postgresErrors'
 import { unlockRateInDB } from './unlockRate'
 import type { PrismaTransactionType } from '../prismaTypes'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import {
-    lockContractRowForUpdate,
-    runTransactionWithRowLock,
-} from '../prismaHelpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
 
 async function unlockContractInsideTransaction(
     tx: PrismaTransactionType,
@@ -322,7 +319,8 @@ async function unlockContract(
     return runTransactionWithRowLock({
         client,
         operationName: 'unlockContract',
-        lock: async (tx) => await lockContractRowForUpdate(tx, args.contractID),
+        table: 'ContractTable',
+        id: args.contractID,
         transaction: async (tx) => {
             const result = await unlockContractInsideTransaction(tx, args)
             if (result instanceof Error) {

--- a/services/app-api/src/postgres/contractAndRates/unlockContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/unlockContract.ts
@@ -4,7 +4,10 @@ import { NotFoundError } from '../postgresErrors'
 import { unlockRateInDB } from './unlockRate'
 import type { PrismaTransactionType } from '../prismaTypes'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import { parseErrorToError } from '@mc-review/helpers'
+import {
+    lockContractRowForUpdate,
+    runTransactionWithRowLock,
+} from '../prismaHelpers'
 
 async function unlockContractInsideTransaction(
     tx: PrismaTransactionType,
@@ -66,15 +69,12 @@ async function unlockContractInsideTransaction(
         },
     })
     if (!currentRev) {
-        const err = `PRISMA ERROR: Cannot find the current revision to unlock with contract id: ${contractID}`
-        console.error(err)
-        return new NotFoundError(err)
+        return new NotFoundError(
+            `PRISMA ERROR: Cannot find the current revision to unlock with contract id: ${contractID}`
+        )
     }
 
     if (!currentRev.submitInfoID) {
-        console.error(
-            'Programming Error: cannot unlock a already unlocked contract'
-        )
         return new Error(
             'Programming Error: cannot unlock a already unlocked contract'
         )
@@ -319,19 +319,19 @@ async function unlockContract(
     client: ExtendedPrismaClient,
     args: UnlockContractArgsType
 ): Promise<UnlockedContractType | NotFoundError | Error> {
-    try {
-        return await client.$transaction(async (tx) => {
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'unlockContract',
+        lock: async (tx) => await lockContractRowForUpdate(tx, args.contractID),
+        transaction: async (tx) => {
             const result = await unlockContractInsideTransaction(tx, args)
             if (result instanceof Error) {
                 throw result
             }
 
             return result
-        })
-    } catch (err) {
-        console.error('UNLOCK PRISMA CONTRACT ERR', err)
-        return parseErrorToError(err)
-    }
+        },
+    })
 }
 
 export { unlockContract, unlockContractInsideTransaction }

--- a/services/app-api/src/postgres/contractAndRates/unlockRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/unlockRate.ts
@@ -2,11 +2,13 @@ import type { RateType } from '../../domain-models'
 import type { ExtendedPrismaClient } from '../prismaClient'
 import type { PrismaTransactionType } from '../prismaTypes'
 import { findRateWithHistory } from './findRateWithHistory'
-import { parseErrorToError } from '@mc-review/helpers'
+import {
+    lockRateRowForUpdate,
+    runTransactionWithRowLock,
+} from '../prismaHelpers'
 
 type UnlockRateArgsType = {
-    rateID?: string
-    rateRevisionID?: string
+    rateID: string
     unlockedByUserID: string
     unlockReason: string
 }
@@ -194,34 +196,16 @@ async function unlockRate(
     client: ExtendedPrismaClient,
     args: UnlockRateArgsType
 ): Promise<RateType | Error> {
-    const { rateRevisionID, unlockedByUserID, unlockReason } = args
-    let rateID = args.rateID
+    const { rateID, unlockedByUserID, unlockReason } = args
 
-    // this is a hack that should not outlive protobuf. Protobufs only have
-    // rate revision IDs in them, so we allow submitting by rate revisionID from our submitHPP resolver
-    if (!rateID && !rateRevisionID) {
-        return new Error(
-            'Either rateID or rateRevisionID must be supplied. both are blank'
-        )
-    }
-
-    try {
-        return await client.$transaction(async (tx) => {
-            if (rateRevisionID) {
-                const rate = await tx.rateRevisionTable.findUniqueOrThrow({
-                    where: { id: rateRevisionID },
-                })
-                rateID = rate.id
-            }
-
-            if (!rateID) {
-                throw new Error(
-                    'Programming Error: we must have a rateID at this point.'
-                )
-            }
-
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'unlockRate',
+        lock: async (tx) => await lockRateRowForUpdate(tx, rateID),
+        transaction: async (tx) => {
             const currentDateTime = new Date()
-            // create the unlock info to be shared across all submissions.
+            // create the unlock info for unlockRateInDB. unlockRateInDB is used
+            // in other store functions so it cannot be done inside of it.
             const unlockInfo = await tx.updateInfoTable.create({
                 data: {
                     updatedAt: currentDateTime,
@@ -237,11 +221,8 @@ async function unlockRate(
             }
 
             return findRateWithHistory(tx, rateID)
-        })
-    } catch (err) {
-        console.error('SUBMIT PRISMA CONTRACT ERR', err)
-        return parseErrorToError(err)
-    }
+        },
+    })
 }
 
 export { unlockRate, unlockRateInDB }

--- a/services/app-api/src/postgres/contractAndRates/unlockRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/unlockRate.ts
@@ -2,10 +2,7 @@ import type { RateType } from '../../domain-models'
 import type { ExtendedPrismaClient } from '../prismaClient'
 import type { PrismaTransactionType } from '../prismaTypes'
 import { findRateWithHistory } from './findRateWithHistory'
-import {
-    lockRateRowForUpdate,
-    runTransactionWithRowLock,
-} from '../prismaHelpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
 
 type UnlockRateArgsType = {
     rateID: string
@@ -201,7 +198,8 @@ async function unlockRate(
     return runTransactionWithRowLock({
         client,
         operationName: 'unlockRate',
-        lock: async (tx) => await lockRateRowForUpdate(tx, rateID),
+        table: 'RateTable',
+        id: rateID,
         transaction: async (tx) => {
             const currentDateTime = new Date()
             // create the unlock info for unlockRateInDB. unlockRateInDB is used

--- a/services/app-api/src/postgres/contractAndRates/updateDraftContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/updateDraftContract.ts
@@ -26,9 +26,9 @@ async function updateDraftContractInsideTransaction(
     })
 
     if (!currentContractRev) {
-        const err = `PRISMA ERROR: Cannot find the current rev to update with contract id: ${contractID}`
-        console.error(err)
-        return new NotFoundError(err)
+        return new NotFoundError(
+            `PRISMA ERROR: Cannot find the current rev to update with contract id: ${contractID}`
+        )
     }
 
     // Then update the contractRevision, adjusting all simple fields

--- a/services/app-api/src/postgres/contractAndRates/updateDraftContractRates.ts
+++ b/services/app-api/src/postgres/contractAndRates/updateDraftContractRates.ts
@@ -10,10 +10,7 @@ import {
     prismaRateCreateFormDataFromDomain,
     prismaUpdateRateFormDataFromDomain,
 } from './prismaContractRateAdaptors'
-import {
-    lockContractRowForUpdate,
-    runTransactionWithRowLock,
-} from '../prismaHelpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
 
 interface UpdatedRatesType {
     create: {
@@ -233,7 +230,8 @@ async function updateDraftContractRates(
     return runTransactionWithRowLock({
         client,
         operationName: 'updateDraftContractRates',
-        lock: async (tx) => await lockContractRowForUpdate(tx, args.contractID),
+        table: 'ContractTable',
+        id: args.contractID,
         transaction: async (tx) => {
             const result = await updateDraftContractRatesInsideTransaction(
                 tx,

--- a/services/app-api/src/postgres/contractAndRates/updateDraftContractRates.ts
+++ b/services/app-api/src/postgres/contractAndRates/updateDraftContractRates.ts
@@ -10,7 +10,10 @@ import {
     prismaRateCreateFormDataFromDomain,
     prismaUpdateRateFormDataFromDomain,
 } from './prismaContractRateAdaptors'
-import { parseErrorToError } from '@mc-review/helpers'
+import {
+    lockContractRowForUpdate,
+    runTransactionWithRowLock,
+} from '../prismaHelpers'
 
 interface UpdatedRatesType {
     create: {
@@ -227,19 +230,22 @@ async function updateDraftContractRates(
     client: ExtendedPrismaClient,
     args: UpdateDraftContractRatesArgsType
 ): Promise<ContractType | Error> {
-    try {
-        return await client.$transaction(async (tx) => {
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'updateDraftContractRates',
+        lock: async (tx) => await lockContractRowForUpdate(tx, args.contractID),
+        transaction: async (tx) => {
             const result = await updateDraftContractRatesInsideTransaction(
                 tx,
                 args
             )
+            if (result instanceof Error) {
+                throw result
+            }
 
             return result
-        })
-    } catch (err) {
-        console.error('PRISMA ERR', err)
-        return parseErrorToError(err)
-    }
+        },
+    })
 }
 
 export type { UpdateDraftContractRatesArgsType }

--- a/services/app-api/src/postgres/contractAndRates/updateDraftContractWithRates.ts
+++ b/services/app-api/src/postgres/contractAndRates/updateDraftContractWithRates.ts
@@ -6,10 +6,7 @@ import { prismaUpdateContractFormDataFromDomain } from './prismaContractRateAdap
 import { includeFullRate } from './prismaFullContractRateHelpers'
 import type { ExtendedPrismaClient } from '../prismaClient'
 import type { UpdateContractArgsType } from './updateDraftContract'
-import {
-    lockContractRowForUpdate,
-    runTransactionWithRowLock,
-} from '../prismaHelpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
 
 // Update the given draft
 // * can change the set of draftRates
@@ -23,7 +20,8 @@ async function updateDraftContractFormData(
     return runTransactionWithRowLock({
         client,
         operationName: 'updateDraftContractFormData',
-        lock: async (tx) => await lockContractRowForUpdate(tx, contractID),
+        table: 'ContractTable',
+        id: contractID,
         transaction: async (tx) => {
             // Given all the Contracts associated with this draft, find the most recent submitted
             const currentContractRev = await tx.contractRevisionTable.findFirst(

--- a/services/app-api/src/postgres/contractAndRates/updateDraftContractWithRates.ts
+++ b/services/app-api/src/postgres/contractAndRates/updateDraftContractWithRates.ts
@@ -6,7 +6,10 @@ import { prismaUpdateContractFormDataFromDomain } from './prismaContractRateAdap
 import { includeFullRate } from './prismaFullContractRateHelpers'
 import type { ExtendedPrismaClient } from '../prismaClient'
 import type { UpdateContractArgsType } from './updateDraftContract'
-import { parseErrorToError } from '@mc-review/helpers'
+import {
+    lockContractRowForUpdate,
+    runTransactionWithRowLock,
+} from '../prismaHelpers'
 
 // Update the given draft
 // * can change the set of draftRates
@@ -17,8 +20,11 @@ async function updateDraftContractFormData(
 ): Promise<ContractType | NotFoundError | Error> {
     const { contractID, formData } = args
 
-    try {
-        return await client.$transaction(async (tx) => {
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'updateDraftContractFormData',
+        lock: async (tx) => await lockContractRowForUpdate(tx, contractID),
+        transaction: async (tx) => {
             // Given all the Contracts associated with this draft, find the most recent submitted
             const currentContractRev = await tx.contractRevisionTable.findFirst(
                 {
@@ -46,9 +52,9 @@ async function updateDraftContractFormData(
                 }
             )
             if (!currentContractRev) {
-                const err = `PRISMA ERROR: Cannot find the current rev to update with contract id: ${contractID}`
-                console.error(err)
-                return new NotFoundError(err)
+                return new NotFoundError(
+                    `PRISMA ERROR: Cannot find the current rev to update with contract id: ${contractID}`
+                )
             }
 
             // Then update the contractRevision, adjusting all simple fields
@@ -62,11 +68,8 @@ async function updateDraftContractFormData(
             })
 
             return findContractWithHistory(tx, contractID)
-        })
-    } catch (err) {
-        console.error('Prisma error updating contract', err)
-        return parseErrorToError(err)
-    }
+        },
+    })
 }
 
 export { updateDraftContractFormData }

--- a/services/app-api/src/postgres/contractAndRates/updateMCCRSID.ts
+++ b/services/app-api/src/postgres/contractAndRates/updateMCCRSID.ts
@@ -1,10 +1,13 @@
 import { findContractWithHistory } from './findContractWithHistory'
 import type { NotFoundError } from '../postgresErrors'
 
-import type { ContractType } from '../../domain-models/contractAndRates'
+import type { ContractType } from '../../domain-models'
 import { nullify } from '../prismaDomainAdaptors'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import { parseErrorToError } from '@mc-review/helpers'
+import {
+    lockContractRowForUpdate,
+    runTransactionWithRowLock,
+} from '../prismaHelpers'
 
 type UpdateMCCRSIDFormArgsType = {
     contractID: string
@@ -18,8 +21,11 @@ async function updateMCCRSID(
 ): Promise<ContractType | NotFoundError | Error> {
     const { contractID, mccrsID } = args
 
-    try {
-        return await client.$transaction(async (tx) => {
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'updateMCCRSID',
+        lock: async (tx) => await lockContractRowForUpdate(tx, contractID),
+        transaction: async (tx) => {
             // Get the Contract associated with this given contract ID
             await tx.contractTable.update({
                 data: {
@@ -31,11 +37,8 @@ async function updateMCCRSID(
             })
 
             return findContractWithHistory(tx, contractID)
-        })
-    } catch (err) {
-        console.error('Prisma error updating contract', err)
-        return parseErrorToError(err)
-    }
+        },
+    })
 }
 
 export { updateMCCRSID }

--- a/services/app-api/src/postgres/contractAndRates/updateMCCRSID.ts
+++ b/services/app-api/src/postgres/contractAndRates/updateMCCRSID.ts
@@ -4,10 +4,7 @@ import type { NotFoundError } from '../postgresErrors'
 import type { ContractType } from '../../domain-models'
 import { nullify } from '../prismaDomainAdaptors'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import {
-    lockContractRowForUpdate,
-    runTransactionWithRowLock,
-} from '../prismaHelpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
 
 type UpdateMCCRSIDFormArgsType = {
     contractID: string
@@ -24,7 +21,8 @@ async function updateMCCRSID(
     return runTransactionWithRowLock({
         client,
         operationName: 'updateMCCRSID',
-        lock: async (tx) => await lockContractRowForUpdate(tx, contractID),
+        table: 'ContractTable',
+        id: contractID,
         transaction: async (tx) => {
             // Get the Contract associated with this given contract ID
             await tx.contractTable.update({

--- a/services/app-api/src/postgres/contractAndRates/withdrawContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawContract.ts
@@ -16,10 +16,7 @@ import {
 import type { RatesToReassign } from './reassignParentContract'
 import { reassignParentContractInTransaction } from './reassignParentContract'
 import type { RateForDisplayType } from '../../emailer/templateHelpers'
-import {
-    lockContractRowForUpdate,
-    runTransactionWithRowLock,
-} from '../prismaHelpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
 
 export type WithdrawContractArgsType = {
     contract: ContractType
@@ -281,8 +278,8 @@ const withdrawContract = async (
     return runTransactionWithRowLock({
         client,
         operationName: 'withdrawContract',
-        lock: async (tx) =>
-            await lockContractRowForUpdate(tx, args.contract.id),
+        table: 'ContractTable',
+        id: args.contract.id,
         transaction: async (tx) =>
             await withdrawContractInsideTransaction(tx, args),
         transactionOptions: {

--- a/services/app-api/src/postgres/contractAndRates/withdrawContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawContract.ts
@@ -54,6 +54,38 @@ const withdrawContractInsideTransaction = async (
 ): Promise<WithdrawContractReturnType> => {
     const { contract, updatedReason, updatedByID } = args
 
+    const currentContractReviewStatus = await tx.contractTable.findUnique({
+        where: {
+            id: contract.id,
+        },
+        select: {
+            reviewStatusActions: {
+                orderBy: {
+                    updatedAt: 'desc',
+                },
+                take: 1,
+                select: {
+                    actionType: true,
+                },
+            },
+        },
+    })
+
+    if (!currentContractReviewStatus) {
+        throw new NotFoundError(
+            `Could not find contract ${contract.id} to withdraw.`
+        )
+    }
+
+    if (
+        currentContractReviewStatus.reviewStatusActions[0]?.actionType ===
+        'WITHDRAW'
+    ) {
+        throw new Error(
+            'Cannot withdraw contract: contract is already withdrawn'
+        )
+    }
+
     const latestSubmission = contract.packageSubmissions[0]
     const rateIDS = latestSubmission.rateRevisions.map((rr) => rr.rateID)
 

--- a/services/app-api/src/postgres/contractAndRates/withdrawContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawContract.ts
@@ -16,7 +16,10 @@ import {
 import type { RatesToReassign } from './reassignParentContract'
 import { reassignParentContractInTransaction } from './reassignParentContract'
 import type { RateForDisplayType } from '../../emailer/templateHelpers'
-import { parseErrorToError } from '@mc-review/helpers'
+import {
+    lockContractRowForUpdate,
+    runTransactionWithRowLock,
+} from '../prismaHelpers'
 
 export type WithdrawContractArgsType = {
     contract: ContractType
@@ -275,19 +278,17 @@ const withdrawContract = async (
     client: ExtendedPrismaClient,
     args: WithdrawContractArgsType
 ): Promise<WithdrawContractReturnType | Error> => {
-    try {
-        return await client.$transaction(
-            async (tx) => await withdrawContractInsideTransaction(tx, args),
-            {
-                timeout: 30000,
-            }
-        )
-    } catch (err) {
-        const parsedError = parseErrorToError(err)
-        const msg = `PRISMA ERROR: Error withdrawing contract: ${parsedError.message}`
-        console.error(msg)
-        return parsedError
-    }
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'withdrawContract',
+        lock: async (tx) =>
+            await lockContractRowForUpdate(tx, args.contract.id),
+        transaction: async (tx) =>
+            await withdrawContractInsideTransaction(tx, args),
+        transactionOptions: {
+            timeout: 30000,
+        },
+    })
 }
 
 export { withdrawContractInsideTransaction, withdrawContract }

--- a/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
@@ -17,10 +17,7 @@ import { submitContractInsideTransaction } from './submitContract'
 import { submitRateInsideTransaction } from './submitRate'
 import { parseContractWithHistory } from './parseContractWithHistory'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import {
-    lockRateRowForUpdate,
-    runTransactionWithRowLock,
-} from '../prismaHelpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
 
 type WithdrawRateArgsType = {
     rateID: string
@@ -335,7 +332,8 @@ const withdrawRate = async (
     return runTransactionWithRowLock({
         client,
         operationName: 'withdrawRate',
-        lock: async (tx) => await lockRateRowForUpdate(tx, args.rateID),
+        table: 'RateTable',
+        id: args.rateID,
         transaction: async (tx) =>
             await withdrawRateInsideTransaction(tx, args),
         transactionOptions: {

--- a/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
@@ -17,7 +17,10 @@ import { submitContractInsideTransaction } from './submitContract'
 import { submitRateInsideTransaction } from './submitRate'
 import { parseContractWithHistory } from './parseContractWithHistory'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import { parseErrorToError } from '@mc-review/helpers'
+import {
+    lockRateRowForUpdate,
+    runTransactionWithRowLock,
+} from '../prismaHelpers'
 
 type WithdrawRateArgsType = {
     rateID: string
@@ -329,17 +332,16 @@ const withdrawRate = async (
     client: ExtendedPrismaClient,
     args: WithdrawRateArgsType
 ): Promise<RateType | Error> => {
-    try {
-        return await client.$transaction(
-            async (tx) => await withdrawRateInsideTransaction(tx, args),
-            {
-                timeout: 30000,
-            }
-        )
-    } catch (err) {
-        console.error('PRISMA ERROR: Error withdrawing rate', err)
-        return parseErrorToError(err)
-    }
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'withdrawRate',
+        lock: async (tx) => await lockRateRowForUpdate(tx, args.rateID),
+        transaction: async (tx) =>
+            await withdrawRateInsideTransaction(tx, args),
+        transactionOptions: {
+            timeout: 30000,
+        },
+    })
 }
 
 export {

--- a/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
+++ b/services/app-api/src/postgres/contractAndRates/withdrawRate.ts
@@ -72,6 +72,15 @@ const withdrawRateInsideTransaction = async (
                     },
                 },
             },
+            reviewStatusActions: {
+                orderBy: {
+                    updatedAt: 'desc',
+                },
+                take: 1,
+                select: {
+                    actionType: true,
+                },
+            },
         },
     })
 
@@ -79,6 +88,10 @@ const withdrawRateInsideTransaction = async (
         throw new NotFoundError(
             `PRISMA ERROR: Cannot find rate with id: ${rateID}`
         )
+    }
+
+    if (rate.reviewStatusActions[0]?.actionType === 'WITHDRAW') {
+        throw new Error('Cannot withdraw rate: rate is already withdrawn')
     }
 
     const latestRateRev = getLatestActiveRevision(rate.revisions)

--- a/services/app-api/src/postgres/postgresErrors.ts
+++ b/services/app-api/src/postgres/postgresErrors.ts
@@ -60,4 +60,16 @@ export const handleUserInputPostgresError = (
     })
 }
 
+/**
+ * Prisma transaction write conflicts can surface as `P2034` from the standard
+ * engine or as a driver-adapter error whose `cause.kind` is
+ * `TransactionWriteConflict`.
+ */
+export const isRetryablePrismaWriteConflict = (error: unknown): boolean => {
+    const code = (error as { code?: string }).code
+    const cause = (error as { cause?: { kind?: string } }).cause
+
+    return code === 'P2034' || cause?.kind === 'TransactionWriteConflict'
+}
+
 export { NotFoundError, UserInputPostgresError }

--- a/services/app-api/src/postgres/postgresErrors.ts
+++ b/services/app-api/src/postgres/postgresErrors.ts
@@ -60,16 +60,4 @@ export const handleUserInputPostgresError = (
     })
 }
 
-/**
- * Prisma transaction write conflicts can surface as `P2034` from the standard
- * engine or as a driver-adapter error whose `cause.kind` is
- * `TransactionWriteConflict`.
- */
-export const isRetryablePrismaWriteConflict = (error: unknown): boolean => {
-    const code = (error as { code?: string }).code
-    const cause = (error as { cause?: { kind?: string } }).cause
-
-    return code === 'P2034' || cause?.kind === 'TransactionWriteConflict'
-}
-
 export { NotFoundError, UserInputPostgresError }

--- a/services/app-api/src/postgres/prismaHelpers.test.ts
+++ b/services/app-api/src/postgres/prismaHelpers.test.ts
@@ -17,7 +17,7 @@ describe('runTransactionWithRowLock', () => {
         vi.restoreAllMocks()
     })
 
-    it('serializes concurrent work on the same locked contract row', async () => {
+    it('prevents concurrent updates on the same locked contract row', async () => {
         const client = await sharedTestPrismaClient()
         const contract = must(
             await insertDraftContract(client, mockInsertContractArgs({}))

--- a/services/app-api/src/postgres/prismaHelpers.test.ts
+++ b/services/app-api/src/postgres/prismaHelpers.test.ts
@@ -1,0 +1,95 @@
+import { sharedTestPrismaClient } from '../testHelpers/storeHelpers'
+import { insertDraftContract } from './contractAndRates'
+import { must, mockInsertContractArgs } from '../testHelpers'
+import {
+    lockContractRowForUpdate,
+    runTransactionWithRowLock,
+} from './prismaHelpers'
+
+describe('runTransactionWithRowLock', () => {
+    // Lets the test wait for a specific point, then continue when `resolve()` is called.
+    const deferred = () => {
+        let resolve!: () => void
+        const promise = new Promise<void>((res) => {
+            resolve = res
+        })
+        return { promise, resolve }
+    }
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('serializes concurrent work on the same locked contract row', async () => {
+        const client = await sharedTestPrismaClient()
+        const contract = must(
+            await insertDraftContract(client, mockInsertContractArgs({}))
+        )
+
+        // Tells the test when the first transaction has updated the row and still holds the lock.
+        const firstTransactionUpdatedRow = deferred()
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        const firstTransaction = runTransactionWithRowLock({
+            client,
+            operationName: 'row lock test',
+            lock: async (tx) => await lockContractRowForUpdate(tx, contract.id),
+            transaction: async (tx) => {
+                await tx.contractTable.update({
+                    where: { id: contract.id },
+                    data: { mccrsID: 'ROW_LOCK_WINNER' },
+                })
+
+                // Tell the test the first transaction is ready.
+                firstTransactionUpdatedRow.resolve()
+
+                // Keep the lock open long enough for the second transaction to wait on it.
+                await tx.$queryRaw<Array<{ slept: number }>>`
+                    SELECT 1 AS slept
+                    FROM pg_sleep(0.2)
+                `
+
+                return 'winner'
+            },
+        })
+
+        // Start the second transaction only after the first one is holding the lock.
+        await firstTransactionUpdatedRow.promise
+
+        const secondTransaction = runTransactionWithRowLock({
+            client,
+            operationName: 'row lock test',
+            lock: async (tx) => await lockContractRowForUpdate(tx, contract.id),
+            transaction: async (tx) => {
+                const lockedContract = await tx.contractTable.findUnique({
+                    where: { id: contract.id },
+                    select: { mccrsID: true },
+                })
+
+                // If locking works, this read happens after the first transaction commits.
+                if (lockedContract?.mccrsID === 'ROW_LOCK_WINNER') {
+                    return new Error('Second transaction observed winner state')
+                }
+
+                return 'loser should not win'
+            },
+        })
+
+        const [firstResult, secondResult] = await Promise.all([
+            firstTransaction,
+            secondTransaction,
+        ])
+
+        expect(firstResult).toBe('winner')
+        expect(secondResult).toBeInstanceOf(Error)
+        expect((secondResult as Error).message).toBe(
+            'Second transaction observed winner state'
+        )
+
+        const updatedContract = await client.contractTable.findUnique({
+            where: { id: contract.id },
+            select: { mccrsID: true },
+        })
+        expect(updatedContract?.mccrsID).toBe('ROW_LOCK_WINNER')
+    })
+})

--- a/services/app-api/src/postgres/prismaHelpers.test.ts
+++ b/services/app-api/src/postgres/prismaHelpers.test.ts
@@ -1,10 +1,7 @@
 import { sharedTestPrismaClient } from '../testHelpers/storeHelpers'
 import { insertDraftContract } from './contractAndRates'
 import { must, mockInsertContractArgs } from '../testHelpers'
-import {
-    lockContractRowForUpdate,
-    runTransactionWithRowLock,
-} from './prismaHelpers'
+import { runTransactionWithRowLock } from './prismaHelpers'
 
 describe('runTransactionWithRowLock', () => {
     // Lets the test wait for a specific point, then continue when `resolve()` is called.
@@ -33,7 +30,8 @@ describe('runTransactionWithRowLock', () => {
         const firstTransaction = runTransactionWithRowLock({
             client,
             operationName: 'row lock test',
-            lock: async (tx) => await lockContractRowForUpdate(tx, contract.id),
+            table: 'ContractTable',
+            id: contract.id,
             transaction: async (tx) => {
                 await tx.contractTable.update({
                     where: { id: contract.id },
@@ -59,7 +57,8 @@ describe('runTransactionWithRowLock', () => {
         const secondTransaction = runTransactionWithRowLock({
             client,
             operationName: 'row lock test',
-            lock: async (tx) => await lockContractRowForUpdate(tx, contract.id),
+            table: 'ContractTable',
+            id: contract.id,
             transaction: async (tx) => {
                 const lockedContract = await tx.contractTable.findUnique({
                     where: { id: contract.id },
@@ -91,5 +90,124 @@ describe('runTransactionWithRowLock', () => {
             select: { mccrsID: true },
         })
         expect(updatedContract?.mccrsID).toBe('ROW_LOCK_WINNER')
+    })
+
+    it('does not block concurrent work on different locked contract rows', async () => {
+        const client = await sharedTestPrismaClient()
+        const firstContract = must(
+            await insertDraftContract(client, mockInsertContractArgs({}))
+        )
+        const secondContract = must(
+            await insertDraftContract(client, mockInsertContractArgs({}))
+        )
+        const thirdContract = must(
+            await insertDraftContract(client, mockInsertContractArgs({}))
+        )
+
+        const firstTransactionLockedRow = deferred()
+        const allowFirstTransactionToFinish = deferred()
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        const firstTransaction = runTransactionWithRowLock({
+            client,
+            operationName: 'different row lock test',
+            table: 'ContractTable',
+            id: firstContract.id,
+            transaction: async (tx) => {
+                await tx.contractTable.update({
+                    where: { id: firstContract.id },
+                    data: { mccrsID: 'FIRST_CONTRACT_UPDATED' },
+                })
+
+                firstTransactionLockedRow.resolve()
+                await allowFirstTransactionToFinish.promise
+
+                return 'first transaction finished'
+            },
+        })
+
+        await firstTransactionLockedRow.promise
+
+        const secondTransaction = runTransactionWithRowLock({
+            client,
+            operationName: 'different row lock test',
+            table: 'ContractTable',
+            id: secondContract.id,
+            transaction: async (tx) => {
+                await tx.contractTable.update({
+                    where: { id: secondContract.id },
+                    data: { mccrsID: 'SECOND_CONTRACT_UPDATED' },
+                })
+
+                return 'second transaction finished'
+            },
+        })
+
+        const thirdTransaction = runTransactionWithRowLock({
+            client,
+            operationName: 'different row lock test',
+            table: 'ContractTable',
+            id: thirdContract.id,
+            transaction: async (tx) => {
+                await tx.contractTable.update({
+                    where: { id: thirdContract.id },
+                    data: { mccrsID: 'THIRD_CONTRACT_UPDATED' },
+                })
+
+                return 'third transaction finished'
+            },
+        })
+
+        const [secondResult, thirdResult] = await Promise.all([
+            Promise.race([
+                secondTransaction,
+                new Promise<string>((resolve) =>
+                    setTimeout(
+                        () => resolve('timed out waiting for second'),
+                        200
+                    )
+                ),
+            ]),
+            Promise.race([
+                thirdTransaction,
+                new Promise<string>((resolve) =>
+                    setTimeout(
+                        () => resolve('timed out waiting for third'),
+                        200
+                    )
+                ),
+            ]),
+        ])
+
+        expect(secondResult).toBe('second transaction finished')
+        expect(thirdResult).toBe('third transaction finished')
+
+        allowFirstTransactionToFinish.resolve()
+
+        const firstResult = await firstTransaction
+        expect(firstResult).toBe('first transaction finished')
+
+        const [
+            updatedFirstContract,
+            updatedSecondContract,
+            updatedThirdContract,
+        ] = await Promise.all([
+            client.contractTable.findUnique({
+                where: { id: firstContract.id },
+                select: { mccrsID: true },
+            }),
+            client.contractTable.findUnique({
+                where: { id: secondContract.id },
+                select: { mccrsID: true },
+            }),
+            client.contractTable.findUnique({
+                where: { id: thirdContract.id },
+                select: { mccrsID: true },
+            }),
+        ])
+
+        expect(updatedFirstContract?.mccrsID).toBe('FIRST_CONTRACT_UPDATED')
+        expect(updatedSecondContract?.mccrsID).toBe('SECOND_CONTRACT_UPDATED')
+        expect(updatedThirdContract?.mccrsID).toBe('THIRD_CONTRACT_UPDATED')
     })
 })

--- a/services/app-api/src/postgres/prismaHelpers.ts
+++ b/services/app-api/src/postgres/prismaHelpers.ts
@@ -85,6 +85,24 @@ async function lockContractQuestionRowForUpdate(
     }
 }
 
+async function lockRateRowForUpdate(
+    tx: PrismaTransactionType,
+    rateID: string
+): Promise<void | Error> {
+    const lockedRateRows = await tx.$queryRaw<Array<{ id: string }>>`
+        SELECT id
+        FROM "RateTable"
+        WHERE id = ${rateID}
+        FOR UPDATE
+    `
+
+    if (lockedRateRows.length === 0) {
+        return new NotFoundError(
+            `Rate with id ${rateID} was not found for row lock.`
+        )
+    }
+}
+
 async function lockRateQuestionRowForUpdate(
     tx: PrismaTransactionType,
     questionID: string
@@ -106,6 +124,7 @@ async function lockRateQuestionRowForUpdate(
 export {
     runTransactionWithRowLock,
     lockContractRowForUpdate,
+    lockRateRowForUpdate,
     lockContractQuestionRowForUpdate,
     lockRateQuestionRowForUpdate,
 }

--- a/services/app-api/src/postgres/prismaHelpers.ts
+++ b/services/app-api/src/postgres/prismaHelpers.ts
@@ -1,13 +1,20 @@
 import { parseErrorToError } from '@mc-review/helpers'
-import { NotFoundError } from './postgresErrors'
+import { NotFoundError, UserInputPostgresError } from './postgresErrors'
 import type { ExtendedPrismaClient } from './prismaClient'
-import type { Prisma } from '../generated/client'
+import { Prisma } from '../generated/client'
 import type { PrismaTransactionType } from './prismaTypes'
+
+type LockableTables =
+    | 'ContractTable'
+    | 'RateTable'
+    | 'ContractQuestion'
+    | 'RateQuestion'
 
 type RunTransactionWithRowLockArgs<T> = {
     client: ExtendedPrismaClient
     operationName: string
-    lock: (tx: PrismaTransactionType) => Promise<void | Error>
+    table: LockableTables
+    id: string
     transaction: (tx: PrismaTransactionType) => Promise<T | Error>
     transactionOptions?: {
         maxWait?: number
@@ -17,24 +24,28 @@ type RunTransactionWithRowLockArgs<T> = {
 }
 
 /**
- * Helper function that row-locks records before database writes so concurrent
- * updates to the same record cannot run before the other finishes.
+ * Row-locks a record before database writes so concurrent updates to the same
+ * record cannot run before the other finishes.
  *
  * Callers must perform validation inside the transaction after the lock is
  * acquired, so a later transaction re-checks current state instead of
  * overwriting changes made by the first one.
+ *
+ * @param args.client Prisma client used to run the transaction.
+ * @param args.operationName Operation name used in error logging.
+ * @param args.table Table containing the row to lock before writes begin.
+ * @param args.id Identifier of the row to lock.
+ * @param args.transaction Store write logic to run after the row lock is acquired.
+ * @param args.transactionOptions Optional Prisma transaction settings.
  */
 async function runTransactionWithRowLock<T>(
     args: RunTransactionWithRowLockArgs<T>
 ): Promise<T | Error> {
-    const { client, lock, transaction, transactionOptions } = args
+    const { client, table, id, transaction, transactionOptions } = args
 
     try {
         return await client.$transaction(async (tx) => {
-            const lockResult = await lock(tx)
-            if (lockResult instanceof Error) {
-                throw lockResult
-            }
+            await lockTableRowForUpdate(tx, table, id)
 
             const result = await transaction(tx)
             if (result instanceof Error) {
@@ -44,87 +55,44 @@ async function runTransactionWithRowLock<T>(
             return result
         }, transactionOptions)
     } catch (err) {
+        if (
+            err instanceof NotFoundError ||
+            err instanceof UserInputPostgresError
+        ) {
+            return err
+        }
+
         console.error(`Prisma error ${args.operationName}`, err)
         return parseErrorToError(err)
     }
 }
 
-async function lockContractRowForUpdate(
+async function lockTableRowForUpdate(
     tx: PrismaTransactionType,
-    contractID: string
-): Promise<void | Error> {
-    const lockedContractRows = await tx.$queryRaw<Array<{ id: string }>>`
-        SELECT id
-        FROM "ContractTable"
-        WHERE id = ${contractID}
-        FOR UPDATE
-    `
+    table: LockableTables,
+    id: string
+) {
+    const lockableTables = {
+        ContractTable: Prisma.raw('"ContractTable"'),
+        RateTable: Prisma.raw('"RateTable"'),
+        ContractQuestion: Prisma.raw('"ContractQuestion"'),
+        RateQuestion: Prisma.raw('"RateQuestion"'),
+    } as const
 
-    if (lockedContractRows.length === 0) {
-        return new NotFoundError(
-            `Contract with id ${contractID} was not found for row lock.`
+    const lockedRows = await tx.$queryRaw<Array<{ id: string }>>(
+        Prisma.sql`
+            SELECT id
+            FROM ${lockableTables[table]}
+            WHERE id = ${id}
+            FOR UPDATE
+        `
+    )
+
+    if (lockedRows.length === 0) {
+        throw new NotFoundError(
+            `${table} with id ${id} was not found for row lock.`
         )
     }
 }
 
-async function lockContractQuestionRowForUpdate(
-    tx: PrismaTransactionType,
-    questionID: string
-): Promise<void | Error> {
-    const lockedQuestionRows = await tx.$queryRaw<Array<{ id: string }>>`
-        SELECT id
-        FROM "ContractQuestion"
-        WHERE id = ${questionID}
-        FOR UPDATE
-    `
-
-    if (lockedQuestionRows.length === 0) {
-        return new NotFoundError(
-            `Question with id ${questionID} was not found for row lock.`
-        )
-    }
-}
-
-async function lockRateRowForUpdate(
-    tx: PrismaTransactionType,
-    rateID: string
-): Promise<void | Error> {
-    const lockedRateRows = await tx.$queryRaw<Array<{ id: string }>>`
-        SELECT id
-        FROM "RateTable"
-        WHERE id = ${rateID}
-        FOR UPDATE
-    `
-
-    if (lockedRateRows.length === 0) {
-        return new NotFoundError(
-            `Rate with id ${rateID} was not found for row lock.`
-        )
-    }
-}
-
-async function lockRateQuestionRowForUpdate(
-    tx: PrismaTransactionType,
-    questionID: string
-): Promise<void | Error> {
-    const lockedQuestionRows = await tx.$queryRaw<Array<{ id: string }>>`
-        SELECT id
-        FROM "RateQuestion"
-        WHERE id = ${questionID}
-        FOR UPDATE
-    `
-
-    if (lockedQuestionRows.length === 0) {
-        return new NotFoundError(
-            `Rate question with id ${questionID} was not found for row lock.`
-        )
-    }
-}
-
-export {
-    runTransactionWithRowLock,
-    lockContractRowForUpdate,
-    lockRateRowForUpdate,
-    lockContractQuestionRowForUpdate,
-    lockRateQuestionRowForUpdate,
-}
+export { runTransactionWithRowLock }

--- a/services/app-api/src/postgres/prismaHelpers.ts
+++ b/services/app-api/src/postgres/prismaHelpers.ts
@@ -17,8 +17,8 @@ type RunTransactionWithRowLockArgs<T> = {
 }
 
 /**
- * Row-locks records before database writes so concurrent updates to the same
- * record cannot run before the other finishes.
+ * Helper function that row-locks records before database writes so concurrent
+ * updates to the same record cannot run before the other finishes.
  *
  * Callers must perform validation inside the transaction after the lock is
  * acquired, so a later transaction re-checks current state instead of
@@ -85,8 +85,27 @@ async function lockContractQuestionRowForUpdate(
     }
 }
 
+async function lockRateQuestionRowForUpdate(
+    tx: PrismaTransactionType,
+    questionID: string
+): Promise<void | Error> {
+    const lockedQuestionRows = await tx.$queryRaw<Array<{ id: string }>>`
+        SELECT id
+        FROM "RateQuestion"
+        WHERE id = ${questionID}
+        FOR UPDATE
+    `
+
+    if (lockedQuestionRows.length === 0) {
+        return new NotFoundError(
+            `Rate question with id ${questionID} was not found for row lock.`
+        )
+    }
+}
+
 export {
     runTransactionWithRowLock,
     lockContractRowForUpdate,
     lockContractQuestionRowForUpdate,
+    lockRateQuestionRowForUpdate,
 }

--- a/services/app-api/src/postgres/prismaHelpers.ts
+++ b/services/app-api/src/postgres/prismaHelpers.ts
@@ -1,0 +1,92 @@
+import { parseErrorToError } from '@mc-review/helpers'
+import { NotFoundError } from './postgresErrors'
+import type { ExtendedPrismaClient } from './prismaClient'
+import type { Prisma } from '../generated/client'
+import type { PrismaTransactionType } from './prismaTypes'
+
+type RunTransactionWithRowLockArgs<T> = {
+    client: ExtendedPrismaClient
+    operationName: string
+    lock: (tx: PrismaTransactionType) => Promise<void | Error>
+    transaction: (tx: PrismaTransactionType) => Promise<T | Error>
+    transactionOptions?: {
+        maxWait?: number
+        timeout?: number
+        isolationLevel?: Prisma.TransactionIsolationLevel
+    }
+}
+
+/**
+ * Row-locks records before database writes so concurrent updates to the same
+ * record cannot run before the other finishes.
+ *
+ * Callers must perform validation inside the transaction after the lock is
+ * acquired, so a later transaction re-checks current state instead of
+ * overwriting changes made by the first one.
+ */
+async function runTransactionWithRowLock<T>(
+    args: RunTransactionWithRowLockArgs<T>
+): Promise<T | Error> {
+    const { client, lock, transaction, transactionOptions } = args
+
+    try {
+        return await client.$transaction(async (tx) => {
+            const lockResult = await lock(tx)
+            if (lockResult instanceof Error) {
+                throw lockResult
+            }
+
+            const result = await transaction(tx)
+            if (result instanceof Error) {
+                throw result
+            }
+
+            return result
+        }, transactionOptions)
+    } catch (err) {
+        console.error(`Prisma error ${args.operationName}`, err)
+        return parseErrorToError(err)
+    }
+}
+
+async function lockContractRowForUpdate(
+    tx: PrismaTransactionType,
+    contractID: string
+): Promise<void | Error> {
+    const lockedContractRows = await tx.$queryRaw<Array<{ id: string }>>`
+        SELECT id
+        FROM "ContractTable"
+        WHERE id = ${contractID}
+        FOR UPDATE
+    `
+
+    if (lockedContractRows.length === 0) {
+        return new NotFoundError(
+            `Contract with id ${contractID} was not found for row lock.`
+        )
+    }
+}
+
+async function lockContractQuestionRowForUpdate(
+    tx: PrismaTransactionType,
+    questionID: string
+): Promise<void | Error> {
+    const lockedQuestionRows = await tx.$queryRaw<Array<{ id: string }>>`
+        SELECT id
+        FROM "ContractQuestion"
+        WHERE id = ${questionID}
+        FOR UPDATE
+    `
+
+    if (lockedQuestionRows.length === 0) {
+        return new NotFoundError(
+            `Question with id ${questionID} was not found for row lock.`
+        )
+    }
+}
+
+export {
+    runTransactionWithRowLock,
+    lockContractRowForUpdate,
+    lockContractQuestionRowForUpdate,
+}

--- a/services/app-api/src/postgres/questionResponse/insertContractQuestionResponse.ts
+++ b/services/app-api/src/postgres/questionResponse/insertContractQuestionResponse.ts
@@ -10,7 +10,7 @@ import {
 } from './questionHelpers'
 import { NotFoundError } from '../postgresErrors'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import { runTransactionWithRowLock } from '../prismaHelpers'
+import { parseErrorToError } from '@mc-review/helpers'
 
 export async function insertContractQuestionResponse(
     client: ExtendedPrismaClient,
@@ -24,58 +24,61 @@ export async function insertContractQuestionResponse(
         s3Key: document.s3Key,
     }))
 
-    return runTransactionWithRowLock({
-        client,
-        operationName: 'insertContractQuestionResponse',
-        table: 'ContractQuestion',
-        id: response.questionID,
-        transaction: async (tx) => {
-            const question = await tx.contractQuestion.findFirst({
-                where: {
-                    id: response.questionID,
-                },
-                include: {
-                    actions: {
-                        orderBy: {
-                            createdAt: 'desc',
-                        },
-                        take: 1,
+    try {
+        const question = await client.contractQuestion.findFirst({
+            where: {
+                id: response.questionID,
+            },
+            include: {
+                actions: {
+                    orderBy: {
+                        createdAt: 'desc',
                     },
+                    take: 1,
                 },
-            })
+            },
+        })
 
-            if (!question) {
-                return new NotFoundError('Question was not found to respond to')
-            }
+        if (!question) {
+            return new NotFoundError('Question was not found to respond to')
+        }
 
-            if (isDeleted(question)) {
-                return new Error(
-                    `Cannot create response for question with the ID: ${response.questionID}. Question was deleted.`
-                )
-            }
+        if (isDeleted(question)) {
+            return new Error(
+                `Cannot create response for question with the ID: ${response.questionID}. Question was deleted.`
+            )
+        }
 
-            const result = await tx.contractQuestion.update({
-                where: {
-                    id: response.questionID,
-                },
-                data: {
-                    responses: {
-                        create: {
-                            addedBy: {
-                                connect: {
-                                    id: user.id,
-                                },
+        const result = await client.contractQuestion.update({
+            where: {
+                id: response.questionID,
+            },
+            data: {
+                responses: {
+                    create: {
+                        addedBy: {
+                            connect: {
+                                id: user.id,
                             },
-                            documents: {
-                                create: documents,
-                            },
+                        },
+                        documents: {
+                            create: documents,
                         },
                     },
                 },
-                include: questionInclude,
-            })
+            },
+            include: questionInclude,
+        })
 
-            return contractQuestionPrismaToDomainType(result)
-        },
-    })
+        return contractQuestionPrismaToDomainType(result)
+    } catch (e) {
+        const parsedError = parseErrorToError(e)
+        // Return a NotFoundError if prisma fails on the primary key constraint
+        // An operation failed because it depends on one or more records
+        // that were required but not found.
+        if ((parsedError as unknown as { code?: string }).code === 'P2025') {
+            return new NotFoundError('Question was not found to respond to')
+        }
+        return parsedError
+    }
 }

--- a/services/app-api/src/postgres/questionResponse/insertContractQuestionResponse.ts
+++ b/services/app-api/src/postgres/questionResponse/insertContractQuestionResponse.ts
@@ -4,12 +4,16 @@ import type {
     ContractQuestionType,
 } from '../../domain-models'
 import {
+    isDeleted,
     questionInclude,
     contractQuestionPrismaToDomainType,
 } from './questionHelpers'
 import { NotFoundError } from '../postgresErrors'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import { parseErrorToError } from '@mc-review/helpers'
+import {
+    lockContractQuestionRowForUpdate,
+    runTransactionWithRowLock,
+} from '../prismaHelpers'
 
 export async function insertContractQuestionResponse(
     client: ExtendedPrismaClient,
@@ -23,57 +27,58 @@ export async function insertContractQuestionResponse(
         s3Key: document.s3Key,
     }))
 
-    try {
-        const question = await client.contractQuestion.findFirst({
-            where: {
-                id: response.questionID,
-            },
-            include: {
-                actions: {
-                    orderBy: {
-                        createdAt: 'desc',
-                    },
-                    take: 1,
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'insertContractQuestionResponse',
+        lock: async (tx) =>
+            await lockContractQuestionRowForUpdate(tx, response.questionID),
+        transaction: async (tx) => {
+            const question = await tx.contractQuestion.findFirst({
+                where: {
+                    id: response.questionID,
                 },
-            },
-        })
+                include: {
+                    actions: {
+                        orderBy: {
+                            createdAt: 'desc',
+                        },
+                        take: 1,
+                    },
+                },
+            })
 
-        if (question?.actions?.[0]?.action === 'DELETE') {
-            return new Error(
-                `Cannot create response for question with the ID: ${response.questionID}. Question was deleted.`
-            )
-        }
+            if (!question) {
+                return new NotFoundError('Question was not found to respond to')
+            }
 
-        const result = await client.contractQuestion.update({
-            where: {
-                id: response.questionID,
-            },
-            data: {
-                responses: {
-                    create: {
-                        addedBy: {
-                            connect: {
-                                id: user.id,
+            if (isDeleted(question)) {
+                return new Error(
+                    `Cannot create response for question with the ID: ${response.questionID}. Question was deleted.`
+                )
+            }
+
+            const result = await tx.contractQuestion.update({
+                where: {
+                    id: response.questionID,
+                },
+                data: {
+                    responses: {
+                        create: {
+                            addedBy: {
+                                connect: {
+                                    id: user.id,
+                                },
+                            },
+                            documents: {
+                                create: documents,
                             },
                         },
-                        documents: {
-                            create: documents,
-                        },
                     },
                 },
-            },
-            include: questionInclude,
-        })
+                include: questionInclude,
+            })
 
-        return contractQuestionPrismaToDomainType(result)
-    } catch (e) {
-        const parsedError = parseErrorToError(e)
-        // Return a NotFoundError if prisma fails on the primary key constraint
-        // An operation failed because it depends on one or more records
-        // that were required but not found.
-        if ((parsedError as unknown as { code?: string }).code === 'P2025') {
-            return new NotFoundError('Question was not found to respond to')
-        }
-        return parsedError
-    }
+            return contractQuestionPrismaToDomainType(result)
+        },
+    })
 }

--- a/services/app-api/src/postgres/questionResponse/insertContractQuestionResponse.ts
+++ b/services/app-api/src/postgres/questionResponse/insertContractQuestionResponse.ts
@@ -10,10 +10,7 @@ import {
 } from './questionHelpers'
 import { NotFoundError } from '../postgresErrors'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import {
-    lockContractQuestionRowForUpdate,
-    runTransactionWithRowLock,
-} from '../prismaHelpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
 
 export async function insertContractQuestionResponse(
     client: ExtendedPrismaClient,
@@ -30,8 +27,8 @@ export async function insertContractQuestionResponse(
     return runTransactionWithRowLock({
         client,
         operationName: 'insertContractQuestionResponse',
-        lock: async (tx) =>
-            await lockContractQuestionRowForUpdate(tx, response.questionID),
+        table: 'ContractQuestion',
+        id: response.questionID,
         transaction: async (tx) => {
             const question = await tx.contractQuestion.findFirst({
                 where: {

--- a/services/app-api/src/postgres/questionResponse/insertRateQuestionResponse.ts
+++ b/services/app-api/src/postgres/questionResponse/insertRateQuestionResponse.ts
@@ -4,12 +4,16 @@ import type {
     StateUserType,
 } from '../../domain-models'
 import {
+    isDeleted,
     questionInclude,
     rateQuestionPrismaToDomainType,
 } from './questionHelpers'
 import { NotFoundError } from '../postgresErrors'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import { parseErrorToError } from '@mc-review/helpers'
+import {
+    lockRateQuestionRowForUpdate,
+    runTransactionWithRowLock,
+} from '../prismaHelpers'
 
 export async function insertRateQuestionResponse(
     client: ExtendedPrismaClient,
@@ -23,57 +27,58 @@ export async function insertRateQuestionResponse(
         s3Key: document.s3Key,
     }))
 
-    try {
-        const question = await client.rateQuestion.findFirst({
-            where: {
-                id: response.questionID,
-            },
-            include: {
-                actions: {
-                    orderBy: {
-                        createdAt: 'desc',
-                    },
-                    take: 1,
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'insertRateQuestionResponse',
+        lock: async (tx) =>
+            await lockRateQuestionRowForUpdate(tx, response.questionID),
+        transaction: async (tx) => {
+            const question = await tx.rateQuestion.findFirst({
+                where: {
+                    id: response.questionID,
                 },
-            },
-        })
+                include: {
+                    actions: {
+                        orderBy: {
+                            createdAt: 'desc',
+                        },
+                        take: 1,
+                    },
+                },
+            })
 
-        if (question?.actions?.[0]?.action === 'DELETE') {
-            return new Error(
-                `Cannot create response for question with the ID: ${response.questionID}. Question was deleted.`
-            )
-        }
+            if (!question) {
+                return new NotFoundError('Question was not found to respond to')
+            }
 
-        const result = await client.rateQuestion.update({
-            where: {
-                id: response.questionID,
-            },
-            data: {
-                responses: {
-                    create: {
-                        addedBy: {
-                            connect: {
-                                id: user.id,
+            if (isDeleted(question)) {
+                return new Error(
+                    `Cannot create response for question with the ID: ${response.questionID}. Question was deleted.`
+                )
+            }
+
+            const result = await tx.rateQuestion.update({
+                where: {
+                    id: response.questionID,
+                },
+                data: {
+                    responses: {
+                        create: {
+                            addedBy: {
+                                connect: {
+                                    id: user.id,
+                                },
+                            },
+                            documents: {
+                                create: documents,
                             },
                         },
-                        documents: {
-                            create: documents,
-                        },
                     },
                 },
-            },
-            include: questionInclude,
-        })
+                include: questionInclude,
+            })
 
-        return rateQuestionPrismaToDomainType(result)
-    } catch (e) {
-        const parsedError = parseErrorToError(e)
-        // Return a NotFoundError if prisma fails on the primary key constraint
-        // An operation failed because it depends on one or more records
-        // that were required but not found.
-        if ((parsedError as unknown as { code?: string }).code === 'P2025') {
-            return new NotFoundError('Question was not found to respond to')
-        }
-        return parsedError
-    }
+            return rateQuestionPrismaToDomainType(result)
+        },
+    })
 }

--- a/services/app-api/src/postgres/questionResponse/insertRateQuestionResponse.ts
+++ b/services/app-api/src/postgres/questionResponse/insertRateQuestionResponse.ts
@@ -10,7 +10,7 @@ import {
 } from './questionHelpers'
 import { NotFoundError } from '../postgresErrors'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import { runTransactionWithRowLock } from '../prismaHelpers'
+import { parseErrorToError } from '@mc-review/helpers'
 
 export async function insertRateQuestionResponse(
     client: ExtendedPrismaClient,
@@ -24,58 +24,61 @@ export async function insertRateQuestionResponse(
         s3Key: document.s3Key,
     }))
 
-    return runTransactionWithRowLock({
-        client,
-        operationName: 'insertRateQuestionResponse',
-        table: 'RateQuestion',
-        id: response.questionID,
-        transaction: async (tx) => {
-            const question = await tx.rateQuestion.findFirst({
-                where: {
-                    id: response.questionID,
-                },
-                include: {
-                    actions: {
-                        orderBy: {
-                            createdAt: 'desc',
-                        },
-                        take: 1,
+    try {
+        const question = await client.rateQuestion.findFirst({
+            where: {
+                id: response.questionID,
+            },
+            include: {
+                actions: {
+                    orderBy: {
+                        createdAt: 'desc',
                     },
+                    take: 1,
                 },
-            })
+            },
+        })
 
-            if (!question) {
-                return new NotFoundError('Question was not found to respond to')
-            }
+        if (!question) {
+            return new NotFoundError('Question was not found to respond to')
+        }
 
-            if (isDeleted(question)) {
-                return new Error(
-                    `Cannot create response for question with the ID: ${response.questionID}. Question was deleted.`
-                )
-            }
+        if (isDeleted(question)) {
+            return new Error(
+                `Cannot create response for question with the ID: ${response.questionID}. Question was deleted.`
+            )
+        }
 
-            const result = await tx.rateQuestion.update({
-                where: {
-                    id: response.questionID,
-                },
-                data: {
-                    responses: {
-                        create: {
-                            addedBy: {
-                                connect: {
-                                    id: user.id,
-                                },
+        const result = await client.rateQuestion.update({
+            where: {
+                id: response.questionID,
+            },
+            data: {
+                responses: {
+                    create: {
+                        addedBy: {
+                            connect: {
+                                id: user.id,
                             },
-                            documents: {
-                                create: documents,
-                            },
+                        },
+                        documents: {
+                            create: documents,
                         },
                     },
                 },
-                include: questionInclude,
-            })
+            },
+            include: questionInclude,
+        })
 
-            return rateQuestionPrismaToDomainType(result)
-        },
-    })
+        return rateQuestionPrismaToDomainType(result)
+    } catch (e) {
+        const parsedError = parseErrorToError(e)
+        // Return a NotFoundError if prisma fails on the primary key constraint
+        // An operation failed because it depends on one or more records
+        // that were required but not found.
+        if ((parsedError as unknown as { code?: string }).code === 'P2025') {
+            return new NotFoundError('Question was not found to respond to')
+        }
+        return parsedError
+    }
 }

--- a/services/app-api/src/postgres/questionResponse/insertRateQuestionResponse.ts
+++ b/services/app-api/src/postgres/questionResponse/insertRateQuestionResponse.ts
@@ -10,10 +10,7 @@ import {
 } from './questionHelpers'
 import { NotFoundError } from '../postgresErrors'
 import type { ExtendedPrismaClient } from '../prismaClient'
-import {
-    lockRateQuestionRowForUpdate,
-    runTransactionWithRowLock,
-} from '../prismaHelpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
 
 export async function insertRateQuestionResponse(
     client: ExtendedPrismaClient,
@@ -30,8 +27,8 @@ export async function insertRateQuestionResponse(
     return runTransactionWithRowLock({
         client,
         operationName: 'insertRateQuestionResponse',
-        lock: async (tx) =>
-            await lockRateQuestionRowForUpdate(tx, response.questionID),
+        table: 'RateQuestion',
+        id: response.questionID,
         transaction: async (tx) => {
             const question = await tx.rateQuestion.findFirst({
                 where: {

--- a/services/app-api/src/postgres/questionResponse/softDeleteContractQuestion.test.ts
+++ b/services/app-api/src/postgres/questionResponse/softDeleteContractQuestion.test.ts
@@ -18,7 +18,7 @@ describe('softDeleteContractQuestion', () => {
     const mockS3 = testS3Client()
 
     // Test race conditions, but not reliability. There is complexity in trying to truly test the race condition in js.
-    it('serializes concurrent deletes — no duplicate action rows under a race', async () => {
+    it('locks concurrent deletes on the same question — no duplicate action rows under a race', async () => {
         const cmsUser = testCMSUser()
         const adminUser = testAdminUser()
         await createDBUsersWithFullData([cmsUser, adminUser])
@@ -51,11 +51,10 @@ describe('softDeleteContractQuestion', () => {
         const prismaClient = await sharedTestPrismaClient()
 
         // Fire two store-level deletes in parallel. Going straight to the
-        // store cuts out the resolver/auth overhead so the two transactions
-        // open close together, giving Postgres a real shot at overlapping
-        // their snapshots and triggering P2034 → retry. If one transaction
-        // commits first, the other hits the idempotency branch instead.
-        // Either way we should never see duplicate action rows.
+        // store cuts out the resolver/auth overhead so both transactions can
+        // contend on the same question row lock. One delete wins; the other
+        // waits, rereads fresh state, and lands in the "already deleted"
+        // branch. Either way we should never see duplicate action rows.
         const [r1, r2] = await Promise.all([
             softDeleteContractQuestion(prismaClient, {
                 questionID: question.id,

--- a/services/app-api/src/postgres/questionResponse/softDeleteContractQuestion.ts
+++ b/services/app-api/src/postgres/questionResponse/softDeleteContractQuestion.ts
@@ -7,10 +7,7 @@ import {
 import { NotFoundError, UserInputPostgresError } from '../postgresErrors'
 import type { ExtendedPrismaClient } from '../prismaClient'
 import type { PrismaTransactionType } from '../prismaTypes'
-import {
-    lockContractQuestionRowForUpdate,
-    runTransactionWithRowLock,
-} from '../prismaHelpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
 
 export type SoftDeleteContractQuestionArgsType = {
     questionID: string
@@ -145,8 +142,8 @@ const softDeleteContractQuestion = async (
     return runTransactionWithRowLock({
         client,
         operationName: 'soft deleting contract question',
-        lock: async (tx) =>
-            await lockContractQuestionRowForUpdate(tx, args.questionID),
+        table: 'ContractQuestion',
+        id: args.questionID,
         transaction: async (tx) =>
             await softDeleteContractQuestionInsideTransaction(tx, args),
     })

--- a/services/app-api/src/postgres/questionResponse/softDeleteContractQuestion.ts
+++ b/services/app-api/src/postgres/questionResponse/softDeleteContractQuestion.ts
@@ -7,16 +7,16 @@ import {
 import { NotFoundError, UserInputPostgresError } from '../postgresErrors'
 import type { ExtendedPrismaClient } from '../prismaClient'
 import type { PrismaTransactionType } from '../prismaTypes'
-import { parseErrorToError } from '@mc-review/helpers'
-import { Prisma } from '../../generated/client'
+import {
+    lockContractQuestionRowForUpdate,
+    runTransactionWithRowLock,
+} from '../prismaHelpers'
 
 export type SoftDeleteContractQuestionArgsType = {
     questionID: string
     user: AdminUserType
     reason: string
 }
-
-const MAX_SERIALIZATION_RETRIES = 2
 
 /**
  * Soft-deletes a contract question and cascades the delete to its responses
@@ -62,7 +62,7 @@ const softDeleteContractQuestionInsideTransaction = async (
 
     if (!existing) {
         return new NotFoundError(
-            `Question with id ${questionID} was not found to delete`
+            `Question with id ${questionID} was not found for deletion`
         )
     }
 
@@ -138,54 +138,18 @@ const softDeleteContractQuestionInsideTransaction = async (
     return contractQuestionPrismaToDomainType(result)
 }
 
-/**
- * Wrapper around `softDeleteContractQuestionInsideTransaction` that owns the
- * transaction lifecycle.
- *
- * Race-condition protection follows Prisma's recommendation for write-write
- * conflicts: run the transaction at Serializable isolation and retry on
- * serialization failures. Depending on which engine is active, Prisma surfaces
- * these as either `P2034` (standard engine) or a DriverAdapterError with
- * `cause.kind === 'TransactionWriteConflict'` (driver adapters).
- */
 const softDeleteContractQuestion = async (
     client: ExtendedPrismaClient,
     args: SoftDeleteContractQuestionArgsType
 ): Promise<ContractQuestionType | Error> => {
-    let attempt = 0
-    while (true) {
-        try {
-            return await client.$transaction(
-                async (tx) =>
-                    await softDeleteContractQuestionInsideTransaction(tx, args),
-                {
-                    isolationLevel:
-                        Prisma.TransactionIsolationLevel.Serializable,
-                }
-            )
-        } catch (err) {
-            // Serialization conflicts surface two ways depending on the
-            // engine in use: as `code: 'P2034'` from the standard Prisma
-            // engine, or as a DriverAdapterError whose `cause.kind` is
-            // `'TransactionWriteConflict'` from driver adapters. Match both.
-            const code = (err as { code?: string }).code
-            const cause = (err as { cause?: { kind?: string } }).cause
-            const isWriteConflict =
-                code === 'P2034' || cause?.kind === 'TransactionWriteConflict'
-            if (isWriteConflict && attempt < MAX_SERIALIZATION_RETRIES - 1) {
-                console.warn(
-                    `softDeleteContractQuestion: serialization conflict, retrying. questionID=${args.questionID} attempt=${attempt + 1}`
-                )
-                attempt++
-                continue
-            }
-            const parsedError = parseErrorToError(err)
-            console.error(
-                `PRISMA ERROR: Error soft deleting contract question: ${parsedError.message}`
-            )
-            return parsedError
-        }
-    }
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'soft deleting contract question',
+        lock: async (tx) =>
+            await lockContractQuestionRowForUpdate(tx, args.questionID),
+        transaction: async (tx) =>
+            await softDeleteContractQuestionInsideTransaction(tx, args),
+    })
 }
 
 export {

--- a/skills/skill-api/SKILL.md
+++ b/skills/skill-api/SKILL.md
@@ -11,9 +11,10 @@ Reference for any agent building or modifying contract/rate features in the `ser
 
 Read the relevant reference files when the task involves:
 - Building or modifying a contract/rate feature (any new mutation, status transition, history view, etc.)
+- Building or modifying question/response store or resolver behavior in `services/app-api/src/postgres/questionResponse/` or `services/app-api/src/resolvers/questionResponse/`
 - Reasoning about why a status, package snapshot, or relationship looks the way it does
-- Touching the `services/app-api/src/postgres/contractAndRates/`, `services/app-api/src/domain-models/contractAndRates/`, or `services/app-api/src/resolvers/{contract,rate}/` directories
-- Following code that interacts with `ContractTable`, `RateTable`, `UpdateInfoTable`, `SubmissionPackageJoinTable`, or `DraftRateJoinTable`
+- Touching the `services/app-api/src/postgres/contractAndRates/`, `services/app-api/src/postgres/questionResponse/`, `services/app-api/src/postgres/prismaHelpers.ts`, `services/app-api/src/domain-models/contractAndRates/`, or `services/app-api/src/resolvers/{contract,rate,questionResponse}/` directories
+- Following code that interacts with `ContractTable`, `RateTable`, `ContractQuestion`, `RateQuestion`, `UpdateInfoTable`, `SubmissionPackageJoinTable`, or `DraftRateJoinTable`
 
 If the task only involves UI/frontend without touching the data layer, you probably don't need these references.
 
@@ -25,6 +26,7 @@ If the task only involves UI/frontend without touching the data layer, you proba
 | Reading data via `findContractWithHistory` / `findRateWithHistory`; building a new query path; understanding `packageSubmissions` shape | `references/03-parse-pipeline.md` |
 | Creating a new draft contract or rate; editing form data on a draft; reconciling rates on a draft | `references/04-insert-and-update.md` |
 | Submit, unlock, or resubmit (any state-flip operation) | `references/05-submit-unlock-resubmit.md` |
+| Adding or changing `questionResponse` store/resolver logic; reasoning about lock-vs-stale-state behavior on `ContractQuestion` / `RateQuestion` | Read this `SKILL.md` for the row-lock rules, then inspect `services/app-api/src/postgres/questionResponse/` directly because there is no dedicated reference file yet |
 | Anything involving rates that span multiple contracts (linking, parent reassignment, withdraw rate fallout) | `references/06-linked-rates.md` |
 | Withdraw contract specifically | `references/07-withdraw.md` |
 | Working out what status a contract or rate ends up in; computing parent contract; resolving cause on `packageSubmissions`; recursion in domain types | `references/08-derived-state.md` |
@@ -42,6 +44,9 @@ For broad multi-area features (e.g. a new "undo unlock contract" mutation): read
 - **One `UpdateInfoTable` event row per submit-or-unlock; shared across the contract and every child rate touched in that transaction.** This is what lets the parser later detect "these were submitted/unlocked together."
 - **`SubmissionPackageJoinTable`** is the immutable snapshot of contract↔rate at submit time, joining specific contract revision + specific rate revision + position. **`DraftRateJoinTable`** is the working set on a contract that's currently in draft, joining parent tables only.
 - **Form-data writes via `updateDraftContract` are full replaces, not merges.** Omitted fields are nulled (`nullify`) or emptied (`emptify`). Child collections (documents, contacts) are delete-and-recreate, so row IDs are not stable across updates.
+- **Resolver-called store function writes to `ContractTable`, `RateTable`, `ContractQuestion`, or `RateQuestion` should default to `runTransactionWithRowLock`.** Use `services/app-api/src/postgres/prismaHelpers.ts` and pass the table + row id so concurrent writes to the same record serialize before the store performs additional reads or writes.
+- **After acquiring a row lock, re-check write preconditions inside the transaction.** Resolver-time validation can be stale by the time the lock is acquired; the store should validate current state again before applying writes.
+- **Question-response writes follow the same rule as contract/rate state changes.** If a resolver-called store function writes a `ContractQuestion` or `RateQuestion` row or appends related responses based on current question state, default to `runTransactionWithRowLock` and validate deleted/current status after the lock is acquired.
 - **Undo unlock is revision history, not a new submission event.** Read `09-undo-unlock.md` if you touch `undoUnlockInfo`, active-draft logic, or linked-rate cleanup.
 - **Overrides are sparse metadata patches on submitted revisions.** Read `10-revision-overrides.md` if you touch revision overrides, document overrides, or unlock behavior for overridden revisions.
 - **Deprecated — do not include in new designs:**
@@ -141,12 +146,13 @@ The repo's `docs/` directory has broader architecture and conventions docs that 
 1. **Start at the schema** (reference 01) to confirm what's actually stored vs derived. Most "states" are derived in the parse layer.
 2. **Read the parser** (reference 03) to understand how the change will surface in the domain output. A status change usually means flipping `submitInfo`/`unlockInfo` on the latest revision, adding a new revision, or appending an action row.
 3. **Trace the relevant mutation** (references 04–07) end-to-end. The resolver does authorization, validation, and formatting; the postgres layer does the actual DB work — they often have important guards in different places.
-4. **Check `packageSubmissions` and cause impact** (reference 08) if the change involves an `UpdateInfoTable` event. The change may append entries to the package history from both contract and rate perspectives.
-5. **Don't include `sharedRateRevisions`** in any new design — deprecated.
-6. **Watch for `DRAFT_PARENT_PLACEHOLDER`** if the change involves draft rates without a submitted parent yet — the placeholder needs the outer parser to patch.
-7. **Verify file paths and code shapes against the current state of the repo** before depending on specifics. This reference was synthesized at a point in time; it can drift.
-8. **Never hand-write Prisma migrations.** If a schema change needs a migration, generate it with the Prisma CLI and review the generated SQL rather than manually creating `migration.sql` files.
-9. **Sandbox limitation for Prisma CLI.** In the Codex sandbox, Prisma CLI commands that need database access may fail because the sandbox cannot connect to local Postgres (for example `localhost:5432`). If a task requires `prisma migrate`, `prisma db push`, `prisma migrate reset`, or similar DB-connected Prisma commands, the human user should run them in their own shell and provide the results back for review.
-10. **Migration transaction wrapper.** When reviewing or adjusting generated Prisma migration SQL in this repo, make sure the migration statements are wrapped in an explicit `BEGIN;` / `COMMIT;` transaction block.
-11. **Never assume this skill is up-to-date.** Scan the relevant code areas during work and check if the skill is out of date with the codebase.
-12. **Prompt to update skill.** If the skill is out of date with the codebase, prompt the human user on if they want to update the skill.
+4. **If the resolver calls a store function that writes a row in `ContractTable`, `RateTable`, `ContractQuestion`, or `RateQuestion`, default to `runTransactionWithRowLock`.** Only skip it when last-write-wins behavior is intentional and acceptable for that path.
+5. **Check `packageSubmissions` and cause impact** (reference 08) if the change involves an `UpdateInfoTable` event. The change may append entries to the package history from both contract and rate perspectives.
+6. **Don't include `sharedRateRevisions`** in any new design — deprecated.
+7. **Watch for `DRAFT_PARENT_PLACEHOLDER`** if the change involves draft rates without a submitted parent yet — the placeholder needs the outer parser to patch.
+8. **Verify file paths and code shapes against the current state of the repo** before depending on specifics. This reference was synthesized at a point in time; it can drift.
+9. **Never hand-write Prisma migrations.** If a schema change needs a migration, generate it with the Prisma CLI and review the generated SQL rather than manually creating `migration.sql` files.
+10. **Sandbox limitation for Prisma CLI.** In the Codex sandbox, Prisma CLI commands that need database access may fail because the sandbox cannot connect to local Postgres (for example `localhost:5432`). If a task requires `prisma migrate`, `prisma db push`, `prisma migrate reset`, or similar DB-connected Prisma commands, the human user should run them in their own shell and provide the results back for review.
+11. **Migration transaction wrapper.** When reviewing or adjusting generated Prisma migration SQL in this repo, make sure the migration statements are wrapped in an explicit `BEGIN;` / `COMMIT;` transaction block.
+12. **Never assume this skill is up-to-date.** Scan the relevant code areas during work and check if the skill is out of date with the codebase.
+13. **Prompt to update skill.** If the skill is out of date with the codebase, prompt the human user on if they want to update the skill.


### PR DESCRIPTION
## Summary
[MCR-6223](https://jiraent.cms.gov/browse/MCR-6223)

This implements a new way of handling race conditions, [Postgres row-lock](https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-ROWS). In the ticket, we had mentioned using Prisma's ioslationLevel of Serializable for transactions, but Serializable in Postgres doesn't actually lock rows — it watches which rows each transaction reads and writes, and aborts one with a serialization error if it detects overlap. The catch: that overlap check is approximate. Two transactions updating unrelated contracts can still be flagged as conflicting if they happen to scan the same parts of the underlying table or index, even though they share no actual rows.

I.E. Updating two different contracts and the same time would result in an error, but actually we want that to be allows.

So this new approach locks the row of the record while the transaction is happening and releases it after transaction finishes or rollback.

I only applied this to select updates as not all of them need this row lock. It mostly revolves around contract and rate updates like submit, unlock. withdraw, ...etc.
- approveContract
- overrideRateData
- reverseApproveContract
- submitContract
- submitRate
- undoUnlockContract
- undoWithdrawContract
- undoWithdrawRate
- unlockContract
- unlockRate (unused, but implemented anyways)
- updateDraftContract
- updateDraftContractRates
- updateDraftContractWithRates
- updateMCCRSID
- withdrawContract
- withdrawRate
- softDeleteContractQuestion

I skipped some other resolvers, like create Q&A question and response. This row lock won't prevent those from being able to create duplicates on concurrent API calls. 

#### Related issues

#### Screenshots

#### Test cases covered

`prismaHelpers.test.ts`
- `'runTransactionWithRowLock'`
   - `'prevents concurrent updates on the same locked contract row'`
   - `'does not block concurrent work on different locked contract rows'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
- Validate that each listed action in the description still works in the app.
- (Difficult) Try to send two action requests at the same time in the app.

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed