### PR TITLE
Remove functionality to assign admin to question or response.

### DIFF
--- a/packages/common-code/src/featureFlags/flags.ts
+++ b/packages/common-code/src/featureFlags/flags.ts
@@ -97,6 +97,14 @@ const featureFlags = {
         defaultValue: false,
     },
     /**
+     * When enabled, an admin user can create a question or response
+     * assigning an admin user as the addedBy.
+     */
+    ADMIN_ONLY_QA_ROUNDS: {
+        flag: 'admin-only-qa-rounds',
+        defaultValue: false,
+    },
+    /**
      * This flag toggles the ability for external API users to send write requests.
      */
     EXTERNAL_API_WRITE_REQUEST: {

--- a/packages/common-code/src/featureFlags/flags.ts
+++ b/packages/common-code/src/featureFlags/flags.ts
@@ -97,14 +97,6 @@ const featureFlags = {
         defaultValue: false,
     },
     /**
-     * When enabled, an admin user can create a question or response
-     * assigning an admin user as the addedBy.
-     */
-    ADMIN_ONLY_QA_ROUNDS: {
-        flag: 'admin-only-qa-rounds',
-        defaultValue: false,
-    },
-    /**
      * This flag toggles the ability for external API users to send write requests.
      */
     EXTERNAL_API_WRITE_REQUEST: {

--- a/services/app-api/src/resolvers/configureResolvers.ts
+++ b/services/app-api/src/resolvers/configureResolvers.ts
@@ -154,15 +154,10 @@ export function configureResolvers(
                 store,
                 launchDarkly
             ),
-            adminCreateContractQuestion: adminCreateContractQuestionResolver(
-                store,
-                launchDarkly
-            ),
+            adminCreateContractQuestion:
+                adminCreateContractQuestionResolver(store),
             adminCreateContractQuestionResponse:
-                adminCreateContractQuestionResponseResolver(
-                    store,
-                    launchDarkly
-                ),
+                adminCreateContractQuestionResponseResolver(store),
             createContractQuestionResponse:
                 createContractQuestionResponseResolver(store, emailer),
             createRateQuestion: createRateQuestionResolver(store, emailer),
@@ -226,26 +221,10 @@ export function configureResolvers(
                 }
             },
         },
-        QuestionAuthor: {
-            __resolveType(obj) {
-                if (obj.role === 'CMS_USER') {
-                    return 'CMSUser'
-                } else if (obj.role === 'ADMIN_USER') {
-                    return 'AdminUser'
-                } else {
-                    return 'CMSApproverUser'
-                }
-            },
-        },
-        ResponseAuthor: {
-            __resolveType(obj) {
-                if (obj.role === 'ADMIN_USER') {
-                    return 'AdminUser'
-                } else {
-                    return 'StateUser'
-                }
-            },
-        },
+        // TODO: Restore QuestionAuthor resolver when union is re-enabled
+        // in schema for ContractQuestion/RateQuestion.addedBy.
+        // TODO: Restore ResponseAuthor resolver when union is re-enabled
+        // in schema for QuestionResponse.addedBy.
         SubmittableRevision: {
             __resolveType(obj) {
                 if ('contract' in obj) {

--- a/services/app-api/src/resolvers/configureResolvers.ts
+++ b/services/app-api/src/resolvers/configureResolvers.ts
@@ -154,10 +154,15 @@ export function configureResolvers(
                 store,
                 launchDarkly
             ),
-            adminCreateContractQuestion:
-                adminCreateContractQuestionResolver(store),
+            adminCreateContractQuestion: adminCreateContractQuestionResolver(
+                store,
+                launchDarkly
+            ),
             adminCreateContractQuestionResponse:
-                adminCreateContractQuestionResponseResolver(store),
+                adminCreateContractQuestionResponseResolver(
+                    store,
+                    launchDarkly
+                ),
             createContractQuestionResponse:
                 createContractQuestionResponseResolver(store, emailer),
             createRateQuestion: createRateQuestionResolver(store, emailer),

--- a/services/app-api/src/resolvers/questionResponse/adminCreateContractQuestion.test.ts
+++ b/services/app-api/src/resolvers/questionResponse/adminCreateContractQuestion.test.ts
@@ -13,7 +13,7 @@ import {
     assertAnErrorCode,
     fetchTestContractWithQuestions,
 } from '../../testHelpers'
-import { testLDService } from '../../testHelpers/launchDarklyHelpers'
+
 import {
     createDBUsersWithFullData,
     testAdminUser,
@@ -109,14 +109,13 @@ describe('adminCreateContractQuestion', () => {
         const stateServer = await constructTestPostgresServer()
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
-            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
 
         const question = await adminCreateTestContractQuestion(adminServer, {
             contractID: contract.id,
-            division: 'DMCO',
+            addedByUserID: cmsUserWithDivision.id,
             createdAt: '2024-01-15',
             reason: 'Recording prior Q&A',
             documents: questionDocuments,
@@ -131,7 +130,6 @@ describe('adminCreateContractQuestion', () => {
         const stateServer = await constructTestPostgresServer()
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
-            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -141,7 +139,7 @@ describe('adminCreateContractQuestion', () => {
             variables: {
                 input: {
                     contractID: contract.id,
-                    division: 'DMCO',
+                    addedByUserID: cmsUserWithDivision.id,
                     createdAt: '2999-01-01',
                     reason: 'Recording prior Q&A',
                     documents: questionDocuments,
@@ -160,14 +158,13 @@ describe('adminCreateContractQuestion', () => {
         const stateServer = await constructTestPostgresServer()
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
-            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
 
         const question = await adminCreateTestContractQuestion(adminServer, {
             contractID: contract.id,
-            division: 'DMCO',
+            addedByUserID: cmsUserWithDivision.id,
             createdAt: '2024-01-15',
             reason: 'Backfilling DMCO round 1',
             documents: questionDocuments,
@@ -193,7 +190,6 @@ describe('adminCreateContractQuestion', () => {
         const stateServer = await constructTestPostgresServer()
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
-            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -203,7 +199,7 @@ describe('adminCreateContractQuestion', () => {
             variables: {
                 input: {
                     contractID: contract.id,
-                    division: 'DMCO',
+                    addedByUserID: cmsUserWithDivision.id,
                     reason: '   ',
                     documents: questionDocuments,
                 },
@@ -298,18 +294,17 @@ describe('adminCreateContractQuestion', () => {
         )
     })
 
-    it('creates an admin-authored question attributed to the chosen division', async () => {
+    it('creates a question attributed to a CMS user and their division', async () => {
         const stateServer = await constructTestPostgresServer()
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
-            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
 
         const question = await adminCreateTestContractQuestion(adminServer, {
             contractID: contract.id,
-            division: 'OACT',
+            addedByUserID: cmsUserWithDivision.id,
             reason: 'Recording prior Q&A',
             documents: questionDocuments,
         })
@@ -318,10 +313,10 @@ describe('adminCreateContractQuestion', () => {
             expect.objectContaining({
                 id: expect.any(String),
                 contractID: contract.id,
-                division: 'OACT',
+                division: 'DMCP',
                 addedBy: expect.objectContaining({
-                    id: adminUser.id,
-                    role: 'ADMIN_USER',
+                    id: cmsUserWithDivision.id,
+                    role: 'CMS_USER',
                 }),
                 responses: [],
             })
@@ -332,14 +327,13 @@ describe('adminCreateContractQuestion', () => {
         const stateServer = await constructTestPostgresServer()
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
-            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
 
         await adminCreateTestContractQuestion(adminServer, {
             contractID: contract.id,
-            division: 'DMCO',
+            addedByUserID: cmsUserWithDivision.id,
             reason: 'Recording prior Q&A',
             documents: questionDocuments,
         })
@@ -348,7 +342,8 @@ describe('adminCreateContractQuestion', () => {
             stateServer,
             contract.id
         )
-        expect(withQuestions.questions?.DMCOQuestions.totalCount).toBe(1)
+        // cmsUserWithDivision has DMCP division
+        expect(withQuestions.questions?.DMCPQuestions.totalCount).toBe(1)
     })
 
     it.each([
@@ -383,7 +378,7 @@ describe('adminCreateContractQuestion', () => {
                 variables: {
                     input: {
                         contractID: contract.id,
-                        division: 'DMCO',
+                        addedByUserID: cmsUserWithDivision.id,
                         reason: 'Recording prior Q&A',
                         documents: questionDocuments,
                     },
@@ -402,7 +397,6 @@ describe('adminCreateContractQuestion', () => {
         const stateServer = await constructTestPostgresServer()
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
-            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const draftContract = await createTestContract(stateServer)
@@ -412,7 +406,7 @@ describe('adminCreateContractQuestion', () => {
             variables: {
                 input: {
                     contractID: draftContract.id,
-                    division: 'DMCO',
+                    addedByUserID: cmsUserWithDivision.id,
                     reason: 'Recording prior Q&A',
                     documents: questionDocuments,
                 },
@@ -430,7 +424,6 @@ describe('adminCreateContractQuestion', () => {
         })
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
-            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -445,7 +438,7 @@ describe('adminCreateContractQuestion', () => {
             variables: {
                 input: {
                     contractID: withdrawnContract.id,
-                    division: 'DMCO',
+                    addedByUserID: cmsUserWithDivision.id,
                     reason: 'Recording prior Q&A',
                     documents: questionDocuments,
                 },
@@ -466,7 +459,6 @@ describe('adminCreateContractQuestion', () => {
         })
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
-            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -474,7 +466,7 @@ describe('adminCreateContractQuestion', () => {
 
         const question = await adminCreateTestContractQuestion(adminServer, {
             contractID: approved.id,
-            division: 'DMCO',
+            addedByUserID: cmsUserWithDivision.id,
             reason: 'Recording prior Q&A',
             documents: questionDocuments,
         })
@@ -482,7 +474,7 @@ describe('adminCreateContractQuestion', () => {
         expect(question).toEqual(
             expect.objectContaining({
                 contractID: approved.id,
-                division: 'DMCO',
+                division: 'DMCP',
             })
         )
     })
@@ -491,7 +483,6 @@ describe('adminCreateContractQuestion', () => {
         const stateServer = await constructTestPostgresServer()
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
-            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -501,7 +492,7 @@ describe('adminCreateContractQuestion', () => {
             variables: {
                 input: {
                     contractID: contract.id,
-                    division: 'DMCO',
+                    addedByUserID: cmsUserWithDivision.id,
                     reason: 'Recording prior Q&A',
                     documents: [],
                 },

--- a/services/app-api/src/resolvers/questionResponse/adminCreateContractQuestion.test.ts
+++ b/services/app-api/src/resolvers/questionResponse/adminCreateContractQuestion.test.ts
@@ -13,6 +13,7 @@ import {
     assertAnErrorCode,
     fetchTestContractWithQuestions,
 } from '../../testHelpers'
+import { testLDService } from '../../testHelpers/launchDarklyHelpers'
 import {
     createDBUsersWithFullData,
     testAdminUser,
@@ -108,6 +109,7 @@ describe('adminCreateContractQuestion', () => {
         const stateServer = await constructTestPostgresServer()
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
+            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -129,6 +131,7 @@ describe('adminCreateContractQuestion', () => {
         const stateServer = await constructTestPostgresServer()
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
+            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -157,6 +160,7 @@ describe('adminCreateContractQuestion', () => {
         const stateServer = await constructTestPostgresServer()
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
+            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -189,6 +193,7 @@ describe('adminCreateContractQuestion', () => {
         const stateServer = await constructTestPostgresServer()
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
+            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -297,6 +302,7 @@ describe('adminCreateContractQuestion', () => {
         const stateServer = await constructTestPostgresServer()
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
+            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -326,6 +332,7 @@ describe('adminCreateContractQuestion', () => {
         const stateServer = await constructTestPostgresServer()
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
+            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -395,6 +402,7 @@ describe('adminCreateContractQuestion', () => {
         const stateServer = await constructTestPostgresServer()
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
+            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const draftContract = await createTestContract(stateServer)
@@ -422,6 +430,7 @@ describe('adminCreateContractQuestion', () => {
         })
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
+            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -457,6 +466,7 @@ describe('adminCreateContractQuestion', () => {
         })
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
+            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -481,6 +491,7 @@ describe('adminCreateContractQuestion', () => {
         const stateServer = await constructTestPostgresServer()
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
+            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)

--- a/services/app-api/src/resolvers/questionResponse/adminCreateContractQuestion.ts
+++ b/services/app-api/src/resolvers/questionResponse/adminCreateContractQuestion.ts
@@ -16,13 +16,15 @@ import type {
     DivisionType,
 } from '../../domain-models'
 import { isAdminQuestionResponseAllowedStatus } from '@mc-review/constants'
+import type { LDService } from '../../launchDarkly/launchDarkly'
 
 // Lets an AdminUser record a question on behalf of CMS. The admin can either pick
 // a division directly (the question is then attributed to the admin), or select a
 // CMS user to ask on behalf of (the question's addedBy and division come from that
 // user). No notification emails are sent.
 export function adminCreateContractQuestionResolver(
-    store: Store
+    store: Store,
+    launchDarkly: LDService
 ): MutationResolvers['adminCreateContractQuestion'] {
     return async (_parent, { input }, context) => {
         const { user } = context
@@ -84,6 +86,22 @@ export function adminCreateContractQuestionResolver(
                 if (input.createdAt && new Date(input.createdAt) > new Date()) {
                     const msg =
                         'the question created date cannot be in the future'
+                    logResolverError(
+                        'adminCreateContractQuestion',
+                        msg,
+                        context
+                    )
+                    throw createUserInputError(msg)
+                }
+
+                const adminOnlyQaRounds = await launchDarkly.getFeatureFlag({
+                    key: context.user.email,
+                    flag: 'admin-only-qa-rounds',
+                })
+
+                if (!adminOnlyQaRounds && !input.addedByUserID) {
+                    const msg =
+                        'a CMS user must be assigned as the question author'
                     logResolverError(
                         'adminCreateContractQuestion',
                         msg,

--- a/services/app-api/src/resolvers/questionResponse/adminCreateContractQuestion.ts
+++ b/services/app-api/src/resolvers/questionResponse/adminCreateContractQuestion.ts
@@ -16,15 +16,12 @@ import type {
     DivisionType,
 } from '../../domain-models'
 import { isAdminQuestionResponseAllowedStatus } from '@mc-review/constants'
-import type { LDService } from '../../launchDarkly/launchDarkly'
 
-// Lets an AdminUser record a question on behalf of CMS. The admin can either pick
-// a division directly (the question is then attributed to the admin), or select a
-// CMS user to ask on behalf of (the question's addedBy and division come from that
+// Lets an AdminUser record a question on behalf of CMS. The admin selects a CMS
+// user to ask on behalf of (the question's addedBy and division come from that
 // user). No notification emails are sent.
 export function adminCreateContractQuestionResolver(
-    store: Store,
-    launchDarkly: LDService
+    store: Store
 ): MutationResolvers['adminCreateContractQuestion'] {
     return async (_parent, { input }, context) => {
         const { user } = context
@@ -94,12 +91,7 @@ export function adminCreateContractQuestionResolver(
                     throw createUserInputError(msg)
                 }
 
-                const adminOnlyQaRounds = await launchDarkly.getFeatureFlag({
-                    key: context.user.email,
-                    flag: 'admin-only-qa-rounds',
-                })
-
-                if (!adminOnlyQaRounds && !input.addedByUserID) {
+                if (!input.addedByUserID) {
                     const msg =
                         'a CMS user must be assigned as the question author'
                     logResolverError(
@@ -140,83 +132,62 @@ export function adminCreateContractQuestionResolver(
                     })
                 }
 
-                // Resolve who the question is attributed to and which division it
-                // belongs to. When a CMS user is selected, both come from that
-                // user (asking on their behalf); otherwise it is the admin plus
-                // the division they picked.
-                let addedByUserID: string = user.id
+                // Resolve who the question is attributed to and which division
+                // it belongs to from the selected CMS user.
+                const cmsUser = await store.findUser(input.addedByUserID)
+                if (cmsUser instanceof Error) {
+                    const errMessage = `Issue finding user ${input.addedByUserID}. Message: ${cmsUser.message}`
+                    logResolverError(
+                        'adminCreateContractQuestion',
+                        errMessage,
+                        context
+                    )
+                    throw new GraphQLError(errMessage, {
+                        extensions: {
+                            code: 'INTERNAL_SERVER_ERROR',
+                            cause: 'DB_ERROR',
+                        },
+                    })
+                }
+                if (!cmsUser) {
+                    const msg = `CMS user with id ${input.addedByUserID} does not exist`
+                    logResolverError(
+                        'adminCreateContractQuestion',
+                        msg,
+                        context
+                    )
+                    throw createUserInputError(msg)
+                }
+                if (!hasCMSPermissions(cmsUser)) {
+                    const msg = 'addedByUserID must reference a CMS user'
+                    logResolverError(
+                        'adminCreateContractQuestion',
+                        msg,
+                        context
+                    )
+                    throw createUserInputError(msg)
+                }
+                const addedByUserID = cmsUser.id
                 let division: DivisionType
-
-                if (input.addedByUserID) {
-                    const cmsUser = await store.findUser(input.addedByUserID)
-                    if (cmsUser instanceof Error) {
-                        const errMessage = `Issue finding user ${input.addedByUserID}. Message: ${cmsUser.message}`
-                        logResolverError(
-                            'adminCreateContractQuestion',
-                            errMessage,
-                            context
-                        )
-                        throw new GraphQLError(errMessage, {
-                            extensions: {
-                                code: 'INTERNAL_SERVER_ERROR',
-                                cause: 'DB_ERROR',
-                            },
-                        })
-                    }
-                    if (!cmsUser) {
-                        const msg = `CMS user with id ${input.addedByUserID} does not exist`
-                        logResolverError(
-                            'adminCreateContractQuestion',
-                            msg,
-                            context
-                        )
-                        throw createUserInputError(msg)
-                    }
-                    if (!hasCMSPermissions(cmsUser)) {
-                        const msg = 'addedByUserID must reference a CMS user'
-                        logResolverError(
-                            'adminCreateContractQuestion',
-                            msg,
-                            context
-                        )
-                        throw createUserInputError(msg)
-                    }
-                    addedByUserID = cmsUser.id
-                    if (
-                        cmsUser.divisionAssignment &&
-                        isValidCmsDivison(cmsUser.divisionAssignment)
-                    ) {
-                        // The CMS user has a division — attribute the question to it.
-                        division = cmsUser.divisionAssignment
-                    } else if (
-                        input.division &&
-                        isValidCmsDivison(input.division)
-                    ) {
-                        // The CMS user has no division; fall back to the division
-                        // the admin picked for them.
-                        division = input.division
-                    } else {
-                        const msg =
-                            'a division is required when the selected CMS user has no division assignment'
-                        logResolverError(
-                            'adminCreateContractQuestion',
-                            msg,
-                            context
-                        )
-                        throw createUserInputError(msg)
-                    }
-                } else {
-                    if (!input.division || !isValidCmsDivison(input.division)) {
-                        const msg =
-                            'a division is required when no CMS user is selected'
-                        logResolverError(
-                            'adminCreateContractQuestion',
-                            msg,
-                            context
-                        )
-                        throw createUserInputError(msg)
-                    }
+                if (
+                    cmsUser.divisionAssignment &&
+                    isValidCmsDivison(cmsUser.divisionAssignment)
+                ) {
+                    division = cmsUser.divisionAssignment
+                } else if (
+                    input.division &&
+                    isValidCmsDivison(input.division)
+                ) {
                     division = input.division
+                } else {
+                    const msg =
+                        'a division is required when the selected CMS user has no division assignment'
+                    logResolverError(
+                        'adminCreateContractQuestion',
+                        msg,
+                        context
+                    )
+                    throw createUserInputError(msg)
                 }
 
                 // Keep the EQRO/DMCO data rule consistent with the CMS path.

--- a/services/app-api/src/resolvers/questionResponse/adminCreateContractQuestionResponse.test.ts
+++ b/services/app-api/src/resolvers/questionResponse/adminCreateContractQuestionResponse.test.ts
@@ -23,7 +23,6 @@ import {
     createAndSubmitTestContractWithRate,
     withdrawTestContract,
 } from '../../testHelpers/gqlContractHelpers'
-import { testLDService } from '../../testHelpers/launchDarklyHelpers'
 
 const responseDocuments = [
     {
@@ -66,14 +65,13 @@ describe('adminCreateContractQuestionResponse', () => {
         await createDBUsersWithFullData([adminUser, cmsUser, stateUser])
     })
 
-    it('records an admin response on a CMS-authored question, attributed to the admin', async () => {
+    it('records an admin response on a CMS-authored question, attributed to the state user', async () => {
         const stateServer = await constructTestPostgresServer()
         const cmsServer = await constructTestPostgresServer({
             context: { user: cmsUser },
         })
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
-            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -84,6 +82,7 @@ describe('adminCreateContractQuestionResponse', () => {
             adminServer,
             {
                 questionID: cmsQuestion.id,
+                addedByUserID: stateUser.id,
                 reason: 'Recording prior response',
                 documents: responseDocuments,
             }
@@ -94,8 +93,8 @@ describe('adminCreateContractQuestionResponse', () => {
         expect(question.responses[0]).toEqual(
             expect.objectContaining({
                 addedBy: expect.objectContaining({
-                    id: adminUser.id,
-                    role: 'ADMIN_USER',
+                    id: stateUser.id,
+                    role: 'STATE_USER',
                 }),
                 documents: expect.arrayContaining([
                     expect.objectContaining({ name: 'Admin Response' }),
@@ -118,6 +117,7 @@ describe('adminCreateContractQuestionResponse', () => {
             variables: {
                 input: {
                     questionID: cmsQuestion.id,
+                    addedByUserID: stateUser.id,
                     reason: 'Recording prior response',
                     documents: responseDocuments,
                 },
@@ -138,7 +138,6 @@ describe('adminCreateContractQuestionResponse', () => {
         })
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
-            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -149,6 +148,7 @@ describe('adminCreateContractQuestionResponse', () => {
             variables: {
                 input: {
                     questionID: cmsQuestion.id,
+                    addedByUserID: stateUser.id,
                     reason: 'Recording prior response',
                     documents: [],
                 },
@@ -169,7 +169,6 @@ describe('adminCreateContractQuestionResponse', () => {
         })
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
-            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -180,6 +179,7 @@ describe('adminCreateContractQuestionResponse', () => {
             adminServer,
             {
                 questionID: cmsQuestion.id,
+                addedByUserID: stateUser.id,
                 reason: 'Recording prior response',
                 documents: responseDocuments,
             }
@@ -187,7 +187,7 @@ describe('adminCreateContractQuestionResponse', () => {
 
         expect(question.responses).toHaveLength(1)
         expect(question.responses[0].addedBy).toEqual(
-            expect.objectContaining({ id: adminUser.id, role: 'ADMIN_USER' })
+            expect.objectContaining({ id: stateUser.id, role: 'STATE_USER' })
         )
     })
 
@@ -198,7 +198,6 @@ describe('adminCreateContractQuestionResponse', () => {
         })
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
-            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -214,6 +213,7 @@ describe('adminCreateContractQuestionResponse', () => {
             variables: {
                 input: {
                     questionID: cmsQuestion.id,
+                    addedByUserID: stateUser.id,
                     reason: 'Recording prior response',
                     documents: responseDocuments,
                 },
@@ -230,7 +230,6 @@ describe('adminCreateContractQuestionResponse', () => {
     it('returns a BAD_USER_INPUT error when the question does not exist', async () => {
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
-            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const result = await executeGraphQLOperation(adminServer, {
@@ -238,6 +237,7 @@ describe('adminCreateContractQuestionResponse', () => {
             variables: {
                 input: {
                     questionID: '550e8400-e29b-41d4-a716-446655440000',
+                    addedByUserID: stateUser.id,
                     reason: 'Recording prior response',
                     documents: responseDocuments,
                 },
@@ -316,7 +316,6 @@ describe('adminCreateContractQuestionResponse', () => {
         })
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
-            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -327,6 +326,7 @@ describe('adminCreateContractQuestionResponse', () => {
             variables: {
                 input: {
                     questionID: cmsQuestion.id,
+                    addedByUserID: stateUser.id,
                     reason: '   ',
                     documents: responseDocuments,
                 },
@@ -345,7 +345,6 @@ describe('adminCreateContractQuestionResponse', () => {
         })
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
-            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -356,6 +355,7 @@ describe('adminCreateContractQuestionResponse', () => {
             variables: {
                 input: {
                     questionID: cmsQuestion.id,
+                    addedByUserID: stateUser.id,
                     reason: 'Recording prior response',
                     createdAt: '2999-01-01',
                     documents: responseDocuments,
@@ -377,7 +377,6 @@ describe('adminCreateContractQuestionResponse', () => {
         })
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
-            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -389,6 +388,7 @@ describe('adminCreateContractQuestionResponse', () => {
             variables: {
                 input: {
                     questionID: cmsQuestion.id,
+                    addedByUserID: stateUser.id,
                     reason: 'Recording prior response',
                     createdAt: '2020-01-01',
                     documents: responseDocuments,
@@ -451,7 +451,6 @@ describe('adminCreateContractQuestionResponse', () => {
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
             emailer: mockEmailer,
-            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -459,6 +458,7 @@ describe('adminCreateContractQuestionResponse', () => {
 
         await adminCreateTestContractQuestionResponse(adminServer, {
             questionID: cmsQuestion.id,
+            addedByUserID: stateUser.id,
             reason: 'Recording prior response',
             documents: responseDocuments,
         })

--- a/services/app-api/src/resolvers/questionResponse/adminCreateContractQuestionResponse.test.ts
+++ b/services/app-api/src/resolvers/questionResponse/adminCreateContractQuestionResponse.test.ts
@@ -23,6 +23,7 @@ import {
     createAndSubmitTestContractWithRate,
     withdrawTestContract,
 } from '../../testHelpers/gqlContractHelpers'
+import { testLDService } from '../../testHelpers/launchDarklyHelpers'
 
 const responseDocuments = [
     {
@@ -72,6 +73,7 @@ describe('adminCreateContractQuestionResponse', () => {
         })
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
+            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -136,6 +138,7 @@ describe('adminCreateContractQuestionResponse', () => {
         })
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
+            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -166,6 +169,7 @@ describe('adminCreateContractQuestionResponse', () => {
         })
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
+            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -194,6 +198,7 @@ describe('adminCreateContractQuestionResponse', () => {
         })
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
+            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -225,6 +230,7 @@ describe('adminCreateContractQuestionResponse', () => {
     it('returns a BAD_USER_INPUT error when the question does not exist', async () => {
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
+            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const result = await executeGraphQLOperation(adminServer, {
@@ -310,6 +316,7 @@ describe('adminCreateContractQuestionResponse', () => {
         })
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
+            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -338,6 +345,7 @@ describe('adminCreateContractQuestionResponse', () => {
         })
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
+            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -369,6 +377,7 @@ describe('adminCreateContractQuestionResponse', () => {
         })
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
+            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)
@@ -442,6 +451,7 @@ describe('adminCreateContractQuestionResponse', () => {
         const adminServer = await constructTestPostgresServer({
             context: { user: adminUser },
             emailer: mockEmailer,
+            ldService: testLDService({ 'admin-only-qa-rounds': true }),
         })
 
         const contract = await createAndSubmitTestContractWithRate(stateServer)

--- a/services/app-api/src/resolvers/questionResponse/adminCreateContractQuestionResponse.ts
+++ b/services/app-api/src/resolvers/questionResponse/adminCreateContractQuestionResponse.ts
@@ -12,12 +12,14 @@ import { GraphQLError } from 'graphql'
 import { canWrite } from '../../oauth/oauthAuthorization'
 import { parseAndValidateDocuments } from '../documentHelpers'
 import { isAdminQuestionResponseAllowedStatus } from '@mc-review/constants'
+import type { LDService } from '../../launchDarkly/launchDarkly'
 
 // Lets an AdminUser record a response on behalf of the state, attached to any
 // existing contract question (including questions authored by CMS). No
 // notification emails are sent.
 export function adminCreateContractQuestionResponseResolver(
-    store: Store
+    store: Store,
+    launchDarkly: LDService
 ): MutationResolvers['adminCreateContractQuestionResponse'] {
     return async (_parent, { input }, context) => {
         const { user } = context
@@ -77,6 +79,22 @@ export function adminCreateContractQuestionResponseResolver(
 
                 if (input.createdAt && new Date(input.createdAt) > new Date()) {
                     const msg = 'the response date cannot be in the future'
+                    logResolverError(
+                        'adminCreateContractQuestionResponse',
+                        msg,
+                        context
+                    )
+                    throw createUserInputError(msg)
+                }
+
+                const adminOnlyQaRounds = await launchDarkly.getFeatureFlag({
+                    key: context.user.email,
+                    flag: 'admin-only-qa-rounds',
+                })
+
+                if (!adminOnlyQaRounds && !input.addedByUserID) {
+                    const msg =
+                        'a state user must be assigned as the response author'
                     logResolverError(
                         'adminCreateContractQuestionResponse',
                         msg,

--- a/services/app-api/src/resolvers/questionResponse/adminCreateContractQuestionResponse.ts
+++ b/services/app-api/src/resolvers/questionResponse/adminCreateContractQuestionResponse.ts
@@ -12,14 +12,11 @@ import { GraphQLError } from 'graphql'
 import { canWrite } from '../../oauth/oauthAuthorization'
 import { parseAndValidateDocuments } from '../documentHelpers'
 import { isAdminQuestionResponseAllowedStatus } from '@mc-review/constants'
-import type { LDService } from '../../launchDarkly/launchDarkly'
-
 // Lets an AdminUser record a response on behalf of the state, attached to any
 // existing contract question (including questions authored by CMS). No
 // notification emails are sent.
 export function adminCreateContractQuestionResponseResolver(
-    store: Store,
-    launchDarkly: LDService
+    store: Store
 ): MutationResolvers['adminCreateContractQuestionResponse'] {
     return async (_parent, { input }, context) => {
         const { user } = context
@@ -87,12 +84,7 @@ export function adminCreateContractQuestionResponseResolver(
                     throw createUserInputError(msg)
                 }
 
-                const adminOnlyQaRounds = await launchDarkly.getFeatureFlag({
-                    key: context.user.email,
-                    flag: 'admin-only-qa-rounds',
-                })
-
-                if (!adminOnlyQaRounds && !input.addedByUserID) {
+                if (!input.addedByUserID) {
                     const msg =
                         'a state user must be assigned as the response author'
                     logResolverError(
@@ -175,45 +167,42 @@ export function adminCreateContractQuestionResponseResolver(
                     throw createUserInputError(errMessage)
                 }
 
-                // Attribute the response to the chosen state user, or to the
-                // admin when none is selected.
-                let addedByUserID: string = user.id
-                if (input.addedByUserID) {
-                    const stateUser = await store.findUser(input.addedByUserID)
-                    if (stateUser instanceof Error) {
-                        const errMessage = `Issue finding user ${input.addedByUserID}. Message: ${stateUser.message}`
-                        logResolverError(
-                            'adminCreateContractQuestionResponse',
-                            errMessage,
-                            context
-                        )
-                        throw new GraphQLError(errMessage, {
-                            extensions: {
-                                code: 'INTERNAL_SERVER_ERROR',
-                                cause: 'DB_ERROR',
-                            },
-                        })
-                    }
-                    if (!stateUser) {
-                        const msg = `state user with id ${input.addedByUserID} does not exist`
-                        logResolverError(
-                            'adminCreateContractQuestionResponse',
-                            msg,
-                            context
-                        )
-                        throw createUserInputError(msg)
-                    }
-                    if (!isStateUser(stateUser)) {
-                        const msg = 'addedByUserID must reference a state user'
-                        logResolverError(
-                            'adminCreateContractQuestionResponse',
-                            msg,
-                            context
-                        )
-                        throw createUserInputError(msg)
-                    }
-                    addedByUserID = stateUser.id
+                // Attribute the response to the chosen state user.
+                // Admin users cannot be assigned as the response author.
+                const stateUser = await store.findUser(input.addedByUserID)
+                if (stateUser instanceof Error) {
+                    const errMessage = `Issue finding user ${input.addedByUserID}. Message: ${stateUser.message}`
+                    logResolverError(
+                        'adminCreateContractQuestionResponse',
+                        errMessage,
+                        context
+                    )
+                    throw new GraphQLError(errMessage, {
+                        extensions: {
+                            code: 'INTERNAL_SERVER_ERROR',
+                            cause: 'DB_ERROR',
+                        },
+                    })
                 }
+                if (!stateUser) {
+                    const msg = `state user with id ${input.addedByUserID} does not exist`
+                    logResolverError(
+                        'adminCreateContractQuestionResponse',
+                        msg,
+                        context
+                    )
+                    throw createUserInputError(msg)
+                }
+                if (!isStateUser(stateUser)) {
+                    const msg = 'addedByUserID must reference a state user'
+                    logResolverError(
+                        'adminCreateContractQuestionResponse',
+                        msg,
+                        context
+                    )
+                    throw createUserInputError(msg)
+                }
+                const addedByUserID = stateUser.id
 
                 const docs = parseAndValidateDocuments(
                     input.documents.map((d) => ({

--- a/services/app-graphql/src/fragments/questionFragment.graphql
+++ b/services/app-graphql/src/fragments/questionFragment.graphql
@@ -9,9 +9,6 @@ fragment contractQuestionFragment on ContractQuestion {
         ... on CMSApproverUser {
             ...cmsApproverUserFragment
         }
-        ... on AdminUser {
-            ...adminUserFragment
-        }
     }
     division
     round
@@ -42,9 +39,6 @@ fragment rateQuestionFragment on RateQuestion {
         }
         ... on CMSApproverUser {
             ...cmsApproverUserFragment
-        }
-        ... on AdminUser {
-            ...adminUserFragment
         }
     }
     division

--- a/services/app-graphql/src/fragments/questionResponseFragment.graphql
+++ b/services/app-graphql/src/fragments/questionResponseFragment.graphql
@@ -6,9 +6,6 @@ fragment questionResponseFragment on QuestionResponse {
         ... on StateUser {
             ...stateUserFragment
         }
-        ... on AdminUser {
-            ...adminUserFragment
-        }
     }
     documents {
         ...documentFragment

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -915,17 +915,12 @@ input AdminCreateContractQuestionInput {
     "The ID of the contract for which to create a question"
     contractID: ID!
     """
-    The CMS division to attribute the question to. Required when addedByUserID is
-    omitted; ignored when addedByUserID is provided (the division is derived from
-    that CMS user instead).
+    The CMS division to attribute the question to. Required when the selected CMS
+    user has no division assignment; ignored when the CMS user has one.
     """
     division: Division
-    """
-    Optional CMS user to attribute the question to (asking on their behalf). When
-    provided, the question's addedBy and division are taken from this user. When
-    omitted, the question is attributed to the admin and uses the division above.
-    """
-    addedByUserID: ID
+    "The CMS user to attribute the question to (asking on their behalf)."
+    addedByUserID: ID!
     """
     Optional date to record as the question's created date (for backfilling Q&A
     that happened earlier). Cannot be in the future. Defaults to now when omitted.
@@ -1009,11 +1004,8 @@ Input for an admin recording a response on an existing contract question.
 input AdminCreateContractQuestionResponseInput {
     "The ID of the question for which to create a response"
     questionID: ID!
-    """
-    Optional state user to attribute the response to (recording on their behalf).
-    When omitted, the response is attributed to the admin.
-    """
-    addedByUserID: ID
+    "The state user to attribute the response to (recording on their behalf)."
+    addedByUserID: ID!
     """
     Optional date to record as the response's created date. Must be on or after
     the question's created date and not in the future. Defaults to now when omitted.
@@ -1242,17 +1234,15 @@ union CMSUsersUnion = CMSUser | CMSApproverUser
 
 union OAuthUser = CMSUser | CMSApproverUser | AdminUser
 
-"""
-Possible authors of a Q&A question: a CMS reviewer/approver, or an AdminUser
-recording a round on their behalf.
-"""
-union QuestionAuthor = CMSUser | CMSApproverUser | AdminUser
+# TODO: Restore QuestionAuthor union when external API clients support inline
+# fragments on ContractQuestion/RateQuestion.addedBy. Revert addedBy back to
+# QuestionAuthor! and restore the fragment and resolver.
+# union QuestionAuthor = CMSUser | CMSApproverUser | AdminUser
 
-"""
-Possible authors of a Q&A response: a state user, or an AdminUser recording a
-round on their behalf.
-"""
-union ResponseAuthor = StateUser | AdminUser
+# TODO: Restore ResponseAuthor union when external API clients support inline
+# fragments on QuestionResponse.addedBy. Revert addedBy on QuestionResponse back
+# to ResponseAuthor! and restore the fragment and resolver.
+# union ResponseAuthor = StateUser | AdminUser
 
 "AdminUser is a user that works on the MC Review app itself"
 type AdminUser {
@@ -1498,7 +1488,7 @@ type ContractQuestion {
     id: ID!
     contractID: ID!
     createdAt: DateTime!
-    addedBy: QuestionAuthor!
+    addedBy: CMSUsersUnion!
     documents: [Document!]!
     division: Division!
     round: Int!
@@ -1539,7 +1529,7 @@ type RateQuestion {
     id: ID!
     rateID: ID!
     createdAt: DateTime!
-    addedBy: QuestionAuthor!
+    addedBy: CMSUsersUnion!
     documents: [Document!]!
     division: Division!
     round: Int!
@@ -1558,7 +1548,7 @@ type QuestionResponse {
     id: ID!
     questionID: ID!
     createdAt: DateTime!
-    addedBy: ResponseAuthor!
+    addedBy: StateUser!
     documents: [Document!]!
     #    noteText: String
 }

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponse.module.scss
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponse.module.scss
@@ -80,6 +80,22 @@
     background: none;
     margin: uswds.units(2) auto;
 }
+.selectedUserSummary {
+    margin-bottom: 1.5rem;
+    margin-top: 1.5rem;
+}
+
+.selectedUserLabel {
+    font-size: 1rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+    margin-top: 0;
+}
+
+.selectedUserAddress {
+    font-style: normal;
+}
+
 .formContainer {
     > [class^='usa-fieldset'] {
         padding: uswds.units(4);

--- a/services/app-web/src/pages/QuestionResponse/UploadQuestions/AdminUploadContractQuestions.test.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadQuestions/AdminUploadContractQuestions.test.tsx
@@ -147,6 +147,35 @@ describe('AdminUploadContractQuestions', () => {
         ).toBeLessThan(summaryMessages.indexOf('You must provide a reason'))
     })
 
+    it('requires a CMS user to be selected before submitting', async () => {
+        const user = userEvent.setup()
+        renderAdminUploadQuestions()
+
+        const submit = await screen.findByRole('button', {
+            name: 'Add questions',
+        })
+        await user.click(submit)
+
+        expect(
+            (await screen.findAllByText('You must select a CMS user')).length
+        ).toBeGreaterThan(0)
+
+        // Error summary link points to (and can focus) the user select.
+        const userLink = screen.getByRole('link', {
+            name: 'You must select a CMS user',
+        })
+        expect(userLink).toHaveAttribute('href', '#cms-user-select')
+        expect(document.getElementById('cms-user-select')).toBeInTheDocument()
+
+        // The CMS user error is listed first, before the division error.
+        const summaryMessages = screen
+            .getAllByTestId('error-summary-message')
+            .map((el) => el.textContent)
+        expect(
+            summaryMessages.indexOf('You must select a CMS user')
+        ).toBeLessThan(summaryMessages.indexOf('You must select a division'))
+    })
+
     it('offers an optional question date field that disallows future dates', async () => {
         renderAdminUploadQuestions()
 

--- a/services/app-web/src/pages/QuestionResponse/UploadQuestions/AdminUploadContractQuestions.test.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadQuestions/AdminUploadContractQuestions.test.tsx
@@ -28,9 +28,7 @@ const cmsUserNoDivision = mockValidCMSUser({
     divisionAssignment: null,
 })
 
-const renderAdminUploadQuestions = (options?: {
-    featureFlags?: Record<string, boolean>
-}) => {
+const renderAdminUploadQuestions = () => {
     const contract = mockContractPackageSubmittedWithQuestions()
     return renderWithProviders(
         <Routes>
@@ -66,19 +64,16 @@ const renderAdminUploadQuestions = (options?: {
             routerProvider: {
                 route: `/submissions/health-plan/15/question-and-answers/admin-upload-questions`,
             },
-            featureFlags: options?.featureFlags,
         }
     )
 }
 
 describe('AdminUploadContractQuestions', () => {
-    it('offers an "ask on behalf of" picker with "Myself (admin)" when the flag is on, but does not pre-select', async () => {
+    it('offers an "ask on behalf of" picker with CMS users only', async () => {
         const user = userEvent.setup()
-        renderAdminUploadQuestions({
-            featureFlags: { 'admin-only-qa-rounds': true },
-        })
+        renderAdminUploadQuestions()
 
-        // Nothing is pre-selected; the admin info section is not shown
+        // Nothing is pre-selected; the user info section is not shown
         const onBehalfOf = await screen.findByRole('combobox', {
             name: 'Ask on behalf of',
         })
@@ -86,9 +81,9 @@ describe('AdminUploadContractQuestions', () => {
             screen.queryByTestId('selected-user-info')
         ).not.toBeInTheDocument()
 
-        // Opening the menu shows "Myself (admin)" and CMS users
+        // Opening the menu shows CMS users but no "Myself" option
         await user.click(onBehalfOf)
-        expect(await screen.findByText('Myself (admin)')).toBeInTheDocument()
+        expect(screen.queryByText('Myself (admin)')).not.toBeInTheDocument()
         expect(
             await screen.findByText(/anna\.analyst@example\.com/)
         ).toBeInTheDocument()
@@ -157,24 +152,6 @@ describe('AdminUploadContractQuestions', () => {
 
         expect(await screen.findByText('Question date')).toBeInTheDocument()
         expect(screen.getByText(/Cannot be a future date/)).toBeInTheDocument()
-    })
-
-    it('displays the admin\'s own info after explicitly selecting "Myself (admin)"', async () => {
-        const user = userEvent.setup()
-        renderAdminUploadQuestions({
-            featureFlags: { 'admin-only-qa-rounds': true },
-        })
-
-        const onBehalfOf = await screen.findByRole('combobox', {
-            name: 'Ask on behalf of',
-        })
-        await user.click(onBehalfOf)
-        await user.click(await screen.findByText('Myself (admin)'))
-
-        const info = await screen.findByTestId('selected-user-info')
-        expect(info).toHaveTextContent('Adam Admin')
-        expect(info).toHaveTextContent('adam.admin@example.com')
-        expect(info).toHaveTextContent('Admin')
     })
 
     it("displays the selected CMS user's details below the dropdown", async () => {

--- a/services/app-web/src/pages/QuestionResponse/UploadQuestions/AdminUploadContractQuestions.test.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadQuestions/AdminUploadContractQuestions.test.tsx
@@ -28,7 +28,9 @@ const cmsUserNoDivision = mockValidCMSUser({
     divisionAssignment: null,
 })
 
-const renderAdminUploadQuestions = () => {
+const renderAdminUploadQuestions = (options?: {
+    featureFlags?: Record<string, boolean>
+}) => {
     const contract = mockContractPackageSubmittedWithQuestions()
     return renderWithProviders(
         <Routes>
@@ -64,35 +66,35 @@ const renderAdminUploadQuestions = () => {
             routerProvider: {
                 route: `/submissions/health-plan/15/question-and-answers/admin-upload-questions`,
             },
+            featureFlags: options?.featureFlags,
         }
     )
 }
 
 describe('AdminUploadContractQuestions', () => {
-    it('offers an optional "ask on behalf of" CMS user picker, defaulting to the admin', async () => {
+    it('offers an "ask on behalf of" picker with "Myself (admin)" when the flag is on, but does not pre-select', async () => {
         const user = userEvent.setup()
-        renderAdminUploadQuestions()
+        renderAdminUploadQuestions({
+            featureFlags: { 'admin-only-qa-rounds': true },
+        })
 
-        // The react-select control shows the default "Myself (admin)" selection
-        expect(await screen.findByText('Myself (admin)')).toBeInTheDocument()
-
-        // By default the admin picks a division manually
-        expect(
-            screen.getByRole('combobox', { name: 'Division' })
-        ).toBeInTheDocument()
-
-        // CMS users from indexUsers appear as options once the menu opens
-        const onBehalfOf = screen.getByRole('combobox', {
+        // Nothing is pre-selected; the admin info section is not shown
+        const onBehalfOf = await screen.findByRole('combobox', {
             name: 'Ask on behalf of',
         })
+        expect(
+            screen.queryByTestId('selected-user-info')
+        ).not.toBeInTheDocument()
+
+        // Opening the menu shows "Myself (admin)" and CMS users
         await user.click(onBehalfOf)
-        // CMS users are listed by email
+        expect(await screen.findByText('Myself (admin)')).toBeInTheDocument()
         expect(
             await screen.findByText(/anna\.analyst@example\.com/)
         ).toBeInTheDocument()
     })
 
-    it('locks the division to the selected CMS user’s division', async () => {
+    it("locks the division to the selected CMS user's division", async () => {
         const user = userEvent.setup()
         renderAdminUploadQuestions()
 
@@ -157,8 +159,17 @@ describe('AdminUploadContractQuestions', () => {
         expect(screen.getByText(/Cannot be a future date/)).toBeInTheDocument()
     })
 
-    it('displays the admin’s own info by default', async () => {
-        renderAdminUploadQuestions()
+    it('displays the admin\'s own info after explicitly selecting "Myself (admin)"', async () => {
+        const user = userEvent.setup()
+        renderAdminUploadQuestions({
+            featureFlags: { 'admin-only-qa-rounds': true },
+        })
+
+        const onBehalfOf = await screen.findByRole('combobox', {
+            name: 'Ask on behalf of',
+        })
+        await user.click(onBehalfOf)
+        await user.click(await screen.findByText('Myself (admin)'))
 
         const info = await screen.findByTestId('selected-user-info')
         expect(info).toHaveTextContent('Adam Admin')
@@ -166,7 +177,7 @@ describe('AdminUploadContractQuestions', () => {
         expect(info).toHaveTextContent('Admin')
     })
 
-    it('displays the selected CMS user’s details below the dropdown', async () => {
+    it("displays the selected CMS user's details below the dropdown", async () => {
         const user = userEvent.setup()
         renderAdminUploadQuestions()
 

--- a/services/app-web/src/pages/QuestionResponse/UploadQuestions/AdminUploadContractQuestions.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadQuestions/AdminUploadContractQuestions.tsx
@@ -13,9 +13,6 @@ import {
     IndexUsersDocument,
 } from '../../../gen/gqlClient'
 import { usePage } from '../../../contexts/PageContext'
-import { useAuth } from '../../../contexts/AuthContext'
-import { useLDClient } from 'launchdarkly-react-client-sdk'
-import { featureFlags } from '@mc-review/common-code'
 import { Breadcrumbs } from '../../../components'
 import { RoutesRecord } from '@mc-review/constants'
 import { GenericErrorPage } from '../../Errors/GenericErrorPage'
@@ -37,12 +34,6 @@ export const AdminUploadContractQuestions = () => {
         contractSubmissionType: ContractSubmissionType
     }>()
     const navigate = useNavigate()
-    const { loggedInUser } = useAuth()
-    const ldClient = useLDClient()
-    const adminOnlyQaRounds: boolean = ldClient?.variation(
-        featureFlags.ADMIN_ONLY_QA_ROUNDS.flag,
-        featureFlags.ADMIN_ONLY_QA_ROUNDS.defaultValue
-    )
 
     const {
         data: fetchContractData,
@@ -116,13 +107,11 @@ export const AdminUploadContractQuestions = () => {
 
         const input: AdminCreateContractQuestionInput = {
             contractID: id as string,
+            addedByUserID: data.addedByUserID,
             reason: data.reason.trim(),
             documents: questionDocs,
         }
 
-        if (data.addedByUserID && data.addedByUserID !== 'myself') {
-            input.addedByUserID = data.addedByUserID
-        }
         if (data.division) {
             input.division = data.division as Division
         }
@@ -165,8 +154,6 @@ export const AdminUploadContractQuestions = () => {
                 apiError={Boolean(apiError)}
                 contract={contract}
                 cmsUsers={cmsUsers}
-                loggedInUser={loggedInUser}
-                adminOnlyQaRounds={adminOnlyQaRounds}
             />
         </div>
     )

--- a/services/app-web/src/pages/QuestionResponse/UploadQuestions/AdminUploadContractQuestions.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadQuestions/AdminUploadContractQuestions.tsx
@@ -14,6 +14,8 @@ import {
 } from '../../../gen/gqlClient'
 import { usePage } from '../../../contexts/PageContext'
 import { useAuth } from '../../../contexts/AuthContext'
+import { useLDClient } from 'launchdarkly-react-client-sdk'
+import { featureFlags } from '@mc-review/common-code'
 import { Breadcrumbs } from '../../../components'
 import { RoutesRecord } from '@mc-review/constants'
 import { GenericErrorPage } from '../../Errors/GenericErrorPage'
@@ -36,6 +38,11 @@ export const AdminUploadContractQuestions = () => {
     }>()
     const navigate = useNavigate()
     const { loggedInUser } = useAuth()
+    const ldClient = useLDClient()
+    const adminOnlyQaRounds: boolean = ldClient?.variation(
+        featureFlags.ADMIN_ONLY_QA_ROUNDS.flag,
+        featureFlags.ADMIN_ONLY_QA_ROUNDS.defaultValue
+    )
 
     const {
         data: fetchContractData,
@@ -113,7 +120,7 @@ export const AdminUploadContractQuestions = () => {
             documents: questionDocs,
         }
 
-        if (data.addedByUserID) {
+        if (data.addedByUserID && data.addedByUserID !== 'myself') {
             input.addedByUserID = data.addedByUserID
         }
         if (data.division) {
@@ -159,6 +166,7 @@ export const AdminUploadContractQuestions = () => {
                 contract={contract}
                 cmsUsers={cmsUsers}
                 loggedInUser={loggedInUser}
+                adminOnlyQaRounds={adminOnlyQaRounds}
             />
         </div>
     )

--- a/services/app-web/src/pages/QuestionResponse/UploadQuestions/AdminUploadQuestionsForm.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadQuestions/AdminUploadQuestionsForm.tsx
@@ -118,6 +118,7 @@ const AdminUploadQuestionsForm = ({
     // the selected CMS user supplies the division (in which case it is derived).
     // Field order matches the page so the error summary lists them in page order.
     const validationSchema = Yup.object().shape({
+        addedByUserID: Yup.string().required('You must select a CMS user'),
         division: Yup.string().test(
             'division-required',
             'You must select a division',
@@ -149,6 +150,7 @@ const AdminUploadQuestionsForm = ({
     // on hidden inputs, so a `#id` key (focus by id) is used rather than the
     // field name.
     const fieldFocusId: Record<string, string> = {
+        addedByUserID: 'cms-user-select',
         reason: 'reason',
         division: 'division-select',
         createdAt: 'admin-question-createdAt',
@@ -264,12 +266,14 @@ const AdminUploadQuestionsForm = ({
                                 />
                             </FormGroup>
 
-                            <FormGroup>
+                            <FormGroup
+                                error={showFieldErrors(errors.addedByUserID)}
+                            >
                                 <Label htmlFor="cms-user-select">
                                     Ask on behalf of
                                 </Label>
                                 <span className={styles.requiredOptionalText}>
-                                    Optional
+                                    Required
                                 </span>
                                 <span
                                     className="usa-hint"
@@ -280,6 +284,11 @@ const AdminUploadQuestionsForm = ({
                                     they have one; otherwise pick a division
                                     below.
                                 </span>
+                                {showFieldErrors(errors.addedByUserID) && (
+                                    <PoliteErrorMessage formFieldLabel="Ask on behalf of">
+                                        {errors.addedByUserID}
+                                    </PoliteErrorMessage>
+                                )}
                                 <AccessibleSelect<AdminSelectOption>
                                     inputId="cms-user-select"
                                     name="addedByUserID"

--- a/services/app-web/src/pages/QuestionResponse/UploadQuestions/AdminUploadQuestionsForm.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadQuestions/AdminUploadQuestionsForm.tsx
@@ -71,6 +71,7 @@ type AdminUploadQuestionsFormProps = {
     contract: ContractWithQuestions
     cmsUsers: CmsUserNode[]
     loggedInUser?: User
+    adminOnlyQaRounds: boolean
 }
 
 // Owns the admin question form: the Formik state, the document upload, and the
@@ -84,6 +85,7 @@ const AdminUploadQuestionsForm = ({
     contract,
     cmsUsers,
     loggedInUser,
+    adminOnlyQaRounds,
 }: AdminUploadQuestionsFormProps) => {
     const navigate = useNavigate()
     const { handleUploadFile, handleScanFile } = useS3()
@@ -104,7 +106,9 @@ const AdminUploadQuestionsForm = ({
     const todayISO = new Date().toISOString().slice(0, 10)
 
     const userOptions: AdminSelectOption[] = [
-        { label: 'Myself (admin)', value: '' },
+        ...(adminOnlyQaRounds
+            ? [{ label: 'Myself (admin)', value: 'myself' }]
+            : []),
         ...cmsUsers.map((user) => ({
             label: user.email,
             value: user.id,
@@ -207,7 +211,12 @@ const AdminUploadQuestionsForm = ({
                 )
 
                 // Who the question is attributed to — the CMS user, or the admin.
-                const displayedUser = selectedCmsUser ?? loggedInUser
+                // Show the admin only when they explicitly pick "Myself".
+                const myselfSelected =
+                    adminOnlyQaRounds && values.addedByUserID === 'myself'
+                const displayedUser =
+                    selectedCmsUser ??
+                    (myselfSelected ? loggedInUser : undefined)
                 const displayedUserDivision =
                     displayedUser && 'divisionAssignment' in displayedUser
                         ? displayedUser.divisionAssignment
@@ -215,7 +224,7 @@ const AdminUploadQuestionsForm = ({
 
                 const selectedCmsUserOption =
                     userOptions.find((o) => o.value === values.addedByUserID) ??
-                    userOptions[0]
+                    null
                 const selectedDivisionOption =
                     divisionOptions.find((o) => o.value === values.division) ??
                     null
@@ -299,6 +308,7 @@ const AdminUploadQuestionsForm = ({
                                     className={selectStyles.multiSelect}
                                     classNamePrefix="select"
                                     isSearchable
+                                    isClearable={!adminOnlyQaRounds}
                                     options={userOptions}
                                     value={selectedCmsUserOption}
                                     onChange={(newValue) =>
@@ -309,30 +319,42 @@ const AdminUploadQuestionsForm = ({
                                     }
                                 />
                                 {displayedUser && (
-                                    <address
-                                        className="margin-top-1"
+                                    <div
+                                        className={styles.selectedUserSummary}
                                         data-testid="selected-user-info"
                                     >
-                                        {displayedUser.givenName}{' '}
-                                        {displayedUser.familyName}
-                                        <br />
-                                        {userRoleDisplayNames[
-                                            displayedUser.role
-                                        ] ?? displayedUser.role}
-                                        <br />
-                                        <LinkWithLogging
-                                            href={`mailto:${displayedUser.email}`}
-                                            target="_blank"
-                                            variant="external"
-                                            rel="noreferrer"
-                                            event_name="contact_click"
-                                            contact_method="email"
+                                        <div
+                                            className={styles.selectedUserLabel}
                                         >
-                                            {displayedUser.email}
-                                        </LinkWithLogging>
-                                        <br />
-                                        {displayedUserDivision ?? 'No division'}
-                                    </address>
+                                            Selected user
+                                        </div>
+                                        <address
+                                            className={
+                                                styles.selectedUserAddress
+                                            }
+                                        >
+                                            {displayedUser.givenName}{' '}
+                                            {displayedUser.familyName}
+                                            <br />
+                                            {userRoleDisplayNames[
+                                                displayedUser.role
+                                            ] ?? displayedUser.role}
+                                            <br />
+                                            <LinkWithLogging
+                                                href={`mailto:${displayedUser.email}`}
+                                                target="_blank"
+                                                variant="external"
+                                                rel="noreferrer"
+                                                event_name="contact_click"
+                                                contact_method="email"
+                                            >
+                                                {displayedUser.email}
+                                            </LinkWithLogging>
+                                            <br />
+                                            {displayedUserDivision ??
+                                                'No division'}
+                                        </address>
+                                    </div>
                                 )}
                             </FormGroup>
 
@@ -371,6 +393,7 @@ const AdminUploadQuestionsForm = ({
                                         className={selectStyles.multiSelect}
                                         classNamePrefix="select"
                                         placeholder="- Select division -"
+                                        isClearable
                                         options={divisionOptions}
                                         value={selectedDivisionOption}
                                         onChange={(newValue) =>

--- a/services/app-web/src/pages/QuestionResponse/UploadQuestions/AdminUploadQuestionsForm.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadQuestions/AdminUploadQuestionsForm.tsx
@@ -14,7 +14,6 @@ import {
     Division,
     CmsUser,
     CmsApproverUser,
-    User,
     FetchContractWithQuestionsQuery,
 } from '../../../gen/gqlClient'
 import { formatUserInputDate } from '@mc-review/dates'
@@ -61,7 +60,6 @@ export type AdminUploadQuestionsFormData = AdminQuestionFormValues & {
 const userRoleDisplayNames: Record<string, string> = {
     CMS_USER: 'CMS User',
     CMS_APPROVER_USER: 'CMS Approver',
-    ADMIN_USER: 'Admin',
 }
 
 type AdminUploadQuestionsFormProps = {
@@ -70,8 +68,6 @@ type AdminUploadQuestionsFormProps = {
     apiError: boolean
     contract: ContractWithQuestions
     cmsUsers: CmsUserNode[]
-    loggedInUser?: User
-    adminOnlyQaRounds: boolean
 }
 
 // Owns the admin question form: the Formik state, the document upload, and the
@@ -84,8 +80,6 @@ const AdminUploadQuestionsForm = ({
     apiError,
     contract,
     cmsUsers,
-    loggedInUser,
-    adminOnlyQaRounds,
 }: AdminUploadQuestionsFormProps) => {
     const navigate = useNavigate()
     const { handleUploadFile, handleScanFile } = useS3()
@@ -105,15 +99,10 @@ const AdminUploadQuestionsForm = ({
 
     const todayISO = new Date().toISOString().slice(0, 10)
 
-    const userOptions: AdminSelectOption[] = [
-        ...(adminOnlyQaRounds
-            ? [{ label: 'Myself (admin)', value: 'myself' }]
-            : []),
-        ...cmsUsers.map((user) => ({
-            label: user.email,
-            value: user.id,
-        })),
-    ]
+    const userOptions: AdminSelectOption[] = cmsUsers.map((user) => ({
+        label: user.email,
+        value: user.id,
+    }))
     const divisionOptions: AdminSelectOption[] = (
         Object.keys(divisionFullNames) as Division[]
     ).map((d) => ({ label: divisionFullNames[d], value: d }))
@@ -210,17 +199,8 @@ const AdminUploadQuestionsForm = ({
                     values.addedByUserID && selectedUserDivision
                 )
 
-                // Who the question is attributed to — the CMS user, or the admin.
-                // Show the admin only when they explicitly pick "Myself".
-                const myselfSelected =
-                    adminOnlyQaRounds && values.addedByUserID === 'myself'
-                const displayedUser =
-                    selectedCmsUser ??
-                    (myselfSelected ? loggedInUser : undefined)
                 const displayedUserDivision =
-                    displayedUser && 'divisionAssignment' in displayedUser
-                        ? displayedUser.divisionAssignment
-                        : undefined
+                    selectedCmsUser?.divisionAssignment ?? undefined
 
                 const selectedCmsUserOption =
                     userOptions.find((o) => o.value === values.addedByUserID) ??
@@ -298,8 +278,7 @@ const AdminUploadQuestionsForm = ({
                                     Select a CMS user to attribute this question
                                     to. The division is set from that user when
                                     they have one; otherwise pick a division
-                                    below. Leave as "Myself" to attribute the
-                                    question to your admin account.
+                                    below.
                                 </span>
                                 <AccessibleSelect<AdminSelectOption>
                                     inputId="cms-user-select"
@@ -308,7 +287,7 @@ const AdminUploadQuestionsForm = ({
                                     className={selectStyles.multiSelect}
                                     classNamePrefix="select"
                                     isSearchable
-                                    isClearable={!adminOnlyQaRounds}
+                                    isClearable
                                     options={userOptions}
                                     value={selectedCmsUserOption}
                                     onChange={(newValue) =>
@@ -318,7 +297,7 @@ const AdminUploadQuestionsForm = ({
                                         )
                                     }
                                 />
-                                {displayedUser && (
+                                {selectedCmsUser && (
                                     <div
                                         className={styles.selectedUserSummary}
                                         data-testid="selected-user-info"
@@ -333,22 +312,22 @@ const AdminUploadQuestionsForm = ({
                                                 styles.selectedUserAddress
                                             }
                                         >
-                                            {displayedUser.givenName}{' '}
-                                            {displayedUser.familyName}
+                                            {selectedCmsUser.givenName}{' '}
+                                            {selectedCmsUser.familyName}
                                             <br />
                                             {userRoleDisplayNames[
-                                                displayedUser.role
-                                            ] ?? displayedUser.role}
+                                                selectedCmsUser.role
+                                            ] ?? selectedCmsUser.role}
                                             <br />
                                             <LinkWithLogging
-                                                href={`mailto:${displayedUser.email}`}
+                                                href={`mailto:${selectedCmsUser.email}`}
                                                 target="_blank"
                                                 variant="external"
                                                 rel="noreferrer"
                                                 event_name="contact_click"
                                                 contact_method="email"
                                             >
-                                                {displayedUser.email}
+                                                {selectedCmsUser.email}
                                             </LinkWithLogging>
                                             <br />
                                             {displayedUserDivision ??

--- a/services/app-web/src/pages/QuestionResponse/UploadResponse/AdminUploadContractResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadResponse/AdminUploadContractResponse.tsx
@@ -11,6 +11,8 @@ import {
 import styles from '../QuestionResponse.module.scss'
 import { usePage } from '../../../contexts/PageContext'
 import { useAuth } from '../../../contexts/AuthContext'
+import { useLDClient } from 'launchdarkly-react-client-sdk'
+import { featureFlags } from '@mc-review/common-code'
 import { Breadcrumbs } from '../../../components'
 import { RoutesRecord } from '@mc-review/constants'
 import { GenericErrorPage } from '../../Errors/GenericErrorPage'
@@ -36,6 +38,11 @@ export const AdminUploadContractResponse = () => {
     const navigate = useNavigate()
     const { updateHeading, updateActiveMainContent } = usePage()
     const { loggedInUser } = useAuth()
+    const ldClient = useLDClient()
+    const adminOnlyQaRounds: boolean = ldClient?.variation(
+        featureFlags.ADMIN_ONLY_QA_ROUNDS.flag,
+        featureFlags.ADMIN_ONLY_QA_ROUNDS.defaultValue
+    )
 
     const {
         data: fetchContractData,
@@ -124,7 +131,7 @@ export const AdminUploadContractResponse = () => {
         }
 
         //checks for empty strings as formik and forms need initial values to be ''
-        if (data.addedByUserID) {
+        if (data.addedByUserID && data.addedByUserID !== 'myself') {
             input.addedByUserID = data.addedByUserID
         }
         if (data.createdAt) {
@@ -171,6 +178,7 @@ export const AdminUploadContractResponse = () => {
                 question={question}
                 stateUsers={stateUsers}
                 loggedInUser={loggedInUser}
+                adminOnlyQaRounds={adminOnlyQaRounds}
             />
         </div>
     )

--- a/services/app-web/src/pages/QuestionResponse/UploadResponse/AdminUploadContractResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadResponse/AdminUploadContractResponse.tsx
@@ -11,8 +11,6 @@ import {
 import styles from '../QuestionResponse.module.scss'
 import { usePage } from '../../../contexts/PageContext'
 import { useAuth } from '../../../contexts/AuthContext'
-import { useLDClient } from 'launchdarkly-react-client-sdk'
-import { featureFlags } from '@mc-review/common-code'
 import { Breadcrumbs } from '../../../components'
 import { RoutesRecord } from '@mc-review/constants'
 import { GenericErrorPage } from '../../Errors/GenericErrorPage'
@@ -38,11 +36,6 @@ export const AdminUploadContractResponse = () => {
     const navigate = useNavigate()
     const { updateHeading, updateActiveMainContent } = usePage()
     const { loggedInUser } = useAuth()
-    const ldClient = useLDClient()
-    const adminOnlyQaRounds: boolean = ldClient?.variation(
-        featureFlags.ADMIN_ONLY_QA_ROUNDS.flag,
-        featureFlags.ADMIN_ONLY_QA_ROUNDS.defaultValue
-    )
 
     const {
         data: fetchContractData,
@@ -126,14 +119,11 @@ export const AdminUploadContractResponse = () => {
 
         const input: AdminCreateContractQuestionResponseInput = {
             questionID: questionID as string,
+            addedByUserID: data.addedByUserID,
             reason: data.reason.trim(),
             documents: responseDocs,
         }
 
-        //checks for empty strings as formik and forms need initial values to be ''
-        if (data.addedByUserID && data.addedByUserID !== 'myself') {
-            input.addedByUserID = data.addedByUserID
-        }
         if (data.createdAt) {
             input.createdAt = data.createdAt
         }
@@ -178,7 +168,6 @@ export const AdminUploadContractResponse = () => {
                 question={question}
                 stateUsers={stateUsers}
                 loggedInUser={loggedInUser}
-                adminOnlyQaRounds={adminOnlyQaRounds}
             />
         </div>
     )

--- a/services/app-web/src/pages/QuestionResponse/UploadResponse/AdminUploadResponseForm.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadResponse/AdminUploadResponseForm.tsx
@@ -72,6 +72,7 @@ type AdminUploadResponseFormProps = {
     question?: QuestionType
     stateUsers: StateUser[]
     loggedInUser?: User
+    adminOnlyQaRounds: boolean
 }
 
 // Owns the admin response form: the Formik state, the document upload, and the
@@ -86,6 +87,7 @@ const AdminUploadResponseForm = ({
     question,
     stateUsers,
     loggedInUser,
+    adminOnlyQaRounds,
 }: AdminUploadResponseFormProps) => {
     const navigate = useNavigate()
     const { handleUploadFile, handleScanFile } = useS3()
@@ -112,7 +114,9 @@ const AdminUploadResponseForm = ({
     const questionRound = question?.round ?? 0
 
     const userOptions: AdminSelectOption[] = [
-        { label: 'Myself (admin)', value: '' },
+        ...(adminOnlyQaRounds
+            ? [{ label: 'Myself (admin)', value: 'myself' }]
+            : []),
         ...stateUsers.map((u) => ({ label: u.email, value: u.id })),
     ]
 
@@ -189,7 +193,11 @@ const AdminUploadResponseForm = ({
                 const selectedStateUser = stateUsers.find(
                     (u) => u.id === values.addedByUserID
                 )
-                const displayedUser = selectedStateUser ?? loggedInUser
+                const myselfSelected =
+                    adminOnlyQaRounds && values.addedByUserID === 'myself'
+                const displayedUser =
+                    selectedStateUser ??
+                    (myselfSelected ? loggedInUser : undefined)
                 const displayedUserState =
                     displayedUser && 'state' in displayedUser
                         ? displayedUser.state.code
@@ -197,7 +205,7 @@ const AdminUploadResponseForm = ({
 
                 const selectedUserOption =
                     userOptions.find((o) => o.value === values.addedByUserID) ??
-                    userOptions[0]
+                    null
 
                 return (
                     <UswdsForm
@@ -295,6 +303,7 @@ const AdminUploadResponseForm = ({
                                     className={selectStyles.multiSelect}
                                     classNamePrefix="select"
                                     isSearchable
+                                    isClearable={!adminOnlyQaRounds}
                                     options={userOptions}
                                     value={selectedUserOption}
                                     onChange={(newValue) =>
@@ -305,34 +314,45 @@ const AdminUploadResponseForm = ({
                                     }
                                 />
                                 {displayedUser && (
-                                    <address
-                                        className="margin-top-1"
+                                    <div
+                                        className={styles.selectedUserSummary}
                                         data-testid="selected-response-user-info"
                                     >
-                                        {displayedUser.givenName}{' '}
-                                        {displayedUser.familyName}
-                                        <br />
-                                        {userRoleDisplayNames[
-                                            displayedUser.role
-                                        ] ?? displayedUser.role}
-                                        <br />
-                                        <LinkWithLogging
-                                            href={`mailto:${displayedUser.email}`}
-                                            target="_blank"
-                                            variant="external"
-                                            rel="noreferrer"
-                                            event_name="contact_click"
-                                            contact_method="email"
+                                        <div
+                                            className={styles.selectedUserLabel}
                                         >
-                                            {displayedUser.email}
-                                        </LinkWithLogging>
-                                        {displayedUserState && (
-                                            <>
-                                                <br />
-                                                {displayedUserState}
-                                            </>
-                                        )}
-                                    </address>
+                                            Selected user
+                                        </div>
+                                        <address
+                                            className={
+                                                styles.selectedUserAddress
+                                            }
+                                        >
+                                            {displayedUser.givenName}{' '}
+                                            {displayedUser.familyName}
+                                            <br />
+                                            {userRoleDisplayNames[
+                                                displayedUser.role
+                                            ] ?? displayedUser.role}
+                                            <br />
+                                            <LinkWithLogging
+                                                href={`mailto:${displayedUser.email}`}
+                                                target="_blank"
+                                                variant="external"
+                                                rel="noreferrer"
+                                                event_name="contact_click"
+                                                contact_method="email"
+                                            >
+                                                {displayedUser.email}
+                                            </LinkWithLogging>
+                                            {displayedUserState && (
+                                                <>
+                                                    <br />
+                                                    {displayedUserState}
+                                                </>
+                                            )}
+                                        </address>
+                                    </div>
                                 )}
                             </FormGroup>
 

--- a/services/app-web/src/pages/QuestionResponse/UploadResponse/AdminUploadResponseForm.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadResponse/AdminUploadResponseForm.tsx
@@ -61,7 +61,6 @@ export type AdminUploadResponseFormData = AdminResponseFormValues & {
 
 const userRoleDisplayNames: Record<string, string> = {
     STATE_USER: 'State User',
-    ADMIN_USER: 'Admin',
 }
 
 type AdminUploadResponseFormProps = {
@@ -72,7 +71,6 @@ type AdminUploadResponseFormProps = {
     question?: QuestionType
     stateUsers: StateUser[]
     loggedInUser?: User
-    adminOnlyQaRounds: boolean
 }
 
 // Owns the admin response form: the Formik state, the document upload, and the
@@ -87,7 +85,6 @@ const AdminUploadResponseForm = ({
     question,
     stateUsers,
     loggedInUser,
-    adminOnlyQaRounds,
 }: AdminUploadResponseFormProps) => {
     const navigate = useNavigate()
     const { handleUploadFile, handleScanFile } = useS3()
@@ -113,12 +110,10 @@ const AdminUploadResponseForm = ({
         : undefined
     const questionRound = question?.round ?? 0
 
-    const userOptions: AdminSelectOption[] = [
-        ...(adminOnlyQaRounds
-            ? [{ label: 'Myself (admin)', value: 'myself' }]
-            : []),
-        ...stateUsers.map((u) => ({ label: u.email, value: u.id })),
-    ]
+    const userOptions: AdminSelectOption[] = stateUsers.map((u) => ({
+        label: u.email,
+        value: u.id,
+    }))
 
     const initialValues: AdminResponseFormValues = {
         addedByUserID: '',
@@ -128,6 +123,7 @@ const AdminUploadResponseForm = ({
 
     // Field order matches the page so the error summary lists them in page order.
     const validationSchema = Yup.object().shape({
+        addedByUserID: Yup.string().required('You must select a state user'),
         createdAt: Yup.string()
             .test(
                 'not-future',
@@ -153,6 +149,7 @@ const AdminUploadResponseForm = ({
     // on hidden inputs, so a `#id` key (focus by id) is used rather than the
     // field name.
     const fieldFocusId: Record<string, string> = {
+        addedByUserID: 'response-user-select',
         reason: 'reason',
         createdAt: 'admin-response-createdAt',
     }
@@ -188,20 +185,11 @@ const AdminUploadResponseForm = ({
             onSubmit={(values) => onFormSubmit(values)}
         >
             {({ values, errors, setFieldValue, handleSubmit: submitForm }) => {
-                // The state user being recorded on behalf of (if any), otherwise
-                // the response is attributed to the admin.
+                // The state user being recorded on behalf of.
                 const selectedStateUser = stateUsers.find(
                     (u) => u.id === values.addedByUserID
                 )
-                const myselfSelected =
-                    adminOnlyQaRounds && values.addedByUserID === 'myself'
-                const displayedUser =
-                    selectedStateUser ??
-                    (myselfSelected ? loggedInUser : undefined)
-                const displayedUserState =
-                    displayedUser && 'state' in displayedUser
-                        ? displayedUser.state.code
-                        : undefined
+                const displayedUserState = selectedStateUser?.state.code
 
                 const selectedUserOption =
                     userOptions.find((o) => o.value === values.addedByUserID) ??
@@ -285,16 +273,12 @@ const AdminUploadResponseForm = ({
                                 <Label htmlFor="response-user-select">
                                     Respond on behalf of
                                 </Label>
-                                <span className={styles.requiredOptionalText}>
-                                    Optional
-                                </span>
                                 <span
                                     className="usa-hint"
                                     id="response-user-select-hint"
                                 >
                                     Select a state user to attribute this
-                                    response to. Leave as "Myself" to attribute
-                                    it to your admin account.
+                                    response to.
                                 </span>
                                 <AccessibleSelect<AdminSelectOption>
                                     inputId="response-user-select"
@@ -303,7 +287,7 @@ const AdminUploadResponseForm = ({
                                     className={selectStyles.multiSelect}
                                     classNamePrefix="select"
                                     isSearchable
-                                    isClearable={!adminOnlyQaRounds}
+                                    isClearable
                                     options={userOptions}
                                     value={selectedUserOption}
                                     onChange={(newValue) =>
@@ -313,7 +297,7 @@ const AdminUploadResponseForm = ({
                                         )
                                     }
                                 />
-                                {displayedUser && (
+                                {selectedStateUser && (
                                     <div
                                         className={styles.selectedUserSummary}
                                         data-testid="selected-response-user-info"
@@ -328,22 +312,22 @@ const AdminUploadResponseForm = ({
                                                 styles.selectedUserAddress
                                             }
                                         >
-                                            {displayedUser.givenName}{' '}
-                                            {displayedUser.familyName}
+                                            {selectedStateUser.givenName}{' '}
+                                            {selectedStateUser.familyName}
                                             <br />
                                             {userRoleDisplayNames[
-                                                displayedUser.role
-                                            ] ?? displayedUser.role}
+                                                selectedStateUser.role
+                                            ] ?? selectedStateUser.role}
                                             <br />
                                             <LinkWithLogging
-                                                href={`mailto:${displayedUser.email}`}
+                                                href={`mailto:${selectedStateUser.email}`}
                                                 target="_blank"
                                                 variant="external"
                                                 rel="noreferrer"
                                                 event_name="contact_click"
                                                 contact_method="email"
                                             >
-                                                {displayedUser.email}
+                                                {selectedStateUser.email}
                                             </LinkWithLogging>
                                             {displayedUserState && (
                                                 <>


### PR DESCRIPTION
## Summary

This work removes the admin assigned Q&A rounds. Admin can still add Q&A round, they can only assign CMS users to questions and state users to responses.

This reverts the GraphQL schema so that the Mulesoft team does not have to update their query to define the user type of the question. They were having issues updating their query for this change so we will revert it for now since this isn't a critical part of the feature. We still define it in our query as it is probably better for future changes.

#### Related issues

#### Screenshots

#### Test cases covered

- Updated all unit tests to feature flag admin assigned Q&A tests.

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

Use curl command or postman to test this query.

NOTE: There is a input at the end for a contract ID {"contractID":"<CONTRACT_ID>"}

```
curl --location 'https://s2e2v4c289.execute-api.us-east-1.amazonaws.com/jlfeatureflagadmin07676/v1/graphql/external' \
  --header 'Content-Type: application/json' \
  --header 'Authorization: Bearer <BEARER_TOKEN>' \
  --data @- <<'GRAPHQL'
{"query":"query FetchContract($input: FetchContractInput!) { fetchContract(input: $input) { contract { id createdAt updatedAt status consolidatedStatus initiallySubmittedAt lastUpdatedForDisplay stateCode stateNumber mccrsID webURL dateContractDocsExecuted state { code name programs { id name fullName isRateProgram } } withdrawnRates { id createdAt updatedAt status consolidatedStatus initiallySubmittedAt stateCode stateNumber parentContractID state { code name } withdrawnFromContracts { id createdAt updatedAt status stateCode stateNumber mccrsID webURL dateContractDocsExecuted initiallySubmittedAt state { code name programs { id name fullName isRateProgram } } } } packageSubmissions { cause submitInfo { updatedAt updatedBy { role email givenName familyName } updatedReason } rateRevisions { rate { id createdAt updatedAt status consolidatedStatus initiallySubmittedAt stateCode stateNumber parentContractID state { code name } withdrawnFromContracts { id createdAt updatedAt status stateCode stateNumber mccrsID webURL dateContractDocsExecuted initiallySubmittedAt state { code name programs { id name fullName isRateProgram } } } } formData { rateMedicaidPopulations rateDateStart rateDateEnd rateType rateDateCertified amendmentEffectiveDateStart amendmentEffectiveDateEnd rateCertificationName actuaryCommunicationPreference rateCapitationType rateProgramIDs rateDocuments { id name s3URL sha256 downloadURL dateAdded } supportingDocuments { id name s3URL sha256 downloadURL dateAdded } certifyingActuaryContacts { id name titleRole email actuarialFirm actuarialFirmOther } addtlActuaryContacts { id name titleRole email actuarialFirm actuarialFirmOther } } } contractRevision { id contractID contractName createdAt updatedAt submitInfo { updatedAt updatedBy { role email givenName familyName } updatedReason } unlockInfo { updatedAt updatedBy { role email givenName familyName } updatedReason } formData { dsnpContract programIDs populationCovered submissionType riskBasedContract submissionDescription stateContacts { name titleRole email } supportingDocuments { id name s3URL sha256 downloadURL dateAdded } contractType contractExecutionStatus contractDocuments { id name s3URL sha256 downloadURL dateAdded } contractDateStart contractDateEnd managedCareEntities federalAuthorities inLieuServicesAndSettings modifiedBenefitsProvided modifiedGeoAreaServed modifiedMedicaidBeneficiaries modifiedRiskSharingStrategy modifiedIncentiveArrangements modifiedWitholdAgreements modifiedStateDirectedPayments modifiedPassThroughPayments modifiedPaymentsForMentalDiseaseInstitutions modifiedMedicalLossRatioStandards modifiedOtherFinancialPaymentIncentive modifiedEnrollmentProcess modifiedGrevienceAndAppeal modifiedNetworkAdequacyStandards modifiedLengthOfContract modifiedNonRiskPaymentArrangements statutoryRegulatoryAttestation statutoryRegulatoryAttestationDescription } } } questions { DMCOQuestions { edges { node { id contractID createdAt division round documents { id downloadURL name s3URL } addedBy { ... on CMSUser { id email givenName familyName role divisionAssignment stateAssignments { code name programs { id name fullName isRateProgram } } } ... on CMSApproverUser { id email givenName familyName role divisionAssignment stateAssignments { code name programs { id name fullName isRateProgram } } } } responses { id questionID createdAt documents { id downloadURL name s3URL } addedBy { id email givenName familyName role state { code name } } } } } } DMCPQuestions { edges { node { id contractID createdAt division round documents { id downloadURL name s3URL } addedBy { ... on CMSUser { id email givenName familyName role divisionAssignment stateAssignments { code name programs { id name fullName isRateProgram } } } ... on CMSApproverUser { id email givenName familyName role divisionAssignment stateAssignments { code name programs { id name fullName isRateProgram } } } } responses { id questionID createdAt documents { id downloadURL name s3URL } addedBy { id email givenName familyName role state { code name } } } } } } OACTQuestions { edges { node { id contractID createdAt division round documents { id downloadURL name s3URL } addedBy { ... on CMSUser { id email givenName familyName role divisionAssignment stateAssignments { code name programs { id name fullName isRateProgram } } } ... on CMSApproverUser { id email givenName familyName role divisionAssignment stateAssignments { code name programs { id name fullName isRateProgram } } } } responses { id questionID createdAt documents { id downloadURL name s3URL } addedBy { id email givenName familyName role state { code name } } } } } } } } } }","variables":{"input":{"contractID":"<CONTRACT_ID>"}}}
GRAPHQL
```

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed