### PR TITLE
[MCR-6032] cms emails for Q&A response

### DIFF
--- a/services/app-api/src/emailer/emails/sendQuestionResponseCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/sendQuestionResponseCMSEmail.test.ts
@@ -129,6 +129,80 @@ test.each([
     }
 )
 
+test('EQRO Q&A response email contains only devReviewTeam + DMCO recipients', async () => {
+    const currentQuestion = mockQuestionAndResponses({
+        id: 'test-question-id-2',
+        createdAt: new Date('02/03/2024'),
+        contractID: contractRev.id,
+        addedBy: dmcpUser,
+        division: 'DMCO',
+    })
+
+    const result = await sendQuestionResponseCMSEmail(
+        contractRev,
+        'EQRO',
+        testEmailConfig(),
+        defaultMNStatePrograms,
+        stateAnalysts,
+        currentQuestion,
+        questions
+    )
+
+    if (result instanceof Error) {
+        throw new Error(`Unexpect error: ${result.message}`)
+    }
+
+    const expectedRecipients = [
+        ...testEmailConfig().devReviewTeamEmails,
+        ...testEmailConfig().dmcoEmails,
+    ]
+    expect(result).toEqual(
+        expect.objectContaining({
+            toAddresses: expect.arrayContaining(expectedRecipients),
+        })
+    )
+    expect(result.toAddresses).toEqual(
+        expect.not.arrayContaining(stateAnalysts)
+    )
+    expect(result.toAddresses).toEqual(
+        expect.not.arrayContaining(testEmailConfig().dmcpReviewEmails)
+    )
+    expect(result.toAddresses).toEqual(
+        expect.not.arrayContaining(testEmailConfig().oactEmails)
+    )
+})
+
+test('EQRO Q&A response email ignores division-specific recipient rules even for OACT risk-based contracts', async () => {
+    const currentQuestion = mockQuestionAndResponses({
+        id: 'test-question-id-4',
+        createdAt: new Date('02/03/2024'),
+        contractID: contractRev.id,
+        addedBy: oactCMSUser,
+        division: 'OACT',
+    })
+
+    const result = await sendQuestionResponseCMSEmail(
+        contractRev,
+        'EQRO',
+        testEmailConfig(),
+        defaultMNStatePrograms,
+        stateAnalysts,
+        currentQuestion,
+        questions
+    )
+
+    if (result instanceof Error) {
+        throw new Error(`Unexpect error: ${result.message}`)
+    }
+
+    expect(result.toAddresses).toEqual(
+        expect.not.arrayContaining(testEmailConfig().oactEmails)
+    )
+    expect(result.toAddresses).toEqual(
+        expect.not.arrayContaining(stateAnalysts)
+    )
+})
+
 test('renders overall CMS email for a new state response as expected', async () => {
     const currentQuestion = questions[0]
 

--- a/services/app-api/src/emailer/emails/sendQuestionResponseCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/sendQuestionResponseCMSEmail.ts
@@ -38,15 +38,23 @@ export const sendQuestionResponseCMSEmail = async (
         return questionRound
     }
 
-    let receiverEmails = [
-        ...stateAnalystsEmails,
-        ...config.devReviewTeamEmails,
-        ...config.dmcoEmails,
-    ]
-    if (division === 'DMCP') {
-        receiverEmails.push(...config.dmcpReviewEmails)
-    } else if (division === 'OACT' && contractRev.formData.riskBasedContract) {
-        receiverEmails.push(...config.oactEmails)
+    let receiverEmails: string[]
+    if (contractSubmissionType === 'EQRO') {
+        receiverEmails = [...config.devReviewTeamEmails, ...config.dmcoEmails]
+    } else {
+        receiverEmails = [
+            ...stateAnalystsEmails,
+            ...config.devReviewTeamEmails,
+            ...config.dmcoEmails,
+        ]
+        if (division === 'DMCP') {
+            receiverEmails.push(...config.dmcpReviewEmails)
+        } else if (
+            division === 'OACT' &&
+            contractRev.formData.riskBasedContract
+        ) {
+            receiverEmails.push(...config.oactEmails)
+        }
     }
     receiverEmails = pruneDuplicateEmails(receiverEmails)
 

--- a/services/app-api/src/resolvers/questionResponse/createContractQuestionResponse.test.ts
+++ b/services/app-api/src/resolvers/questionResponse/createContractQuestionResponse.test.ts
@@ -17,8 +17,13 @@ import {
 } from '../../testHelpers/userHelpers'
 import { testEmailConfig, testEmailer } from '../../testHelpers/emailerHelpers'
 import { findStatePrograms } from '../../postgres'
-import { createAndSubmitTestContractWithRate } from '../../testHelpers/gqlContractHelpers'
+import {
+    createAndSubmitTestContractWithRate,
+    createAndUpdateTestEQROContract,
+    submitTestContract,
+} from '../../testHelpers/gqlContractHelpers'
 import { ContractSubmissionTypeRecord } from '@mc-review/constants'
+import { testS3Client } from '../../testHelpers/s3Helpers'
 
 describe('createContractQuestionResponse', () => {
     const cmsUser = testCMSUser()
@@ -234,6 +239,88 @@ describe('createContractQuestionResponse', () => {
                 ),
                 bodyHTML: expect.stringContaining(
                     `<a href="http://localhost/submissions/${ContractSubmissionTypeRecord[contract.contractSubmissionType]}/${contract.id}/question-and-answers">View submission Q&A</a>`
+                ),
+            })
+        )
+    })
+
+    it('sends CMS-only email for EQRO submissions (no state email)', async () => {
+        const emailConfig = testEmailConfig()
+        const mockEmailer = testEmailer(emailConfig)
+        const dmcoCMS = testCMSUser({
+            divisionAssignment: 'DMCO' as const,
+        })
+        const mockS3 = testS3Client()
+        const stateServer = await constructTestPostgresServer({
+            emailer: mockEmailer,
+            s3Client: mockS3,
+        })
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: dmcoCMS,
+            },
+            emailer: mockEmailer,
+            s3Client: mockS3,
+        })
+
+        const assignedUserIDs = assignedUsers.map((u) => u.id)
+        await updateTestStateAssignments(cmsServer, 'FL', assignedUserIDs)
+        const assignedUserEmails = assignedUsers.map((u) => u.email)
+
+        const draft = await createAndUpdateTestEQROContract(stateServer, 'FL')
+        const contract = await submitTestContract(stateServer, draft.id)
+
+        const createdQuestion = await createTestQuestion(cmsServer, contract.id)
+        await createTestQuestionResponse(stateServer, createdQuestion?.id)
+
+        const contractName =
+            contract.packageSubmissions[0].contractRevision.contractName
+
+        // CMS response email was sent with EQRO recipient policy:
+        // devReviewTeamEmails + dmcoEmails only — no state analysts, no division-specific.
+        expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                subject: expect.stringContaining(
+                    `New Responses for ${contractName}`
+                ),
+                toAddresses: expect.arrayContaining([
+                    ...emailConfig.devReviewTeamEmails,
+                    ...emailConfig.dmcoEmails,
+                ]),
+            })
+        )
+        expect(mockEmailer.sendEmail).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                subject: expect.stringContaining(
+                    `New Responses for ${contractName}`
+                ),
+                toAddresses: expect.arrayContaining(assignedUserEmails),
+            })
+        )
+        expect(mockEmailer.sendEmail).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                subject: expect.stringContaining(
+                    `New Responses for ${contractName}`
+                ),
+                toAddresses: expect.arrayContaining(
+                    emailConfig.dmcpReviewEmails
+                ),
+            })
+        )
+        expect(mockEmailer.sendEmail).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                subject: expect.stringContaining(
+                    `New Responses for ${contractName}`
+                ),
+                toAddresses: expect.arrayContaining(emailConfig.oactEmails),
+            })
+        )
+
+        // No state-side response confirmation email was sent for EQRO.
+        expect(mockEmailer.sendEmail).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                subject: expect.stringContaining(
+                    `Response submitted to CMS for ${contractName}`
                 ),
             })
         )

--- a/services/app-api/src/resolvers/questionResponse/createContractQuestionResponse.ts
+++ b/services/app-api/src/resolvers/questionResponse/createContractQuestionResponse.ts
@@ -188,31 +188,33 @@ export function createContractQuestionResponseResolver(
             })
         }
 
-        const sendQuestionResponseStateEmailResult =
-            await emailer.sendQuestionResponseStateEmail(
-                contract.revisions[0],
-                contract.contractSubmissionType,
-                statePrograms,
-                submitterEmails,
-                createResponseResult,
-                questions
-            )
+        if (contract.contractSubmissionType !== 'EQRO') {
+            const sendQuestionResponseStateEmailResult =
+                await emailer.sendQuestionResponseStateEmail(
+                    contract.revisions[0],
+                    contract.contractSubmissionType,
+                    statePrograms,
+                    submitterEmails,
+                    createResponseResult,
+                    questions
+                )
 
-        if (sendQuestionResponseStateEmailResult instanceof Error) {
-            logError(
-                'sendQuestionResponseStateEmail - Send State email',
-                sendQuestionResponseStateEmailResult.message
-            )
-            setErrorAttributesOnActiveSpan(
-                `Send State email failed: ${sendQuestionResponseStateEmailResult.message}`,
-                span
-            )
-            throw new GraphQLError('Email failed', {
-                extensions: {
-                    code: 'INTERNAL_SERVER_ERROR',
-                    cause: 'EMAIL_ERROR',
-                },
-            })
+            if (sendQuestionResponseStateEmailResult instanceof Error) {
+                logError(
+                    'sendQuestionResponseStateEmail - Send State email',
+                    sendQuestionResponseStateEmailResult.message
+                )
+                setErrorAttributesOnActiveSpan(
+                    `Send State email failed: ${sendQuestionResponseStateEmailResult.message}`,
+                    span
+                )
+                throw new GraphQLError('Email failed', {
+                    extensions: {
+                        code: 'INTERNAL_SERVER_ERROR',
+                        cause: 'EMAIL_ERROR',
+                    },
+                })
+            }
         }
 
         logSuccess('createContractQuestionResponse')


### PR DESCRIPTION
## Summary
**User Story:**
As a CMS user I want to receive an email notification when a response related to a question that I sent to the state on an EQRO submission has been sent by the state so that I am aware of the response and can continue my review.

**Acceptance Criteria:**
- Email is sent to CMS user(s) when a response to a question is added to an EQRO submission
- Established patterns for emails will be followed
- The recipient for this email should be limited to the following inbox: [MCGDMCOActions@hhs.cms.gov](mailto:MCGDMCOActions@hhs.cms.gov)

**Eng Note:** We should try to use the emailer function as what currently exists for Health Plans, as these emails should function in the same manner and have no design difference
#### Related issues
[MCR-6032](https://jiraent.cms.gov/browse/MCR-6032)
#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed