### PR TITLE
Revert "MCR-6241: Remove prod block for oauth writes"

### DIFF
--- a/services/app-api/src/authorization/oauthAuthorization.test.ts
+++ b/services/app-api/src/authorization/oauthAuthorization.test.ts
@@ -157,5 +157,22 @@ describe('OAuth Authorization', () => {
 
             expect(canOauthWrite(context)).toBe(false)
         })
+
+        it('denies writing for OAuth client when stage is prod', () => {
+            process.env.stage = 'prod'
+
+            const context: Context = {
+                user: mockCMSUser,
+                oauthClient: {
+                    clientId: 'test-client',
+                    grants: ['client_credentials'],
+                    iss: 'mcreview-test',
+                    scopes: ['CMS_SUBMISSION_ACTIONS'],
+                    isDelegatedUser: true,
+                },
+            }
+
+            expect(canOauthWrite(context)).toBe(false)
+        })
     })
 })

--- a/services/app-api/src/authorization/oauthAuthorization.ts
+++ b/services/app-api/src/authorization/oauthAuthorization.ts
@@ -1,4 +1,4 @@
-import { OAuthScope } from '../generated/enums'
+import { OAuthScope } from '../generated/client'
 import type { Context } from '../handlers/apollo_gql'
 
 /**
@@ -51,10 +51,12 @@ export function canWrite(context: Context): boolean {
  * specific endpoints will allow if the OAuth client has been validated for delegated user
  */
 export function canOauthWrite(context: Context): boolean {
-    // OAuth clients can only write if they are delegated users
-    // with the required submission-actions scope.
+    const stageName = process.env.stage
+    // OAuth clients can only write if scopes is populated
+    // and we are temporarily restricting them from writing in prod
     if (context.oauthClient) {
         if (
+            stageName !== 'prod' &&
             context.oauthClient?.isDelegatedUser &&
             context.oauthClient?.scopes?.includes(
                 OAuthScope.CMS_SUBMISSION_ACTIONS


### PR DESCRIPTION
Reverts Enterprise-CMCS/managed-care-review#4513

Due to recent issues with the Mulesoft integration the team discussed temporarily re-instating the prod block until the mulesoft team is able to resolve their issues