### PR TITLE
MCR-6266: Update pnpm to v11

### DIFF
--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -7,7 +7,6 @@ runs:
     - uses: pnpm/action-setup@v4
       name: Install pnpm
       with:
-        version: 9
         run_install: false
 
     - name: Configure pnpm to use HTTPS

--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -9,10 +9,6 @@ runs:
       with:
         run_install: false
 
-    - name: Configure pnpm to use HTTPS
-      shell: bash
-      run: pnpm config set git-prefer-https true
-
     # We need this override until pnpm fixes this as we use CMSGov repos:
     # https://github.com/pnpm/pnpm/issues/3948
     - name: Configure git

--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -4,7 +4,7 @@ description: 'Runs common tasks for setting up the build environment in GHA'
 runs:
   using: 'composite'
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v6
       name: Install pnpm
       with:
         run_install: false

--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -4,6 +4,10 @@ description: 'Runs common tasks for setting up the build environment in GHA'
 runs:
   using: 'composite'
   steps:
+    - uses: actions/setup-node@v6
+      with:
+        node-version-file: '.nvmrc'
+
     - uses: pnpm/action-setup@v6
       name: Install pnpm
       with:
@@ -31,11 +35,6 @@ runs:
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
-
-    - uses: actions/setup-node@v6
-      with:
-        node-version-file: '.nvmrc'
-        cache: 'pnpm'
 
     - name: Install dependencies
       shell: bash

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "description": "",
     "main": "index.js",
     "private": true,
+    "packageManager": "pnpm@11.1.3",
     "workspaces": [
         "packages/**",
         "services/**"

--- a/package.json
+++ b/package.json
@@ -76,36 +76,6 @@
         "url": "https://github.com/Enterprise-CMCS/managed-care-review/issues"
     },
     "homepage": "https://github.com/Enterprise-CMCS/managed-care-review#readme",
-    "pnpm": {
-        "overrides": {
-            "@babel/runtime": ">=7.29.2",
-            "axios": ">=1.15.2",
-            "@hono/node-server": ">=2.0.2",
-            "defu": ">=6.1.7",
-            "diff": ">=4.0.4 <5",
-            "effect": ">=3.20.0",
-            "fast-uri": ">=3.1.2",
-            "fast-xml-builder": ">=1.2.0",
-            "fast-xml-parser": ">=5.8.0",
-            "handlebars": ">=4.7.9",
-            "hono": ">=4.12.18",
-            "immutable": ">=5.1.5",
-            "ip-address": ">=10.2.0",
-            "js-yaml": ">=4.1.1",
-            "lodash": ">=4.18.1",
-            "lodash-es": ">=4.18.1",
-            "picomatch": ">=4.0.4",
-            "postcss": ">=8.5.14",
-            "protobufjs": ">=8.2.0",
-            "qs": ">=6.14.2",
-            "rollup": ">=4.60.4",
-            "systeminformation": ">=5.31.6",
-            "undici": ">=7.25.0 <8",
-            "vite": ">=7.3.2",
-            "ws": ">=8.20.1 <9",
-            "yaml": ">=2.9.0"
-        }
-    },
     "devDependencies": {
         "c8": "^11.0.0",
         "cypress": "^13.13.2",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,17 +1,19 @@
+# yaml-language-server: $schema=none
+# SchemaStore's pnpm-workspace schema can lag pnpm; pnpm 11 supports gitPreferHttps.
 packages:
-  - 'services/**'
-  - 'packages/**'
-  - 'dev_tool'
-  - 'scripts'
+    - 'services/**'
+    - 'packages/**'
+    - 'dev_tool'
+    - 'scripts'
+gitPreferHttps: true
 allowBuilds:
-  '@apollo/protobufjs': false
-  '@parcel/watcher': true
-  '@prisma/engines': true
-  core-js: false
-  cpu-features: false
-  cypress: true
-  esbuild: true
-  prisma: true
-  protobufjs: false
-  ssh2: false
-  unrs-resolver: true
+    '@apollo/protobufjs': false
+    '@parcel/watcher': true
+    '@prisma/engines': true
+    core-js: false
+    cpu-features: false
+    cypress: true
+    esbuild: true
+    prisma: true
+    ssh2: false
+    unrs-resolver: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
     - 'services/**'
+    - '!services/**/cdk.out/**'
     - 'packages/**'
     - 'dev_tool'
     - 'scripts'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,35 @@
-# yaml-language-server: $schema=none
-# SchemaStore's pnpm-workspace schema can lag pnpm; pnpm 11 supports gitPreferHttps.
 packages:
     - 'services/**'
     - 'packages/**'
     - 'dev_tool'
     - 'scripts'
-gitPreferHttps: true
+overrides:
+    '@babel/runtime': '>=7.29.2'
+    axios: '>=1.15.2'
+    '@hono/node-server': '>=2.0.2'
+    defu: '>=6.1.7'
+    diff: '>=4.0.4 <5'
+    effect: '>=3.20.0'
+    fast-uri: '>=3.1.2'
+    fast-xml-builder: '>=1.2.0'
+    fast-xml-parser: '>=5.8.0'
+    handlebars: '>=4.7.9'
+    hono: '>=4.12.18'
+    immutable: '>=5.1.5'
+    ip-address: '>=10.2.0'
+    js-yaml: '>=4.1.1'
+    lodash: '>=4.18.1'
+    lodash-es: '>=4.18.1'
+    picomatch: '>=4.0.4'
+    postcss: '>=8.5.14'
+    protobufjs: '>=8.2.0'
+    qs: '>=6.14.2'
+    rollup: '>=4.60.4'
+    systeminformation: '>=5.31.6'
+    undici: '>=7.25.0 <8'
+    vite: '>=7.3.2'
+    ws: '>=8.20.1 <9'
+    yaml: '>=2.9.0'
 allowBuilds:
     '@apollo/protobufjs': false
     '@parcel/watcher': true
@@ -15,5 +39,9 @@ allowBuilds:
     cypress: true
     esbuild: true
     prisma: true
+    protobufjs: false
     ssh2: false
     unrs-resolver: true
+# SchemaStore's pnpm-workspace schema can lag pnpm; pnpm 11 supports gitPreferHttps.
+# yaml-language-server-disable
+gitPreferHttps: true

--- a/services/infra-cdk/lib/stacks/app-api.ts
+++ b/services/infra-cdk/lib/stacks/app-api.ts
@@ -366,6 +366,12 @@ export class AppApiStack extends BaseStack {
                 bundling: {
                     format: OutputFormat.ESM,
                     banner: AppApiStack.ESM_BANNER,
+                    // CDK stages a synthetic package for nodeModules installs with an empty
+                    // pnpm-workspace.yaml, so pnpm cannot see the repo's allowBuilds config.
+                    // This bundling install only contains prisma and its transitive deps.
+                    environment: {
+                        PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS: 'true',
+                    },
                     // CRITICAL: Keep prisma CLI as node module (not bundled) so it can be executed via spawnSync
                     nodeModules: ['prisma'],
                     ...this.createBundling(


### PR DESCRIPTION
Adds the pnpm version to `package.json` via the `packageManager` field and removes the hardcoded pnpm version from the shared GitHub Actions setup. This lets pnpm/action-setup use the project-declared version instead of maintaining the version in CI separately.

**Changes**

- Added `"packageManager": "pnpm@11.1.3"` to `package.json`
- Removed `version: 9` from `.github/actions/setup_env/action.yml