### PR TITLE
Fix eslint error from react-router-dom v7 upgrade

### DIFF
--- a/services/app-web/eslint.config.ts
+++ b/services/app-web/eslint.config.ts
@@ -80,7 +80,34 @@ export default tseslint.config([
                     allowTaggedTemplates: true,
                 },
             ],
-            '@typescript-eslint/no-floating-promises': 'error',
+            // react-router v7 typed NavigateFunction as `void | Promise<void>`
+            // to cover both declarative (<BrowserRouter>) and data-router modes.
+            // We use <BrowserRouter> (see src/pages/App/App.tsx), so navigate()
+            // is synchronous at runtime and the Promise half of the union never
+            // materializes. allowForKnownSafeCalls silences this rule for any
+            // value typed NavigateFunction (covers both `navigate` from
+            // useNavigate() and the `testNavigate: NavigateFunction` bindings
+            // used in tests). NavigateFunction is declared in the `react-router`
+            // package; `react-router-dom` only re-exports it in v7.
+            // Refs:
+            //   Root cause (v7 union return type):
+            //     https://github.com/remix-run/react-router/issues/12348
+            //   This exact eslint config (credit qsoo):
+            //     https://github.com/remix-run/react-router/issues/12348#issuecomment-3022478918
+            //   Rule option docs:
+            //     https://typescript-eslint.io/rules/no-floating-promises/#allowforknownsafecalls
+            '@typescript-eslint/no-floating-promises': [
+                'error',
+                {
+                    allowForKnownSafeCalls: [
+                        {
+                            from: 'package',
+                            name: 'NavigateFunction',
+                            package: 'react-router',
+                        },
+                    ],
+                },
+            ],
 
             // Jest rules
             'jest/no-focused-tests': 'error',


### PR DESCRIPTION
## Summary

This fixes a eslint error that came with the react-router-dom v7 upgrade

The react-router-dom v7 upgrade retyped useNavigate's return as void | Promise<void> — one signature covering both <BrowserRouter> (sync) and the new data router (async). ESLint's no-floating-promises saw the Promise half and 70 navigate(...) calls.

The fix here was to add `allowForKnownSafeCalls` to @typescript-eslint/no-floating-promises in services/app-web/eslint.config.ts, scoped to NavigateFunction from react-router. One config entry, all 70 errors gone, covers navigate and the testNavigate: NavigateFunction bindings in tests.

This was suggested in this issue: https://github.com/remix-run/react-router/issues/12348#issuecomment-3022478918

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed