### PR TITLE
MCR-6255: Update Dashboards to use ConsolidatedStatus

### DIFF
--- a/services/app-web/src/pages/CMSDashboard/SubmissionsDashboard/SubmissionsDashboard.tsx
+++ b/services/app-web/src/pages/CMSDashboard/SubmissionsDashboard/SubmissionsDashboard.tsx
@@ -39,13 +39,6 @@ const SubmissionsDashboard = (): React.ReactElement => {
     data.indexContractsStripped.edges
         .map((edge) => edge.node)
         .forEach((sub) => {
-            // When a sub.reviewStatus has been moved out of 'UNDER_REVIEW'
-            // have the reviewStatus supersede the sub.status
-            const status =
-                sub.reviewStatus !== 'UNDER_REVIEW'
-                    ? sub.reviewStatus
-                    : sub.status
-
             // Errors - data handling
             if (sub.consolidatedStatus === 'DRAFT') {
                 recordJSException(
@@ -122,7 +115,7 @@ const SubmissionsDashboard = (): React.ReactElement => {
                     displayRateFormData.programIDs.includes(program.id)
                 ),
                 submittedAt: sub.initiallySubmittedAt,
-                status: status,
+                status: sub.consolidatedStatus,
                 updatedAt: lastUpdated,
                 submissionType:
                     SubmissionTypeRecord[displayRateFormData.submissionType],

--- a/services/app-web/src/pages/StateDashboard/StateDashboard.tsx
+++ b/services/app-web/src/pages/StateDashboard/StateDashboard.tsx
@@ -79,12 +79,6 @@ export const StateDashboard = (): React.ReactElement => {
     data.indexContractsStripped.edges
         .map((edge) => edge.node)
         .forEach((sub) => {
-            // When a sub.reviewStatus has been moved out of 'UNDER_REVIEW'
-            // have the reviewStatus supersede the sub.status
-            const status =
-                sub.reviewStatus !== 'UNDER_REVIEW'
-                    ? sub.reviewStatus
-                    : sub.status
             const subReviewActions =
                 sub.reviewStatusActions && sub.reviewStatusActions[0]
 
@@ -106,7 +100,7 @@ export const StateDashboard = (): React.ReactElement => {
                         )
                     }),
                     submittedAt: sub.initiallySubmittedAt,
-                    status: status,
+                    status: sub.consolidatedStatus,
                     updatedAt: subReviewActions
                         ? subReviewActions.updatedAt
                         : currentRevision.updatedAt,
@@ -131,7 +125,7 @@ export const StateDashboard = (): React.ReactElement => {
                         )
                     }),
                     submittedAt: sub.initiallySubmittedAt,
-                    status: sub.status,
+                    status: sub.consolidatedStatus,
                     updatedAt: currentRevision.updatedAt,
                     contractSubmissionType: sub.contractSubmissionType,
                 })


### PR DESCRIPTION
## Summary

This PR updates both dashboards to rely on the existing `consolidatedStatus` field. This field already takes into account checking if the reviewStatus is UNDER_REVIEW or not and it was created as a central source of truth for what status a contract/rate is currently in.

The custom logic that was created in each dashboard page:

```jsx
const status =
    sub.reviewStatus !== 'UNDER_REVIEW'
        ? sub.reviewStatus
        : sub.status
```

has been replaced with `status = sub.consolidatedStatus` to use the consolidatedStatus across the board

[Notion doc](https://app.notion.com/p/mc-review/Status-Issues-35d4f9e180fa805d92d0e3cf4bd09530?source=copy_link#35d4f9e180fa8020957dd75de57229e7) with context

#### Related issues

https://jiraent.cms.gov/browse/MCR-6255

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed