### PR TITLE
MCR-6279 Fix routing for the help documentation page

### DIFF
--- a/services/app-web/src/components/Header/Header.test.tsx
+++ b/services/app-web/src/components/Header/Header.test.tsx
@@ -176,6 +176,24 @@ describe('Header', () => {
                 ).not.toBeInTheDocument()
             })
         })
+
+        it('does not show public navigation while auth is still loading on an unknown route', async () => {
+            renderWithProviders(<Header authMode={'AWS_COGNITO'} />, {
+                routerProvider: {
+                    route: '/submissions/new/health-plan/stingray',
+                },
+                apolloProvider: {
+                    mocks: [],
+                },
+                featureFlags: { 'resources-nav-pages': true },
+            })
+
+            expect(
+                screen.queryByRole('navigation', {
+                    name: 'Public page navigation',
+                })
+            ).not.toBeInTheDocument()
+        })
     })
 
     describe('when logged in', () => {

--- a/services/app-web/src/components/Header/Header.test.tsx
+++ b/services/app-web/src/components/Header/Header.test.tsx
@@ -120,6 +120,29 @@ describe('Header', () => {
             ).not.toHaveAttribute('aria-current')
         })
 
+        it('shows public navigation on unknown public routes when feature flag is enabled', async () => {
+            renderWithProviders(<Header authMode={'AWS_COGNITO'} />, {
+                routerProvider: { route: '/sport' },
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 403 })],
+                },
+                featureFlags: { 'resources-nav-pages': true },
+            })
+
+            await waitFor(() => {
+                expect(
+                    screen.getByRole('navigation', {
+                        name: 'Public page navigation',
+                    })
+                ).toBeInTheDocument()
+            })
+
+            expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute(
+                'aria-current',
+                'page'
+            )
+        })
+
         it('highlights Resources navigation for the help page when feature flag is enabled', async () => {
             renderWithProviders(<Header authMode={'AWS_COGNITO'} />, {
                 routerProvider: { route: '/resources/help' },

--- a/services/app-web/src/components/Header/Header.tsx
+++ b/services/app-web/src/components/Header/Header.tsx
@@ -44,6 +44,7 @@ export const Header = ({
         showResourcesNavPages &&
         [
             'ROOT',
+            'UNKNOWN_ROUTE',
             'RESOURCES',
             'HELP',
             'CONTACT_US',

--- a/services/app-web/src/components/Header/Header.tsx
+++ b/services/app-web/src/components/Header/Header.tsx
@@ -40,7 +40,7 @@ export const Header = ({
         featureFlags.RESOURCES_NAV_PAGES.defaultValue
     )
     const shouldShowPublicNavigation =
-        !loggedInUser &&
+        loginStatus === 'LOGGED_OUT' &&
         showResourcesNavPages &&
         [
             'ROOT',

--- a/services/app-web/src/components/Header/PublicNavigation/PublicNavigation.tsx
+++ b/services/app-web/src/components/Header/PublicNavigation/PublicNavigation.tsx
@@ -21,7 +21,7 @@ const publicNavItems: PublicNavItem[] = [
     {
         label: 'Home',
         to: RoutesRecord.ROOT,
-        isActive: (route) => route === 'ROOT',
+        isActive: (route) => route === 'ROOT' || route === 'UNKNOWN_ROUTE',
     },
     {
         label: 'Resources',

--- a/services/app-web/src/pages/App/AppRoutes.test.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.test.tsx
@@ -303,63 +303,6 @@ describe('AppRoutes and routing configuration', () => {
         })
     })
 
-    describe('/help', () => {
-        it('shows 404 page for state users', async () => {
-            renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
-                routerProvider: { route: '/help' },
-                apolloProvider: {
-                    mocks: [
-                        fetchCurrentUserMock({
-                            statusCode: 200,
-                        }),
-                    ],
-                },
-                featureFlags: { 'session-expiring-modal': false },
-            })
-
-            await waitFor(() => {
-                expect404Page()
-            })
-        })
-
-        it('shows 404 page for CMS users', async () => {
-            renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
-                routerProvider: { route: '/help' },
-                apolloProvider: {
-                    mocks: [
-                        fetchCurrentUserMock({
-                            statusCode: 200,
-                            user: mockValidCMSUser(),
-                        }),
-                    ],
-                },
-                featureFlags: { 'session-expiring-modal': false },
-            })
-
-            await waitFor(() => {
-                expect404Page()
-            })
-        })
-
-        it('shows 404 page for unauthenticated users', async () => {
-            renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
-                routerProvider: { route: '/help' },
-                apolloProvider: {
-                    mocks: [
-                        fetchCurrentUserMock({
-                            statusCode: 403,
-                        }),
-                    ],
-                },
-                featureFlags: { 'session-expiring-modal': false },
-            })
-
-            await waitFor(() => {
-                expect404Page()
-            })
-        })
-    })
-
     describe('/contact-us', () => {
         it('can be accessed by state user', async () => {
             renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
@@ -722,7 +665,7 @@ describe('AppRoutes and routing configuration', () => {
     })
 
     describe('invalid routes', () => {
-        it('shows 404 page when no user', async () => {
+        it('shows the landing page when no user', async () => {
             renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
                 routerProvider: { route: '/not-a-real-place' },
                 apolloProvider: {
@@ -736,7 +679,12 @@ describe('AppRoutes and routing configuration', () => {
             })
 
             await waitFor(() => {
-                expect404Page()
+                expect(
+                    screen.getByRole('heading', {
+                        name: /How it works/i,
+                        level: 2,
+                    })
+                ).toBeInTheDocument()
             })
         })
 

--- a/services/app-web/src/pages/App/AppRoutes.test.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.test.tsx
@@ -245,10 +245,10 @@ describe('AppRoutes and routing configuration', () => {
         })
     })
 
-    describe('/help', () => {
+    describe('/resources/help', () => {
         it('can be accessed by state user', async () => {
             renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
-                routerProvider: { route: '/help' },
+                routerProvider: { route: '/resources/help' },
                 apolloProvider: {
                     mocks: [
                         fetchCurrentUserMock({
@@ -267,7 +267,7 @@ describe('AppRoutes and routing configuration', () => {
 
         it('can be accessed by CMS user', async () => {
             renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
-                routerProvider: { route: '/help' },
+                routerProvider: { route: '/resources/help' },
                 apolloProvider: {
                     mocks: [
                         fetchCurrentUserMock({
@@ -286,7 +286,7 @@ describe('AppRoutes and routing configuration', () => {
 
         it('can be accessed by unauthenticated users', async () => {
             renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
-                routerProvider: { route: '/help' },
+                routerProvider: { route: '/resources/help' },
                 apolloProvider: {
                     mocks: [
                         fetchCurrentUserMock({
@@ -299,6 +299,63 @@ describe('AppRoutes and routing configuration', () => {
             await screen.findByTestId('help-unauthenticated')
             await waitFor(() => {
                 expectSubmissionFormGuidancePage()
+            })
+        })
+    })
+
+    describe('/help', () => {
+        it('shows 404 page for state users', async () => {
+            renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
+                routerProvider: { route: '/help' },
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            statusCode: 200,
+                        }),
+                    ],
+                },
+                featureFlags: { 'session-expiring-modal': false },
+            })
+
+            await waitFor(() => {
+                expect404Page()
+            })
+        })
+
+        it('shows 404 page for CMS users', async () => {
+            renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
+                routerProvider: { route: '/help' },
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            statusCode: 200,
+                            user: mockValidCMSUser(),
+                        }),
+                    ],
+                },
+                featureFlags: { 'session-expiring-modal': false },
+            })
+
+            await waitFor(() => {
+                expect404Page()
+            })
+        })
+
+        it('shows 404 page for unauthenticated users', async () => {
+            renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
+                routerProvider: { route: '/help' },
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            statusCode: 403,
+                        }),
+                    ],
+                },
+                featureFlags: { 'session-expiring-modal': false },
+            })
+
+            await waitFor(() => {
+                expect404Page()
             })
         })
     })
@@ -640,7 +697,7 @@ describe('AppRoutes and routing configuration', () => {
         })
     })
 
-    describe('/resources/help', () => {
+    describe('/resources/help link', () => {
         it('shows Submission form guidance without sidenav when feature flag is off', async () => {
             renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
                 routerProvider: { route: '/resources/help' },
@@ -665,7 +722,7 @@ describe('AppRoutes and routing configuration', () => {
     })
 
     describe('invalid routes', () => {
-        it('redirect to landing page when no user', async () => {
+        it('shows 404 page when no user', async () => {
             renderWithProviders(<AppRoutes authMode={'AWS_COGNITO'} />, {
                 routerProvider: { route: '/not-a-real-place' },
                 apolloProvider: {
@@ -679,12 +736,7 @@ describe('AppRoutes and routing configuration', () => {
             })
 
             await waitFor(() => {
-                expect(
-                    screen.getByRole('heading', {
-                        name: /How it works/i,
-                        level: 2,
-                    })
-                ).toBeInTheDocument()
+                expect404Page()
             })
         })
 

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -122,20 +122,6 @@ const renderUniversalRoutes = (showResourcesNavPages: boolean) => (
             element={showResourcesNavPages ? <ContactUs /> : <Error404 />}
         />
         <Route
-            path="/help"
-            element={<Navigate to={RoutesRecord.HELP} replace />}
-        />
-        <Route
-            path="/training"
-            element={
-                showResourcesNavPages ? (
-                    <Navigate to={RoutesRecord.RESOURCES_TRAINING} replace />
-                ) : (
-                    <Error404 />
-                )
-            }
-        />
-        <Route
             path={RoutesRecord.RESOURCES}
             element={<ResourcesSideNav showSideNav={showResourcesNavPages} />}
         >
@@ -538,7 +524,7 @@ const UnauthenticatedRoutes = ({
                     element={<AddLocalUser />}
                 />
             )}
-            <Route path="*" element={<Landing />} />
+            <Route path="*" element={<Error404 />} />
         </Routes>
     )
 }

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -524,7 +524,7 @@ const UnauthenticatedRoutes = ({
                     element={<AddLocalUser />}
                 />
             )}
-            <Route path="*" element={<Error404 />} />
+            <Route path="*" element={<Landing />} />
         </Routes>
     )
 }


### PR DESCRIPTION
## Summary
In the previous ticket all existing links to help documentation are updated to reflect new routing: "/resources/help". In this ticket the code to silently promote "/help" to "/resources/help" is removed, since it is no longer needed. 


Also, when navigating to 404 page for logged in user (wrong url entered by user), the nav bar was briefly displayed due to user having undefined Auth status for a moment. Fixed that, which also takes care or MCR-6234

#### Related issues
[MCR-6279](https://jiraent.cms.gov/browse/MCR-6279)
[MCR-6234](https://jiraent.cms.gov/browse/MCR-6234)
#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
Now links: "/help", "/training" are treated as invalid and result in "404" page. Links "/resources/help" and "/resources/training" are recognized.

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed