### PR TITLE
[MCR-6244] eqro contract doc divider fix

### DIFF
--- a/services/app-web/src/components/DocumentHeader/DocumentHeader.module.scss
+++ b/services/app-web/src/components/DocumentHeader/DocumentHeader.module.scss
@@ -6,16 +6,14 @@
     justify-content: space-between;
     height: 2.5rem;
     border-top: 1px solid custom.$mcr-gray-lighter;
+    border-bottom: 1px solid custom.$mcr-gray-lighter;
     margin-top: 0;
+    margin-bottom: 16px;
     padding-top: 40px;
-    padding-bottom: 20px;
+    padding-bottom: 16px;
 
     &.removeTopBorder {
         border-top: none;
         padding-top: 10px;
     }
-}
-
-.header {
-    margin: 0;
 }

--- a/services/app-web/src/components/DocumentHeader/DocumentHeader.tsx
+++ b/services/app-web/src/components/DocumentHeader/DocumentHeader.tsx
@@ -1,3 +1,4 @@
+import { SectionHeader } from '../SectionHeader'
 import {
     ZipDownloadLink,
     ZipDownloadLinkProps,
@@ -7,24 +8,23 @@ import styles from './DocumentHeader.module.scss'
 interface DocumentHeaderProps extends ZipDownloadLinkProps {
     renderZipLink?: boolean
     removeTopBorder?: boolean
-    headingLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 }
 
 export const DocumentHeader = ({
     renderZipLink,
     removeTopBorder,
-    headingLevel = 'h4',
     ...zipLinkProps
 }: DocumentHeaderProps): React.ReactElement => {
-    const Heading = headingLevel
-
     return (
         <div
             className={`${styles.documentHeaderContainer} ${removeTopBorder ? styles.removeTopBorder : ''}`}
         >
-            <Heading className={styles.header}>
-                {zipLinkProps.type === 'RATE' ? 'Rate' : 'Contract'} documents
-            </Heading>
+            <SectionHeader
+                header={`${zipLinkProps.type === 'RATE' ? 'Rate' : 'Contract'} documents`}
+                hideBorderTop
+                hideBorderBottom
+                headingLevel="h3"
+            />
             {renderZipLink && <ZipDownloadLink {...zipLinkProps} />}
         </div>
     )

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -138,7 +138,7 @@ export const ContractDetailsSummarySection = ({
                 header="Contract details"
                 editNavigateTo={editNavigateTo}
                 hideBorderTop
-                headingLevel='h2'
+                headingLevel="h2"
             />
             <dl>
                 {contract438Attestation && (
@@ -198,7 +198,7 @@ export const ContractDetailsSummarySection = ({
                 documentZipPackages={documentZipPackage}
                 documentCount={contractDocumentCount}
                 onDocumentError={onDocumentError}
-                headingLevel='h3'
+                removeTopBorder
                 renderZipLink={
                     !!(
                         isSubmittedOrCMSUser &&

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/EQROContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/EQROContractDetailsSummarySection.tsx
@@ -97,7 +97,7 @@ export const EQROContractDetailsSummarySection = ({
                 header="Contract details"
                 editNavigateTo={editNavigateTo}
                 hideBorderTop
-                headingLevel='h2'
+                headingLevel="h2"
             />
             <dl>
                 <MultiColumnGrid columns={2}>
@@ -120,8 +120,7 @@ export const EQROContractDetailsSummarySection = ({
                 type={'CONTRACT'}
                 documentZipPackages={documentZipPackage}
                 documentCount={contractDocumentCount}
-                onDocumentError={onDocumentError}               
-                headingLevel='h3'
+                onDocumentError={onDocumentError}
                 removeTopBorder
                 renderZipLink={
                     !!(

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummary/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummary/RateDetailsSummarySection.tsx
@@ -500,7 +500,7 @@ export const RateDetailsSummarySection = ({
                                   documentZipPackages={documentZipPackage}
                                   documentCount={rateDocumentCount}
                                   onDocumentError={onDocumentError}
-                                  headingLevel="h4"
+                                  removeTopBorder
                                   renderZipLink={
                                       !!(
                                           isSubmittedOrCMSUser &&

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummary/SingleRateSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummary/SingleRateSummarySection.test.tsx
@@ -108,7 +108,7 @@ describe('SingleRateSummarySection', () => {
         ).toBeInTheDocument()
 
         expect(
-            screen.getByRole('heading', { name: 'Rate documents', level: 2 })
+            screen.getByRole('heading', { name: 'Rate documents', level: 3 })
         ).toBeInTheDocument()
     })
 
@@ -142,7 +142,7 @@ describe('SingleRateSummarySection', () => {
         )
 
         expect(
-            screen.getByRole('heading', { name: 'Rate documents', level: 2 })
+            screen.getByRole('heading', { name: 'Rate documents', level: 3 })
         ).toBeInTheDocument()
 
         const relatedContractActions = screen.getByRole('definition', {
@@ -219,7 +219,7 @@ describe('SingleRateSummarySection', () => {
         )
 
         expect(
-            screen.getByRole('heading', { name: 'Rate documents', level: 2 })
+            screen.getByRole('heading', { name: 'Rate documents', level: 3 })
         ).toBeInTheDocument()
 
         const relatedContractActions = screen.getByRole('definition', {

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummary/SingleRateSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/SingleRateSummary/SingleRateSummarySection.tsx
@@ -363,7 +363,6 @@ export const SingleRateSummarySection = ({
                     documentCount={rateDocumentCount}
                     renderZipLink={isSubmittedOrCMSUser}
                     removeTopBorder
-                    headingLevel="h2"
                 />
                 <UploadedDocumentsTable
                     documents={formData.rateDocuments}

--- a/services/app-web/src/components/ZipDownloadLink/ZipDownloadLink.module.scss
+++ b/services/app-web/src/components/ZipDownloadLink/ZipDownloadLink.module.scss
@@ -3,3 +3,7 @@
 .downloadIcon {
     vertical-align: sub;
 }
+
+.downloadLink {
+    margin-bottom: 16px;
+}

--- a/services/app-web/src/components/ZipDownloadLink/ZipDownloadLink.tsx
+++ b/services/app-web/src/components/ZipDownloadLink/ZipDownloadLink.tsx
@@ -40,7 +40,11 @@ export const ZipDownloadLink = ({
     }
 
     return (
-        <LinkWithLogging href={zippedFilesURL} target="_blank">
+        <LinkWithLogging
+            href={zippedFilesURL}
+            target="_blank"
+            className={styles.downloadLink}
+        >
             <span data-testid="zipDownloadLink">
                 <Icon.FileDownload className={styles.downloadIcon} />
                 Download {`${contractOrRate}`} documents{' '}

--- a/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
+++ b/services/app-web/src/pages/RateSummary/RateSummary.test.tsx
@@ -85,7 +85,7 @@ describe('RateSummary', () => {
                 expect(
                     screen.getByRole('heading', {
                         name: 'Rate documents',
-                        level: 2,
+                        level: 3,
                     })
                 ).toBeInTheDocument()
             })
@@ -585,7 +585,7 @@ describe('RateSummary', () => {
             expect(
                 screen.getByRole('heading', {
                     name: 'Rate documents',
-                    level: 2,
+                    level: 3,
                 })
             ).toBeInTheDocument()
         })


### PR DESCRIPTION
## Summary
We implemented a horizontal divider for EQROs below the contract documents (and provisions) h4 content to give the review and submission pages a visual hierarchy. It's not visible for Contract documents in dev anymore.

**Acceptance criteria:**
- Contract documents header should have a dividing line between it and the document tables
- There is 16px space between Contract documents text and the divider
- The divider matches the visual style of the divider used for provisions

#### Related issues
[MCR-6244](https://jiraent.cms.gov/browse/MCR-6244)
#### Screenshots
<img width="803" height="817" alt="image" src="https://github.com/user-attachments/assets/4e3c10b9-5c88-4546-acb9-f8ebc9af6b7d" />

## QA guidance
- Create EQRO submission
- verify on summary pages that the dividing line is present
<!---These are developer instructions on how to test or validate the work -->