### PR TITLE
MCR-6034 Hide the ability to add questions for DMCP and OACT users

### DIFF
--- a/services/app-web/src/pages/App/AppRoutes.test.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.test.tsx
@@ -4,6 +4,8 @@ import { renderWithProviders } from '../../testHelpers/jestHelpers'
 import { AppRoutes } from './AppRoutes'
 import {
     fetchCurrentUserMock,
+    fetchContractWithQuestionsMockSuccess,
+    fetchRateWithQuestionsMockSuccess,
     mockValidCMSUser,
     indexContractsStrippedMockSuccess,
 } from '@mc-review/mocks'
@@ -115,6 +117,15 @@ describe('AppRoutes and routing configuration', () => {
             'href',
             'https://www.medicaid.gov/medicaid/managed-care/mc-rvw-state-wbnr-sprng-2024.pdf'
         )
+    }
+
+    const expect404Page = () => {
+        expect(
+            screen.getByRole('heading', {
+                name: /Page not found/i,
+                level: 1,
+            })
+        ).toBeInTheDocument()
     }
 
     describe('/[root]', () => {
@@ -377,6 +388,80 @@ describe('AppRoutes and routing configuration', () => {
                         level: 1,
                     })
                 ).toBeInTheDocument()
+            })
+        })
+    })
+
+    describe('CMS upload question routes', () => {
+        it('shows 404 page when a DMCP user enters the contract upload questions URL', async () => {
+            renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
+                routerProvider: {
+                    route: '/submissions/health-plan/test-abc-123/question-and-answers/dmcp/upload-questions',
+                },
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            statusCode: 200,
+                            user: mockValidCMSUser({
+                                divisionAssignment: 'DMCP',
+                            }),
+                        }),
+                        fetchContractWithQuestionsMockSuccess({}),
+                    ],
+                },
+                featureFlags: { 'session-expiring-modal': false },
+            })
+
+            await waitFor(() => {
+                expect404Page()
+            })
+        })
+
+        it('shows 404 page when an OACT user enters the contract upload questions URL', async () => {
+            renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
+                routerProvider: {
+                    route: '/submissions/health-plan/test-abc-123/question-and-answers/dmco/upload-questions',
+                },
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            statusCode: 200,
+                            user: mockValidCMSUser({
+                                divisionAssignment: 'OACT',
+                            }),
+                        }),
+                        fetchContractWithQuestionsMockSuccess({}),
+                    ],
+                },
+                featureFlags: { 'session-expiring-modal': false },
+            })
+
+            await waitFor(() => {
+                expect404Page()
+            })
+        })
+
+        it('shows 404 page when a DMCO user enters the rate upload questions URL with a non-DMCO division', async () => {
+            renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
+                routerProvider: {
+                    route: '/rates/rate-123/question-and-answers/dmcp/upload-questions',
+                },
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            statusCode: 200,
+                            user: mockValidCMSUser({
+                                divisionAssignment: 'DMCO',
+                            }),
+                        }),
+                        fetchRateWithQuestionsMockSuccess({}),
+                    ],
+                },
+                featureFlags: { 'session-expiring-modal': false },
+            })
+
+            await waitFor(() => {
+                expect404Page()
             })
         })
     })

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -1,5 +1,11 @@
 import React, { useEffect, useLayoutEffect, useState } from 'react'
-import { Route, Routes, useLocation, Navigate } from 'react-router-dom'
+import {
+    Route,
+    Routes,
+    useLocation,
+    Navigate,
+    useParams,
+} from 'react-router-dom'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { idmRedirectURL } from '../../pages/Auth/cognitoAuth'
 import { assertNever, AuthModeType } from '@mc-review/common-code'
@@ -70,6 +76,26 @@ import { UndoSubmissionUnlock } from '../UndoSubmissionUnlock/UndoSubmissionUnlo
 import { CreateOauthClient } from '../Settings/Oauth/CreateOauthClient'
 import { User } from '../../gen/gqlClient'
 import { AddLocalUser } from '../../localAuth/AddLocalUser'
+
+const CMSUploadQuestionsRoute = ({
+    loggedInUser,
+    children,
+}: {
+    loggedInUser: User
+    children: React.ReactElement
+}): React.ReactElement => {
+    const { division } = useParams<{ division: string }>()
+    const userDivision =
+        loggedInUser.__typename === 'CMSUser' ||
+        loggedInUser.__typename === 'CMSApproverUser'
+            ? loggedInUser.divisionAssignment
+            : undefined
+
+    const canAccessUploadQuestionsRoute =
+        userDivision === 'DMCO' && division?.toUpperCase() === userDivision
+
+    return canAccessUploadQuestionsRoute ? children : <Error404 />
+}
 
 function componentForAuthMode(
     authMode: AuthModeType
@@ -321,7 +347,13 @@ const CMSUserRoutes = ({
                     />
                     <Route
                         path={RoutesRecord.SUBMISSIONS_UPLOAD_CONTRACT_QUESTION}
-                        element={<UploadContractQuestions />}
+                        element={
+                            <CMSUploadQuestionsRoute
+                                loggedInUser={loggedInUser}
+                            >
+                                <UploadContractQuestions />
+                            </CMSUploadQuestionsRoute>
+                        }
                     />
                     {isAdminUser && (
                         <Route
@@ -352,7 +384,13 @@ const CMSUserRoutes = ({
                     />
                     <Route
                         path={RoutesRecord.RATES_UPLOAD_QUESTION}
-                        element={<UploadRateQuestions />}
+                        element={
+                            <CMSUploadQuestionsRoute
+                                loggedInUser={loggedInUser}
+                            >
+                                <UploadRateQuestions />
+                            </CMSUploadQuestionsRoute>
+                        }
                     />
                     {/*This route will cause the RateSummarySideNav to redirect to rate summary Q&A page*/}
                     <Route

--- a/services/app-web/src/pages/QuestionResponse/QATable/CMSQuestionResponseTable.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/CMSQuestionResponseTable.tsx
@@ -86,7 +86,7 @@ export const CMSQuestionResponseTable = ({
     const canAddQuestions =
         !['APPROVED', 'WITHDRAWN'].includes(consolidatedStatus!) &&
         userDivision &&
-        !['DMCP', 'OACT'].includes(userDivision)
+        userDivision === 'DMCO'
 
     const { usersRounds, otherRounds } = sortQuestionRounds(
         indexQuestions,

--- a/services/app-web/src/pages/QuestionResponse/QATable/CMSQuestionResponseTable.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/CMSQuestionResponseTable.tsx
@@ -84,7 +84,9 @@ export const CMSQuestionResponseTable = ({
 }: CMSQuestionResponseTableProps) => {
     const { loggedInUser } = useAuth()
     const canAddQuestions =
-        !['APPROVED', 'WITHDRAWN'].includes(consolidatedStatus!) && userDivision
+        !['APPROVED', 'WITHDRAWN'].includes(consolidatedStatus!) &&
+        userDivision &&
+        !['DMCP', 'OACT'].includes(userDivision)
 
     const { usersRounds, otherRounds } = sortQuestionRounds(
         indexQuestions,

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/ContractQuestionResponse.test.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/ContractQuestionResponse.test.tsx
@@ -614,6 +614,96 @@ describe('ContractQuestionResponse', () => {
             expect(addQuestion).not.toBeInTheDocument()
         })
 
+        it('does not render an Add questions button for a DMCP user', async () => {
+            renderWithProviders(<CommonCMSRoutes />, {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser({
+                                divisionAssignment: 'DMCP',
+                            }),
+                            statusCode: 200,
+                        }),
+                        fetchRateMockSuccess({
+                            id: 'test-contract-id',
+                        }),
+                        fetchContractWithQuestionsMockSuccess({
+                            contract: {
+                                ...mockContractPackageSubmittedWithQuestions(),
+                                id: 'test-contract-id',
+                                contractSubmissionType: 'HEALTH_PLAN',
+                            },
+                        }),
+                        fetchContractWithQuestionsMockSuccess({
+                            contract: {
+                                ...mockContractPackageSubmittedWithQuestions(),
+                                id: 'test-contract-id',
+                                contractSubmissionType: 'HEALTH_PLAN',
+                            },
+                        }),
+                    ],
+                },
+                routerProvider: {
+                    route: `/submissions/health-plan/test-contract-id/question-and-answers`,
+                },
+            })
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText("Your division's questions")
+                ).toBeInTheDocument()
+            })
+
+            expect(
+                screen.queryByRole('link', { name: 'Add questions' })
+            ).not.toBeInTheDocument()
+        })
+
+        it('does not render an Add questions button for an OACT user', async () => {
+            renderWithProviders(<CommonCMSRoutes />, {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser({
+                                divisionAssignment: 'OACT',
+                            }),
+                            statusCode: 200,
+                        }),
+                        fetchRateMockSuccess({
+                            id: 'test-contract-id',
+                        }),
+                        fetchContractWithQuestionsMockSuccess({
+                            contract: {
+                                ...mockContractPackageSubmittedWithQuestions(),
+                                id: 'test-contract-id',
+                                contractSubmissionType: 'HEALTH_PLAN',
+                            },
+                        }),
+                        fetchContractWithQuestionsMockSuccess({
+                            contract: {
+                                ...mockContractPackageSubmittedWithQuestions(),
+                                id: 'test-contract-id',
+                                contractSubmissionType: 'HEALTH_PLAN',
+                            },
+                        }),
+                    ],
+                },
+                routerProvider: {
+                    route: `/submissions/health-plan/test-contract-id/question-and-answers`,
+                },
+            })
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText("Your division's questions")
+                ).toBeInTheDocument()
+            })
+
+            expect(
+                screen.queryByRole('link', { name: 'Add questions' })
+            ).not.toBeInTheDocument()
+        })
+
         it('renders with question submit banner after question submitted', async () => {
             renderWithProviders(
                 <Routes>

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/RateQuestionResponse.test.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/RateQuestionResponse.test.tsx
@@ -586,5 +586,65 @@ describe('RateQuestionResponse', () => {
                 screen.queryByRole('button', { name: 'Add questions' })
             ).toBeNull()
         })
+
+        it('does not render an Add questions button for a DMCP user', async () => {
+            const rate = rateDataMock()
+            renderWithProviders(<CommonCMSRoutes />, {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser({
+                                divisionAssignment: 'DMCP',
+                            }),
+                            statusCode: 200,
+                        }),
+                        fetchRateWithQuestionsMockSuccess({ rate }),
+                        fetchRateWithQuestionsMockSuccess({ rate }),
+                        fetchRateWithQuestionsMockSuccess({ rate }),
+                    ],
+                },
+                routerProvider: {
+                    route: `/rates/${rate.id}/question-and-answers`,
+                },
+            })
+
+            await waitFor(() => {
+                expect(screen.queryByTestId('sidenav')).toBeInTheDocument()
+            })
+
+            expect(
+                screen.queryByRole('link', { name: 'Add questions' })
+            ).not.toBeInTheDocument()
+        })
+
+        it('does not render an Add questions button for an OACT user', async () => {
+            const rate = rateDataMock()
+            renderWithProviders(<CommonCMSRoutes />, {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser({
+                                divisionAssignment: 'OACT',
+                            }),
+                            statusCode: 200,
+                        }),
+                        fetchRateWithQuestionsMockSuccess({ rate }),
+                        fetchRateWithQuestionsMockSuccess({ rate }),
+                        fetchRateWithQuestionsMockSuccess({ rate }),
+                    ],
+                },
+                routerProvider: {
+                    route: `/rates/${rate.id}/question-and-answers`,
+                },
+            })
+
+            await waitFor(() => {
+                expect(screen.queryByTestId('sidenav')).toBeInTheDocument()
+            })
+
+            expect(
+                screen.queryByRole('link', { name: 'Add questions' })
+            ).not.toBeInTheDocument()
+        })
     })
 })

--- a/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadContractQuestions.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadContractQuestions.tsx
@@ -6,6 +6,7 @@ import {
     ContractSubmissionType,
     CreateContractQuestionInput,
     CreateContractQuestionDocument,
+    Division,
     FetchContractWithQuestionsDocument,
 } from '../../../gen/gqlClient'
 import { usePage } from '../../../contexts/PageContext'
@@ -18,8 +19,6 @@ import { FileItemT } from '../../../components'
 import { getNextCMSRoundNumber } from '../QuestionResponseHelpers'
 import { ErrorOrLoadingPage } from '../../StateSubmission'
 import { handleAndReturnErrorState } from '../../StateSubmission/SharedSubmissionComponents'
-import { isValidCmsDivison } from '../QuestionResponseHelpers/questionResponseHelpers'
-import { Error404 } from '../../Errors/Error404Page'
 import { useMemoizedStateHeader } from '../../../hooks'
 
 export const UploadContractQuestions = () => {
@@ -116,16 +115,7 @@ export const UploadContractQuestions = () => {
         }
     }
 
-    // confirm division is valid
-    const realDivision = division?.toUpperCase()
-
-    if (!realDivision || !isValidCmsDivison(realDivision)) {
-        console.error(
-            'Upload Questions called with bogus division in URL: ',
-            division
-        )
-        return <Error404 />
-    }
+    const realDivision = division.toUpperCase() as Division
 
     const nextRoundNumber = getNextCMSRoundNumber(
         contract.questions,


### PR DESCRIPTION

## Summary
Hide "Add questions" button for DMCP and OACT users.
Note: the button (link) is hidden on both Submissions and Rate questions pages.

#### Related issues
[MCR-6034](https://jiraent.cms.gov/browse/MCR-6034)

#### Screenshots

#### Test cases covered
ContractQuestionResponse.test
RateQuestionResponse.test
<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
Create new Submission and Rate
As CMS Admin (ADMIN_USER), log in and assign DMCP, DMCO, and OACT division to CMS Approvers (CMS_APPROVER_USER). Log in as CMS Approver user. If your Division is DMCP or OACT, the "Add questions" button (link) should not be displayed on the Rate Questions, and Submission Questions pages. This button should be displayed only for DMCO users.

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed