### PR TITLE
Enables automatic Secrets Manager rotation for the Aurora PostgreSQL admin password.

### DIFF
--- a/services/infra-cdk/lib/config/environments.ts
+++ b/services/infra-cdk/lib/config/environments.ts
@@ -11,6 +11,7 @@ export interface DatabaseConfig {
     minCapacity: number
     maxCapacity: number
     backupRetentionDays: number
+    passwordRotationDays: number
     deletionProtection: boolean
     enableDataApi: boolean
 }
@@ -45,6 +46,7 @@ const BASE_CONFIG = {
     database: {
         minCapacity: 1,
         maxCapacity: 16,
+        passwordRotationDays: 90,
         enableDataApi: true,
     },
     lambda: {

--- a/services/infra-cdk/lib/config/environments.ts
+++ b/services/infra-cdk/lib/config/environments.ts
@@ -46,7 +46,7 @@ const BASE_CONFIG = {
     database: {
         minCapacity: 1,
         maxCapacity: 16,
-        passwordRotationDays: 90,
+        passwordRotationDays: 30,
         enableDataApi: true,
     },
     lambda: {

--- a/services/infra-cdk/lib/constructs/database/aurora-serverless-v2.ts
+++ b/services/infra-cdk/lib/constructs/database/aurora-serverless-v2.ts
@@ -67,7 +67,7 @@ export class AuroraServerlessV2 extends Construct {
                 version: AuroraPostgresEngineVersion.VER_16_9,
             }),
             credentials: Credentials.fromGeneratedSecret('mcreviewadmin', {
-                secretName: `aurora-postgres-${props.stage}-cdk`, // pragma: allowlist secret
+                secretName: `aurora-postgres-${props.stage}-cdk-rotating`, // pragma: allowlist secret
                 excludeCharacters: ' %+~`#$&*()|[]{}:;<>?!\'/@"\\',
             }),
             clusterIdentifier: ResourceNames.resourceName(

--- a/services/infra-cdk/lib/constructs/database/aurora-serverless-v2.ts
+++ b/services/infra-cdk/lib/constructs/database/aurora-serverless-v2.ts
@@ -7,15 +7,13 @@ import {
     ClusterInstance,
 } from 'aws-cdk-lib/aws-rds'
 import type { IVpc, SubnetSelection, ISecurityGroup } from 'aws-cdk-lib/aws-ec2'
-import { Secret } from 'aws-cdk-lib/aws-secretsmanager'
-import type { ISecret } from 'aws-cdk-lib/aws-secretsmanager'
+import { Secret, type ISecret } from 'aws-cdk-lib/aws-secretsmanager'
 import { Duration, RemovalPolicy, Stack } from 'aws-cdk-lib'
 import type { DatabaseConfig } from '../../config/environments'
 import { ResourceNames } from '../../config/shared'
 
 export interface AuroraServerlessV2Props {
     databaseName: string
-    databaseSecretName: string
     stage: string
     vpc: IVpc
     vpcSubnets: SubnetSelection
@@ -61,22 +59,27 @@ export class AuroraServerlessV2 extends Construct {
             )
         }
 
-        // Create the Aurora Serverless v2 cluster.
-        // Use the existing, stable database secret so exported secret names do not change.
-        const databaseSecret = Secret.fromSecretNameV2(
-            this,
-            'DatabaseSecret',
-            props.databaseSecretName
-        )
+        // Create database credentials secret
+        // Use CDK-specific naming to avoid conflicts with serverless
+        this.secret = new Secret(this, 'Secret', {
+            secretName: `aurora-postgres-${props.stage}-cdk`, // pragma: allowlist secret
+            description: `Database credentials for ${props.databaseName} - ${props.stage}`,
+            generateSecretString: {
+                secretStringTemplate: JSON.stringify({
+                    username: 'mcreviewadmin',
+                }),
+                generateStringKey: 'password',
+                excludeCharacters: ' %+~`#$&*()|[]{}:;<>?!\'/@"\\',
+                passwordLength: 30,
+            },
+        })
 
+        // Create the Aurora Serverless v2 cluster
         this.cluster = new DatabaseCluster(this, 'Cluster', {
             engine: DatabaseClusterEngine.auroraPostgres({
                 version: AuroraPostgresEngineVersion.VER_16_9,
             }),
-            credentials: Credentials.fromSecret(
-                databaseSecret,
-                'mcreviewadmin'
-            ),
+            credentials: Credentials.fromSecret(this.secret),
             clusterIdentifier: ResourceNames.resourceName(
                 'postgres',
                 'cluster',
@@ -109,9 +112,6 @@ export class AuroraServerlessV2 extends Construct {
                 publiclyAccessible: false,
             }),
         })
-
-        // cluster.secret is the attached database secret with connection fields populated.
-        this.secret = this.cluster.secret!
 
         // Rotate the admin password via the Secrets Manager hosted rotation Lambda.
         this.cluster.addRotationSingleUser({

--- a/services/infra-cdk/lib/constructs/database/aurora-serverless-v2.ts
+++ b/services/infra-cdk/lib/constructs/database/aurora-serverless-v2.ts
@@ -59,15 +59,20 @@ export class AuroraServerlessV2 extends Construct {
             )
         }
 
-        const databaseSecretName = `aurora-postgres-${props.stage}-cdk` // pragma: allowlist secret
-
-        // Import the existing database credentials secret by the same name this
-        // construct previously created.
-        this.secret = Secret.fromSecretNameV2(
-            this,
-            'Secret',
-            databaseSecretName
-        )
+        // Create database credentials secret
+        // Use CDK-specific naming to avoid conflicts with serverless
+        this.secret = new Secret(this, 'Secret', {
+            secretName: `aurora-postgres-${props.stage}-cdk`, // pragma: allowlist secret
+            description: `Database credentials for ${props.databaseName} - ${props.stage}`,
+            generateSecretString: {
+                secretStringTemplate: JSON.stringify({
+                    username: 'mcreviewadmin',
+                }),
+                generateStringKey: 'password',
+                excludeCharacters: ' %+~`#$&*()|[]{}:;<>?!\'/@"\\',
+                passwordLength: 30,
+            },
+        })
 
         // Create the Aurora Serverless v2 cluster
         this.cluster = new DatabaseCluster(this, 'Cluster', {
@@ -116,6 +121,7 @@ export class AuroraServerlessV2 extends Construct {
             vpcSubnets: props.vpcSubnets,
             securityGroup: props.securityGroup,
             excludeCharacters: ' %+~`#$&*()|[]{}:;<>?!\'/@"\\',
+            rotateImmediatelyOnUpdate: false,
         })
     }
 }

--- a/services/infra-cdk/lib/constructs/database/aurora-serverless-v2.ts
+++ b/services/infra-cdk/lib/constructs/database/aurora-serverless-v2.ts
@@ -5,9 +5,10 @@ import {
     AuroraPostgresEngineVersion,
     Credentials,
     ClusterInstance,
+    DatabaseSecret,
 } from 'aws-cdk-lib/aws-rds'
 import type { IVpc, SubnetSelection, ISecurityGroup } from 'aws-cdk-lib/aws-ec2'
-import { Secret, type ISecret } from 'aws-cdk-lib/aws-secretsmanager'
+import type { ISecret } from 'aws-cdk-lib/aws-secretsmanager'
 import { Duration, RemovalPolicy, Stack } from 'aws-cdk-lib'
 import type { DatabaseConfig } from '../../config/environments'
 import { ResourceNames } from '../../config/shared'
@@ -59,19 +60,13 @@ export class AuroraServerlessV2 extends Construct {
             )
         }
 
-        // Create database credentials secret
-        // Use CDK-specific naming to avoid conflicts with serverless
-        this.secret = new Secret(this, 'Secret', {
+        // DatabaseSecret creates a secret in the format the rotation Lambda expects:
+        // { engine, host, port, dbname, username, password }
+        // attach() below populates the connection fields after the cluster is created.
+        const dbSecret = new DatabaseSecret(this, 'Secret', {
+            username: 'mcreviewadmin',
             secretName: `aurora-postgres-${props.stage}-cdk`, // pragma: allowlist secret
-            description: `Database credentials for ${props.databaseName} - ${props.stage}`,
-            generateSecretString: {
-                secretStringTemplate: JSON.stringify({
-                    username: 'mcreviewadmin',
-                }),
-                generateStringKey: 'password',
-                excludeCharacters: ' %+~`#$&*()|[]{}:;<>?!\'/@"\\',
-                passwordLength: 30,
-            },
+            excludeCharacters: ' %+~`#$&*()|[]{}:;<>?!\'/@"\\',
         })
 
         // Create the Aurora Serverless v2 cluster
@@ -79,7 +74,7 @@ export class AuroraServerlessV2 extends Construct {
             engine: DatabaseClusterEngine.auroraPostgres({
                 version: AuroraPostgresEngineVersion.VER_16_9,
             }),
-            credentials: Credentials.fromSecret(this.secret),
+            credentials: Credentials.fromSecret(dbSecret),
             clusterIdentifier: ResourceNames.resourceName(
                 'postgres',
                 'cluster',
@@ -112,6 +107,10 @@ export class AuroraServerlessV2 extends Construct {
                 publiclyAccessible: false,
             }),
         })
+
+        // Attach the secret to the cluster so CDK populates host/port/engine/dbname —
+        // these fields are required by the rotation Lambda to connect to Aurora.
+        this.secret = dbSecret.attach(this.cluster)
 
         // Rotate the admin password every 30 days via the Secrets Manager hosted rotation Lambda
         this.cluster.addRotationSingleUser({

--- a/services/infra-cdk/lib/constructs/database/aurora-serverless-v2.ts
+++ b/services/infra-cdk/lib/constructs/database/aurora-serverless-v2.ts
@@ -115,7 +115,7 @@ export class AuroraServerlessV2 extends Construct {
 
         // Rotate the admin password every 30 days via the Secrets Manager hosted rotation Lambda
         this.cluster.addRotationSingleUser({
-            automaticallyAfter: Duration.days(30),
+            automaticallyAfter: Duration.days(1),
             vpcSubnets: props.vpcSubnets,
             securityGroup: props.securityGroup,
             excludeCharacters: ' %+~`#$&*()|[]{}:;<>?!\'/@"\\',

--- a/services/infra-cdk/lib/constructs/database/aurora-serverless-v2.ts
+++ b/services/infra-cdk/lib/constructs/database/aurora-serverless-v2.ts
@@ -59,20 +59,15 @@ export class AuroraServerlessV2 extends Construct {
             )
         }
 
-        // Create database credentials secret
-        // Use CDK-specific naming to avoid conflicts with serverless
-        this.secret = new Secret(this, 'Secret', {
-            secretName: `aurora-postgres-${props.stage}-cdk`, // pragma: allowlist secret
-            description: `Database credentials for ${props.databaseName} - ${props.stage}`,
-            generateSecretString: {
-                secretStringTemplate: JSON.stringify({
-                    username: 'mcreviewadmin',
-                }),
-                generateStringKey: 'password',
-                excludeCharacters: ' %+~`#$&*()|[]{}:;<>?!\'/@"\\',
-                passwordLength: 30,
-            },
-        })
+        const databaseSecretName = `aurora-postgres-${props.stage}-cdk` // pragma: allowlist secret
+
+        // Import the existing database credentials secret by the same name this
+        // construct previously created.
+        this.secret = Secret.fromSecretNameV2(
+            this,
+            'Secret',
+            databaseSecretName
+        )
 
         // Create the Aurora Serverless v2 cluster
         this.cluster = new DatabaseCluster(this, 'Cluster', {

--- a/services/infra-cdk/lib/constructs/database/aurora-serverless-v2.ts
+++ b/services/infra-cdk/lib/constructs/database/aurora-serverless-v2.ts
@@ -112,5 +112,13 @@ export class AuroraServerlessV2 extends Construct {
                 publiclyAccessible: false,
             }),
         })
+
+        // Rotate the admin password every 30 days via the Secrets Manager hosted rotation Lambda
+        this.cluster.addRotationSingleUser({
+            automaticallyAfter: Duration.days(30),
+            vpcSubnets: props.vpcSubnets,
+            securityGroup: props.securityGroup,
+            excludeCharacters: ' %+~`#$&*()|[]{}:;<>?!\'/@"\\',
+        })
     }
 }

--- a/services/infra-cdk/lib/constructs/database/aurora-serverless-v2.ts
+++ b/services/infra-cdk/lib/constructs/database/aurora-serverless-v2.ts
@@ -7,6 +7,7 @@ import {
     ClusterInstance,
 } from 'aws-cdk-lib/aws-rds'
 import type { IVpc, SubnetSelection, ISecurityGroup } from 'aws-cdk-lib/aws-ec2'
+import { Secret } from 'aws-cdk-lib/aws-secretsmanager'
 import type { ISecret } from 'aws-cdk-lib/aws-secretsmanager'
 import { Duration, RemovalPolicy, Stack } from 'aws-cdk-lib'
 import type { DatabaseConfig } from '../../config/environments'
@@ -14,6 +15,7 @@ import { ResourceNames } from '../../config/shared'
 
 export interface AuroraServerlessV2Props {
     databaseName: string
+    databaseSecretName: string
     stage: string
     vpc: IVpc
     vpcSubnets: SubnetSelection
@@ -60,16 +62,21 @@ export class AuroraServerlessV2 extends Construct {
         }
 
         // Create the Aurora Serverless v2 cluster.
-        // fromGeneratedSecret creates a DatabaseSecret in the format the rotation Lambda expects:
-        // { engine, host, port, dbname, username, password } — auto-attached to the cluster.
+        // Use the existing, stable database secret so exported secret names do not change.
+        const databaseSecret = Secret.fromSecretNameV2(
+            this,
+            'DatabaseSecret',
+            props.databaseSecretName
+        )
+
         this.cluster = new DatabaseCluster(this, 'Cluster', {
             engine: DatabaseClusterEngine.auroraPostgres({
                 version: AuroraPostgresEngineVersion.VER_16_9,
             }),
-            credentials: Credentials.fromGeneratedSecret('mcreviewadmin', {
-                secretName: `aurora-postgres-${props.stage}-cdk-rotating`, // pragma: allowlist secret
-                excludeCharacters: ' %+~`#$&*()|[]{}:;<>?!\'/@"\\',
-            }),
+            credentials: Credentials.fromSecret(
+                databaseSecret,
+                'mcreviewadmin'
+            ),
             clusterIdentifier: ResourceNames.resourceName(
                 'postgres',
                 'cluster',
@@ -103,12 +110,14 @@ export class AuroraServerlessV2 extends Construct {
             }),
         })
 
-        // cluster.secret is the auto-generated DatabaseSecret with all connection fields populated
+        // cluster.secret is the attached database secret with connection fields populated.
         this.secret = this.cluster.secret!
 
-        // Rotate the admin password every 30 days via the Secrets Manager hosted rotation Lambda
+        // Rotate the admin password via the Secrets Manager hosted rotation Lambda.
         this.cluster.addRotationSingleUser({
-            automaticallyAfter: Duration.days(1),
+            automaticallyAfter: Duration.days(
+                props.databaseConfig.passwordRotationDays
+            ),
             vpcSubnets: props.vpcSubnets,
             securityGroup: props.securityGroup,
             excludeCharacters: ' %+~`#$&*()|[]{}:;<>?!\'/@"\\',

--- a/services/infra-cdk/lib/constructs/database/aurora-serverless-v2.ts
+++ b/services/infra-cdk/lib/constructs/database/aurora-serverless-v2.ts
@@ -5,7 +5,6 @@ import {
     AuroraPostgresEngineVersion,
     Credentials,
     ClusterInstance,
-    DatabaseSecret,
 } from 'aws-cdk-lib/aws-rds'
 import type { IVpc, SubnetSelection, ISecurityGroup } from 'aws-cdk-lib/aws-ec2'
 import type { ISecret } from 'aws-cdk-lib/aws-secretsmanager'
@@ -60,21 +59,17 @@ export class AuroraServerlessV2 extends Construct {
             )
         }
 
-        // DatabaseSecret creates a secret in the format the rotation Lambda expects:
-        // { engine, host, port, dbname, username, password }
-        // attach() below populates the connection fields after the cluster is created.
-        const dbSecret = new DatabaseSecret(this, 'Secret', {
-            username: 'mcreviewadmin',
-            secretName: `aurora-postgres-${props.stage}-cdk`, // pragma: allowlist secret
-            excludeCharacters: ' %+~`#$&*()|[]{}:;<>?!\'/@"\\',
-        })
-
-        // Create the Aurora Serverless v2 cluster
+        // Create the Aurora Serverless v2 cluster.
+        // fromGeneratedSecret creates a DatabaseSecret in the format the rotation Lambda expects:
+        // { engine, host, port, dbname, username, password } — auto-attached to the cluster.
         this.cluster = new DatabaseCluster(this, 'Cluster', {
             engine: DatabaseClusterEngine.auroraPostgres({
                 version: AuroraPostgresEngineVersion.VER_16_9,
             }),
-            credentials: Credentials.fromSecret(dbSecret),
+            credentials: Credentials.fromGeneratedSecret('mcreviewadmin', {
+                secretName: `aurora-postgres-${props.stage}-cdk`, // pragma: allowlist secret
+                excludeCharacters: ' %+~`#$&*()|[]{}:;<>?!\'/@"\\',
+            }),
             clusterIdentifier: ResourceNames.resourceName(
                 'postgres',
                 'cluster',
@@ -108,9 +103,8 @@ export class AuroraServerlessV2 extends Construct {
             }),
         })
 
-        // Attach the secret to the cluster so CDK populates host/port/engine/dbname —
-        // these fields are required by the rotation Lambda to connect to Aurora.
-        this.secret = dbSecret.attach(this.cluster)
+        // cluster.secret is the auto-generated DatabaseSecret with all connection fields populated
+        this.secret = this.cluster.secret!
 
         // Rotate the admin password every 30 days via the Secrets Manager hosted rotation Lambda
         this.cluster.addRotationSingleUser({

--- a/services/infra-cdk/lib/stacks/postgres.ts
+++ b/services/infra-cdk/lib/stacks/postgres.ts
@@ -105,7 +105,6 @@ export class Postgres extends BaseStack {
 
             const auroraCluster = new AuroraServerlessV2(this, 'Aurora', {
                 databaseName,
-                databaseSecretName: `aurora-postgres-${this.stage}-cdk`, // pragma: allowlist secret
                 stage: this.stage,
                 vpc: this.vpc,
                 vpcSubnets: {

--- a/services/infra-cdk/lib/stacks/postgres.ts
+++ b/services/infra-cdk/lib/stacks/postgres.ts
@@ -105,6 +105,7 @@ export class Postgres extends BaseStack {
 
             const auroraCluster = new AuroraServerlessV2(this, 'Aurora', {
                 databaseName,
+                databaseSecretName: `aurora-postgres-${this.stage}-cdk`, // pragma: allowlist secret
                 stage: this.stage,
                 vpc: this.vpc,
                 vpcSubnets: {


### PR DESCRIPTION
- Adds `passwordRotationDays` database config with a 90-day default
- Adds `cluster.addRotationSingleUser(...)` for the Aurora Serverless v2 cluster
- Preserves the existing stack-owned DB secret instead of importing it, avoiding CloudFormation deletion/replacement of the existing secret
- Sets `rotateImmediatelyOnUpdate: false` so future schedule updates do not force immediate rotation