### PR TITLE
MCR-6279 Fix links to submission form guidance page

### DIFF
--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -77,24 +77,6 @@ import { CreateOauthClient } from '../Settings/Oauth/CreateOauthClient'
 import { User } from '../../gen/gqlClient'
 import { AddLocalUser } from '../../localAuth/AddLocalUser'
 
-const RedirectPreservingHash = ({
-    pathname,
-}: {
-    pathname: string
-}): React.ReactElement => {
-    const location = useLocation()
-
-    return (
-        <Navigate
-            to={{
-                pathname,
-                hash: location.hash,
-            }}
-            replace
-        />
-    )
-}
-
 const CMSUploadQuestionsRoute = ({
     loggedInUser,
     children,
@@ -141,15 +123,13 @@ const renderUniversalRoutes = (showResourcesNavPages: boolean) => (
         />
         <Route
             path="/help"
-            element={<RedirectPreservingHash pathname={RoutesRecord.HELP} />}
+            element={<Navigate to={RoutesRecord.HELP} replace />}
         />
         <Route
             path="/training"
             element={
                 showResourcesNavPages ? (
-                    <RedirectPreservingHash
-                        pathname={RoutesRecord.RESOURCES_TRAINING}
-                    />
+                    <Navigate to={RoutesRecord.RESOURCES_TRAINING} replace />
                 ) : (
                     <Error404 />
                 )

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -77,6 +77,24 @@ import { CreateOauthClient } from '../Settings/Oauth/CreateOauthClient'
 import { User } from '../../gen/gqlClient'
 import { AddLocalUser } from '../../localAuth/AddLocalUser'
 
+const RedirectPreservingHash = ({
+    pathname,
+}: {
+    pathname: string
+}): React.ReactElement => {
+    const location = useLocation()
+
+    return (
+        <Navigate
+            to={{
+                pathname,
+                hash: location.hash,
+            }}
+            replace
+        />
+    )
+}
+
 const CMSUploadQuestionsRoute = ({
     loggedInUser,
     children,
@@ -123,13 +141,15 @@ const renderUniversalRoutes = (showResourcesNavPages: boolean) => (
         />
         <Route
             path="/help"
-            element={<Navigate to={RoutesRecord.HELP} replace />}
+            element={<RedirectPreservingHash pathname={RoutesRecord.HELP} />}
         />
         <Route
             path="/training"
             element={
                 showResourcesNavPages ? (
-                    <Navigate to={RoutesRecord.RESOURCES_TRAINING} replace />
+                    <RedirectPreservingHash
+                        pathname={RoutesRecord.RESOURCES_TRAINING}
+                    />
                 ) : (
                     <Error404 />
                 )

--- a/services/app-web/src/pages/Landing/Landing.tsx
+++ b/services/app-web/src/pages/Landing/Landing.tsx
@@ -126,7 +126,9 @@ export const Landing = (): React.ReactElement => {
                                             <li>
                                                 <LinkWithLogging
                                                     aria-label="Required supporting documents"
-                                                    href={'/help#key-documents'}
+                                                    href={
+                                                        '/resources/help#key-documents'
+                                                    }
                                                 >
                                                     Required supporting
                                                     documents
@@ -145,7 +147,9 @@ export const Landing = (): React.ReactElement => {
                                             <li>
                                                 <LinkWithLogging
                                                     aria-label="Required supporting documents"
-                                                    href={'/help#key-documents'}
+                                                    href={
+                                                        '/resources/help#key-documents'
+                                                    }
                                                 >
                                                     Supporting documents
                                                 </LinkWithLogging>
@@ -255,7 +259,9 @@ export const Landing = (): React.ReactElement => {
                                     <li>
                                         <LinkWithLogging
                                             aria-label="Required supporting documents"
-                                            href={'/help#key-documents'}
+                                            href={
+                                                '/resources/help#key-documents'
+                                            }
                                         >
                                             Required supporting documents
                                         </LinkWithLogging>{' '}

--- a/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROContractDetails/EQROContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROContractDetails/EQROContractDetails.tsx
@@ -457,7 +457,7 @@ export const EQROContractDetails = ({
                                                         <LinkWithLogging
                                                             aria-label="Document definitions and requirements (opens in new window)"
                                                             href={
-                                                                '/help#key-documents'
+                                                                '/resources/help#key-documents'
                                                             }
                                                             variant="external"
                                                             target="_blank"
@@ -536,7 +536,7 @@ export const EQROContractDetails = ({
                                                         <LinkWithLogging
                                                             aria-label="Document definitions and requirements (opens in new window)"
                                                             href={
-                                                                '/help#supporting-documents'
+                                                                '/resources/help#supporting-documents'
                                                             }
                                                             variant="external"
                                                             target="_blank"
@@ -609,7 +609,7 @@ export const EQROContractDetails = ({
                                                 <LinkWithLogging
                                                     aria-label="Effective date guidance (opens in new window)"
                                                     href={
-                                                        '/help#effective-date-guidance'
+                                                        '/resources/help#effective-date-guidance'
                                                     }
                                                     variant="external"
                                                     target="_blank"

--- a/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROSubmissionDetails/EQROSubmissionDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROSubmissionDetails/EQROSubmissionDetails.tsx
@@ -550,7 +550,7 @@ export const EQROSubmissionDetails = (): React.ReactElement => {
                                             <ReactRouterLinkWithLogging
                                                 variant="external"
                                                 to={{
-                                                    pathname: '/help',
+                                                    pathname: '/resources/help',
                                                     hash: '#submission-description',
                                                 }}
                                                 target="_blank"

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ContractDetails/ContractDetails.tsx
@@ -648,7 +648,7 @@ export const ContractDetails = ({
                                                     <LinkWithLogging
                                                         aria-label="Document definitions and requirements (opens in new window)"
                                                         href={
-                                                            '/help#key-documents'
+                                                            '/resources/help#key-documents'
                                                         }
                                                         variant="external"
                                                         target="_blank"
@@ -725,7 +725,7 @@ export const ContractDetails = ({
                                                         <LinkWithLogging
                                                             aria-label="Document definitions and requirements (opens in new window)"
                                                             href={
-                                                                '/help#supporting-documents'
+                                                                '/resources/help#supporting-documents'
                                                             }
                                                             variant="external"
                                                             target="_blank"
@@ -912,7 +912,7 @@ export const ContractDetails = ({
                                                             }
                                                             to={{
                                                                 pathname:
-                                                                    '/help',
+                                                                    '/resources/help',
                                                                 hash: '#non-compliance-guidance',
                                                             }}
                                                             target="_blank"
@@ -1020,7 +1020,7 @@ export const ContractDetails = ({
                                                     <LinkWithLogging
                                                         aria-label="Effective date guidance (opens in new window)"
                                                         href={
-                                                            '/help#effective-date-guidance'
+                                                            '/resources/help#effective-date-guidance'
                                                         }
                                                         variant="external"
                                                         target="_blank"
@@ -1289,7 +1289,7 @@ export const ContractDetails = ({
                                                             <LinkWithLogging
                                                                 variant="external"
                                                                 href={
-                                                                    '/help#dual-eligible-special-needs-plans'
+                                                                    '/resources/help#dual-eligible-special-needs-plans'
                                                                 }
                                                                 target="_blank"
                                                                 data-testid="dsnpGuidanceLink"

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/RateDetails/SingleRateFormFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/RateDetails/SingleRateFormFields.tsx
@@ -121,7 +121,7 @@ export const SingleRateFormFields = ({
                         <span className={styles.guidanceTextBlockNoPadding}>
                             <LinkWithLogging
                                 aria-label="Document definitions and requirements (opens in new window)"
-                                href={'/help#key-documents'}
+                                href={'/resources/help#key-documents'}
                                 variant="external"
                                 target="_blank"
                             >
@@ -163,7 +163,7 @@ export const SingleRateFormFields = ({
                         <span className={styles.guidanceTextBlockNoPadding}>
                             <LinkWithLogging
                                 aria-label="Document definitions and requirements (opens in new window)"
-                                href={'/help#key-documents'}
+                                href={'/resources/help#key-documents'}
                                 variant="external"
                                 target="_blank"
                             >
@@ -312,7 +312,7 @@ export const SingleRateFormFields = ({
 
                     <LinkWithLogging
                         aria-label="Rate certification type definitions (opens in new window)"
-                        href={'/help#rate-cert-type-definitions'}
+                        href={'/resources/help#rate-cert-type-definitions'}
                         variant="external"
                         target="_blank"
                     >

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/SubmissionType/SubmissionType.tsx
@@ -740,7 +740,8 @@ export const SubmissionType = ({
                                                 <ReactRouterLinkWithLogging
                                                     variant="external"
                                                     to={{
-                                                        pathname: '/help',
+                                                        pathname:
+                                                            '/resources/help',
                                                         hash: '#submission-description',
                                                     }}
                                                     target="_blank"


### PR DESCRIPTION
## Summary
Links to the submission form guidance page should scroll to the different sections of the page depending on context
#### Related issues
[MCR-6279](https://jiraent.cms.gov/browse/MCR-6279)
#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
Click on links to submission form guidance page. See if it scrolls to the section noted in the link.

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed