### PR TITLE
MCR-6274: field level resolvers in otel

### DIFF
--- a/services/app-api/src/handlers/apollo_gql.ts
+++ b/services/app-api/src/handlers/apollo_gql.ts
@@ -138,6 +138,7 @@ function contextForRequestForFetcher(
                     'http.method': event.httpMethod,
                     'http.url': event.path,
                     'http.route': event.requestContext.resourcePath,
+                    'http.request_id': event.requestContext.requestId,
                 },
             },
             parentContext // Use the extracted context as the parent
@@ -164,6 +165,12 @@ function contextForRequestForFetcher(
                 }
 
                 if (fromThirdPartyAuthorizer) {
+                    const authMethod = 'OAuth 2.0'
+                    const operationName = extractOAuthOperationName(event)
+                    requestSpan.setAttributes({
+                        'graphql.operation.name': operationName ?? 'anonymous',
+                        'mcreview.auth_method': authMethod,
+                    })
                     const principalId =
                         event.requestContext.authorizer?.principalId
                     const authorizerContext = event.requestContext.authorizer
@@ -190,11 +197,11 @@ function contextForRequestForFetcher(
                     // extra context for logging
                     const oauthContext = {
                         operation: 'contextForRequestForFetcher',
-                        authMethod: 'OAuth 2.0',
+                        authMethod,
                         principalId,
                         path: event.path,
                         requestId: event.requestContext.requestId,
-                        queryName: extractOAuthOperationName(event),
+                        queryName: operationName,
                         ['x-acting-as-user']: delegatedUser,
                     }
 
@@ -276,13 +283,19 @@ function contextForRequestForFetcher(
                         oauthClient,
                     }
                 } else {
+                    const authMethod = 'Cognito'
+                    const operationName = extractOperationName(event)
+                    requestSpan.setAttributes({
+                        'graphql.operation.name': operationName ?? 'anonymous',
+                        'mcreview.auth_method': authMethod,
+                    })
                     const userResult = await userFetcher(authProvider!, store)
                     const cognitoContext = {
                         operation: 'contextForRequestForFetcher',
-                        authMethod: 'Cognito',
+                        authMethod,
                         path: event.path,
                         requestId: event.requestContext.requestId,
-                        queryName: extractOperationName(event),
+                        queryName: operationName,
                     }
 
                     if (userResult === undefined) {

--- a/services/app-api/src/handlers/apollo_gql.ts
+++ b/services/app-api/src/handlers/apollo_gql.ts
@@ -60,6 +60,7 @@ let s3Client: S3ClientT
 // The Context type passed to all of our GraphQL resolvers
 export interface Context {
     user: UserType
+    requestId?: string
     span?: Span
     tracer?: Tracer
     ctx?: OTELContext
@@ -277,6 +278,7 @@ function contextForRequestForFetcher(
 
                     return {
                         user: userResult,
+                        requestId: event.requestContext.requestId,
                         tracer: tracer,
                         ctx: parentContext,
                         span: requestSpan,
@@ -325,6 +327,7 @@ function contextForRequestForFetcher(
 
                     const context: Context = {
                         user: userResult,
+                        requestId: event.requestContext.requestId,
                         tracer: tracer,
                         ctx: parentContext,
                         span: requestSpan,

--- a/services/app-api/src/logger/logger.ts
+++ b/services/app-api/src/logger/logger.ts
@@ -1,8 +1,10 @@
 import type { Context } from '../handlers/apollo_gql'
 
-function createRequestContext(context: Pick<Context, 'user' | 'oauthClient'>) {
+function createRequestContext(
+    context: Pick<Context, 'user' | 'oauthClient' | 'requestId'>
+) {
     return {
-        // TODO: Include API Gateway requestId here to correlate resolver logs with OTEL http.request_id.
+        requestId: context.requestId,
         userId: context.user?.id,
         role: context.user?.role,
         oauthClient: context.oauthClient,
@@ -28,7 +30,7 @@ function logSuccess(operation: string) {
  */
 function logResolverSuccess(
     operation: string,
-    context: Pick<Context, 'user' | 'oauthClient'>
+    context: Pick<Context, 'user' | 'oauthClient' | 'requestId'>
 ) {
     console.info({
         message: `${operation} succeeded`,
@@ -60,7 +62,7 @@ function logError(operation: string, error: Error | string) {
 function logResolverError(
     operation: string,
     error: Error | string,
-    context: Pick<Context, 'user' | 'oauthClient'>
+    context: Pick<Context, 'user' | 'oauthClient' | 'requestId'>
 ) {
     console.error({
         message: `${operation} failed`,

--- a/services/app-api/src/logger/logger.ts
+++ b/services/app-api/src/logger/logger.ts
@@ -2,6 +2,7 @@ import type { Context } from '../handlers/apollo_gql'
 
 function createRequestContext(context: Pick<Context, 'user' | 'oauthClient'>) {
     return {
+        // TODO: Include API Gateway requestId here to correlate resolver logs with OTEL http.request_id.
         userId: context.user?.id,
         role: context.user?.role,
         oauthClient: context.oauthClient,

--- a/services/app-api/src/resolvers/attributeHelper.ts
+++ b/services/app-api/src/resolvers/attributeHelper.ts
@@ -99,8 +99,10 @@ export async function withResolverSpan<T>(
         const result = await otelContext.with(resolverContext, () =>
             resolver(span)
         )
-        // Success: set OK status and end span
-        span.setStatus({ code: SpanStatusCode.OK })
+        // Leave the span status Unset (the default) on a non-throwing return.
+        // Backends treat Unset as non-error, and—unlike OK, which the OTEL spec
+        // makes final—it lets a non-fatal ERROR set inside the resolver (e.g. via
+        // recordResolverError) survive instead of being clobbered back to healthy.
         span.end()
         return result
     } catch (error) {
@@ -144,9 +146,13 @@ export function setResolverDetails(
 }
 
 /**
- * Records an error on the span and adds it as an attribute.
- * Use this for errors that don't terminate the resolver (non-fatal errors).
- * For fatal errors, just throw - withResolverSpan will handle it.
+ * Records a non-fatal error on the span: attaches the exception event AND marks
+ * the span status ERROR so it surfaces in status-based dashboards/alerts.
+ *
+ * Use this for errors that don't terminate the resolver (the resolver still
+ * returns a fallback value). A recorded exception should always be actionable in
+ * the trace—an exception event without an ERROR status looks healthy and hides
+ * the failure. For fatal errors, just throw; withResolverSpan handles those.
  *
  * @param span - The resolver span
  * @param error - The error to record (Error object or string message)
@@ -156,11 +162,9 @@ export function recordResolverError(
     error: Error | string
 ): void {
     if (!span) return
-    if (error instanceof Error) {
-        span.recordException(error)
-    } else {
-        span.recordException(new Error(error))
-    }
+    const err = error instanceof Error ? error : new Error(error)
+    span.recordException(err)
+    span.setStatus({ code: SpanStatusCode.ERROR, message: err.message })
 }
 
 // ===== DEPRECATED FUNCTIONS =====

--- a/services/app-api/src/resolvers/contract/contractResolver.ts
+++ b/services/app-api/src/resolvers/contract/contractResolver.ts
@@ -70,27 +70,36 @@ function genericContractResolver<
             _args: Record<string, never>,
             context: Context
         ) {
-            const packageState = parent.stateCode
-            const state = typedStatePrograms.states.find(
-                (st) => st.code === packageState
-            )
+            return withResolverSpan(
+                context,
+                'Contract.state',
+                { 'contract.id': parent.id },
+                async (span) => {
+                    setResolverDetails(span, context.user)
 
-            if (state === undefined) {
-                const errMessage =
-                    'State not found in database: ' + packageState
-                logResolverError(
-                    'genericContractResolver.state',
-                    errMessage,
-                    context
-                )
-                throw new GraphQLError(errMessage, {
-                    extensions: {
-                        code: 'INTERNAL_SERVER_ERROR',
-                        cause: 'DB_ERROR',
-                    },
-                })
-            }
-            return state
+                    const packageState = parent.stateCode
+                    const state = typedStatePrograms.states.find(
+                        (st) => st.code === packageState
+                    )
+
+                    if (state === undefined) {
+                        const errMessage =
+                            'State not found in database: ' + packageState
+                        logResolverError(
+                            'genericContractResolver.state',
+                            errMessage,
+                            context
+                        )
+                        throw new GraphQLError(errMessage, {
+                            extensions: {
+                                code: 'INTERNAL_SERVER_ERROR',
+                                cause: 'DB_ERROR',
+                            },
+                        })
+                    }
+                    return state
+                }
+            )
         },
         dateContractDocsExecuted(parent: ParentType) {
             let dateFirstSubmitted: Date | null = null
@@ -120,76 +129,85 @@ function genericContractResolver<
             _args: Record<string, never>,
             context: Context
         ) {
-            const gqlSubs: ContractPackageSubmissionWithCauseType[] = []
-            for (let i = 0; i < parent.packageSubmissions.length; i++) {
-                const thisSub = parent.packageSubmissions[i]
-                let prevSub = undefined
-                if (i < parent.packageSubmissions.length - 1) {
-                    prevSub = parent.packageSubmissions[i + 1]
-                }
+            return withResolverSpan(
+                context,
+                'Contract.packageSubmissions',
+                { 'contract.id': parent.id },
+                async (span) => {
+                    setResolverDetails(span, context.user)
 
-                // determine the cause for this submission
-                let cause: SubmissionReason = 'CONTRACT_SUBMISSION'
-
-                if (
-                    !thisSub.submittedRevisions.find(
-                        (r) => r.id === thisSub.contractRevision.id
-                    )
-                ) {
-                    // not a contract submission, this contract wasn't in the submitted bits
-                    const connectedRateRevisionIDs = thisSub.rateRevisions.map(
-                        (r) => r.id
-                    )
-                    const submittedRate = thisSub.submittedRevisions.find((r) =>
-                        connectedRateRevisionIDs.includes(r.id)
-                    )
-
-                    if (!submittedRate) {
-                        cause = 'RATE_UNLINK'
-                    } else {
-                        const thisSubmittedRate =
-                            submittedRate as RateRevisionType
-                        if (!prevSub) {
-                            const errorMsg =
-                                'Cannot determine contract package submission cause: non-contract package submission is missing a previous package submission'
-                            logResolverError(
-                                'genericContractResolver.packageSubmissions',
-                                errorMsg,
-                                context
-                            )
-                            throw new GraphQLError(errorMsg, {
-                                extensions: {
-                                    code: 'INTERNAL_SERVER_ERROR',
-                                    cause: 'DB_ERROR',
-                                },
-                            })
+                    const gqlSubs: ContractPackageSubmissionWithCauseType[] = []
+                    for (let i = 0; i < parent.packageSubmissions.length; i++) {
+                        const thisSub = parent.packageSubmissions[i]
+                        let prevSub = undefined
+                        if (i < parent.packageSubmissions.length - 1) {
+                            prevSub = parent.packageSubmissions[i + 1]
                         }
-                        const previousRateRevisionIDs =
-                            prevSub.rateRevisions.map((r) => r.rateID)
+
+                        // determine the cause for this submission
+                        let cause: SubmissionReason = 'CONTRACT_SUBMISSION'
+
                         if (
-                            previousRateRevisionIDs.includes(
-                                thisSubmittedRate.rateID
+                            !thisSub.submittedRevisions.find(
+                                (r) => r.id === thisSub.contractRevision.id
                             )
                         ) {
-                            cause = 'RATE_SUBMISSION'
-                        } else {
-                            cause = 'RATE_LINK'
+                            // not a contract submission, this contract wasn't in the submitted bits
+                            const connectedRateRevisionIDs =
+                                thisSub.rateRevisions.map((r) => r.id)
+                            const submittedRate =
+                                thisSub.submittedRevisions.find((r) =>
+                                    connectedRateRevisionIDs.includes(r.id)
+                                )
+
+                            if (!submittedRate) {
+                                cause = 'RATE_UNLINK'
+                            } else {
+                                const thisSubmittedRate =
+                                    submittedRate as RateRevisionType
+                                if (!prevSub) {
+                                    const errorMsg =
+                                        'Cannot determine contract package submission cause: non-contract package submission is missing a previous package submission'
+                                    logResolverError(
+                                        'genericContractResolver.packageSubmissions',
+                                        errorMsg,
+                                        context
+                                    )
+                                    throw new GraphQLError(errorMsg, {
+                                        extensions: {
+                                            code: 'INTERNAL_SERVER_ERROR',
+                                            cause: 'DB_ERROR',
+                                        },
+                                    })
+                                }
+                                const previousRateRevisionIDs =
+                                    prevSub.rateRevisions.map((r) => r.rateID)
+                                if (
+                                    previousRateRevisionIDs.includes(
+                                        thisSubmittedRate.rateID
+                                    )
+                                ) {
+                                    cause = 'RATE_SUBMISSION'
+                                } else {
+                                    cause = 'RATE_LINK'
+                                }
+                            }
                         }
+
+                        const gqlSub: ContractPackageSubmissionWithCauseType = {
+                            cause,
+                            submitInfo: thisSub.submitInfo,
+                            submittedRevisions: thisSub.submittedRevisions,
+                            contractRevision: thisSub.contractRevision,
+                            rateRevisions: thisSub.rateRevisions,
+                        }
+
+                        gqlSubs.push(gqlSub)
                     }
+
+                    return gqlSubs
                 }
-
-                const gqlSub: ContractPackageSubmissionWithCauseType = {
-                    cause,
-                    submitInfo: thisSub.submitInfo,
-                    submittedRevisions: thisSub.submittedRevisions,
-                    contractRevision: thisSub.contractRevision,
-                    rateRevisions: thisSub.rateRevisions,
-                }
-
-                gqlSubs.push(gqlSub)
-            }
-
-            return gqlSubs
+            )
         },
 
         questions: async (
@@ -271,28 +289,37 @@ export function contractStrippedResolver(): Resolvers['ContractStripped'] {
             _args: Record<string, never>,
             context: Context
         ) {
-            const packageState = parent.stateCode
-            const state = typedStatePrograms.states.find(
-                (st) => st.code === packageState
+            return withResolverSpan(
+                context,
+                'ContractStripped.state',
+                { 'contract.id': parent.id },
+                async (span) => {
+                    setResolverDetails(span, context.user)
+
+                    const packageState = parent.stateCode
+                    const state = typedStatePrograms.states.find(
+                        (st) => st.code === packageState
+                    )
+
+                    if (state === undefined) {
+                        const errMessage =
+                            'State not found in database: ' + packageState
+                        logResolverError(
+                            'contractStrippedResolver.state',
+                            errMessage,
+                            context
+                        )
+
+                        throw new GraphQLError(errMessage, {
+                            extensions: {
+                                code: 'INTERNAL_SERVER_ERROR',
+                                cause: 'DB_ERROR',
+                            },
+                        })
+                    }
+                    return state
+                }
             )
-
-            if (state === undefined) {
-                const errMessage =
-                    'State not found in database: ' + packageState
-                logResolverError(
-                    'contractStrippedResolver.state',
-                    errMessage,
-                    context
-                )
-
-                throw new GraphQLError(errMessage, {
-                    extensions: {
-                        code: 'INTERNAL_SERVER_ERROR',
-                        cause: 'DB_ERROR',
-                    },
-                })
-            }
-            return state
         },
     }
 }

--- a/services/app-api/src/resolvers/contract/contractResolver.ts
+++ b/services/app-api/src/resolvers/contract/contractResolver.ts
@@ -11,10 +11,7 @@ import type { StrippedContractType } from '../../domain-models'
 import path from 'path'
 import type { Store } from '../../postgres'
 import { NotFoundError } from '../../postgres'
-import {
-    setErrorAttributesOnActiveSpan,
-    setResolverDetailsOnActiveSpan,
-} from '../attributeHelper'
+import { setResolverDetails, withResolverSpan } from '../attributeHelper'
 import { convertToIndexQuestionsPayload } from '../../postgres/questionResponse'
 import type { Context } from '../../handlers/apollo_gql'
 import { ContractSubmissionTypeRecord } from '@mc-review/constants'
@@ -200,50 +197,44 @@ function genericContractResolver<
             _args: Record<string, never>,
             context: Context
         ) => {
-            const { user, ctx, tracer } = context
-            // add a span to OTEL
-            const span = tracer?.startSpan(
-                'fetchContractWithQuestionsResolver',
-                {},
-                ctx
-            )
-            setResolverDetailsOnActiveSpan(
-                'fetchContractWithQuestions',
-                user,
-                span
-            )
+            return withResolverSpan(
+                context,
+                'Contract.questions',
+                { 'contract.id': parent.id },
+                async (span) => {
+                    setResolverDetails(span, context.user)
 
-            const questionsForContract = await store.findAllQuestionsByContract(
-                parent.id
-            )
+                    const questionsForContract =
+                        await store.findAllQuestionsByContract(parent.id)
 
-            if (questionsForContract instanceof Error) {
-                const errMessage = `Issue finding contract message: ${questionsForContract.message}`
-                logResolverError(
-                    'genericContractResolver.questions',
-                    errMessage,
-                    context
-                )
-                setErrorAttributesOnActiveSpan(errMessage, span)
+                    if (questionsForContract instanceof Error) {
+                        const errMessage = `Issue finding contract message: ${questionsForContract.message}`
+                        logResolverError(
+                            'genericContractResolver.questions',
+                            errMessage,
+                            context
+                        )
 
-                if (questionsForContract instanceof NotFoundError) {
-                    throw new GraphQLError(errMessage, {
-                        extensions: {
-                            code: 'NOT_FOUND',
-                            cause: 'DB_ERROR',
-                        },
-                    })
+                        if (questionsForContract instanceof NotFoundError) {
+                            throw new GraphQLError(errMessage, {
+                                extensions: {
+                                    code: 'NOT_FOUND',
+                                    cause: 'DB_ERROR',
+                                },
+                            })
+                        }
+
+                        throw new GraphQLError(errMessage, {
+                            extensions: {
+                                code: 'INTERNAL_SERVER_ERROR',
+                                cause: 'DB_ERROR',
+                            },
+                        })
+                    }
+
+                    return convertToIndexQuestionsPayload(questionsForContract)
                 }
-
-                throw new GraphQLError(errMessage, {
-                    extensions: {
-                        code: 'INTERNAL_SERVER_ERROR',
-                        cause: 'DB_ERROR',
-                    },
-                })
-            }
-
-            return convertToIndexQuestionsPayload(questionsForContract)
+            )
         },
     }
 }

--- a/services/app-api/src/resolvers/contract/contractRevisionResolver.ts
+++ b/services/app-api/src/resolvers/contract/contractRevisionResolver.ts
@@ -27,29 +27,39 @@ export function contractRevisionResolver(
             parent: ContractRevisionType,
             _args: Record<string, never>,
             context: Context
-        ): string {
-            const stateCode = parent.contract.stateCode
-            const programsForContractState = store.findStatePrograms(stateCode)
-            if (programsForContractState instanceof Error) {
-                const errMessage = `Failed to fetch state programs. ${programsForContractState.message}`
-                logResolverError(
-                    'contractRevisionResolver.contractName',
-                    errMessage,
-                    context
-                )
-                throw new GraphQLError(errMessage, {
-                    extensions: {
-                        code: 'INTERNAL_SERVER_ERROR',
-                        cause: 'DB_ERROR',
-                    },
-                })
-            }
+        ) {
+            return withResolverSpan(
+                context,
+                'ContractRevision.contractName',
+                { 'contract_revision.id': parent.id },
+                async (span) => {
+                    setResolverDetails(span, context.user)
 
-            return packageName(
-                stateCode,
-                parent.contract.stateNumber,
-                parent.formData.programIDs,
-                programsForContractState ?? []
+                    const stateCode = parent.contract.stateCode
+                    const programsForContractState =
+                        store.findStatePrograms(stateCode)
+                    if (programsForContractState instanceof Error) {
+                        const errMessage = `Failed to fetch state programs. ${programsForContractState.message}`
+                        logResolverError(
+                            'contractRevisionResolver.contractName',
+                            errMessage,
+                            context
+                        )
+                        throw new GraphQLError(errMessage, {
+                            extensions: {
+                                code: 'INTERNAL_SERVER_ERROR',
+                                cause: 'DB_ERROR',
+                            },
+                        })
+                    }
+
+                    return packageName(
+                        stateCode,
+                        parent.contract.stateNumber,
+                        parent.formData.programIDs,
+                        programsForContractState ?? []
+                    )
+                }
             )
         },
         documentZipPackages: async (
@@ -112,27 +122,37 @@ export function contractRevisionStrippedResolver(
             _args: Record<string, never>,
             context: Context
         ) {
-            const stateCode = parent.contract.stateCode
-            const programsForContractState = store.findStatePrograms(stateCode)
-            if (programsForContractState instanceof Error) {
-                const errMessage = `Failed to fetch state programs. ${programsForContractState.message}`
-                logResolverError(
-                    'contractRevisionStrippedResolver.contractName',
-                    errMessage,
-                    context
-                )
-                throw new GraphQLError(errMessage, {
-                    extensions: {
-                        code: 'INTERNAL_SERVER_ERROR',
-                        cause: 'DB_ERROR',
-                    },
-                })
-            }
-            return packageName(
-                stateCode,
-                parent.contract.stateNumber,
-                parent.formData.programIDs,
-                programsForContractState ?? []
+            return withResolverSpan(
+                context,
+                'ContractRevisionStripped.contractName',
+                { 'contract_revision.id': parent.id },
+                async (span) => {
+                    setResolverDetails(span, context.user)
+
+                    const stateCode = parent.contract.stateCode
+                    const programsForContractState =
+                        store.findStatePrograms(stateCode)
+                    if (programsForContractState instanceof Error) {
+                        const errMessage = `Failed to fetch state programs. ${programsForContractState.message}`
+                        logResolverError(
+                            'contractRevisionStrippedResolver.contractName',
+                            errMessage,
+                            context
+                        )
+                        throw new GraphQLError(errMessage, {
+                            extensions: {
+                                code: 'INTERNAL_SERVER_ERROR',
+                                cause: 'DB_ERROR',
+                            },
+                        })
+                    }
+                    return packageName(
+                        stateCode,
+                        parent.contract.stateNumber,
+                        parent.formData.programIDs,
+                        programsForContractState ?? []
+                    )
+                }
             )
         },
     }

--- a/services/app-api/src/resolvers/contract/contractRevisionResolver.ts
+++ b/services/app-api/src/resolvers/contract/contractRevisionResolver.ts
@@ -5,7 +5,11 @@ import type {
 } from '../../domain-models'
 import type { Resolvers } from '../../gen/gqlServer'
 import type { Store } from '../../postgres'
-import { setErrorAttributesOnActiveSpan } from '../attributeHelper'
+import {
+    recordResolverError,
+    setResolverDetails,
+    withResolverSpan,
+} from '../attributeHelper'
 import { logResolverError } from '../../logger'
 import type { DocumentZipPackageType } from '../../domain-models/ZipType'
 import type { Context } from '../../handlers/apollo_gql'
@@ -53,43 +57,45 @@ export function contractRevisionResolver(
             _args: Record<string, never>,
             context: Context
         ): Promise<DocumentZipPackageType[]> => {
-            const { ctx, tracer } = context
-            const span = tracer?.startSpan(
-                'fetchContractRevisionZipPackages',
-                {},
-                ctx
-            )
+            return withResolverSpan(
+                context,
+                'ContractRevision.documentZipPackages',
+                { 'contract_revision.id': parent.id },
+                async (span) => {
+                    setResolverDetails(span, context.user)
 
-            try {
-                const documentZipPackages =
-                    await store.findDocumentZipPackagesByContractRevision(
-                        parent.id
-                    )
+                    try {
+                        const documentZipPackages =
+                            await store.findDocumentZipPackagesByContractRevision(
+                                parent.id
+                            )
 
-                if (documentZipPackages instanceof Error) {
-                    const errMessage = `Error fetching document zip packages for contract revision ${parent.id}: ${documentZipPackages.message}`
-                    logResolverError(
-                        'contractRevision.documentZipPackages',
-                        errMessage,
-                        context
-                    )
-                    setErrorAttributesOnActiveSpan(errMessage, span)
-                    return []
+                        if (documentZipPackages instanceof Error) {
+                            const errMessage = `Error fetching document zip packages for contract revision ${parent.id}: ${documentZipPackages.message}`
+                            logResolverError(
+                                'contractRevision.documentZipPackages',
+                                errMessage,
+                                context
+                            )
+                            // This resolver intentionally falls back to an empty list, so record the non-fatal error on the span.
+                            recordResolverError(span, errMessage)
+                            return []
+                        }
+                        return documentZipPackages
+                    } catch (error) {
+                        const errorMessage = parseErrorToError(error).message
+                        const errMessage = `Unexpected error fetching document zip packages: ${errorMessage}`
+                        logResolverError(
+                            'contractRevision.documentZipPackages',
+                            errMessage,
+                            context
+                        )
+                        // This resolver intentionally falls back to an empty list, so record the non-fatal error on the span.
+                        recordResolverError(span, errMessage)
+                        return []
+                    }
                 }
-                return documentZipPackages
-            } catch (error) {
-                const errorMessage = parseErrorToError(error).message
-                const errMessage = `Unexpected error fetching document zip packages: ${errorMessage}`
-                logResolverError(
-                    'contractRevision.documentZipPackages',
-                    errMessage,
-                    context
-                )
-                setErrorAttributesOnActiveSpan(errMessage, span)
-                return []
-            } finally {
-                span?.end()
-            }
+            )
         },
     }
 }

--- a/services/app-api/src/resolvers/documents/documentZipPackageResolver.ts
+++ b/services/app-api/src/resolvers/documents/documentZipPackageResolver.ts
@@ -3,45 +3,58 @@ import type { S3ClientT } from '../../s3'
 import { getS3Key } from '../../s3'
 import { logResolverError } from '../../logger'
 import { GraphQLError } from 'graphql/index'
+import { setResolverDetails, withResolverSpan } from '../attributeHelper'
 
 export function documentZipPackageResolver(
     s3Client: S3ClientT
 ): Resolvers['DocumentZipPackage'] {
     return {
         downloadUrl: async (parent, _args, context) => {
-            const key = getS3Key(parent)
+            return withResolverSpan(
+                context,
+                'DocumentZipPackage.downloadUrl',
+                { 'document_zip_package.id': parent.id },
+                async (span) => {
+                    setResolverDetails(span, context.user)
 
-            if (key instanceof Error) {
-                const errMessage = `Zip package missing valid s3Key: ${key.message}`
-                logResolverError(
-                    'documentZipPackageResolver.downloadUrl',
-                    errMessage,
-                    context
-                )
-                throw new GraphQLError(errMessage, {
-                    extensions: {
-                        code: 'INTERNAL_SERVER_ERROR',
-                        cause: 'S3_ERROR',
-                    },
-                })
-            }
+                    const key = getS3Key(parent)
 
-            const url = await s3Client.getZipURL(key, 'HEALTH_PLAN_DOCS')
-            if (!url) {
-                const errMessage = 'error getting download url from S3'
-                logResolverError(
-                    'documentZipPackageResolver.downloadUrl',
-                    errMessage,
-                    context
-                )
-                throw new GraphQLError(errMessage, {
-                    extensions: {
-                        code: 'INTERNAL_SERVER_ERROR',
-                        cause: 'S3_ERROR',
-                    },
-                })
-            }
-            return url
+                    if (key instanceof Error) {
+                        const errMessage = `Zip package missing valid s3Key: ${key.message}`
+                        logResolverError(
+                            'documentZipPackageResolver.downloadUrl',
+                            errMessage,
+                            context
+                        )
+                        throw new GraphQLError(errMessage, {
+                            extensions: {
+                                code: 'INTERNAL_SERVER_ERROR',
+                                cause: 'S3_ERROR',
+                            },
+                        })
+                    }
+
+                    const url = await s3Client.getZipURL(
+                        key,
+                        'HEALTH_PLAN_DOCS'
+                    )
+                    if (!url) {
+                        const errMessage = 'error getting download url from S3'
+                        logResolverError(
+                            'documentZipPackageResolver.downloadUrl',
+                            errMessage,
+                            context
+                        )
+                        throw new GraphQLError(errMessage, {
+                            extensions: {
+                                code: 'INTERNAL_SERVER_ERROR',
+                                cause: 'S3_ERROR',
+                            },
+                        })
+                    }
+                    return url
+                }
+            )
         },
     }
 }

--- a/services/app-api/src/resolvers/questionResponse/questionResolver.ts
+++ b/services/app-api/src/resolvers/questionResponse/questionResolver.ts
@@ -7,6 +7,7 @@ import type { Store } from '../../postgres'
 import { GraphQLError } from 'graphql'
 import type { Context } from '../../handlers/apollo_gql'
 import { logResolverError } from '../../logger'
+import { setResolverDetails, withResolverSpan } from '../attributeHelper'
 
 export function questionResolver(store: Store): Resolvers['QuestionResolver'] {
     return {
@@ -15,54 +16,77 @@ export function questionResolver(store: Store): Resolvers['QuestionResolver'] {
             _args: Record<string, never>,
             context: Context
         ) => {
-            const isContractQuestion = 'contractID' in parent
-            const type = isContractQuestion ? 'contract' : 'rate'
-            const id = isContractQuestion ? parent.contractID : parent.rateID
-            const storeMethod = isContractQuestion
-                ? store.findAllQuestionsByContract
-                : store.findAllQuestionsByRate
+            return withResolverSpan(
+                context,
+                'QuestionResolver.round',
+                { 'question.id': parent.id },
+                async (span) => {
+                    setResolverDetails(span, context.user)
 
-            const questions:
-                | (ContractQuestionType | RateQuestionType)[]
-                | Error = await storeMethod(id)
+                    const isContractQuestion = 'contractID' in parent
+                    const type = isContractQuestion ? 'contract' : 'rate'
+                    const id = isContractQuestion
+                        ? parent.contractID
+                        : parent.rateID
+                    const storeMethod = isContractQuestion
+                        ? store.findAllQuestionsByContract
+                        : store.findAllQuestionsByRate
 
-            if (!questions) {
-                const errMessage = `Questions not found for ${type}: ${id}`
-                logResolverError('questionResolver.round', errMessage, context)
-                throw new GraphQLError(errMessage, {
-                    extensions: {
-                        code: 'INTERNAL_SERVER_ERROR',
-                        cause: 'DB_ERROR',
-                    },
-                })
-            }
+                    const questions:
+                        | (ContractQuestionType | RateQuestionType)[]
+                        | Error = await storeMethod(id)
 
-            if (questions instanceof Error) {
-                const errMessage = `Issue return questions for ${type} message: ${questions.message}`
-                logResolverError('questionResolver.round', errMessage, context)
-                throw new GraphQLError(errMessage, {
-                    extensions: {
-                        code: 'INTERNAL_SERVER_ERROR',
-                        cause: 'DB_ERROR',
-                    },
-                })
-            }
+                    if (!questions) {
+                        const errMessage = `Questions not found for ${type}: ${id}`
+                        logResolverError(
+                            'questionResolver.round',
+                            errMessage,
+                            context
+                        )
+                        throw new GraphQLError(errMessage, {
+                            extensions: {
+                                code: 'INTERNAL_SERVER_ERROR',
+                                cause: 'DB_ERROR',
+                            },
+                        })
+                    }
 
-            const divisionQuestions = questions
-                .filter((q) => q.division === parent.division)
-                .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+                    if (questions instanceof Error) {
+                        const errMessage = `Issue return questions for ${type} message: ${questions.message}`
+                        logResolverError(
+                            'questionResolver.round',
+                            errMessage,
+                            context
+                        )
+                        throw new GraphQLError(errMessage, {
+                            extensions: {
+                                code: 'INTERNAL_SERVER_ERROR',
+                                cause: 'DB_ERROR',
+                            },
+                        })
+                    }
 
-            const matchingQuestion = divisionQuestions.find(
-                (question) => question.id == parent.id
+                    const divisionQuestions = questions
+                        .filter((q) => q.division === parent.division)
+                        .sort(
+                            (a, b) =>
+                                a.createdAt.getTime() - b.createdAt.getTime()
+                        )
+
+                    const matchingQuestion = divisionQuestions.find(
+                        (question) => question.id == parent.id
+                    )
+
+                    if (!matchingQuestion) {
+                        return 0
+                    } else {
+                        return divisionQuestions.indexOf(matchingQuestion) !==
+                            undefined
+                            ? divisionQuestions.indexOf(matchingQuestion) + 1
+                            : 0
+                    }
+                }
             )
-
-            if (!matchingQuestion) {
-                return 0
-            } else {
-                return divisionQuestions.indexOf(matchingQuestion) !== undefined
-                    ? divisionQuestions.indexOf(matchingQuestion) + 1
-                    : 0
-            }
         },
     }
 }

--- a/services/app-api/src/resolvers/questionResponse/questionResponseDocumentResolver.ts
+++ b/services/app-api/src/resolvers/questionResponse/questionResponseDocumentResolver.ts
@@ -28,7 +28,7 @@ export function questionResponseDocumentResolver(
                     if (key instanceof Error) {
                         const errMsg = `Document missing valid s3Key: ${key.message}`
                         logResolverError(
-                            'genericDocumentResolver.downloadURL',
+                            'questionResponseDocumentResolver.downloadURL',
                             errMsg,
                             context
                         )

--- a/services/app-api/src/resolvers/questionResponse/questionResponseDocumentResolver.ts
+++ b/services/app-api/src/resolvers/questionResponse/questionResponseDocumentResolver.ts
@@ -5,6 +5,7 @@ import type { QuestionAndResponseDocument } from '../../domain-models'
 import { logResolverError } from '../../logger'
 import { GraphQLError } from 'graphql'
 import type { Context } from '../../handlers/apollo_gql'
+import { setResolverDetails, withResolverSpan } from '../attributeHelper'
 
 export function questionResponseDocumentResolver(
     s3Client: S3ClientT
@@ -15,39 +16,51 @@ export function questionResponseDocumentResolver(
             _args: Record<string, never>,
             context: Context
         ) => {
-            const key = getS3Key(parent)
+            return withResolverSpan(
+                context,
+                'QuestionResponseDocument.downloadURL',
+                { 'document.id': parent.id },
+                async (span) => {
+                    setResolverDetails(span, context.user)
 
-            if (key instanceof Error) {
-                const errMsg = `Document missing valid s3Key: ${key.message}`
-                logResolverError(
-                    'genericDocumentResolver.downloadURL',
-                    errMsg,
-                    context
-                )
-                throw new GraphQLError(errMsg, {
-                    extensions: {
-                        code: 'INTERNAL_SERVER_ERROR',
-                        cause: 'DB_ERROR',
-                    },
-                })
-            }
+                    const key = getS3Key(parent)
 
-            const url = await s3Client.getURL(key, 'QUESTION_ANSWER_DOCS')
-            if (!url) {
-                const errMsg = 'error getting download url from S3'
-                logResolverError(
-                    'questionResponseDocumentResolver.downloadURL',
-                    errMsg,
-                    context
-                )
-                throw new GraphQLError(errMsg, {
-                    extensions: {
-                        code: 'INTERNAL_SERVER_ERROR',
-                        cause: 'S3_ERROR',
-                    },
-                })
-            }
-            return url
+                    if (key instanceof Error) {
+                        const errMsg = `Document missing valid s3Key: ${key.message}`
+                        logResolverError(
+                            'genericDocumentResolver.downloadURL',
+                            errMsg,
+                            context
+                        )
+                        throw new GraphQLError(errMsg, {
+                            extensions: {
+                                code: 'INTERNAL_SERVER_ERROR',
+                                cause: 'DB_ERROR',
+                            },
+                        })
+                    }
+
+                    const url = await s3Client.getURL(
+                        key,
+                        'QUESTION_ANSWER_DOCS'
+                    )
+                    if (!url) {
+                        const errMsg = 'error getting download url from S3'
+                        logResolverError(
+                            'questionResponseDocumentResolver.downloadURL',
+                            errMsg,
+                            context
+                        )
+                        throw new GraphQLError(errMsg, {
+                            extensions: {
+                                code: 'INTERNAL_SERVER_ERROR',
+                                cause: 'S3_ERROR',
+                            },
+                        })
+                    }
+                    return url
+                }
+            )
         },
     }
 }

--- a/services/app-api/src/resolvers/rate/rateResolver.ts
+++ b/services/app-api/src/resolvers/rate/rateResolver.ts
@@ -7,10 +7,7 @@ import type {
     RateType,
 } from '../../domain-models'
 import path from 'path'
-import {
-    setErrorAttributesOnActiveSpan,
-    setResolverDetailsOnActiveSpan,
-} from '../attributeHelper'
+import { setResolverDetails, withResolverSpan } from '../attributeHelper'
 import type { Store } from '../../postgres'
 import { NotFoundError } from '../../postgres'
 import { convertToIndexRateQuestionsPayload } from '../../postgres/questionResponse'
@@ -135,42 +132,45 @@ export function rateResolver(
             return gqlSubs
         },
         questions: async (parent, _args, context) => {
-            const { user, ctx, tracer } = context
-            // add a span to OTEL
-            const span = tracer?.startSpan(
-                'fetchRateWithQuestionsResolver',
-                {},
-                ctx
-            )
-            setResolverDetailsOnActiveSpan('fetchRateWithQuestions', user, span)
+            return withResolverSpan(
+                context,
+                'Rate.questions',
+                { 'rate.id': parent.id },
+                async (span) => {
+                    setResolverDetails(span, context.user)
 
-            const questionsForRate = await store.findAllQuestionsByRate(
-                parent.id
-            )
+                    const questionsForRate = await store.findAllQuestionsByRate(
+                        parent.id
+                    )
 
-            if (questionsForRate instanceof Error) {
-                const errMessage = `Issue finding questions for rate. Message: ${questionsForRate.message}`
-                logResolverError('rateResolver.questions', errMessage, context)
-                setErrorAttributesOnActiveSpan(errMessage, span)
+                    if (questionsForRate instanceof Error) {
+                        const errMessage = `Issue finding questions for rate. Message: ${questionsForRate.message}`
+                        logResolverError(
+                            'rateResolver.questions',
+                            errMessage,
+                            context
+                        )
 
-                if (questionsForRate instanceof NotFoundError) {
-                    throw new GraphQLError(errMessage, {
-                        extensions: {
-                            code: 'NOT_FOUND',
-                            cause: 'DB_ERROR',
-                        },
-                    })
+                        if (questionsForRate instanceof NotFoundError) {
+                            throw new GraphQLError(errMessage, {
+                                extensions: {
+                                    code: 'NOT_FOUND',
+                                    cause: 'DB_ERROR',
+                                },
+                            })
+                        }
+
+                        throw new GraphQLError(errMessage, {
+                            extensions: {
+                                code: 'INTERNAL_SERVER_ERROR',
+                                cause: 'DB_ERROR',
+                            },
+                        })
+                    }
+
+                    return convertToIndexRateQuestionsPayload(questionsForRate)
                 }
-
-                throw new GraphQLError(errMessage, {
-                    extensions: {
-                        code: 'INTERNAL_SERVER_ERROR',
-                        cause: 'DB_ERROR',
-                    },
-                })
-            }
-
-            return convertToIndexRateQuestionsPayload(questionsForRate)
+            )
         },
     }
 }
@@ -208,33 +208,34 @@ export function rateStrippedResolver(
             return state
         },
         relatedContracts: async (parent, _args, context) => {
-            const { ctx, tracer } = context
-            const span = tracer?.startSpan(
-                'rateStrippedResolver.relatedContracts',
-                {},
-                ctx
-            )
-            const relatedContracts = await store.findRateRelatedContracts(
-                parent.id
-            )
+            return withResolverSpan(
+                context,
+                'RateStripped.relatedContracts',
+                { 'rate.id': parent.id },
+                async (span) => {
+                    setResolverDetails(span, context.user)
 
-            if (relatedContracts instanceof Error) {
-                const msg = `Issue finding related contracts for rate with id: ${parent.id}. Message: ${relatedContracts.message}`
-                logResolverError(
-                    'rateStrippedResolver.relatedContracts',
-                    msg,
-                    context
-                )
-                setErrorAttributesOnActiveSpan(msg, span)
-                throw new GraphQLError(msg, {
-                    extensions: {
-                        code: 'INTERNAL_SERVER_ERROR',
-                        cause: 'DB_ERROR',
-                    },
-                })
-            }
+                    const relatedContracts =
+                        await store.findRateRelatedContracts(parent.id)
 
-            return relatedContracts
+                    if (relatedContracts instanceof Error) {
+                        const msg = `Issue finding related contracts for rate with id: ${parent.id}. Message: ${relatedContracts.message}`
+                        logResolverError(
+                            'rateStrippedResolver.relatedContracts',
+                            msg,
+                            context
+                        )
+                        throw new GraphQLError(msg, {
+                            extensions: {
+                                code: 'INTERNAL_SERVER_ERROR',
+                                cause: 'DB_ERROR',
+                            },
+                        })
+                    }
+
+                    return relatedContracts
+                }
+            )
         },
     }
 }

--- a/services/app-api/src/resolvers/rate/rateResolver.ts
+++ b/services/app-api/src/resolvers/rate/rateResolver.ts
@@ -38,98 +38,123 @@ export function rateResolver(
             return new URL(urlPath, applicationEndpoint).href
         },
         state(parent, _args: Record<string, never>, context: Context) {
-            const packageState = parent.stateCode
-            const state = typedStatePrograms.states.find(
-                (st) => st.code === packageState
-            )
+            return withResolverSpan(
+                context,
+                'Rate.state',
+                { 'rate.id': parent.id },
+                async (span) => {
+                    setResolverDetails(span, context.user)
 
-            if (state === undefined) {
-                const errMessage =
-                    'State not found in database: ' + packageState
-                logResolverError('rateResolver.state', errMessage, context)
-                throw new GraphQLError(errMessage, {
-                    extensions: {
-                        code: 'INTERNAL_SERVER_ERROR',
-                        cause: 'DB_ERROR',
-                    },
-                })
-            }
-            return state
+                    const packageState = parent.stateCode
+                    const state = typedStatePrograms.states.find(
+                        (st) => st.code === packageState
+                    )
+
+                    if (state === undefined) {
+                        const errMessage =
+                            'State not found in database: ' + packageState
+                        logResolverError(
+                            'rateResolver.state',
+                            errMessage,
+                            context
+                        )
+                        throw new GraphQLError(errMessage, {
+                            extensions: {
+                                code: 'INTERNAL_SERVER_ERROR',
+                                cause: 'DB_ERROR',
+                            },
+                        })
+                    }
+                    return state
+                }
+            )
         },
         packageSubmissions(
             parent,
             _args: Record<string, never>,
             context: Context
         ) {
-            const gqlSubs: RatePackageSubmissionWithCauseType[] = []
-            for (let i = 0; i < parent.packageSubmissions.length; i++) {
-                const thisSub = parent.packageSubmissions[i]
-                let prevSub = undefined
-                if (i < parent.packageSubmissions.length - 1) {
-                    prevSub = parent.packageSubmissions[i + 1]
-                }
+            return withResolverSpan(
+                context,
+                'Rate.packageSubmissions',
+                { 'rate.id': parent.id },
+                async (span) => {
+                    setResolverDetails(span, context.user)
 
-                // determine the cause for this submission
-                let cause: SubmissionReason = 'RATE_SUBMISSION'
-
-                if (
-                    !thisSub.submittedRevisions.find(
-                        (r) => r.id === thisSub.rateRevision.id
-                    )
-                ) {
-                    // not a rate submission, this rate wasn't in the submitted bits
-                    const connectedContractRevisionIDs =
-                        thisSub.contractRevisions.map((r) => r.id)
-                    const submittedContract = thisSub.submittedRevisions.find(
-                        (r) => connectedContractRevisionIDs.includes(r.id)
-                    )
-
-                    if (!submittedContract) {
-                        cause = 'RATE_UNLINK'
-                    } else {
-                        const thisSubmittedContract =
-                            submittedContract as ContractRevisionType
-                        if (!prevSub) {
-                            const errorMsg =
-                                'Cannot determine rate package submission cause: non-rate package submission is missing a previous package submission'
-                            logResolverError(
-                                'rateResolver.packageSubmissions',
-                                errorMsg,
-                                context
-                            )
-                            throw new GraphQLError(errorMsg, {
-                                extensions: {
-                                    code: 'INTERNAL_SERVER_ERROR',
-                                    cause: 'DB_ERROR',
-                                },
-                            })
+                    const gqlSubs: RatePackageSubmissionWithCauseType[] = []
+                    for (let i = 0; i < parent.packageSubmissions.length; i++) {
+                        const thisSub = parent.packageSubmissions[i]
+                        let prevSub = undefined
+                        if (i < parent.packageSubmissions.length - 1) {
+                            prevSub = parent.packageSubmissions[i + 1]
                         }
-                        const previousContractRevisionIDs =
-                            prevSub.contractRevisions.map((r) => r.contract.id)
+
+                        // determine the cause for this submission
+                        let cause: SubmissionReason = 'RATE_SUBMISSION'
+
                         if (
-                            previousContractRevisionIDs.includes(
-                                thisSubmittedContract.contract.id
+                            !thisSub.submittedRevisions.find(
+                                (r) => r.id === thisSub.rateRevision.id
                             )
                         ) {
-                            cause = 'CONTRACT_SUBMISSION'
-                        } else {
-                            cause = 'RATE_LINK'
+                            // not a rate submission, this rate wasn't in the submitted bits
+                            const connectedContractRevisionIDs =
+                                thisSub.contractRevisions.map((r) => r.id)
+                            const submittedContract =
+                                thisSub.submittedRevisions.find((r) =>
+                                    connectedContractRevisionIDs.includes(r.id)
+                                )
+
+                            if (!submittedContract) {
+                                cause = 'RATE_UNLINK'
+                            } else {
+                                const thisSubmittedContract =
+                                    submittedContract as ContractRevisionType
+                                if (!prevSub) {
+                                    const errorMsg =
+                                        'Cannot determine rate package submission cause: non-rate package submission is missing a previous package submission'
+                                    logResolverError(
+                                        'rateResolver.packageSubmissions',
+                                        errorMsg,
+                                        context
+                                    )
+                                    throw new GraphQLError(errorMsg, {
+                                        extensions: {
+                                            code: 'INTERNAL_SERVER_ERROR',
+                                            cause: 'DB_ERROR',
+                                        },
+                                    })
+                                }
+                                const previousContractRevisionIDs =
+                                    prevSub.contractRevisions.map(
+                                        (r) => r.contract.id
+                                    )
+                                if (
+                                    previousContractRevisionIDs.includes(
+                                        thisSubmittedContract.contract.id
+                                    )
+                                ) {
+                                    cause = 'CONTRACT_SUBMISSION'
+                                } else {
+                                    cause = 'RATE_LINK'
+                                }
+                            }
                         }
+
+                        const gqlSub: RatePackageSubmissionWithCauseType = {
+                            cause,
+                            submitInfo: thisSub.submitInfo,
+                            submittedRevisions: thisSub.submittedRevisions,
+                            rateRevision: thisSub.rateRevision,
+                            contractRevisions: thisSub.contractRevisions,
+                        }
+
+                        gqlSubs.push(gqlSub)
                     }
+
+                    return gqlSubs
                 }
-
-                const gqlSub: RatePackageSubmissionWithCauseType = {
-                    cause,
-                    submitInfo: thisSub.submitInfo,
-                    submittedRevisions: thisSub.submittedRevisions,
-                    rateRevision: thisSub.rateRevision,
-                    contractRevisions: thisSub.contractRevisions,
-                }
-
-                gqlSubs.push(gqlSub)
-            }
-
-            return gqlSubs
+            )
         },
         questions: async (parent, _args, context) => {
             return withResolverSpan(
@@ -185,27 +210,36 @@ export function rateStrippedResolver(
             return new URL(urlPath, applicationEndpoint).href
         },
         state(parent, _args, context) {
-            const packageState = parent.stateCode
-            const state = typedStatePrograms.states.find(
-                (st) => st.code === packageState
-            )
+            return withResolverSpan(
+                context,
+                'RateStripped.state',
+                { 'rate.id': parent.id },
+                async (span) => {
+                    setResolverDetails(span, context.user)
 
-            if (state === undefined) {
-                const errMessage =
-                    'State not found in database: ' + packageState
-                logResolverError(
-                    'rateStrippedResolver.state',
-                    errMessage,
-                    context
-                )
-                throw new GraphQLError(errMessage, {
-                    extensions: {
-                        code: 'INTERNAL_SERVER_ERROR',
-                        cause: 'DB_ERROR',
-                    },
-                })
-            }
-            return state
+                    const packageState = parent.stateCode
+                    const state = typedStatePrograms.states.find(
+                        (st) => st.code === packageState
+                    )
+
+                    if (state === undefined) {
+                        const errMessage =
+                            'State not found in database: ' + packageState
+                        logResolverError(
+                            'rateStrippedResolver.state',
+                            errMessage,
+                            context
+                        )
+                        throw new GraphQLError(errMessage, {
+                            extensions: {
+                                code: 'INTERNAL_SERVER_ERROR',
+                                cause: 'DB_ERROR',
+                            },
+                        })
+                    }
+                    return state
+                }
+            )
         },
         relatedContracts: async (parent, _args, context) => {
             return withResolverSpan(

--- a/services/app-api/src/resolvers/rate/rateRevisionResolver.ts
+++ b/services/app-api/src/resolvers/rate/rateRevisionResolver.ts
@@ -1,7 +1,11 @@
 import type { Resolvers } from '../../gen/gqlServer'
 import type { Store } from '../../postgres'
 import { logResolverError } from '../../logger'
-import { setErrorAttributesOnActiveSpan } from '../attributeHelper'
+import {
+    recordResolverError,
+    setResolverDetails,
+    withResolverSpan,
+} from '../attributeHelper'
 import { GraphQLError } from 'graphql'
 import type { DocumentZipPackageType } from '../../domain-models/ZipType'
 import type { RateRevisionType } from '../../domain-models'
@@ -11,68 +15,80 @@ import { parseErrorToError } from '@mc-review/helpers'
 export function rateRevisionResolver(store: Store): Resolvers['RateRevision'] {
     return {
         rate: async (parent, _args, context) => {
-            const { ctx, tracer } = context
-            const span = tracer?.startSpan('rateRevisionResolver.rate', {}, ctx)
+            return withResolverSpan(
+                context,
+                'RateRevision.rate',
+                {
+                    'rate.id': parent.rateID,
+                    'rate_revision.id': parent.id,
+                },
+                async (span) => {
+                    setResolverDetails(span, context.user)
 
-            const rate = await store.findRateWithHistory(parent.rateID)
-            if (rate instanceof Error) {
-                const errMessage = `Issue finding rate with id: ${parent.rateID}. Message: ${rate.message}`
-                logResolverError(
-                    'rateRevisionResolver.rate',
-                    errMessage,
-                    context
-                )
-                setErrorAttributesOnActiveSpan(errMessage, span)
-                throw new GraphQLError(errMessage, {
-                    extensions: {
-                        code: 'INTERNAL_SERVER_ERROR',
-                        cause: 'DB_ERROR',
-                    },
-                })
-            }
-            return rate
+                    const rate = await store.findRateWithHistory(parent.rateID)
+                    if (rate instanceof Error) {
+                        const errMessage = `Issue finding rate with id: ${parent.rateID}. Message: ${rate.message}`
+                        logResolverError(
+                            'rateRevisionResolver.rate',
+                            errMessage,
+                            context
+                        )
+                        throw new GraphQLError(errMessage, {
+                            extensions: {
+                                code: 'INTERNAL_SERVER_ERROR',
+                                cause: 'DB_ERROR',
+                            },
+                        })
+                    }
+                    return rate
+                }
+            )
         },
         documentZipPackages: async (
             parent: RateRevisionType,
             _args: Record<string, never>,
             context: Context
         ): Promise<DocumentZipPackageType[]> => {
-            const { ctx, tracer } = context
-            const span = tracer?.startSpan(
-                'fetchRateRevisionZipPackages',
-                {},
-                ctx
-            )
+            return withResolverSpan(
+                context,
+                'RateRevision.documentZipPackages',
+                { 'rate_revision.id': parent.id },
+                async (span) => {
+                    setResolverDetails(span, context.user)
 
-            try {
-                const documentZipPackages =
-                    await store.findDocumentZipPackagesByRateRevision(parent.id)
+                    try {
+                        const documentZipPackages =
+                            await store.findDocumentZipPackagesByRateRevision(
+                                parent.id
+                            )
 
-                if (documentZipPackages instanceof Error) {
-                    const errMessage = `Error fetching document zip packages for rate revision ${parent.id}: ${documentZipPackages.message}`
-                    logResolverError(
-                        'rateRevision.documentZipPackages',
-                        errMessage,
-                        context
-                    )
-                    setErrorAttributesOnActiveSpan(errMessage, span)
-                    return []
+                        if (documentZipPackages instanceof Error) {
+                            const errMessage = `Error fetching document zip packages for rate revision ${parent.id}: ${documentZipPackages.message}`
+                            logResolverError(
+                                'rateRevision.documentZipPackages',
+                                errMessage,
+                                context
+                            )
+                            // This resolver intentionally falls back to an empty list, so record the non-fatal error on the span.
+                            recordResolverError(span, errMessage)
+                            return []
+                        }
+
+                        return documentZipPackages
+                    } catch (error) {
+                        const errorMessage = parseErrorToError(error).message
+                        const errMessage = `Unexpected error fetching document zip packages: ${errorMessage}`
+                        logResolverError(
+                            'rateRevision.documentZipPackages',
+                            errMessage,
+                            context
+                        )
+                        // This resolver intentionally falls back to an empty list, so record the non-fatal error on the span.
+                        recordResolverError(span, errMessage)
+                        return []
+                    }
                 }
-
-                return documentZipPackages
-            } catch (error) {
-                const errorMessage = parseErrorToError(error).message
-                const errMessage = `Unexpected error fetching document zip packages: ${errorMessage}`
-                logResolverError(
-                    'rateRevision.documentZipPackages',
-                    errMessage,
-                    context
-                )
-                setErrorAttributesOnActiveSpan(errMessage, span)
-                return []
-            } finally {
-                span?.end()
-            }
+            )
         },
     }
 }

--- a/services/app-api/src/resolvers/shared/genericDocumentResolver.ts
+++ b/services/app-api/src/resolvers/shared/genericDocumentResolver.ts
@@ -3,45 +3,55 @@ import type { S3ClientT } from '../../s3'
 import { getS3Key } from '../../s3'
 import { logResolverError } from '../../logger'
 import { GraphQLError } from 'graphql/index'
+import { setResolverDetails, withResolverSpan } from '../attributeHelper'
 
 export function genericDocumentResolver(
     s3Client: S3ClientT
 ): Resolvers['GenericDocument'] {
     return {
         downloadURL: async (parent, args, context) => {
-            const key = getS3Key(parent)
+            return withResolverSpan(
+                context,
+                'GenericDocument.downloadURL',
+                { 'document.id': parent.id ?? 'unknown' },
+                async (span) => {
+                    setResolverDetails(span, context.user)
 
-            if (key instanceof Error) {
-                const errMsg = `Document missing valid s3Key: ${key.message}`
-                logResolverError(
-                    'genericDocumentResolver.downloadURL',
-                    errMsg,
-                    context
-                )
-                throw new GraphQLError(errMsg, {
-                    extensions: {
-                        code: 'INTERNAL_SERVER_ERROR',
-                        cause: 'DB_ERROR',
-                    },
-                })
-            }
+                    const key = getS3Key(parent)
 
-            const url = await s3Client.getURL(key, 'HEALTH_PLAN_DOCS')
-            if (!url) {
-                const errMsg = 'error getting download url from S3'
-                logResolverError(
-                    'genericDocumentResolver.downloadURL',
-                    errMsg,
-                    context
-                )
-                throw new GraphQLError(errMsg, {
-                    extensions: {
-                        code: 'INTERNAL_SERVER_ERROR',
-                        cause: 'DB_ERROR',
-                    },
-                })
-            }
-            return url
+                    if (key instanceof Error) {
+                        const errMsg = `Document missing valid s3Key: ${key.message}`
+                        logResolverError(
+                            'genericDocumentResolver.downloadURL',
+                            errMsg,
+                            context
+                        )
+                        throw new GraphQLError(errMsg, {
+                            extensions: {
+                                code: 'INTERNAL_SERVER_ERROR',
+                                cause: 'DB_ERROR',
+                            },
+                        })
+                    }
+
+                    const url = await s3Client.getURL(key, 'HEALTH_PLAN_DOCS')
+                    if (!url) {
+                        const errMsg = 'error getting download url from S3'
+                        logResolverError(
+                            'genericDocumentResolver.downloadURL',
+                            errMsg,
+                            context
+                        )
+                        throw new GraphQLError(errMsg, {
+                            extensions: {
+                                code: 'INTERNAL_SERVER_ERROR',
+                                cause: 'DB_ERROR',
+                            },
+                        })
+                    }
+                    return url
+                }
+            )
         },
     }
 }


### PR DESCRIPTION
## Summary
[MCR-6274](https://jiraent.cms.gov/browse/MCR-6274)

This updates our field level resolvers to also use `withResolverSpan` function to set spans for each resolver. In addition I added more data into the span attributes about the request in apollo_gql handler.

Added:
- `http.request_id`: APIGatewayProxyEvent request id
   - This will also be logged in `logResolverError` and `logResolverSuccess`
- `graphql.operation.name`: Extracted GraphQL operation from the request body
- `mcreview.auth_method`: Auth method of the request.
   - `OAuth 2.0` is the external API auth method
   - Cognito is our frontend app

With this we should be able to see what GQL operation the field resolver failed on in traces.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
- Unsure how to test this @mojotalantikite any ideas?

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed