### PR TITLE
MCR-6275: users can view eqro previous submission page

### DIFF
--- a/services/app-web/src/components/Banner/PreviousSubmissionBanner/PreviousSubmissionBanner.tsx
+++ b/services/app-web/src/components/Banner/PreviousSubmissionBanner/PreviousSubmissionBanner.tsx
@@ -4,10 +4,11 @@ import { AccessibleAlertBanner } from '../AccessibleAlertBanner/AccessibleAlertB
 
 export type UnlockedProps = {
     link: string
-}
+} & React.HTMLAttributes<HTMLDivElement>
 
 export const PreviousSubmissionBanner = ({
     link,
+    className,
 }: UnlockedProps): React.ReactElement => {
     return (
         <AccessibleAlertBanner
@@ -17,6 +18,7 @@ export const PreviousSubmissionBanner = ({
             headingLevel="h4"
             data-testid="previousSubmissionBanner"
             validation
+            className={className}
         >
             <p
                 className="usa-alert__text"

--- a/services/app-web/src/components/Banner/PreviousSubmissionBanner/PreviousSubmissionBanner.tsx
+++ b/services/app-web/src/components/Banner/PreviousSubmissionBanner/PreviousSubmissionBanner.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { LinkWithLogging } from '../../TealiumLogging/Link'
+import { LinkWithLogging } from '../../TealiumLogging'
 import { AccessibleAlertBanner } from '../AccessibleAlertBanner/AccessibleAlertBanner'
 
 export type UnlockedProps = {

--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/EQROSubmissionTypeSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/EQROSubmissionTypeSummarySection.tsx
@@ -9,7 +9,11 @@ import {
     getVisibleLatestContractFormData,
 } from '@mc-review/submissions'
 import { GenericErrorPage } from '../../../pages/Errors/GenericErrorPage'
-import { Contract, UnlockedContract } from '../../../gen/gqlClient'
+import {
+    Contract,
+    ContractRevision,
+    UnlockedContract,
+} from '../../../gen/gqlClient'
 import styles from '../SubmissionSummarySection.module.scss'
 import {
     ContractProgramsSummary,
@@ -24,6 +28,7 @@ import { formattedProgramNames } from '../../../formHelpers'
 
 export type EQROSubmissionTypeSummarySection = {
     contract: Contract | UnlockedContract
+    contractRev?: ContractRevision
     editNavigateTo?: string
     headerChildComponent?: React.ReactElement
     subHeaderComponent?: React.ReactElement
@@ -69,6 +74,7 @@ const calcChangeInReviewDetermination = (
 
 export const EQROSubmissionTypeSummarySection = ({
     contract,
+    contractRev,
     initiallySubmittedAt,
     isStateUser,
     editNavigateTo,
@@ -77,8 +83,9 @@ export const EQROSubmissionTypeSummarySection = ({
     explainMissingData,
     headerText,
 }: EQROSubmissionTypeSummarySection): React.ReactElement => {
+    const contractOrRev = contractRev ? contractRev : contract
     const contractFormData = getVisibleLatestContractFormData(
-        contract,
+        contractOrRev,
         isStateUser
     )
     if (!contractFormData) return <GenericErrorPage />
@@ -95,21 +102,34 @@ export const EQROSubmissionTypeSummarySection = ({
     const isDraft = contract.status === 'DRAFT'
     const showReviewDetermination = !(isStateUser && (isUnlocked || isDraft))
 
-    const lastReviewDetermination = contract.reviewStatusActions?.find(
-        (action) =>
-            action.actionType === 'UNDER_REVIEW' ||
-            action.actionType === 'NOT_SUBJECT_TO_REVIEW'
-    )
+    let subjectToReview: boolean | undefined
+    let hasReviewDeterminationChanged = false
 
-    const subjectToReview =
-        lastReviewDetermination === undefined
-            ? undefined
-            : lastReviewDetermination.actionType === 'UNDER_REVIEW'
+    if (contractRev) {
+        // For a historical revision view, derive the determination from this
+        // revision's own form data rather than from contract-level review actions.
+        const derived = eqroValidationAndReviewDetermination(
+            contract.id,
+            contractFormData
+        )
+        subjectToReview = derived instanceof Error ? undefined : derived
+    } else {
+        const lastReviewDetermination = contract.reviewStatusActions?.find(
+            (action) =>
+                action.actionType === 'UNDER_REVIEW' ||
+                action.actionType === 'NOT_SUBJECT_TO_REVIEW'
+        )
 
-    const hasReviewDeterminationChanged = calcChangeInReviewDetermination(
-        contract,
-        subjectToReview
-    )
+        subjectToReview =
+            lastReviewDetermination === undefined
+                ? undefined
+                : lastReviewDetermination.actionType === 'UNDER_REVIEW'
+
+        hasReviewDeterminationChanged = calcChangeInReviewDetermination(
+            contract,
+            subjectToReview
+        )
+    }
 
     return (
         <SectionCard

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useLayoutEffect, useState } from 'react'
 import { Route, Routes, useLocation, Navigate } from 'react-router-dom'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
-import { idmRedirectURL } from '../../pages/Auth/cognitoAuth'
+import { idmRedirectURL } from '../Auth/cognitoAuth'
 import { assertNever, AuthModeType } from '@mc-review/common-code'
 import { PageTitlesRecord, RoutesRecord, RouteT } from '@mc-review/constants'
 import { getRouteName } from '../../routeHelpers'
 import { useAuth } from '../../contexts/AuthContext'
 import { usePage } from '../../contexts/PageContext'
-import { useTitle } from '../../hooks/useTitle'
+import { useTitle } from '../../hooks'
 import { LocalLogin } from '../../localAuth'
 import { CognitoLogin } from '../Auth/CognitoLogin'
 import {
@@ -32,10 +32,10 @@ import {
     NewSubmissionForm,
 } from '../StateSubmission'
 import { SubmissionSummaryRoutes } from '../SubmissionSummary'
-import { SubmissionRevisionSummary } from '../SubmissionRevisionSummary'
-import { useScrollToPageTop } from '../../hooks/useScrollToPageTop'
+import { RevisionSummaryRoutes } from '../SubmissionRevisionSummary'
+import { useScrollToPageTop } from '../../hooks'
 import { featureFlags } from '@mc-review/common-code'
-import { useLocalStorage } from '../../hooks/useLocalStorage'
+import { useLocalStorage } from '../../hooks'
 import { recordJSException } from '@mc-review/otel'
 import { SubmissionSideNav } from '../SubmissionSideNav'
 import {
@@ -239,7 +239,11 @@ const StateUserRoutes = ({
                 </Route>
                 <Route
                     path={RoutesRecord.SUBMISSIONS_REVISION}
-                    element={<SubmissionRevisionSummary />}
+                    element={
+                        <RevisionSummaryRoutes
+                            showEqroSubmissions={showEqroSubmissions}
+                        />
+                    }
                 />
                 {renderUniversalRoutes(showResourcesNavPages)}
                 {isExplorerAllowed(stageName) && (
@@ -407,7 +411,11 @@ const CMSUserRoutes = ({
 
                 <Route
                     path={RoutesRecord.SUBMISSIONS_REVISION}
-                    element={<SubmissionRevisionSummary />}
+                    element={
+                        <RevisionSummaryRoutes
+                            showEqroSubmissions={showEqroSubmissions}
+                        />
+                    }
                 />
                 {isExplorerAllowed(stageName) && (
                     <Route

--- a/services/app-web/src/pages/SubmissionRevisionSummary/EQROSubmissionRevisionSummary/EQROSubmissionRevisionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/EQROSubmissionRevisionSummary/EQROSubmissionRevisionSummary.test.tsx
@@ -157,6 +157,47 @@ describe('EQROSubmissionRevisionSummary', () => {
                 }
             )
 
+            it('returns 404 when the contract is not an EQRO submission', async () => {
+                renderWithProviders(
+                    <Routes>
+                        <Route
+                            path={RoutesRecord.SUBMISSIONS_REVISION}
+                            element={<EQROSubmissionRevisionSummary />}
+                        />
+                    </Routes>,
+                    {
+                        apolloProvider: {
+                            mocks: [
+                                fetchCurrentUserMock({
+                                    user: mockUser(),
+                                    statusCode: 200,
+                                }),
+                                fetchContractMockSuccess({
+                                    contract:
+                                        mockContractPackageSubmittedWithRevisions(
+                                            {
+                                                id: '15',
+                                                contractSubmissionType:
+                                                    'HEALTH_PLAN',
+                                            }
+                                        ),
+                                }),
+                            ],
+                        },
+                        routerProvider: {
+                            route: '/submissions/eqro/15/revisions/2',
+                        },
+                        featureFlags: {},
+                    }
+                )
+
+                expect(
+                    await screen.findByRole('heading', {
+                        name: '404 / Page not found',
+                    })
+                ).toBeInTheDocument()
+            })
+
             it('returns 404 when the requested revision does not exist', async () => {
                 renderWithProviders(
                     <Routes>

--- a/services/app-web/src/pages/SubmissionRevisionSummary/EQROSubmissionRevisionSummary/EQROSubmissionRevisionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/EQROSubmissionRevisionSummary/EQROSubmissionRevisionSummary.test.tsx
@@ -1,0 +1,201 @@
+import { screen, waitFor } from '@testing-library/react'
+import { Route, Routes } from 'react-router-dom'
+import { RoutesRecord } from '@mc-review/constants'
+import {
+    fetchCurrentUserMock,
+    fetchContractMockSuccess,
+    mockContractPackageSubmittedWithRevisions,
+    iterableCmsUsersMockData,
+} from '@mc-review/mocks'
+import { renderWithProviders } from '../../../testHelpers'
+import { EQROSubmissionRevisionSummary } from './EQROSubmissionRevisionSummary'
+
+describe('EQROSubmissionRevisionSummary', () => {
+    describe.each(iterableCmsUsersMockData)(
+        '$userRole EQROSubmissionRevisionSummary tests',
+        ({ mockUser }) => {
+            it('renders the EQRO revision snapshot without status tag or banners', async () => {
+                renderWithProviders(
+                    <Routes>
+                        <Route
+                            path={RoutesRecord.SUBMISSIONS_REVISION}
+                            element={<EQROSubmissionRevisionSummary />}
+                        />
+                    </Routes>,
+                    {
+                        apolloProvider: {
+                            mocks: [
+                                fetchCurrentUserMock({
+                                    user: mockUser(),
+                                    statusCode: 200,
+                                }),
+                                fetchContractMockSuccess({
+                                    contract:
+                                        mockContractPackageSubmittedWithRevisions(
+                                            {
+                                                id: '15',
+                                                contractSubmissionType: 'EQRO',
+                                            }
+                                        ),
+                                }),
+                            ],
+                        },
+                        routerProvider: {
+                            route: '/submissions/eqro/15/revisions/2',
+                        },
+                        featureFlags: {},
+                    }
+                )
+
+                await waitFor(() => {
+                    expect(
+                        screen.getByTestId('submission-summary')
+                    ).toBeInTheDocument()
+                })
+
+                // EQRO-style heading (the standard page would say "Submission type")
+                expect(
+                    await screen.findByRole('heading', {
+                        name: 'Submission details',
+                        level: 2,
+                    })
+                ).toBeInTheDocument()
+
+                // Contract details section still shows
+                expect(
+                    await screen.findByRole('heading', {
+                        name: 'Contract details',
+                    })
+                ).toBeInTheDocument()
+
+                // Previous submission banner is visible
+                expect(
+                    await screen.findByTestId('previous-submission-banner')
+                ).toBeInTheDocument()
+
+                // Version stamp on the selected revision
+                expect(
+                    await screen.findByTestId('revision-version')
+                ).toBeInTheDocument()
+
+                // EQRO summary section should not render rate details
+                expect(
+                    screen.queryByRole('heading', { name: 'Rate details' })
+                ).not.toBeInTheDocument()
+            })
+
+            it.each([
+                {
+                    revisionVersion: '1',
+                    submissionDescription: 'Submission 1',
+                    contractDocumentName: 'contract1',
+                    otherRevisionContractDocumentName: 'contract2',
+                },
+                {
+                    revisionVersion: '2',
+                    submissionDescription: 'Submission 2',
+                    contractDocumentName: 'contract2',
+                    otherRevisionContractDocumentName: 'contract3',
+                },
+                {
+                    revisionVersion: '3',
+                    submissionDescription: 'Submission 3',
+                    contractDocumentName: 'contract3',
+                    otherRevisionContractDocumentName: 'contract2',
+                },
+            ])(
+                'renders the snapshot form data for revision $revisionVersion',
+                async ({
+                    revisionVersion,
+                    submissionDescription,
+                    contractDocumentName,
+                    otherRevisionContractDocumentName,
+                }) => {
+                    renderWithProviders(
+                        <Routes>
+                            <Route
+                                path={RoutesRecord.SUBMISSIONS_REVISION}
+                                element={<EQROSubmissionRevisionSummary />}
+                            />
+                        </Routes>,
+                        {
+                            apolloProvider: {
+                                mocks: [
+                                    fetchCurrentUserMock({
+                                        user: mockUser(),
+                                        statusCode: 200,
+                                    }),
+                                    fetchContractMockSuccess({
+                                        contract:
+                                            mockContractPackageSubmittedWithRevisions(
+                                                {
+                                                    id: '15',
+                                                    contractSubmissionType:
+                                                        'EQRO',
+                                                }
+                                            ),
+                                    }),
+                                ],
+                            },
+                            routerProvider: {
+                                route: `/submissions/eqro/15/revisions/${revisionVersion}`,
+                            },
+                            featureFlags: {},
+                        }
+                    )
+
+                    expect(
+                        await screen.findByLabelText('Submission description')
+                    ).toHaveTextContent(submissionDescription)
+                    expect(
+                        await screen.findByText(contractDocumentName)
+                    ).toBeInTheDocument()
+                    // Documents table only lists this revision's snapshot docs
+                    expect(
+                        screen.queryByText(otherRevisionContractDocumentName)
+                    ).not.toBeInTheDocument()
+                }
+            )
+
+            it('returns 404 when the requested revision does not exist', async () => {
+                renderWithProviders(
+                    <Routes>
+                        <Route
+                            path={RoutesRecord.SUBMISSIONS_REVISION}
+                            element={<EQROSubmissionRevisionSummary />}
+                        />
+                    </Routes>,
+                    {
+                        apolloProvider: {
+                            mocks: [
+                                fetchCurrentUserMock({
+                                    user: mockUser(),
+                                    statusCode: 200,
+                                }),
+                                fetchContractMockSuccess({
+                                    contract:
+                                        mockContractPackageSubmittedWithRevisions(
+                                            {
+                                                id: '15',
+                                                contractSubmissionType: 'EQRO',
+                                            }
+                                        ),
+                                }),
+                            ],
+                        },
+                        routerProvider: {
+                            route: '/submissions/eqro/15/revisions/99',
+                        },
+                        featureFlags: {},
+                    }
+                )
+
+                expect(
+                    await screen.findByRole('heading', {
+                        name: '404 / Page not found',
+                    })
+                ).toBeInTheDocument()
+            })
+        }
+    )
+})

--- a/services/app-web/src/pages/SubmissionRevisionSummary/EQROSubmissionRevisionSummary/EQROSubmissionRevisionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/EQROSubmissionRevisionSummary/EQROSubmissionRevisionSummary.tsx
@@ -86,7 +86,12 @@ export const EQROSubmissionRevisionSummary = (): React.ReactElement => {
         )
     }
 
-    if (!contract || !targetPreviousSubmission || !name) {
+    if (
+        !contract ||
+        contract.contractSubmissionType !== 'EQRO' ||
+        !targetPreviousSubmission ||
+        !name
+    ) {
         return <Error404 />
     }
 

--- a/services/app-web/src/pages/SubmissionRevisionSummary/EQROSubmissionRevisionSummary/EQROSubmissionRevisionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/EQROSubmissionRevisionSummary/EQROSubmissionRevisionSummary.tsx
@@ -1,0 +1,141 @@
+import React, { useLayoutEffect } from 'react'
+import { GridContainer } from '@trussworks/react-uswds'
+import { useParams } from 'react-router-dom'
+import { useAuth } from '../../../contexts/AuthContext'
+import {
+    ContactsSummarySection,
+    EQROContractDetailsSummarySection,
+    EQROSubmissionTypeSummarySection,
+} from '../../../components/SubmissionSummarySection'
+import { usePage } from '../../../contexts/PageContext'
+import { formatToPacificTime } from '@mc-review/dates'
+import styles from '../SubmissionRevisionSummary.module.scss'
+import { PreviousSubmissionBanner } from '../../../components'
+import { FetchContractDocument } from '../../../gen/gqlClient'
+import { useQuery } from '@apollo/client/react'
+import {
+    ErrorOrLoadingPage,
+    handleAndReturnErrorState,
+} from '../../StateSubmission/SharedSubmissionComponents/ErrorOrLoadingPage'
+import { Error404 } from '../../Errors/Error404Page'
+import { getSubmissionPath } from '../../../routeHelpers'
+import { useMemoizedStateHeader } from '../../../hooks'
+
+export const EQROSubmissionRevisionSummary = (): React.ReactElement => {
+    const { id, revisionVersion } = useParams()
+    if (!id) {
+        throw new Error(
+            'PROGRAMMING ERROR: id param not set in state submission form.'
+        )
+    }
+    const { updateHeading } = usePage()
+    const { loggedInUser } = useAuth()
+
+    const isStateUser = loggedInUser?.role === 'STATE_USER'
+
+    const {
+        data: fetchContractData,
+        loading: fetchContractLoading,
+        error: fetchContractError,
+    } = useQuery(FetchContractDocument, {
+        variables: {
+            input: {
+                contractID: id ?? 'unknown-contract',
+            },
+        },
+        fetchPolicy: 'cache-and-network',
+    })
+    const contract = fetchContractData?.fetchContract.contract
+
+    const revisionIndex = Number(revisionVersion) - 1
+
+    const packageSubmissions = contract
+        ? [...contract.packageSubmissions]
+              .filter((submission) => {
+                  return submission.cause === 'CONTRACT_SUBMISSION'
+              })
+              .reverse()
+        : []
+    const targetPreviousSubmission =
+        packageSubmissions[revisionIndex] &&
+        packageSubmissions[revisionIndex].__typename
+            ? packageSubmissions[revisionIndex]
+            : undefined
+    const name = targetPreviousSubmission?.contractRevision.contractName
+
+    const stateHeader = useMemoizedStateHeader({
+        subHeaderText: name,
+        stateCode: contract?.state.code,
+        stateName: contract?.state.name,
+        contractType: contract?.contractSubmissionType,
+    })
+
+    useLayoutEffect(() => {
+        updateHeading({ customHeading: stateHeader })
+    }, [stateHeader, updateHeading])
+
+    if (!fetchContractData && fetchContractLoading) {
+        return <ErrorOrLoadingPage state="LOADING" />
+    }
+
+    if (!fetchContractData && fetchContractError) {
+        return (
+            <ErrorOrLoadingPage
+                state={handleAndReturnErrorState(fetchContractError)}
+            />
+        )
+    }
+
+    if (!contract || !targetPreviousSubmission || !name) {
+        return <Error404 />
+    }
+
+    const revision = targetPreviousSubmission.contractRevision
+    const submitInfo = revision.submitInfo || undefined
+
+    return (
+        <div className={styles.background}>
+            <GridContainer
+                data-testid="submission-summary"
+                className={styles.container}
+            >
+                <PreviousSubmissionBanner
+                    className={styles.banner}
+                    link={getSubmissionPath(
+                        'SUBMISSIONS_SUMMARY',
+                        contract.contractSubmissionType,
+                        contract.id
+                    )}
+                />
+                <EQROSubmissionTypeSummarySection
+                    contract={contract}
+                    contractRev={revision}
+                    isStateUser={isStateUser}
+                    headerText="Submission details"
+                    initiallySubmittedAt={contract.initiallySubmittedAt}
+                    headerChildComponent={
+                        submitInfo && (
+                            <p
+                                className={styles.submissionVersion}
+                                data-testid="revision-version"
+                            >
+                                {`${formatToPacificTime(submitInfo?.updatedAt)} version`}
+                            </p>
+                        )
+                    }
+                />
+
+                <EQROContractDetailsSummarySection
+                    contract={contract}
+                    contractRev={revision}
+                />
+
+                <ContactsSummarySection
+                    contract={contract}
+                    contractRev={revision}
+                    isStateUser={isStateUser}
+                />
+            </GridContainer>
+        </div>
+    )
+}

--- a/services/app-web/src/pages/SubmissionRevisionSummary/EQROSubmissionRevisionSummary/index.ts
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/EQROSubmissionRevisionSummary/index.ts
@@ -1,0 +1,1 @@
+export { EQROSubmissionRevisionSummary } from './EQROSubmissionRevisionSummary'

--- a/services/app-web/src/pages/SubmissionRevisionSummary/RevisionSummaryRoutes.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/RevisionSummaryRoutes.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { useRouteParams } from '../../hooks'
+import { Error404 } from '../Errors/Error404Page'
+import { EQROSubmissionRevisionSummary } from './EQROSubmissionRevisionSummary'
+import { SubmissionRevisionSummary } from './SubmissionRevisionSummary'
+
+const RevisionSummaryRoutes = ({
+    showEqroSubmissions,
+}: {
+    showEqroSubmissions: boolean
+}) => {
+    const { contractSubmissionType } = useRouteParams()
+
+    if (showEqroSubmissions && contractSubmissionType === 'eqro') {
+        return <EQROSubmissionRevisionSummary />
+    }
+    if (contractSubmissionType === 'health-plan') {
+        return <SubmissionRevisionSummary />
+    }
+    return <Error404 />
+}
+
+export { RevisionSummaryRoutes }

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.module.scss
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.module.scss
@@ -30,3 +30,7 @@
     color: custom.$mcr-gold-dark;
     margin: 0;
 }
+
+.banner {
+    margin: uswds.units(3) auto uswds.units(4) auto;
+}

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.test.tsx
@@ -259,6 +259,43 @@ describe('SubmissionRevisionSummary', () => {
                 ).toHaveTextContent('Submission 3')
             })
 
+            it('returns 404 when the contract is an EQRO submission', async () => {
+                renderWithProviders(
+                    <Routes>
+                        <Route
+                            path={RoutesRecord.SUBMISSIONS_REVISION}
+                            element={<SubmissionRevisionSummary />}
+                        />
+                    </Routes>,
+                    {
+                        apolloProvider: {
+                            mocks: [
+                                fetchCurrentUserMock({
+                                    user: mockUser(),
+                                    statusCode: 200,
+                                }),
+                                fetchContractMockSuccess({
+                                    contract:
+                                        mockContractPackageSubmittedWithRevisions(
+                                            {
+                                                id: '15',
+                                                contractSubmissionType: 'EQRO',
+                                            }
+                                        ),
+                                }),
+                            ],
+                        },
+                        routerProvider: {
+                            route: '/submissions/health-plan/15/revisions/2',
+                        },
+                        featureFlags: {},
+                    }
+                )
+                expect(await screen.findByRole('heading')).toHaveTextContent(
+                    '404 / Page not found'
+                )
+            })
+
             it('renders the error indexed version 4', async () => {
                 renderWithProviders(
                     <Routes>

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.tsx
@@ -45,7 +45,7 @@ export const SubmissionRevisionSummary = (): React.ReactElement => {
                 contractID: id ?? 'unknown-contract',
             },
         },
-        fetchPolicy: 'network-only',
+        fetchPolicy: 'cache-and-network',
     })
     const contract = fetchContractData?.fetchContract.contract
 
@@ -79,11 +79,11 @@ export const SubmissionRevisionSummary = (): React.ReactElement => {
     }, [stateHeader, updateHeading])
 
     // Display any full page interim state resulting from the initial fetch API requests
-    if (fetchContractLoading) {
+    if (!fetchContractData && fetchContractLoading) {
         return <ErrorOrLoadingPage state="LOADING" />
     }
 
-    if (fetchContractError) {
+    if (!fetchContractData && fetchContractError) {
         return (
             <ErrorOrLoadingPage
                 state={handleAndReturnErrorState(fetchContractError)}
@@ -115,6 +115,7 @@ export const SubmissionRevisionSummary = (): React.ReactElement => {
                 className={styles.container}
             >
                 <PreviousSubmissionBanner
+                    className={styles.banner}
                     link={getSubmissionPath(
                         'SUBMISSIONS_SUMMARY',
                         contract.contractSubmissionType,

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.tsx
@@ -91,7 +91,12 @@ export const SubmissionRevisionSummary = (): React.ReactElement => {
         )
     }
 
-    if (!contract || !targetPreviousSubmission || !name) {
+    if (
+        !contract ||
+        contract.contractSubmissionType !== 'HEALTH_PLAN' ||
+        !targetPreviousSubmission ||
+        !name
+    ) {
         return <Error404 />
     }
 

--- a/services/app-web/src/pages/SubmissionRevisionSummary/index.ts
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/index.ts
@@ -1,1 +1,3 @@
 export { SubmissionRevisionSummary } from './SubmissionRevisionSummary'
+export { RevisionSummaryRoutes } from './RevisionSummaryRoutes'
+export { EQROSubmissionRevisionSummary } from './EQROSubmissionRevisionSummary'

--- a/services/cypress/support/stateSubmissionFormCommands.ts
+++ b/services/cypress/support/stateSubmissionFormCommands.ts
@@ -663,10 +663,17 @@ Cypress.Commands.add('fillOutSupportingDocuments', () => {
 
 // for file upload with the table view and checkboxes- tableView can be assigned to a number that represents how many items in the list should be preses
 Cypress.Commands.add('waitForDocumentsToLoad', () => {
-    // list view is the default behavior
-    cy.findAllByTestId('file-input-preview-image', {
-        timeout: 200_000,
-    }).should('not.have.class', 'is-loading')
+    // React 19 + current FileUpload/Formik updates can replace preview nodes while
+    // uploads transition from PENDING -> SCANNING -> UPLOAD_COMPLETE.
+    // Use the current query root so this works both inside and outside `within()`.
+    // Assert via a callback so Cypress retries the whole check without requiring
+    // a transient loading element to exist first.
+    cy.root({ timeout: 200_000 }).should(($root) => {
+        expect(
+            $root.find('[data-testid="file-input-preview-image"].is-loading')
+                .length
+        ).to.eq(0)
+    })
 })
 
 Cypress.Commands.add('verifyDocumentsHaveNoErrors', () => {


### PR DESCRIPTION
## Summary
[MCR-6275](https://jiraent.cms.gov/browse/MCR-6275): Users can view the previous submissions for EQRO submissions
[MCR-6089](https://jiraent.cms.gov/browse/MCR-6089): No padding between alert and content section (prev submission page)

This work adds a EQRO previous submission summary page and fixes the banner spacing on that page

AC:
- When a user view a previous EQRO submission, they should see EQRO specific fields.
- Review determination should be for the version being viewed.
- State tag and EQRO banners are not to be added.
- Keep the current previous submission banner to allow users to navigate back to latest submission summary.
- Unit tests

#### Related issues

#### Screenshots

#### Test cases covered

`EQROSubmissionRevisionSummary.test.tsx`
- 'renders the EQRO revision snapshot without status tag or banners'
- `'renders the snapshot form data for revision $revisionVersion'`: Validating displaying correct data on multiple submission versions.
- `'returns 404 when the requested revision does not exist'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

- Test to make sure previous submission page displays correctly for EQRO and Health plan submissions
- Test to make EQRO flag off does not break Health plan previous submission summary page

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed