### PR TITLE
MCR-6033 Add hide logic for Add questions button when an open round of questions exist

### DIFF
--- a/services/app-web/src/pages/QuestionResponse/QATable/CMSQuestionResponseTable.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/CMSQuestionResponseTable.tsx
@@ -17,6 +17,7 @@ type CMSQuestionResponseTableProps = {
     questionType: 'contract' | 'rate'
     consolidatedStatus?: ConsolidatedContractStatus | ConsolidatedRateStatus
     userDivision?: Division
+    canAddQuestionsGotAllResponses?: boolean
 }
 
 // Reusable function for sorting rounds by createdAt and reversing
@@ -81,12 +82,14 @@ export const CMSQuestionResponseTable = ({
     questionType,
     consolidatedStatus,
     userDivision,
+    canAddQuestionsGotAllResponses,
 }: CMSQuestionResponseTableProps) => {
     const { loggedInUser } = useAuth()
     const canAddQuestions =
         !['APPROVED', 'WITHDRAWN'].includes(consolidatedStatus!) &&
         userDivision &&
-        userDivision === 'DMCO'
+        userDivision === 'DMCO' &&
+        (canAddQuestionsGotAllResponses ?? true)
 
     const { usersRounds, otherRounds } = sortQuestionRounds(
         indexQuestions,

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/ContractQuestionResponse.test.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/ContractQuestionResponse.test.tsx
@@ -352,6 +352,55 @@ describe('ContractQuestionResponse', () => {
                 </Route>
             </Routes>
         )
+
+        const mockSubmittedContractWithAnsweredQuestions = () => {
+            const contract = mockContractPackageSubmittedWithQuestions()
+
+            return {
+                ...contract,
+                questions: {
+                    ...contract.questions!,
+                    DMCOQuestions: {
+                        ...contract.questions!.DMCOQuestions,
+                        edges: contract.questions!.DMCOQuestions.edges.map(
+                            (edge) =>
+                                edge.node.id === 'dmco-question-2-id'
+                                    ? {
+                                          ...edge,
+                                          node: {
+                                              ...edge.node,
+                                              responses: [
+                                                  {
+                                                      __typename:
+                                                          'QuestionResponse' as const,
+                                                      id: 'response-to-dmco-2-id',
+                                                      questionID:
+                                                          'dmco-question-2-id',
+                                                      addedBy:
+                                                          mockValidStateUser(),
+                                                      createdAt: new Date(
+                                                          '2022-12-20'
+                                                      ),
+                                                      documents: [
+                                                          {
+                                                              id: 'response-to-dmco-2-document-1',
+                                                              s3URL: 's3://bucketname/key/response-to-dmco-2-document-1',
+                                                              name: 'response-to-dmco-2-document-1',
+                                                              downloadURL:
+                                                                  'https://example.com/response-to-dmco-2-document-1',
+                                                          },
+                                                      ],
+                                                  },
+                                              ],
+                                          },
+                                      }
+                                    : edge
+                        ),
+                    },
+                },
+            }
+        }
+
         it('renders no questions text', async () => {
             const indexContractQuestions: IndexContractQuestionsPayload = {
                 __typename: 'IndexContractQuestionsPayload',
@@ -519,11 +568,51 @@ describe('ContractQuestionResponse', () => {
                 'response-to-oact-1-document-1'
             )
 
-            // ability to add questions should exist for non approved contracts
-            const addQuestion = await screen.findByRole('link', {
+            // ability to add questions should not exist while any question is unanswered
+            const addQuestion = screen.queryByRole('link', {
                 name: 'Add questions',
             })
-            expect(addQuestion).toBeInTheDocument()
+            expect(addQuestion).not.toBeInTheDocument()
+        })
+
+        it('renders Add questions button when all existing questions have responses', async () => {
+            renderWithProviders(<CommonCMSRoutes />, {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchRateMockSuccess({
+                            id: 'test-contract-id',
+                        }),
+                        fetchContractWithQuestionsMockSuccess({
+                            contract: {
+                                ...mockSubmittedContractWithAnsweredQuestions(),
+                                id: 'test-contract-id',
+                                contractSubmissionType: 'HEALTH_PLAN',
+                            },
+                        }),
+                        fetchContractWithQuestionsMockSuccess({
+                            contract: {
+                                ...mockSubmittedContractWithAnsweredQuestions(),
+                                id: 'test-contract-id',
+                                contractSubmissionType: 'HEALTH_PLAN',
+                            },
+                        }),
+                    ],
+                },
+                routerProvider: {
+                    route: `/submissions/health-plan/test-contract-id/question-and-answers`,
+                },
+            })
+
+            expect(
+                await screen.findByRole('link', { name: 'Add questions' })
+            ).toHaveAttribute(
+                'href',
+                '/submissions/health-plan/test-contract-id/question-and-answers/dmco/upload-questions'
+            )
         })
 
         it('renders Add questions link for EQRO when the feature flag is on', async () => {
@@ -539,14 +628,14 @@ describe('ContractQuestionResponse', () => {
                         }),
                         fetchContractWithQuestionsMockSuccess({
                             contract: {
-                                ...mockContractPackageSubmittedWithQuestions(),
+                                ...mockSubmittedContractWithAnsweredQuestions(),
                                 id: 'test-contract-id',
                                 contractSubmissionType: 'EQRO',
                             },
                         }),
                         fetchContractWithQuestionsMockSuccess({
                             contract: {
-                                ...mockContractPackageSubmittedWithQuestions(),
+                                ...mockSubmittedContractWithAnsweredQuestions(),
                                 id: 'test-contract-id',
                                 contractSubmissionType: 'EQRO',
                             },

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/ContractQuestionResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/ContractQuestionResponse.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../../gen/gqlClient'
 import { GenericErrorPage } from '../../Errors/GenericErrorPage'
 import { hasCMSUserPermissions } from '@mc-review/helpers'
-import { getUserDivision } from '../QuestionResponseHelpers'
+import { extractQuestions, getUserDivision } from '../QuestionResponseHelpers'
 import { CMSQuestionResponseTable } from '../QATable/CMSQuestionResponseTable'
 import { StateQuestionResponseTable } from '../QATable/StateQuestionResponseTable'
 import { ErrorOrLoadingPage } from '../../StateSubmission'
@@ -81,6 +81,13 @@ export const ContractQuestionResponse = () => {
     if (hasCMSPermissions) {
         division = getUserDivision(loggedInUser as CmsUser)
     }
+
+    const canAddQuestions = contract.questions
+        ? extractQuestions(contract.questions).every(
+              (question) => question.responses.length > 0
+          )
+        : false
+
     return (
         <div className={styles.background} id={activeMainContentId}>
             <GridContainer className={styles.container}>
@@ -98,6 +105,7 @@ export const ContractQuestionResponse = () => {
                         questionType="contract"
                         userDivision={division}
                         consolidatedStatus={contract.consolidatedStatus}
+                        canAddQuestionsGotAllResponses={canAddQuestions}
                     />
                 ) : (
                     <StateQuestionResponseTable

--- a/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.test.tsx
+++ b/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.test.tsx
@@ -198,7 +198,10 @@ describe('SubmissionSideNav', () => {
         // validate correct param renders summary page
         await waitFor(() => {
             expect(
-                screen.getByRole('heading', { level: 1, name: 'Submission summary' })
+                screen.getByRole('heading', {
+                    level: 1,
+                    name: 'Submission summary',
+                })
             ).toBeInTheDocument()
         })
 
@@ -219,7 +222,10 @@ describe('SubmissionSideNav', () => {
 
         await waitFor(() => {
             expect(
-                screen.getByRole('link', { name: /Add questions/ })
+                screen.getByRole('heading', {
+                    level: 1,
+                    name: 'Contract questions',
+                })
             ).toBeInTheDocument()
         })
 
@@ -361,7 +367,10 @@ describe('SubmissionSideNav', () => {
         // validate correct param renders summary page
         await waitFor(() => {
             expect(
-                screen.getByRole('heading', { level: 1, name: 'Submission summary' })
+                screen.getByRole('heading', {
+                    level: 1,
+                    name: 'Submission summary',
+                })
             ).toBeInTheDocument()
         })
 


### PR DESCRIPTION
…yet answered

## Summary
If there are questions still not 
#### Related issues
[MCR-6033](https://jiraent.cms.gov/browse/MCR-6033)
#### Screenshots
<img width="1081" height="888" alt="Screenshot 2026-06-05 at 12 18 15 PM" src="https://github.com/user-attachments/assets/91fe4fd9-8845-4334-98ea-9acbe06441d2" />

<img width="1114" height="527" alt="Screenshot 2026-06-05 at 12 21 13 PM" src="https://github.com/user-attachments/assets/1e632c9e-564a-4798-a60a-88ae96d20ba1" />


#### Test cases covered
CMSQuestionResponse.test.tsx
"ability to add questions should not exist while any question is unanswered"
"renders Add questions button when all existing questions have responses"
<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed