### PR TITLE
MCR-6258: Restrict primary button styling to first upload response btn

### DIFF
--- a/services/app-web/src/pages/QuestionResponse/QATable/CMSQuestionResponseTable.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/CMSQuestionResponseTable.tsx
@@ -96,6 +96,14 @@ export const CMSQuestionResponseTable = ({
         userDivision
     )
 
+    // Only the first question rendered on the page (the user's division
+    // questions are rendered before other divisions') gets the primary upload
+    // response button; all subsequent buttons use the secondary (outline)
+    // styling.
+    const firstQuestionId =
+        usersRounds[0]?.[0]?.questionData.id ??
+        otherRounds[0]?.[0]?.questionData.id
+
     return (
         <>
             <section
@@ -126,6 +134,9 @@ export const CMSQuestionResponseTable = ({
                                 roundTitle={roundTitle}
                                 currentUser={loggedInUser!}
                                 questionType={questionType}
+                                isFirstQuestion={
+                                    questionData.id === firstQuestionId
+                                }
                             />
                         ))
                     )
@@ -151,6 +162,9 @@ export const CMSQuestionResponseTable = ({
                                 roundTitle={roundTitle}
                                 currentUser={loggedInUser!}
                                 questionType={questionType}
+                                isFirstQuestion={
+                                    questionData.id === firstQuestionId
+                                }
                             />
                         ))
                     )

--- a/services/app-web/src/pages/QuestionResponse/QATable/QuestionResponseRound.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/QuestionResponseRound.tsx
@@ -23,6 +23,7 @@ export type QuestionResponseRoundPropType = {
     questionType: 'contract' | 'rate'
     contractStatus?: ConsolidatedContractStatus
     qaSectionHeaderId?: string
+    isFirstQuestion?: boolean
 }
 
 /**
@@ -35,6 +36,7 @@ export type QuestionResponseRoundPropType = {
  * @param {User} props.currentUser - Current user viewing the page
  * @param {ConsolidatedContractStatus} [props.contractStatus] - Consolidated contract status.
  * @param {string} [props.qaSectionHeaderId] - ID to the Q&A section header, used for describing the upload response button.
+ * @param {boolean} [props.isFirstQuestion] - Whether this is the first question rendered on the page. Only the first question's upload response button uses the primary (solid) styling; all subsequent buttons use the secondary (outline) styling.
  */
 export const QuestionResponseRound = ({
     question,
@@ -43,12 +45,13 @@ export const QuestionResponseRound = ({
     questionType,
     contractStatus,
     qaSectionHeaderId,
+    isFirstQuestion = false,
 }: QuestionResponseRoundPropType) => {
     const isStateUser = currentUser?.__typename === 'StateUser'
     const isAdminUser = currentUser?.__typename === 'AdminUser'
     const isApprovedContract = contractStatus === 'APPROVED'
     const buttonClass = classNames('usa-button', {
-        'usa-button--outline': question.responses.length > 0,
+        'usa-button--outline': !isFirstQuestion,
     })
 
     const deleteButtonClass = classNames('usa-button', 'usa-button--secondary')

--- a/services/app-web/src/pages/QuestionResponse/QATable/StateQuestionResponseTable.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QATable/StateQuestionResponseTable.tsx
@@ -67,6 +67,13 @@ export const StateQuestionResponseTable = ({
     const sortedAnsweredQuestions = sortRoundsByDate(answeredQuestions)
     const sortedUnansweredQuestions = sortRoundsByDate(unansweredQuestions)
 
+    // Only the first question rendered on the page (outstanding questions are
+    // rendered before answered ones) gets the primary upload response button;
+    // all subsequent buttons use the secondary (outline) styling.
+    const firstQuestionId =
+        sortedUnansweredQuestions[0]?.[0]?.questionData.id ??
+        sortedAnsweredQuestions[0]?.[0]?.questionData.id
+
     return (
         <>
             {header && (
@@ -111,6 +118,9 @@ export const StateQuestionResponseTable = ({
                                 questionType={questionType}
                                 contractStatus={contractStatus}
                                 qaSectionHeaderId="outsandingContractQuestions"
+                                isFirstQuestion={
+                                    questionData.id === firstQuestionId
+                                }
                             />
                         ))
                     )
@@ -139,6 +149,9 @@ export const StateQuestionResponseTable = ({
                                 questionType={questionType}
                                 contractStatus={contractStatus}
                                 qaSectionHeaderId="answeredContractQuestions"
+                                isFirstQuestion={
+                                    questionData.id === firstQuestionId
+                                }
                             />
                         ))
                     )


### PR DESCRIPTION
## Summary

This PR fixes a UI issue (in the ticket it specified this was happening on EQROs but I found it also applied to health plans) where the primary styling button was being applied to all Upload Response buttons. 

Note: this issue only surfaced when there's multiple outstanding open questions. Recent changes to our app removed the ability in the UI and API to add a new question when an existing round is open 

#### Related issues
https://jiraent.cms.gov/browse/MCR-6258
#### Screenshots

BEFORE
<img width="1420" height="741" alt="Screenshot 2026-06-23 at 9 26 03 AM" src="https://github.com/user-attachments/assets/a94a9c61-4ffd-4eee-b9b5-4f98b1af2c2a" />


AFTER
<img width="1353" height="749" alt="Screenshot 2026-06-23 at 10 01 11 AM" src="https://github.com/user-attachments/assets/4a326f3f-830a-4ce2-9c4f-ee4746f04778" />


#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance



## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed