### PR TITLE
Fix syntax on Datadog monitors

### DIFF
--- a/.github/workflows/deploy-datadog-monitors.yml
+++ b/.github/workflows/deploy-datadog-monitors.yml
@@ -79,7 +79,7 @@ jobs:
           tofu plan -var-file=environments/dev.tfvars -no-color -input=false 2>&1 | tee plan_output.txt
 
       - name: Post plan as PR comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         if: always()
         with:
           script: |

--- a/infra/datadog/monitors.tf
+++ b/infra/datadog/monitors.tf
@@ -2,7 +2,7 @@ resource "datadog_monitor" "graphql_errors" {
   name = "[${var.environment}] MCR - GraphQL API Errors"
   type = "trace-analytics alert"
 
-  query = "traces(\"service:app-api-${var.environment} @error:true\").rollup(\"count\").last(\"5m\") > ${var.graphql_error_threshold}"
+  query = "trace-analytics(\"service:app-api-${var.environment} status:error\").rollup(\"count\").last(\"5m\") > ${var.graphql_error_threshold}"
 
   message = <<-EOT
     GraphQL API errors detected in **${var.environment}**.
@@ -37,7 +37,7 @@ resource "datadog_monitor" "web_trace_errors" {
   name = "[${var.environment}] MCR - Web Application Trace Errors"
   type = "trace-analytics alert"
 
-  query = "traces(\"service:app-web-${var.environment} @error:true\").rollup(\"count\").last(\"5m\") > ${var.web_error_threshold}"
+  query = "trace-analytics(\"service:app-web-${var.environment} status:error\").rollup(\"count\").last(\"5m\") > ${var.web_error_threshold}"
 
   message = <<-EOT
     Trace errors detected in the MCR web app in **${var.environment}**.


### PR DESCRIPTION
## Summary

The last PR that went through for Datadog had a chicken/egg problem -- the infra to store the state needed to exist before the planning run that catches syntax issues could actually run. That let some bad syntax for the monitors through.

This fixes up the syntax so that we can actually run the deploy for the monitors.


