### PR TITLE
Refactor OTEL tracing in zips

### DIFF
--- a/infra/datadog/monitors.tf
+++ b/infra/datadog/monitors.tf
@@ -152,13 +152,15 @@ resource "datadog_monitor" "zip_generation_failures" {
   query = "trace-analytics(\"service:app-api-${var.environment} status:error \\\"Document zip generation failed\\\"\").rollup(\"count\").last(\"5m\") > ${var.zip_failure_threshold}"
 
   message = <<-EOT
-    Document zip generation failures detected in **${var.environment}**.
+    A document zip failed to generate in **${var.environment}**.
 
     Triggered when >${var.zip_failure_threshold} contract or rate `zip.generate` spans fail (status:error) in 5 minutes. These zips are produced when a contract is submitted/withdrawn and by the batch zip-regeneration Lambda.
 
-    - Review the failing `zip.generate` spans in Datadog APM under service `app-api-${var.environment}` (filter on `@zip.type`, `@zip.revision_id`, `@zip.document_type`)
-    - Failures are frequently transient (S3 download/upload timeouts) — confirm whether the affected revisions self-healed or still have no `documentZipPackage`
-    - Persistent failures can be backfilled by invoking the `app-api-${var.environment}-cdk-regenerate-zips` Lambda
+    **There is no automatic retry today** — each failure means a submitted contract or rate is sitting without its document zip until someone regenerates it, so treat every alert as actionable:
+
+    - Find the failing `zip.generate` span in Datadog APM under service `app-api-${var.environment}` and note `@zip.type`, `@zip.revision_id`, and `@zip.document_type`
+    - Regenerate the missing zip by invoking the `app-api-${var.environment}-cdk-regenerate-zips` Lambda with that revision ID
+    - If failures are frequent, capture the underlying error (often S3 download/upload timeouts) to inform the planned worker-queue retry work
 
     ${var.notify_slack}
   EOT

--- a/infra/datadog/monitors.tf
+++ b/infra/datadog/monitors.tf
@@ -140,6 +140,48 @@ resource "datadog_monitor" "impersonation_volume_anomaly" {
   ]
 }
 
+resource "datadog_monitor" "zip_generation_failures" {
+  name = "[${var.team}] Document Zip Generation Failures - ${var.environment}"
+  type = "trace-analytics alert"
+
+  # Matches the dedicated `zip.generate` spans emitted by the app-api zip service
+  # (services/app-api/src/zip/zipTracing.ts). Every failed contract or rate zip
+  # records an exception prefixed with the stable "Document zip generation failed"
+  # marker and sets the span status to error. Keep this phrase in sync with
+  # ZIP_FAILURE_MARKER in zipTracing.ts.
+  query = "trace-analytics(\"service:app-api-${var.environment} status:error \\\"Document zip generation failed\\\"\").rollup(\"count\").last(\"5m\") > ${var.zip_failure_threshold}"
+
+  message = <<-EOT
+    Document zip generation failures detected in **${var.environment}**.
+
+    Triggered when >${var.zip_failure_threshold} contract or rate `zip.generate` spans fail (status:error) in 5 minutes. These zips are produced when a contract is submitted/withdrawn and by the batch zip-regeneration Lambda.
+
+    - Review the failing `zip.generate` spans in Datadog APM under service `app-api-${var.environment}` (filter on `@zip.type`, `@zip.revision_id`, `@zip.document_type`)
+    - Failures are frequently transient (S3 download/upload timeouts) — confirm whether the affected revisions self-healed or still have no `documentZipPackage`
+    - Persistent failures can be backfilled by invoking the `app-api-${var.environment}-cdk-regenerate-zips` Lambda
+
+    ${var.notify_slack}
+  EOT
+
+  monitor_thresholds {
+    critical = var.zip_failure_threshold
+  }
+
+  # No failing zips is the normal, healthy state, so absence of data is not an
+  # outage signal here (mirrors large_payload_alert / impersonation monitors).
+  notify_no_data    = false
+  evaluation_delay  = 60
+  renotify_interval = 60
+  include_tags      = true
+
+  tags = [
+    "env:${var.environment}",
+    "service:app-api-${var.environment}",
+    "managed-by:opentofu",
+    "team:${var.team}",
+  ]
+}
+
 resource "datadog_monitor" "web_trace_errors" {
   name = "[${var.team}] Web Application Trace Errors - ${var.environment}"
   type = "trace-analytics alert"

--- a/infra/datadog/variables.tf
+++ b/infra/datadog/variables.tf
@@ -56,8 +56,8 @@ variable "impersonation_volume_threshold" {
 
 variable "zip_failure_threshold" {
   type        = number
-  description = "Alert when more than this many document zip generation failures (contract or rate, submit or batch-regeneration path) occur in 5 minutes. Individual zip failures are often transient and self-heal on regeneration, so the default alerts only on repeated failures. Set to 0 to alert on any single failure."
-  default     = 2
+  description = "Alert when more than this many document zip generation failures (contract or rate, submit or batch-regeneration path) occur in 5 minutes. There is no automatic retry: a failed zip means a submitted contract/rate is left with no document zip until it is manually regenerated, so the default of 0 alerts on every single failure. Raise it only if a known transient source starts generating noise."
+  default     = 0
 }
 
 variable "notify_no_data" {

--- a/infra/datadog/variables.tf
+++ b/infra/datadog/variables.tf
@@ -54,6 +54,12 @@ variable "impersonation_volume_threshold" {
   default     = 20
 }
 
+variable "zip_failure_threshold" {
+  type        = number
+  description = "Alert when more than this many document zip generation failures (contract or rate, submit or batch-regeneration path) occur in 5 minutes. Individual zip failures are often transient and self-heal on regeneration, so the default alerts only on repeated failures. Set to 0 to alert on any single failure."
+  default     = 2
+}
+
 variable "notify_no_data" {
   type        = bool
   description = "Alert when a monitor stops receiving data entirely (e.g. service crash with no traces)"

--- a/services/app-api/src/handlers/regenerate_zips.ts
+++ b/services/app-api/src/handlers/regenerate_zips.ts
@@ -61,6 +61,13 @@ export const main: Handler = async (
         throw new Error('Init Error: DATABASE_URL is required')
     }
 
+    // Initialize OpenTelemetry before creating the Prisma client so the Prisma
+    // instrumentation is registered and db spans nest under zip.generate. This
+    // emits spans under the same `app-api-<stage>` service as the submit path so
+    // failures here are caught by the same Datadog zip monitor. initTracer
+    // throws if `stage` or `DD_API_KEY` is missing, enforcing them at startup.
+    initTracer('app-api-' + process.env.stage)
+
     // Get database connection URL
     const dbConnResult = await getPostgresURL(dbURL, secretsManagerSecret)
     if (dbConnResult instanceof Error) {
@@ -80,10 +87,6 @@ export const main: Handler = async (
     const prismaClient = prismaClientResult
     const postgresStore = NewPostgresStore(prismaClient)
     const zipService = documentZipService(postgresStore, generateDocumentZip)
-
-    // Emit zip.generate spans under the same `app-api-<stage>` service as the
-    // submit path so failures here are caught by the same Datadog zip monitor.
-    initTracer('app-api-' + (process.env.stage ?? 'local'))
 
     const limit = event.limit ?? 100
     const dryRun = event.dryRun ?? false
@@ -224,8 +227,13 @@ export const main: Handler = async (
         response.errors.push(errorMessage)
         return response
     } finally {
-        // Flush queued zip.generate spans before the Lambda freezes.
-        await flushTracer()
+        // Flush queued zip.generate spans before the Lambda freezes. Swallow
+        // flush errors so telemetry failures never fail a regeneration run.
+        try {
+            await flushTracer()
+        } catch (flushErr) {
+            console.warn('otel: flush failed', flushErr)
+        }
     }
     // NOTE: Don't call $disconnect() - we use a singleton pattern to reuse connections
     // across warm Lambda invocations. AWS cleans up when the container terminates.

--- a/services/app-api/src/handlers/regenerate_zips.ts
+++ b/services/app-api/src/handlers/regenerate_zips.ts
@@ -31,6 +31,7 @@ import {
     includeRateFormData,
 } from '../postgres/contractAndRates/prismaSharedContractRateHelpers'
 import { parseErrorToError } from '@mc-review/helpers'
+import { initTracer, flushTracer } from '../otel/otel_handler'
 
 export type RegenerateZipsEvent = {
     contractRevisionID?: string // Optional: regenerate for specific contract revision
@@ -79,6 +80,10 @@ export const main: Handler = async (
     const prismaClient = prismaClientResult
     const postgresStore = NewPostgresStore(prismaClient)
     const zipService = documentZipService(postgresStore, generateDocumentZip)
+
+    // Emit zip.generate spans under the same `app-api-<stage>` service as the
+    // submit path so failures here are caught by the same Datadog zip monitor.
+    initTracer('app-api-' + (process.env.stage ?? 'local'))
 
     const limit = event.limit ?? 100
     const dryRun = event.dryRun ?? false
@@ -218,6 +223,9 @@ export const main: Handler = async (
         response.success = false
         response.errors.push(errorMessage)
         return response
+    } finally {
+        // Flush queued zip.generate spans before the Lambda freezes.
+        await flushTracer()
     }
     // NOTE: Don't call $disconnect() - we use a singleton pattern to reuse connections
     // across warm Lambda invocations. AWS cleans up when the container terminates.

--- a/services/app-api/src/resolvers/contract/submitContract.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.ts
@@ -499,20 +499,16 @@ export function submitContract(
                 }
 
                 // Generate zips!
-                const contractZipRes = await documentZip.createContractZips(
-                    submitContractResult,
-                    span
-                )
+                const contractZipRes =
+                    await documentZip.createContractZips(submitContractResult)
                 if (contractZipRes instanceof Error) {
                     const errMessage = `Failed to zip files for contract revision with ID: ${contractRevisionID}: ${contractZipRes.message}`
                     logResolverError('submitContract', errMessage, context)
                     recordResolverError(span, errMessage)
                 }
 
-                const rateZipRes = await documentZip.createRateZips(
-                    submitContractResult,
-                    span
-                )
+                const rateZipRes =
+                    await documentZip.createRateZips(submitContractResult)
                 if (rateZipRes instanceof Array) {
                     const errorMessage = `Failed to zip files for ${rateZipRes.length} rate revision(s) on contract ${contractRevisionID}`
                     logResolverError('submitContract', errorMessage, context)

--- a/services/app-api/src/resolvers/contract/undoWithdrawContract.ts
+++ b/services/app-api/src/resolvers/contract/undoWithdrawContract.ts
@@ -132,10 +132,8 @@ export function undoWithdrawContract(
 
                 const { contract, ratesForDisplay } = undoWithdrawResult
                 // Generate zips!
-                const contractZipRes = await documentZip.createContractZips(
-                    contract,
-                    span
-                )
+                const contractZipRes =
+                    await documentZip.createContractZips(contract)
                 if (contractZipRes instanceof Error) {
                     const errMessage = `Failed to zip files for contract revision with ID: ${contract.id}: ${contractZipRes.message}`
                     logResolverError(
@@ -145,10 +143,7 @@ export function undoWithdrawContract(
                     )
                     recordResolverError(span, errMessage)
                 }
-                const rateZipRes = await documentZip.createRateZips(
-                    contract,
-                    span
-                )
+                const rateZipRes = await documentZip.createRateZips(contract)
                 if (rateZipRes instanceof Array) {
                     const errorMessage = `Failed to zip files for ${rateZipRes.length} rate revision(s) on contract ${contract.id}`
                     logResolverError(

--- a/services/app-api/src/resolvers/contract/withdrawContract.ts
+++ b/services/app-api/src/resolvers/contract/withdrawContract.ts
@@ -122,19 +122,15 @@ export function withdrawContract(
                 const { withdrawnContract, ratesForDisplay } = withdrawResult
 
                 // Generate zips!
-                const contractZipRes = await documentZip.createContractZips(
-                    withdrawnContract,
-                    span
-                )
+                const contractZipRes =
+                    await documentZip.createContractZips(withdrawnContract)
                 if (contractZipRes instanceof Error) {
                     const errMessage = `Failed to zip files for contract revision with ID: ${withdrawnContract.id}: ${contractZipRes.message}`
                     logResolverError('withdrawContract', errMessage, context)
                     recordResolverError(span, errMessage)
                 }
-                const rateZipRes = await documentZip.createRateZips(
-                    withdrawnContract,
-                    span
-                )
+                const rateZipRes =
+                    await documentZip.createRateZips(withdrawnContract)
                 if (rateZipRes instanceof Array) {
                     const errorMessage = `Failed to zip files for ${rateZipRes.length} rate revision(s) on contract ${withdrawnContract.id}`
                     logResolverError('withdrawContract', errorMessage, context)

--- a/services/app-api/src/zip/generateZip.ts
+++ b/services/app-api/src/zip/generateZip.ts
@@ -18,8 +18,7 @@ import type {
     ContractType,
     RateRevisionType,
 } from '../domain-models'
-import type { Span } from '@opentelemetry/api'
-import { setErrorAttributesOnActiveSpan } from '../resolvers/attributeHelper'
+import { withZipSpan } from './zipTracing'
 
 const s3Client = new S3Client({
     region: process.env.AWS_REGION || 'us-east-1',
@@ -374,21 +373,13 @@ function calculateSHA256(filePath: string): Promise<string | Error> {
 }
 
 export type DocumentZipService = {
-    createContractZips: (
-        contract: ContractType,
-        span?: Span
-    ) => Promise<Error | undefined>
-    createRateZips: (
-        contract: ContractType,
-        span?: Span
-    ) => Promise<Error[] | undefined>
+    createContractZips: (contract: ContractType) => Promise<Error | undefined>
+    createRateZips: (contract: ContractType) => Promise<Error[] | undefined>
     generateRateDocumentsZip: (
-        rateRevision: RateRevisionType,
-        span?: Span
+        rateRevision: RateRevisionType
     ) => Promise<void | Error>
     generateContractDocumentsZip: (
-        contractRevision: ContractRevisionType,
-        span?: Span
+        contractRevision: ContractRevisionType
     ) => Promise<void | Error>
 }
 
@@ -397,7 +388,7 @@ export function documentZipService(
     generateDocumentZip: GenerateDocumentZipFunctionType
 ): DocumentZipService {
     const documentZipMethods: DocumentZipService = {
-        createContractZips: async (contract, span) => {
+        createContractZips: async (contract) => {
             const contractRevision =
                 contract.packageSubmissions[0]?.contractRevision
 
@@ -416,8 +407,7 @@ export function documentZipService(
 
                 const zipResult =
                     await documentZipMethods.generateContractDocumentsZip(
-                        contractRevision,
-                        span
+                        contractRevision
                     )
 
                 if (zipResult instanceof Error) {
@@ -425,13 +415,13 @@ export function documentZipService(
                         `Contract document zip generation failed for revision ${contractRevision.id}: ${zipResult.message}`
                     )
 
+                    // The dedicated zip.generate span already recorded this
+                    // failure (see generateContractDocumentsZip). We just log and
+                    // propagate; submitContract marks the resolver span via
+                    // recordResolverError.
                     logError(
                         'createContractZips - contract documents zip generation failed',
                         errorWithContext
-                    )
-                    setErrorAttributesOnActiveSpan(
-                        'contract documents zip generation failed',
-                        span
                     )
                     console.warn(
                         `Contract document zip generation failed for revision ${contractRevision.id}, but continuing with submission process`
@@ -450,7 +440,7 @@ export function documentZipService(
             }
             return
         },
-        createRateZips: async (contract, span) => {
+        createRateZips: async (contract) => {
             if (!contract.packageSubmissions[0]?.rateRevisions) {
                 return
             }
@@ -478,8 +468,7 @@ export function documentZipService(
 
                     const zipResult =
                         await documentZipMethods.generateRateDocumentsZip(
-                            rateRev,
-                            span
+                            rateRev
                         )
 
                     if (zipResult instanceof Error) {
@@ -488,13 +477,13 @@ export function documentZipService(
                         )
                         errors.push(errorWithContext)
 
+                        // The dedicated zip.generate span already recorded this
+                        // failure (see generateRateDocumentsZip). We just log and
+                        // collect; submitContract marks the resolver span via
+                        // recordResolverError.
                         logError(
                             'createRateZips - rate documents zip generation failed',
                             errorWithContext
-                        )
-                        setErrorAttributesOnActiveSpan(
-                            'rate documents zip generation failed',
-                            span
                         )
                         console.warn(
                             `Rate document zip generation failed for revision ${rateRev.id}, but continuing with other revisions`
@@ -514,7 +503,7 @@ export function documentZipService(
             // Return errors if any occurred, otherwise return void
             return errors.length > 0 ? errors : undefined
         },
-        generateRateDocumentsZip: async (rateRevision, span) => {
+        generateRateDocumentsZip: async (rateRevision) => {
             const rateRevisionID = rateRevision.id
 
             // Get all rate-related documents
@@ -529,70 +518,66 @@ export function documentZipService(
                 return
             }
 
-            try {
-                // Create an S3 key (destination path) for the zip file
-                const s3DestinationKey = `zips/rates/${rateRevisionID}/rate-documents.zip`
-
-                // Generate the zip file and upload it to S3
-                const zipResult = await generateDocumentZip(
-                    rateDocuments,
-                    s3DestinationKey
-                )
-
-                if (zipResult instanceof Error) {
-                    logError('generateRateDocumentsZip', zipResult)
-                    if (span) {
-                        setErrorAttributesOnActiveSpan(
-                            'rate documents zip generation failed',
-                            span
-                        )
-                    }
-                    return zipResult
-                }
-
-                // Store zip information in database
-                const createResult = await store.createDocumentZipPackage({
-                    s3URL: zipResult.s3URL,
-                    sha256: zipResult.sha256,
-                    s3BucketName: zipResult.s3BucketName,
-                    s3Key: zipResult.s3Key,
-                    rateRevisionID,
+            // Trace this attempt on a dedicated zip.generate span. withZipSpan
+            // records any Error we return (or throw) as a span error, so we no
+            // longer manage span state by hand on each branch.
+            return withZipSpan(
+                {
+                    zipType: 'rate',
                     documentType: 'RATE_DOCUMENTS',
-                })
+                    revisionID: rateRevisionID,
+                    documentCount: rateDocuments.length,
+                },
+                async () => {
+                    try {
+                        // Create an S3 key (destination path) for the zip file
+                        const s3DestinationKey = `zips/rates/${rateRevisionID}/rate-documents.zip`
 
-                if (createResult instanceof Error) {
-                    logError(
-                        'generateRateDocumentsZip - database storage failed',
-                        createResult
-                    )
-                    if (span) {
-                        setErrorAttributesOnActiveSpan(
-                            'rate documents zip database storage failed',
-                            span
+                        // Generate the zip file and upload it to S3
+                        const zipResult = await generateDocumentZip(
+                            rateDocuments,
+                            s3DestinationKey
                         )
-                    }
-                    return createResult
-                }
 
-                console.info(
-                    `Successfully generated zip for rate documents: ${zipResult.s3URL}`
-                )
-                return
-            } catch (error: unknown) {
-                const err = new Error(
-                    `Unexpected error in generateRateDocumentsZip: ${parseErrorToError(error).message}`
-                )
-                logError('generateRateDocumentsZip', err)
-                if (span) {
-                    setErrorAttributesOnActiveSpan(
-                        'rate documents zip generation failed',
-                        span
-                    )
+                        if (zipResult instanceof Error) {
+                            logError('generateRateDocumentsZip', zipResult)
+                            return zipResult
+                        }
+
+                        // Store zip information in database
+                        const createResult =
+                            await store.createDocumentZipPackage({
+                                s3URL: zipResult.s3URL,
+                                sha256: zipResult.sha256,
+                                s3BucketName: zipResult.s3BucketName,
+                                s3Key: zipResult.s3Key,
+                                rateRevisionID,
+                                documentType: 'RATE_DOCUMENTS',
+                            })
+
+                        if (createResult instanceof Error) {
+                            logError(
+                                'generateRateDocumentsZip - database storage failed',
+                                createResult
+                            )
+                            return createResult
+                        }
+
+                        console.info(
+                            `Successfully generated zip for rate documents: ${zipResult.s3URL}`
+                        )
+                        return
+                    } catch (error: unknown) {
+                        const err = new Error(
+                            `Unexpected error in generateRateDocumentsZip: ${parseErrorToError(error).message}`
+                        )
+                        logError('generateRateDocumentsZip', err)
+                        return err
+                    }
                 }
-                return err
-            }
+            )
         },
-        generateContractDocumentsZip: async (contractRevision, span) => {
+        generateContractDocumentsZip: async (contractRevision) => {
             const contractRevisionID = contractRevision.id
             const contractDocuments = [
                 ...(contractRevision.formData.contractDocuments || []),
@@ -604,70 +589,66 @@ export function documentZipService(
                 return
             }
 
-            try {
-                // Create an S3 key (destination path) for the zip file. This is where
-                // we are storing it in the S3 bucket.
-                const s3DestinationKey = `zips/contracts/${contractRevisionID}/contract-documents.zip`
-
-                // Generate the zip file and upload it to S3
-                const zipResult = await generateDocumentZip(
-                    contractDocuments,
-                    s3DestinationKey
-                )
-
-                if (zipResult instanceof Error) {
-                    // Return the error to the caller
-                    logError('generateContractDocumentsZip', zipResult)
-                    if (span) {
-                        setErrorAttributesOnActiveSpan(
-                            'contract documents zip generation failed',
-                            span
-                        )
-                    }
-                    return zipResult
-                }
-
-                // Store zip information in database
-                const createResult = await store.createDocumentZipPackage({
-                    s3URL: zipResult.s3URL,
-                    sha256: zipResult.sha256,
-                    s3BucketName: zipResult.s3BucketName,
-                    s3Key: zipResult.s3Key,
-                    contractRevisionID,
+            // Trace this attempt on a dedicated zip.generate span. withZipSpan
+            // records any Error we return (or throw) as a span error, so we no
+            // longer manage span state by hand on each branch.
+            return withZipSpan(
+                {
+                    zipType: 'contract',
                     documentType: 'CONTRACT_DOCUMENTS',
-                })
+                    revisionID: contractRevisionID,
+                    documentCount: contractDocuments.length,
+                },
+                async () => {
+                    try {
+                        // Create an S3 key (destination path) for the zip file. This is where
+                        // we are storing it in the S3 bucket.
+                        const s3DestinationKey = `zips/contracts/${contractRevisionID}/contract-documents.zip`
 
-                if (createResult instanceof Error) {
-                    logError(
-                        'generateContractDocumentsZip - database storage failed',
-                        createResult
-                    )
-                    if (span) {
-                        setErrorAttributesOnActiveSpan(
-                            'contract documents zip database storage failed',
-                            span
+                        // Generate the zip file and upload it to S3
+                        const zipResult = await generateDocumentZip(
+                            contractDocuments,
+                            s3DestinationKey
                         )
-                    }
-                    return createResult
-                }
 
-                console.info(
-                    `Successfully generated zip for contract documents: ${zipResult.s3URL}`
-                )
-                return
-            } catch (error: unknown) {
-                const err = new Error(
-                    `Unexpected error in generateContractDocumentsZip: ${parseErrorToError(error).message}`
-                )
-                logError('generateContractDocumentsZip', err)
-                if (span) {
-                    setErrorAttributesOnActiveSpan(
-                        'contract documents zip generation failed',
-                        span
-                    )
+                        if (zipResult instanceof Error) {
+                            // Return the error to the caller
+                            logError('generateContractDocumentsZip', zipResult)
+                            return zipResult
+                        }
+
+                        // Store zip information in database
+                        const createResult =
+                            await store.createDocumentZipPackage({
+                                s3URL: zipResult.s3URL,
+                                sha256: zipResult.sha256,
+                                s3BucketName: zipResult.s3BucketName,
+                                s3Key: zipResult.s3Key,
+                                contractRevisionID,
+                                documentType: 'CONTRACT_DOCUMENTS',
+                            })
+
+                        if (createResult instanceof Error) {
+                            logError(
+                                'generateContractDocumentsZip - database storage failed',
+                                createResult
+                            )
+                            return createResult
+                        }
+
+                        console.info(
+                            `Successfully generated zip for contract documents: ${zipResult.s3URL}`
+                        )
+                        return
+                    } catch (error: unknown) {
+                        const err = new Error(
+                            `Unexpected error in generateContractDocumentsZip: ${parseErrorToError(error).message}`
+                        )
+                        logError('generateContractDocumentsZip', err)
+                        return err
+                    }
                 }
-                return err
-            }
+            )
         },
     }
 

--- a/services/app-api/src/zip/generateZip.ts
+++ b/services/app-api/src/zip/generateZip.ts
@@ -417,8 +417,8 @@ export function documentZipService(
 
                     // The dedicated zip.generate span already recorded this
                     // failure (see generateContractDocumentsZip). We just log and
-                    // propagate; submitContract marks the resolver span via
-                    // recordResolverError.
+                    // propagate; the calling resolver marks its own resolver span
+                    // via recordResolverError.
                     logError(
                         'createContractZips - contract documents zip generation failed',
                         errorWithContext
@@ -479,8 +479,8 @@ export function documentZipService(
 
                         // The dedicated zip.generate span already recorded this
                         // failure (see generateRateDocumentsZip). We just log and
-                        // collect; submitContract marks the resolver span via
-                        // recordResolverError.
+                        // collect; the calling resolver marks its own resolver
+                        // span via recordResolverError.
                         logError(
                             'createRateZips - rate documents zip generation failed',
                             errorWithContext

--- a/services/app-api/src/zip/zipTracing.ts
+++ b/services/app-api/src/zip/zipTracing.ts
@@ -1,0 +1,108 @@
+import {
+    trace,
+    context as otelContext,
+    SpanStatusCode,
+    type Span,
+    type Attributes,
+} from '@opentelemetry/api'
+import { parseErrorToError } from '@mc-review/helpers'
+
+/**
+ * Instrumentation scope for document-zip spans.
+ *
+ * The Datadog `service` tag is taken from the tracer provider's resource
+ * (service.name = `app-api-<stage>`), NOT from this scope name, so every zip
+ * span still lands under the same `app-api-<env>` service as the rest of the API
+ * while sharing a dedicated, queryable span name.
+ */
+export const ZIP_TRACER_SCOPE = 'mcreview.zip'
+
+/**
+ * Stable span name for every document-zip generation attempt (contract or rate).
+ *
+ * Search Datadog APM with `operation_name:zip.generate` (optionally filtered on
+ * the `@zip.*` attributes below) to see all contract and rate zip traces in one
+ * place — this is the standardized entry point for looking at zip traces.
+ */
+export const ZIP_SPAN_NAME = 'zip.generate'
+
+/**
+ * Stable phrase attached to the recorded exception on every failed zip span. The
+ * Datadog monitor in `infra/datadog/monitors.tf` free-text matches on this exact
+ * string, so it must not change without updating that monitor.
+ */
+export const ZIP_FAILURE_MARKER = 'Document zip generation failed'
+
+export type ZipType = 'contract' | 'rate'
+
+export type ZipSpanAttributes = {
+    zipType: ZipType
+    documentType: string
+    revisionID: string
+    documentCount: number
+}
+
+function toSpanAttributes(attributes: ZipSpanAttributes): Attributes {
+    return {
+        'zip.type': attributes.zipType,
+        'zip.document_type': attributes.documentType,
+        'zip.revision_id': attributes.revisionID,
+        'zip.document_count': attributes.documentCount,
+    }
+}
+
+/**
+ * Records a zip-generation failure on its dedicated span using the current OTEL
+ * pattern (recordException + ERROR status). The recorded exception message is
+ * prefixed with ZIP_FAILURE_MARKER so the Datadog "zip generation failed"
+ * monitor can find it, and `zip.outcome` is set so healthy/failed zips are easy
+ * to split in APM.
+ */
+export function recordZipFailure(span: Span, error: Error | string): void {
+    const err = error instanceof Error ? error : new Error(error)
+    span.setAttribute('zip.outcome', 'failure')
+    span.recordException(new Error(`${ZIP_FAILURE_MARKER}: ${err.message}`))
+    span.setStatus({ code: SpanStatusCode.ERROR, message: err.message })
+}
+
+/**
+ * Wraps a single document-zip generation attempt in a dedicated child span so
+ * contract and rate zips are traced consistently across the submit path and the
+ * batch regeneration path. Mirrors `withResolverSpan`:
+ *
+ * - nested spans (S3, Prisma) become children via context propagation
+ * - an error returned by value (the zip pipeline's convention) is recorded as a
+ *   span error via {@link recordZipFailure}
+ * - a thrown error is recorded and rethrown
+ * - the span is always ended
+ *
+ * The wrapped function's return value (including any `Error` value) is passed
+ * back through unchanged, so callers keep their existing error handling.
+ */
+export async function withZipSpan<T>(
+    attributes: ZipSpanAttributes,
+    fn: (span: Span) => Promise<T>
+): Promise<T> {
+    const tracer = trace.getTracer(ZIP_TRACER_SCOPE)
+    const span = tracer.startSpan(ZIP_SPAN_NAME, {
+        attributes: toSpanAttributes(attributes),
+    })
+
+    // Run within the span's context so any nested S3/Prisma spans parent to it.
+    const spanContext = trace.setSpan(otelContext.active(), span)
+
+    try {
+        const result = await otelContext.with(spanContext, () => fn(span))
+        if (result instanceof Error) {
+            recordZipFailure(span, result)
+        } else {
+            span.setAttribute('zip.outcome', 'success')
+        }
+        return result
+    } catch (error) {
+        recordZipFailure(span, parseErrorToError(error))
+        throw error
+    } finally {
+        span.end()
+    }
+}

--- a/services/app-api/src/zip/zipTracing.ts
+++ b/services/app-api/src/zip/zipTracing.ts
@@ -53,16 +53,28 @@ function toSpanAttributes(attributes: ZipSpanAttributes): Attributes {
 
 /**
  * Records a zip-generation failure on its dedicated span using the current OTEL
- * pattern (recordException + ERROR status). The recorded exception message is
- * prefixed with ZIP_FAILURE_MARKER so the Datadog "zip generation failed"
- * monitor can find it, and `zip.outcome` is set so healthy/failed zips are easy
- * to split in APM.
+ * pattern (recordException + ERROR status). The exception is recorded with the
+ * original stack trace preserved (so the trace stays actionable) but its message
+ * is prefixed with ZIP_FAILURE_MARKER, which is also set as the span status
+ * message. Datadog maps the exception event to the searchable `error.message`
+ * tag, so the marker must live there for the monitor to match it reliably.
+ * `zip.outcome` is set so healthy/failed zips are easy to split in APM.
  */
 export function recordZipFailure(span: Span, error: Error | string): void {
     const err = error instanceof Error ? error : new Error(error)
+    const message = `${ZIP_FAILURE_MARKER}: ${err.message}`
+
+    // Re-wrap so the marker is in the message, but carry over the original
+    // stack/name so we don't lose where the failure actually came from.
+    const markedError = new Error(message)
+    markedError.name = err.name
+    if (err.stack) {
+        markedError.stack = err.stack
+    }
+
     span.setAttribute('zip.outcome', 'failure')
-    span.recordException(new Error(`${ZIP_FAILURE_MARKER}: ${err.message}`))
-    span.setStatus({ code: SpanStatusCode.ERROR, message: err.message })
+    span.recordException(markedError)
+    span.setStatus({ code: SpanStatusCode.ERROR, message })
 }
 
 /**


### PR DESCRIPTION
## Summary

This refactors the way that we handle OTEL tracing in our zip processing. It adds a wrapper to properly parent zip spans as well as adds a monitor that will alert us if a zip fails.

#### Related issues
https://jiraent.cms.gov/browse/MCR-6348