### PR TITLE
MCR-6123 Allow Oauth Write Access on Undo Withdraw Rate

### DIFF
--- a/services/app-api/src/resolvers/rate/undoWithdrawRate.test.ts
+++ b/services/app-api/src/resolvers/rate/undoWithdrawRate.test.ts
@@ -410,6 +410,110 @@ describe('undoWithdrawRate', () => {
         )
     })
 
+    it('denies OAuth client without write permissions', async () => {
+        const stateServer = await constructTestPostgresServer({
+            context: {
+                user: testStateUser(),
+            },
+        })
+
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: testCMSUser(),
+            },
+        })
+
+        const contract = await createAndSubmitTestContractWithRate(stateServer)
+        const rateID = contract.packageSubmissions[0].rateRevisions[0].rateID
+
+        await withdrawTestRate(cmsServer, rateID, 'Withdraw before OAuth test')
+
+        const oauthServer = await constructTestPostgresServer({
+            context: {
+                user: testCMSUser(),
+                oauthClient: {
+                    clientId: 'test-oauth-client',
+                    grants: ['client_credentials'],
+                    iss: 'mcreview-test',
+                    scopes: [],
+                    isDelegatedUser: false,
+                },
+            },
+        })
+
+        const undoWithdrawResult = await executeGraphQLOperation(oauthServer, {
+            query: UndoWithdrawnRateDocument,
+            variables: {
+                input: {
+                    rateID,
+                    updatedReason: 'OAuth undo withdraw attempt',
+                },
+            },
+        })
+
+        expect(undoWithdrawResult.errors).toBeDefined()
+        expect(undoWithdrawResult.errors?.[0].extensions?.code).toBe(
+            'FORBIDDEN'
+        )
+        expect(undoWithdrawResult.errors?.[0].message).toBe(
+            'OAuth client does not have write permissions'
+        )
+    })
+
+    it('allows delegated OAuth client with submission scope to undo withdraw a rate', async () => {
+        const stateServer = await constructTestPostgresServer({
+            context: {
+                user: testStateUser(),
+            },
+        })
+
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: testCMSUser(),
+            },
+        })
+
+        const contract = await createAndSubmitTestContractWithRate(stateServer)
+        const rateID = contract.packageSubmissions[0].rateRevisions[0].rateID
+
+        await withdrawTestRate(
+            cmsServer,
+            rateID,
+            'Withdraw before delegated OAuth test'
+        )
+
+        const oauthServer = await constructTestPostgresServer({
+            context: {
+                user: testCMSUser(),
+                oauthClient: {
+                    clientId: 'test-oauth-client',
+                    grants: ['client_credentials'],
+                    iss: 'mcreview-test',
+                    scopes: ['CMS_SUBMISSION_ACTIONS'],
+                    isDelegatedUser: true,
+                },
+            },
+        })
+
+        const undoWithdrawResult = await executeGraphQLOperation(oauthServer, {
+            query: UndoWithdrawnRateDocument,
+            variables: {
+                input: {
+                    rateID,
+                    updatedReason: 'Delegated OAuth undo withdraw',
+                },
+            },
+        })
+
+        expect(undoWithdrawResult.errors).toBeUndefined()
+        expect(undoWithdrawResult.data?.undoWithdrawRate.rate).toEqual(
+            expect.objectContaining({
+                reviewStatus: 'UNDER_REVIEW',
+                consolidatedStatus: 'RESUBMITTED',
+            })
+        )
+    })
+
     it('sends emails to CMS and state contacts when a rate is unwithdrawn', async () => {
         const emailConfig = testEmailConfig()
         const mockEmailer = testEmailer(emailConfig)

--- a/services/app-api/src/resolvers/rate/undoWithdrawRate.ts
+++ b/services/app-api/src/resolvers/rate/undoWithdrawRate.ts
@@ -12,7 +12,7 @@ import { logError, logSuccess } from '../../logger'
 import { createForbiddenError, createUserInputError } from '../errorUtils'
 import { NotFoundError } from '../../postgres/postgresErrors'
 import { GraphQLError } from 'graphql/index'
-import { canWrite } from '../../authorization/oauthAuthorization'
+import { canOauthWrite } from '../../authorization/oauthAuthorization'
 
 export function undoWithdrawRate(
     store: Store,
@@ -26,8 +26,8 @@ export function undoWithdrawRate(
         const { rateID, updatedReason } = input
         span?.setAttribute('mcreview.package_id', rateID)
 
-        // Check OAuth client read permissions
-        if (!canWrite(context)) {
+        // Check OAuth client write permissions
+        if (!canOauthWrite(context)) {
             const errMessage = `OAuth client does not have write permissions`
             logError('undoWithdrawRate', errMessage)
             setErrorAttributesOnActiveSpan(errMessage, span)


### PR DESCRIPTION
## Summary
Since CMS App will have api access to Withdraw Rate, it makes sense that they should also have access to Undo Withdraw Rate - so that any actions also have available the undo action.
Changed the auth method in resolver to use `canOauthWrite` and added test cases.

#### Related issues
https://jiraent.cms.gov/browse/MCR-6123

#### Screenshots
<img width="870" height="357" alt="image" src="https://github.com/user-attachments/assets/7fb81426-cffd-4b4e-94e5-192b04917cd3" />

#### Test cases covered
- that a delegated user tries to access the api
- that a non-delegated user tries to access the api

## QA guidance
- Log in with Admin user Ihor and get the oauth client that has cms scopes attached
- Call this endpoint to generate a token :: https://8i9f3dl4fj.execute-api.us-east-1.amazonaws.com/akmcr6123updateaut82f28/oauth/token with the client_id and client_secret from the oauth page as well as grant_type = client_credentials
- Fill in the following curl template with the token generated in previous step, as well as the rateID of a rate in Withdrawn status:
`curl -X POST "https://8i9f3dl4fj.execute-api.us-east-1.amazonaws.com/akmcr6123updateaut82f28/v1/graphql/external" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer <TOKEN>" \
  -H "X-Acting-As-User:  c428e4d8-30d1-706a-a6fb-667b34b27358" \
  --data '{
    "query": "mutation UndoWithdrawRate($input: UndoWithdrawRateInput!) { undoWithdrawRate(input: $input) { rate { id reviewStatus updatedAt status } } }",
    "variables": {
      "input": {
        "rateID": "<RATE_ID>",
        "updatedReason": "undo withdraw rate via curl"
      }
    }
  }'`
- verify in UI that the rate has gone back to submitted status

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed