### PR TITLE
MCR-6279 fix  links to specific locations in help documentation

### DIFF
--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/RateDetails/SingleRateCert.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/RateDetails/SingleRateCert.tsx
@@ -271,7 +271,7 @@ export const SingleRateCert = ({
 
                         <LinkWithLogging
                             aria-label="Rate certification type definitions (opens in new window)"
-                            href={'/help#rate-cert-type-definitions'}
+                            href={'/resources/help#rate-cert-type-definitions'}
                             variant="external"
                             target="_blank"
                         >

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/RateDetails/SingleRateCert.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/RateDetails/SingleRateCert.tsx
@@ -154,7 +154,7 @@ export const SingleRateCert = ({
                             <span className={styles.guidanceTextBlockNoPadding}>
                                 <LinkWithLogging
                                     aria-label="Document definitions and requirements (opens in new window)"
-                                    href={'/help#key-documents'}
+                                    href={'/resources/help#key-documents'}
                                     variant="external"
                                     target="_blank"
                                 >
@@ -200,7 +200,7 @@ export const SingleRateCert = ({
                             <span className={styles.guidanceTextBlockNoPadding}>
                                 <LinkWithLogging
                                     aria-label="Document definitions and requirements (opens in new window)"
-                                    href={'/help#key-documents'}
+                                    href={'/resources/help#key-documents'}
                                     variant="external"
                                     target="_blank"
                                 >


### PR DESCRIPTION
## Summary
Links to help page should point to different sections, depending on context
#### Related issues
[MCR-6279](https://jiraent.cms.gov/browse/MCR-6279)
#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
Click on links to help documentation page, observe correct sections being displayed.

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed