### PR TITLE
MCR-6241: Remove prod block for oauth writes

### DIFF
--- a/services/app-api/src/authorization/oauthAuthorization.test.ts
+++ b/services/app-api/src/authorization/oauthAuthorization.test.ts
@@ -157,22 +157,5 @@ describe('OAuth Authorization', () => {
 
             expect(canOauthWrite(context)).toBe(false)
         })
-
-        it('denies writing for OAuth client when stage is prod', () => {
-            process.env.stage = 'prod'
-
-            const context: Context = {
-                user: mockCMSUser,
-                oauthClient: {
-                    clientId: 'test-client',
-                    grants: ['client_credentials'],
-                    iss: 'mcreview-test',
-                    scopes: ['CMS_SUBMISSION_ACTIONS'],
-                    isDelegatedUser: true,
-                },
-            }
-
-            expect(canOauthWrite(context)).toBe(false)
-        })
     })
 })

--- a/services/app-api/src/authorization/oauthAuthorization.ts
+++ b/services/app-api/src/authorization/oauthAuthorization.ts
@@ -51,12 +51,10 @@ export function canWrite(context: Context): boolean {
  * specific endpoints will allow if the OAuth client has been validated for delegated user
  */
 export function canOauthWrite(context: Context): boolean {
-    const stageName = process.env.stage
-    // OAuth clients can only write if scopes is populated
-    // and we are temporarily restricting them from writing in prod
+    // OAuth clients can only write if they are delegated users
+    // with the required submission-actions scope.
     if (context.oauthClient) {
         if (
-            stageName !== 'prod' &&
             context.oauthClient?.isDelegatedUser &&
             context.oauthClient?.scopes?.includes(
                 OAuthScope.CMS_SUBMISSION_ACTIONS

--- a/services/app-api/src/authorization/oauthAuthorization.ts
+++ b/services/app-api/src/authorization/oauthAuthorization.ts
@@ -1,4 +1,4 @@
-import { OAuthScope } from '../generated/client'
+import { OAuthScope } from '../generated/enums'
 import type { Context } from '../handlers/apollo_gql'
 
 /**


### PR DESCRIPTION
## Summary
[MCR-6241](https://jiraent.cms.gov/browse/MCR-6241)

This removes the production block for OAuth writes.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed