### PR TITLE
[MCR-6296] restrict open question rounds at the API level

### DIFF
--- a/API_Changelog.md
+++ b/API_Changelog.md
@@ -7,6 +7,7 @@
     - A question round is considered open when any existing question on the same contract (for `createContractQuestion`) or rate (for `createRateQuestion`) has not yet received a response.
     - All existing questions must be answered before a new question can be created. 
     - New `BAD_USER_INPUT` error when createContractQuestion or createRateQuestion are called when an open round exists
+    - The open-round check is enforced at the database level with a row lock on the parent contract or rate, so two concurrent requests cannot both create a question round.
 
 ### May 28, 2026
 #### Updated

--- a/API_Changelog.md
+++ b/API_Changelog.md
@@ -1,6 +1,13 @@
 # Managed Care Review - API Changelog
 ## This document highlights API changes that have been introduced since May 2025. See the full [GraphQL schema](services/app-graphql/src/schema.graphql).
 
+### June 12, 2026
+#### Updated
+- `createContractQuestion` and `createRateQuestion` now reject a new question while a previous question round is still open.
+    - A question round is considered open when any existing question on the same contract (for `createContractQuestion`) or rate (for `createRateQuestion`) has not yet received a response.
+    - All existing questions must be answered before a new question can be created. 
+    - New `BAD_USER_INPUT` error when createContractQuestion or createRateQuestion are called when an open round exists
+
 ### May 28, 2026
 #### Updated
 - `createContractQuestion` now rejects EQRO contract questions from CMS users who are not assigned to the `DMCO` division.

--- a/services/app-api/src/postgres/index.ts
+++ b/services/app-api/src/postgres/index.ts
@@ -11,3 +11,4 @@ export {
     handleUserInputPostgresError,
 } from './postgresErrors'
 export { findStatePrograms } from './state/findStatePrograms'
+export { OPEN_QUESTION_ROUND_ERROR_MESSAGE } from './questionResponse'

--- a/services/app-api/src/postgres/questionResponse/index.ts
+++ b/services/app-api/src/postgres/questionResponse/index.ts
@@ -6,6 +6,7 @@ export {
     contractQuestionPrismaToDomainType,
     rateQuestionPrismaToDomainType,
     convertToIndexRateQuestionsPayload,
+    OPEN_QUESTION_ROUND_ERROR_MESSAGE,
 } from './questionHelpers'
 export { insertContractQuestionResponse } from './insertContractQuestionResponse'
 export { insertRateQuestion } from './insertRateQuestion'

--- a/services/app-api/src/postgres/questionResponse/insertContractQuestion.ts
+++ b/services/app-api/src/postgres/questionResponse/insertContractQuestion.ts
@@ -7,9 +7,12 @@ import type {
 import type { ExtendedPrismaClient } from '../prismaClient'
 import {
     contractQuestionPrismaToDomainType,
+    hasOpenQuestionRound,
+    OPEN_QUESTION_ROUND_ERROR_MESSAGE,
     questionInclude,
 } from './questionHelpers'
-import { parseErrorToError } from '@mc-review/helpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
+import { UserInputPostgresError } from '../postgresErrors'
 
 export async function insertContractQuestion(
     client: ExtendedPrismaClient,
@@ -24,29 +27,45 @@ export async function insertContractQuestion(
         s3Key: document.s3Key,
     }))
 
-    try {
-        const result = await client.contractQuestion.create({
-            data: {
-                contract: {
-                    connect: {
-                        id: questionInput.contractID,
-                    },
-                },
-                addedBy: {
-                    connect: {
-                        id: user.id,
-                    },
-                },
-                documents: {
-                    create: documents,
-                },
-                division: user.divisionAssignment as DivisionType,
-            },
-            include: questionInclude,
-        })
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'insertContractQuestion',
+        table: 'ContractTable',
+        id: questionInput.contractID,
+        transactionOptions: { timeout: 20000 },
+        transaction: async (tx) => {
+            const existingQuestions = await tx.contractQuestion.findMany({
+                where: { contractID: questionInput.contractID },
+                include: questionInclude,
+            })
 
-        return contractQuestionPrismaToDomainType(result)
-    } catch (e) {
-        return parseErrorToError(e)
-    }
+            if (hasOpenQuestionRound(existingQuestions)) {
+                return new UserInputPostgresError(
+                    OPEN_QUESTION_ROUND_ERROR_MESSAGE
+                )
+            }
+
+            const result = await tx.contractQuestion.create({
+                data: {
+                    contract: {
+                        connect: {
+                            id: questionInput.contractID,
+                        },
+                    },
+                    addedBy: {
+                        connect: {
+                            id: user.id,
+                        },
+                    },
+                    documents: {
+                        create: documents,
+                    },
+                    division: user.divisionAssignment as DivisionType,
+                },
+                include: questionInclude,
+            })
+
+            return contractQuestionPrismaToDomainType(result)
+        },
+    })
 }

--- a/services/app-api/src/postgres/questionResponse/insertRateQuestion.ts
+++ b/services/app-api/src/postgres/questionResponse/insertRateQuestion.ts
@@ -6,10 +6,13 @@ import type {
 } from '../../domain-models'
 import type { ExtendedPrismaClient } from '../prismaClient'
 import {
+    hasOpenQuestionRound,
+    OPEN_QUESTION_ROUND_ERROR_MESSAGE,
     questionInclude,
     rateQuestionPrismaToDomainType,
 } from './questionHelpers'
-import { parseErrorToError } from '@mc-review/helpers'
+import { runTransactionWithRowLock } from '../prismaHelpers'
+import { UserInputPostgresError } from '../postgresErrors'
 
 export async function insertRateQuestion(
     client: ExtendedPrismaClient,
@@ -23,29 +26,45 @@ export async function insertRateQuestion(
         s3Key: document.s3Key,
     }))
 
-    try {
-        const result = await client.rateQuestion.create({
-            data: {
-                rate: {
-                    connect: {
-                        id: questionInput.rateID,
-                    },
-                },
-                addedBy: {
-                    connect: {
-                        id: user.id,
-                    },
-                },
-                documents: {
-                    create: documents,
-                },
-                division: user.divisionAssignment as DivisionType,
-            },
-            include: questionInclude,
-        })
+    return runTransactionWithRowLock({
+        client,
+        operationName: 'insertRateQuestion',
+        table: 'RateTable',
+        id: questionInput.rateID,
+        transactionOptions: { timeout: 20000 },
+        transaction: async (tx) => {
+            const existingQuestions = await tx.rateQuestion.findMany({
+                where: { rateID: questionInput.rateID },
+                include: questionInclude,
+            })
 
-        return rateQuestionPrismaToDomainType(result)
-    } catch (e) {
-        return parseErrorToError(e)
-    }
+            if (hasOpenQuestionRound(existingQuestions)) {
+                return new UserInputPostgresError(
+                    OPEN_QUESTION_ROUND_ERROR_MESSAGE
+                )
+            }
+
+            const result = await tx.rateQuestion.create({
+                data: {
+                    rate: {
+                        connect: {
+                            id: questionInput.rateID,
+                        },
+                    },
+                    addedBy: {
+                        connect: {
+                            id: user.id,
+                        },
+                    },
+                    documents: {
+                        create: documents,
+                    },
+                    division: user.divisionAssignment as DivisionType,
+                },
+                include: questionInclude,
+            })
+
+            return rateQuestionPrismaToDomainType(result)
+        },
+    })
 }

--- a/services/app-api/src/postgres/questionResponse/questionHelpers.ts
+++ b/services/app-api/src/postgres/questionResponse/questionHelpers.ts
@@ -12,6 +12,13 @@ import type { Prisma, QuestionActionType } from '../../generated/client'
 
 const DELETE_ACTIONS: QuestionActionType[] = ['DELETE', 'CASCADE_DELETE']
 
+// Shared message used when a new question is created while a previous question
+// round is still open (any existing question has not yet been answered). Kept
+// in one place so the resolver early-check and the transactional store check
+// stay in sync.
+const OPEN_QUESTION_ROUND_ERROR_MESSAGE =
+    'Cannot create a new question while a previous question round is open. All questions must be answered before a new question can be created.'
+
 // Works for any Q&A parent — their action rows all share QuestionActionType.
 // This filters out soft deleted questions, may not want this if we want to
 // expose soft deleted questions for future UI or API consumer usage
@@ -134,6 +141,18 @@ const excludeSoftDeletedQuestionData = <
     return result
 }
 
+// True when any non-deleted question in the list has not yet received a
+// response, i.e. a question round is still open. Mirrors the
+// allQuestionsAnswered logic in app-web's questionResponseHelpers.ts.
+const hasOpenQuestionRound = <
+    P extends PrismaQuestionType | PrismaRateQuestionType,
+>(
+    prismaQuestions: P[]
+): boolean =>
+    excludeSoftDeletedQuestionData(prismaQuestions).some(
+        (question) => question.responses.length === 0
+    )
+
 const contractQuestionPrismaToDomainType = (
     prismaQuestion: PrismaQuestionType
 ): ContractQuestionType => commonQuestionPrismaToDomainType(prismaQuestion)
@@ -190,7 +209,9 @@ const convertToIndexRateQuestionsPayload = (
 
 export {
     DELETE_ACTIONS,
+    OPEN_QUESTION_ROUND_ERROR_MESSAGE,
     isDeleted,
+    hasOpenQuestionRound,
     questionInclude,
     excludeSoftDeletedQuestionData,
     contractQuestionPrismaToDomainType,

--- a/services/app-api/src/resolvers/questionResponse/createContractQuestion.test.ts
+++ b/services/app-api/src/resolvers/questionResponse/createContractQuestion.test.ts
@@ -298,6 +298,46 @@ describe('createQuestion', () => {
             })
         )
     })
+    it('prevents concurrent requests from creating two open question rounds', async () => {
+        const stateServer = await constructTestPostgresServer()
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+        })
+
+        const contract = await createAndSubmitTestContractWithRate(stateServer)
+
+        const createQuestion = () =>
+            executeGraphQLOperation(cmsServer, {
+                query: CreateContractQuestionDocument,
+                variables: {
+                    input: {
+                        contractID: contract.id,
+                        documents: [
+                            {
+                                name: 'Test Question',
+                                s3URL: 's3://bucketname/key/test1',
+                            },
+                        ],
+                    },
+                },
+            })
+
+        // Fire two requests at once. The parent contract row lock serializes
+        // them so only one question round can be created.
+        const results = await Promise.all([createQuestion(), createQuestion()])
+
+        const succeeded = results.filter((r) => !r.errors)
+        const failed = results.filter((r) => r.errors)
+
+        expect(succeeded).toHaveLength(1)
+        expect(failed).toHaveLength(1)
+        expect(assertAnErrorCode(failed[0])).toBe('BAD_USER_INPUT')
+        expect(assertAnError(failed[0]).message).toBe(
+            'Cannot create a new question while a previous question round is open. All questions must be answered before a new question can be created.'
+        )
+    })
     it('returns an error if a state user attempts to create a question for a package', async () => {
         const stateServer = await constructTestPostgresServer()
         const contract = await createAndSubmitTestContractWithRate(stateServer)

--- a/services/app-api/src/resolvers/questionResponse/createContractQuestion.test.ts
+++ b/services/app-api/src/resolvers/questionResponse/createContractQuestion.test.ts
@@ -2,6 +2,7 @@ import { CreateContractQuestionDocument } from '../../gen/gqlClient'
 import {
     constructTestPostgresServer,
     createTestQuestion,
+    createTestQuestionResponse,
     executeGraphQLOperation,
     updateTestStateAssignments,
 } from '../../testHelpers/gqlHelpers'
@@ -83,8 +84,11 @@ describe('createQuestion', () => {
         const contract = await createAndSubmitTestContractWithRate(stateServer)
 
         await unlockTestContract(cmsServer, contract.id, 'test unlock')
-        await createTestQuestion(cmsServer, contract.id)
+        const firstQuestion = await createTestQuestion(cmsServer, contract.id)
         await submitTestContract(stateServer, contract.id, 'resubmit reason')
+        // Answer the first question so the round is closed and a new question
+        // can be created.
+        await createTestQuestionResponse(stateServer, firstQuestion.id)
         await createTestQuestion(cmsServer, contract.id, {
             documents: [
                 {
@@ -222,6 +226,76 @@ describe('createQuestion', () => {
         expect(assertAnErrorCode(createdQuestion)).toBe('BAD_USER_INPUT')
         expect(assertAnError(createdQuestion).message).toBe(
             'Issue creating question for contract. Message: Cannot create question for contract in APPROVED status'
+        )
+    })
+    it('returns an error if there is an open question round (unanswered questions)', async () => {
+        const stateServer = await constructTestPostgresServer()
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+        })
+
+        const contract = await createAndSubmitTestContractWithRate(stateServer)
+
+        // Create a first question and leave it unanswered to keep the round open
+        await createTestQuestion(cmsServer, contract.id)
+
+        // Attempting to create another question while the round is open should fail
+        const createdQuestion = await executeGraphQLOperation(cmsServer, {
+            query: CreateContractQuestionDocument,
+            variables: {
+                input: {
+                    contractID: contract.id,
+                    documents: [
+                        {
+                            name: 'Test Question 2',
+                            s3URL: 's3://bucketname/key/test2',
+                        },
+                    ],
+                },
+            },
+        })
+
+        expect(createdQuestion.errors).toBeDefined()
+        expect(assertAnErrorCode(createdQuestion)).toBe('BAD_USER_INPUT')
+        expect(assertAnError(createdQuestion).message).toBe(
+            'Cannot create a new question while a previous question round is open. All questions must be answered before a new question can be created.'
+        )
+    })
+    it('allows a new question once the open round has been answered', async () => {
+        const stateServer = await constructTestPostgresServer()
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+        })
+
+        const contract = await createAndSubmitTestContractWithRate(stateServer)
+
+        const firstQuestion = await createTestQuestion(cmsServer, contract.id)
+        // Answer the question to close the round
+        await createTestQuestionResponse(stateServer, firstQuestion.id)
+
+        const secondQuestion = await createTestQuestion(
+            cmsServer,
+            contract.id,
+            {
+                documents: [
+                    {
+                        name: 'Test Question 2',
+                        s3URL: 's3://bucketname/key/test2',
+                    },
+                ],
+            }
+        )
+
+        expect(secondQuestion).toEqual(
+            expect.objectContaining({
+                id: expect.any(String),
+                contractID: contract.id,
+                division: 'DMCO',
+            })
         )
     })
     it('returns an error if a state user attempts to create a question for a package', async () => {
@@ -586,8 +660,20 @@ describe('createQuestion', () => {
         const stateSubmission =
             await createAndSubmitTestContractWithRate(stateServer)
 
-        await createTestQuestion(cmsDMCPServer, stateSubmission.id)
-        await createTestQuestion(cmsServer, stateSubmission.id)
+        // Each question round must be answered before a new question can be
+        // created, so respond to each question before asking the next.
+        const dmcpQuestion = await createTestQuestion(
+            cmsDMCPServer,
+            stateSubmission.id
+        )
+        await createTestQuestionResponse(stateServer, dmcpQuestion.id)
+
+        const dmcoQuestionRound1 = await createTestQuestion(
+            cmsServer,
+            stateSubmission.id
+        )
+        await createTestQuestionResponse(stateServer, dmcoQuestionRound1.id)
+
         await createTestQuestion(cmsServer, stateSubmission.id)
 
         const contractName =
@@ -602,10 +688,9 @@ describe('createQuestion', () => {
         // email subject line is correct for CMS email
         // email is sent to the state anaylsts since it
         // was submitted by a DCMO user
-        // Mock emailer is called 4 times,
-        // first called to send the state email, then to CMS, two times each
-        expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
-            6,
+        // The last email sent is the CMS email for the second DMCO question,
+        // which should report round 2.
+        expect(mockEmailer.sendEmail).toHaveBeenLastCalledWith(
             expect.objectContaining({
                 subject: expect.stringContaining(
                     `[LOCAL] Questions sent for ${contractName}`

--- a/services/app-api/src/resolvers/questionResponse/createContractQuestion.ts
+++ b/services/app-api/src/resolvers/questionResponse/createContractQuestion.ts
@@ -152,6 +152,23 @@ export function createContractQuestionResolver(
                     throw new Error(errMessage)
                 }
 
+                // Do not allow a new question to be created while a previous
+                // question round is still open. A round is open when any
+                // existing question has not yet received a response.
+                const hasOpenQuestionRound = allQuestions.some(
+                    (question) => question.responses.length === 0
+                )
+                if (hasOpenQuestionRound) {
+                    const errMessage =
+                        'Cannot create a new question while a previous question round is open. All questions must be answered before a new question can be created.'
+                    logResolverError(
+                        'createContractQuestion',
+                        errMessage,
+                        context
+                    )
+                    throw createUserInputError(errMessage)
+                }
+
                 // Parse and validate document s3URLs at API boundary
                 const docs = parseAndValidateDocuments(
                     input.documents.map((d) => ({

--- a/services/app-api/src/resolvers/questionResponse/createContractQuestion.ts
+++ b/services/app-api/src/resolvers/questionResponse/createContractQuestion.ts
@@ -3,7 +3,13 @@ import { contractSubmitters, hasCMSPermissions } from '../../domain-models'
 import { logResolverError, logResolverSuccess } from '../../logger'
 import { withResolverSpan, setResolverDetails } from '../attributeHelper'
 import { createForbiddenError, createUserInputError } from '../errorUtils'
-import { NotFoundError, type Store } from '../../postgres'
+import {
+    NotFoundError,
+    OPEN_QUESTION_ROUND_ERROR_MESSAGE,
+    UserInputPostgresError,
+    handleUserInputPostgresError,
+    type Store,
+} from '../../postgres'
 import { GraphQLError } from 'graphql'
 import { isValidCmsDivison } from '../../domain-models'
 import type { Emailer } from '../../emailer'
@@ -159,14 +165,14 @@ export function createContractQuestionResolver(
                     (question) => question.responses.length === 0
                 )
                 if (hasOpenQuestionRound) {
-                    const errMessage =
-                        'Cannot create a new question while a previous question round is open. All questions must be answered before a new question can be created.'
                     logResolverError(
                         'createContractQuestion',
-                        errMessage,
+                        OPEN_QUESTION_ROUND_ERROR_MESSAGE,
                         context
                     )
-                    throw createUserInputError(errMessage)
+                    throw createUserInputError(
+                        OPEN_QUESTION_ROUND_ERROR_MESSAGE
+                    )
                 }
 
                 // Parse and validate document s3URLs at API boundary
@@ -187,6 +193,18 @@ export function createContractQuestionResolver(
                 )
 
                 if (questionResult instanceof Error) {
+                    // The store re-checks for an open question round inside a
+                    // row-locked transaction; a request that loses a concurrent
+                    // race is rejected here with a BAD_USER_INPUT error.
+                    if (questionResult instanceof UserInputPostgresError) {
+                        logResolverError(
+                            'createContractQuestion',
+                            questionResult.message,
+                            context
+                        )
+                        throw handleUserInputPostgresError(questionResult)
+                    }
+
                     const errMessage = `Issue creating question for package. Message: ${questionResult.message}`
                     logResolverError(
                         'createContractQuestion',

--- a/services/app-api/src/resolvers/questionResponse/createRateQuestion.test.ts
+++ b/services/app-api/src/resolvers/questionResponse/createRateQuestion.test.ts
@@ -1,6 +1,7 @@
 import {
     constructTestPostgresServer,
     createTestRateQuestion,
+    createTestRateQuestionResponse,
     executeGraphQLOperation,
     updateTestStateAssignments,
 } from '../../testHelpers/gqlHelpers'
@@ -62,6 +63,44 @@ describe('createRateQuestion', () => {
             })
         )
     })
+    it('returns an error if there is an open question round (unanswered questions)', async () => {
+        const stateServer = await constructTestPostgresServer()
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+        })
+        const submittedContractAndRate =
+            await createAndSubmitTestContractWithRate(stateServer)
+        const rateID =
+            submittedContractAndRate.packageSubmissions[0].rateRevisions[0]
+                .rateID
+
+        // Create a first question and leave it unanswered to keep the round open
+        must(await createTestRateQuestion(cmsServer, rateID))
+
+        // Attempting to create another question while the round is open should fail
+        const rateQuestion = await executeGraphQLOperation(cmsServer, {
+            query: CreateRateQuestionDocument,
+            variables: {
+                input: {
+                    rateID,
+                    documents: [
+                        {
+                            name: 'Test Question 2',
+                            s3URL: 's3://bucketname/key/test2',
+                        },
+                    ],
+                },
+            },
+        })
+
+        expect(rateQuestion.errors).toBeDefined()
+        expect(assertAnErrorCode(rateQuestion)).toBe('BAD_USER_INPUT')
+        expect(assertAnError(rateQuestion).message).toBe(
+            'Cannot create a new question while a previous question round is open. All questions must be answered before a new question can be created.'
+        )
+    })
     it('allows question creation on UNLOCKED and RESUBMITTED rate', async () => {
         const stateServer = await constructTestPostgresServer()
         const cmsServer = await constructTestPostgresServer({
@@ -105,6 +144,9 @@ describe('createRateQuestion', () => {
             submittedContractAndRate.id,
             'Test resubmit reason'
         )
+        // Answer the first question so the round is closed and a new question
+        // can be created.
+        await createTestRateQuestionResponse(stateServer, rateQuestion.id)
         const rateQuestion2 = await createTestRateQuestion(cmsServer, rateID, {
             documents: [
                 {
@@ -432,15 +474,24 @@ describe('createRateQuestion', () => {
             submittedContractAndRate.packageSubmissions[0].rateRevisions[0]
         const rateID = rateRevision.rateID
 
+        // Each question round must be answered before a new question can be
+        // created, so respond to each question before asking the next.
         // round 1 dmco question
-        must(await createTestRateQuestion(cmsServer, rateID))
+        const dmcoQuestionRound1 = must(
+            await createTestRateQuestion(cmsServer, rateID)
+        )
+        await createTestRateQuestionResponse(stateServer, dmcoQuestionRound1.id)
         // round 1 oact question
-        must(await createTestRateQuestion(oactServer, rateID))
+        const oactQuestionRound1 = must(
+            await createTestRateQuestion(oactServer, rateID)
+        )
+        await createTestRateQuestionResponse(stateServer, oactQuestionRound1.id)
         // round 2 dmco
         must(await createTestRateQuestion(cmsServer, rateID))
 
-        expect(mockEmailer.sendEmail).toHaveBeenNthCalledWith(
-            6,
+        // The last email sent is the CMS email for the second DMCO question,
+        // which should report round 2.
+        expect(mockEmailer.sendEmail).toHaveBeenLastCalledWith(
             expect.objectContaining({
                 subject: expect.stringContaining(
                     `[LOCAL] Questions sent for ${rateRevision.formData.rateCertificationName}`

--- a/services/app-api/src/resolvers/questionResponse/createRateQuestion.test.ts
+++ b/services/app-api/src/resolvers/questionResponse/createRateQuestion.test.ts
@@ -101,6 +101,49 @@ describe('createRateQuestion', () => {
             'Cannot create a new question while a previous question round is open. All questions must be answered before a new question can be created.'
         )
     })
+    it('prevents concurrent requests from creating two open question rounds', async () => {
+        const stateServer = await constructTestPostgresServer()
+        const cmsServer = await constructTestPostgresServer({
+            context: {
+                user: cmsUser,
+            },
+        })
+        const submittedContractAndRate =
+            await createAndSubmitTestContractWithRate(stateServer)
+        const rateID =
+            submittedContractAndRate.packageSubmissions[0].rateRevisions[0]
+                .rateID
+
+        const createQuestion = () =>
+            executeGraphQLOperation(cmsServer, {
+                query: CreateRateQuestionDocument,
+                variables: {
+                    input: {
+                        rateID,
+                        documents: [
+                            {
+                                name: 'Test Question',
+                                s3URL: 's3://bucketname/key/test1',
+                            },
+                        ],
+                    },
+                },
+            })
+
+        // Fire two requests at once. The parent rate row lock serializes them
+        // so only one question round can be created.
+        const results = await Promise.all([createQuestion(), createQuestion()])
+
+        const succeeded = results.filter((r) => !r.errors)
+        const failed = results.filter((r) => r.errors)
+
+        expect(succeeded).toHaveLength(1)
+        expect(failed).toHaveLength(1)
+        expect(assertAnErrorCode(failed[0])).toBe('BAD_USER_INPUT')
+        expect(assertAnError(failed[0]).message).toBe(
+            'Cannot create a new question while a previous question round is open. All questions must be answered before a new question can be created.'
+        )
+    })
     it('allows question creation on UNLOCKED and RESUBMITTED rate', async () => {
         const stateServer = await constructTestPostgresServer()
         const cmsServer = await constructTestPostgresServer({

--- a/services/app-api/src/resolvers/questionResponse/createRateQuestion.ts
+++ b/services/app-api/src/resolvers/questionResponse/createRateQuestion.ts
@@ -90,6 +90,30 @@ export function createRateQuestionResolver(
                     throw createUserInputError(errMessage)
                 }
 
+                // Do not allow a new question to be created while a previous
+                // question round is still open. A round is open when any
+                // existing question has not yet received a response. Mirrors
+                // the allQuestionsAnswered logic in app-web's
+                // questionResponseHelpers.ts.
+                const existingQuestions = await store.findAllQuestionsByRate(
+                    rate.id
+                )
+                if (existingQuestions instanceof Error) {
+                    const errMessage = `Issue finding all questions associated with the rate: ${rate.id}`
+                    logResolverError('createRateQuestion', errMessage, context)
+                    throw new Error(errMessage)
+                }
+
+                const hasOpenQuestionRound = existingQuestions.some(
+                    (question) => question.responses.length === 0
+                )
+                if (hasOpenQuestionRound) {
+                    const errMessage =
+                        'Cannot create a new question while a previous question round is open. All questions must be answered before a new question can be created.'
+                    logResolverError('createRateQuestion', errMessage, context)
+                    throw createUserInputError(errMessage)
+                }
+
                 // Parse and validate document s3URLs
                 const docs = parseAndValidateDocuments(
                     input.documents.map((d) => ({

--- a/services/app-api/src/resolvers/questionResponse/createRateQuestion.ts
+++ b/services/app-api/src/resolvers/questionResponse/createRateQuestion.ts
@@ -3,7 +3,13 @@ import { hasCMSPermissions, isValidCmsDivison } from '../../domain-models'
 import { logResolverError, logResolverSuccess } from '../../logger'
 import { withResolverSpan, setResolverDetails } from '../attributeHelper'
 import { createForbiddenError, createUserInputError } from '../errorUtils'
-import { NotFoundError, type Store } from '../../postgres'
+import {
+    NotFoundError,
+    OPEN_QUESTION_ROUND_ERROR_MESSAGE,
+    UserInputPostgresError,
+    handleUserInputPostgresError,
+    type Store,
+} from '../../postgres'
 import { GraphQLError } from 'graphql/index'
 import type { Emailer } from '../../emailer'
 import type { StateCodeType } from '@mc-review/submissions'
@@ -108,10 +114,14 @@ export function createRateQuestionResolver(
                     (question) => question.responses.length === 0
                 )
                 if (hasOpenQuestionRound) {
-                    const errMessage =
-                        'Cannot create a new question while a previous question round is open. All questions must be answered before a new question can be created.'
-                    logResolverError('createRateQuestion', errMessage, context)
-                    throw createUserInputError(errMessage)
+                    logResolverError(
+                        'createRateQuestion',
+                        OPEN_QUESTION_ROUND_ERROR_MESSAGE,
+                        context
+                    )
+                    throw createUserInputError(
+                        OPEN_QUESTION_ROUND_ERROR_MESSAGE
+                    )
                 }
 
                 // Parse and validate document s3URLs
@@ -133,6 +143,18 @@ export function createRateQuestionResolver(
                 )
 
                 if (questionResult instanceof Error) {
+                    // The store re-checks for an open question round inside a
+                    // row-locked transaction; a request that loses a concurrent
+                    // race is rejected here with a BAD_USER_INPUT error.
+                    if (questionResult instanceof UserInputPostgresError) {
+                        logResolverError(
+                            'createRateQuestion',
+                            questionResult.message,
+                            context
+                        )
+                        throw handleUserInputPostgresError(questionResult)
+                    }
+
                     const errMessage = `Issue creating question for rate. Message: ${questionResult.message}`
                     logResolverError('createRateQuestion', errMessage, context)
                     throw new Error(errMessage)

--- a/services/app-api/src/resolvers/questionResponse/deleteContractQuestion.test.ts
+++ b/services/app-api/src/resolvers/questionResponse/deleteContractQuestion.test.ts
@@ -55,6 +55,9 @@ describe('deleteContractQuestion', () => {
                 ],
             }
         )
+        // Answer the first question to close its round so a second question
+        // can be created.
+        await createTestQuestionResponse(stateServer, questionToKeep.id)
 
         const questionToDelete = await createTestQuestion(
             cmsServer,

--- a/services/app-api/src/resolvers/questionResponse/questionResolver.test.ts
+++ b/services/app-api/src/resolvers/questionResponse/questionResolver.test.ts
@@ -1,6 +1,7 @@
 import {
     constructTestPostgresServer,
     createTestQuestion,
+    createTestQuestionResponse,
 } from '../../testHelpers/gqlHelpers'
 import {
     testCMSUser,
@@ -45,6 +46,9 @@ describe(`questionResolver`, () => {
                 ],
             }
         )
+
+        // Answer the first question to close the round before asking the next.
+        await createTestQuestionResponse(stateServer, createdDMCPQuestion.id)
 
         const createdDMCPQuestion2 = await createTestQuestion(
             dmcpCMSServer,

--- a/services/app-api/src/resolvers/rate/fetchRate.test.ts
+++ b/services/app-api/src/resolvers/rate/fetchRate.test.ts
@@ -7,6 +7,7 @@ import { testLDService } from '../../testHelpers/launchDarklyHelpers'
 import {
     constructTestPostgresServer,
     createTestRateQuestion,
+    createTestRateQuestionResponse,
     defaultFloridaRateProgram,
     executeGraphQLOperation,
 } from '../../testHelpers/gqlHelpers'
@@ -732,9 +733,14 @@ describe('fetchRate', () => {
         const rateID =
             submittedRate.packageSubmissions[0].rateRevisions[0].rateID
 
-        await createTestRateQuestion(dmcoServer, rateID)
-        await createTestRateQuestion(dmcpServer, rateID)
-        await createTestRateQuestion(oactServer, rateID)
+        // Each question round must be answered before a new question can be
+        // created, so respond to each question before asking the next.
+        const dmcoQuestion = await createTestRateQuestion(dmcoServer, rateID)
+        await createTestRateQuestionResponse(server, dmcoQuestion.id)
+        const dmcpQuestion = await createTestRateQuestion(dmcpServer, rateID)
+        await createTestRateQuestionResponse(server, dmcpQuestion.id)
+        const oactQuestion = await createTestRateQuestion(oactServer, rateID)
+        await createTestRateQuestionResponse(server, oactQuestion.id)
 
         const result = await executeGraphQLOperation(server, {
             query: FetchRateWithQuestionsDocument,


### PR DESCRIPTION
## Summary

This PR updates the createContractQuestion and createRateQuestion resolvers to reject a new question while a previous question round is still open. When an open round exists, the API returns a BAD_USER_INPUT error.

#### Related issues

https://jiraent.cms.gov/browse/MCR-6296

#### Screenshots

#### Test cases covered

createContractQuestion.test.ts

'returns an error if there is an open question round (unanswered questions)'

- Asserts a second createContractQuestion on the same contract fails with BAD_USER_INPUT.

'allows a new question once the open round has been answered'

- Asserts a new question succeeds after the prior question is answered.

'allows question creation on UNLOCKED and RESUBMITTED package'

- Updated to answer the first question before creating the second.

'send CMS email to state analysts with correct round number if multiple questions have been asked'

- Updated to answer each question between rounds.

## QA guidance

- Pick a submitted contract to add a question to (easier to do this in the UI)
- Without submitting a response to that question, call createContractQuestion again via the graphql explorer on the same contract. Expect a BAD_USER_INPUT error 
- Submit a response to the first question (createContractQuestionResponse), then call createContractQuestion again.  Expect success

## PR Reminders
- [x] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed