### PR TITLE
MCR-6047 Restrict creating EQRO contract questions to DMCO users

### DIFF
--- a/API_Changelog.md
+++ b/API_Changelog.md
@@ -1,6 +1,13 @@
 # Managed Care Review - API Changelog
 ## This document highlights API changes that have been introduced since May 2025. See the full [GraphQL schema](services/app-graphql/src/schema.graphql).
 
+### May 28, 2026
+#### Updated
+- `createContractQuestion` now rejects EQRO contract questions from CMS users who are not assigned to the `DMCO` division.
+    - Applies only to `EQRO` submissions.
+    - `HEALTH_PLAN` submissions continue to allow contract questions from CMS users in any assigned CMS division.
+    - API clients should expect a `FORBIDDEN` error when a non-`DMCO` CMS user attempts to create a question for an `EQRO` contract.
+
 ### May 13, 2026
 #### Updated
 - Renamed mutation `reverseUnlockContract` to `undoUnlockContract`

--- a/services/app-api/src/resolvers/questionResponse/createContractQuestion.test.ts
+++ b/services/app-api/src/resolvers/questionResponse/createContractQuestion.test.ts
@@ -350,6 +350,68 @@ describe('createQuestion', () => {
             `users without an assigned division are not authorized to create a question`
         )
     })
+    it('returns an error if a non-DMCO CMS user attempts to create a question for an EQRO contract', async () => {
+        const oactCmsUser = testCMSUser({ divisionAssignment: 'OACT' })
+        await createDBUsersWithFullData([oactCmsUser])
+
+        const stateServer = await constructTestPostgresServer()
+        const oactCmsServer = await constructTestPostgresServer({
+            context: {
+                user: oactCmsUser,
+            },
+        })
+
+        const draft = await createAndUpdateTestEQROContract(stateServer)
+        const contract = await submitTestContract(stateServer, draft.id)
+
+        const createdQuestion = await executeGraphQLOperation(oactCmsServer, {
+            query: CreateContractQuestionDocument,
+            variables: {
+                input: {
+                    contractID: contract.id,
+                    documents: [
+                        {
+                            name: 'Test Question',
+                            s3URL: 's3://bucketname/key/test1',
+                        },
+                    ],
+                },
+            },
+        })
+
+        expect(createdQuestion.errors).toBeDefined()
+        expect(assertAnErrorCode(createdQuestion)).toBe('FORBIDDEN')
+        expect(assertAnError(createdQuestion).message).toBe(
+            'users not assigned to the DMCO division are not authorized to create EQRO contract questions'
+        )
+    })
+    it('allows a non-DMCO CMS user to create a question for a health plan submission', async () => {
+        const oactCmsUser = testCMSUser({ divisionAssignment: 'OACT' })
+        await createDBUsersWithFullData([oactCmsUser])
+
+        const stateServer = await constructTestPostgresServer()
+        const oactCmsServer = await constructTestPostgresServer({
+            context: {
+                user: oactCmsUser,
+            },
+        })
+
+        const contract = await createAndSubmitTestContractWithRate(stateServer)
+
+        const createdQuestion = await createTestQuestion(
+            oactCmsServer,
+            contract.id
+        )
+
+        expect(createdQuestion).toEqual(
+            expect.objectContaining({
+                id: expect.any(String),
+                contractID: contract.id,
+                division: 'OACT',
+                addedBy: oactCmsUser,
+            })
+        )
+    })
     it('send state email to state contacts and all submitters when submitting a question succeeds', async () => {
         const config = testEmailConfig()
         const mockEmailer = testEmailer(config)

--- a/services/app-api/src/resolvers/questionResponse/createContractQuestion.test.ts
+++ b/services/app-api/src/resolvers/questionResponse/createContractQuestion.test.ts
@@ -382,7 +382,7 @@ describe('createQuestion', () => {
         expect(createdQuestion.errors).toBeDefined()
         expect(assertAnErrorCode(createdQuestion)).toBe('FORBIDDEN')
         expect(assertAnError(createdQuestion).message).toBe(
-            'users not assigned to the DMCO division are not authorized to create EQRO contract questions'
+            'only users assigned to the DMCO division are authorized to create EQRO contract questions'
         )
     })
     it('allows a non-DMCO CMS user to create a question for a health plan submission', async () => {

--- a/services/app-api/src/resolvers/questionResponse/createContractQuestion.ts
+++ b/services/app-api/src/resolvers/questionResponse/createContractQuestion.ts
@@ -95,6 +95,16 @@ export function createContractQuestionResolver(
                     })
                 }
 
+                if (
+                    contractResult.contractSubmissionType === 'EQRO' &&
+                    user.divisionAssignment !== 'DMCO'
+                ) {
+                    const msg =
+                        'only users assigned to the DMCO division are authorized to create EQRO contract questions'
+                    logResolverError('createContractQuestion', msg, context)
+                    throw createForbiddenError(msg)
+                }
+
                 // Return error if contract status is DRAFT, contract will have no submitted revisions
                 // Return error if contract has been approved
                 if (


### PR DESCRIPTION

[CreateContractQuestionGraphqlExplorer.txt](https://github.com/user-attachments/files/28367413/CreateContractQuestionGraphqlExplorer.txt)
## Summary
Restrict non-DMCO users from adding questions to EQRO submissions
#### Related issues
[MCR-6047](https://jiraent.cms.gov/browse/MCR-6047)
#### Screenshots
<img width="993" height="650" alt="Screenshot 2026-05-28 at 4 12 40 PM" src="https://github.com/user-attachments/assets/ee93ad13-efb4-45f0-a0eb-e99689147eaa" />

#### Test cases covered
createContractQuestion.test.ts
returns an error if a non-DMCO CMS user attempts to create a question for an EQRO contract
allows a non-DMCO CMS user to create a question for a health plan submission

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
When logged in as Admin, assign Division to CMS Approver. Log in as CMS Approver, see if question can be created using GraphQL explorer UI (/dev/graphql-explorer). Use mutations -> CreateContractQuestion path. 
See attached file CreateContractQuestionGraphqlExplorer for a sample query statement
<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed