### PR TITLE
Add usePageLoadSpan hook for dashboard telemetry

### DIFF
--- a/infra/datadog/monitors.tf
+++ b/infra/datadog/monitors.tf
@@ -218,3 +218,52 @@ resource "datadog_monitor" "web_trace_errors" {
     "team:${var.team}",
   ]
 }
+
+resource "datadog_monitor" "dashboard_load_time" {
+  # Dashboard load-time only matters against real production traffic, so this
+  # monitor is created in prod only — the dev/val deploys skip it entirely.
+  # (The `page.load` spans themselves are still emitted and viewable in every
+  # environment; only the alert is prod-scoped.)
+  count = var.environment == "prod" ? 1 : 0
+
+  name = "[${var.team}] Slow CMS Dashboard Page Load - ${var.environment}"
+  type = "trace-analytics alert"
+
+  # Rolling average duration of the `page.load` spans emitted by usePageLoadSpan
+  # (services/app-web/src/hooks/usePageLoadSpan.ts) on the CMS dashboard tabs,
+  # which measure mount -> data-ready. @duration is reported in nanoseconds, so
+  # the millisecond threshold is converted with * 1,000,000. Abandoned loads
+  # (user navigated away before data arrived, tagged @page.load.abandoned) are
+  # excluded so partial timings don't drag the average down.
+  query = "trace-analytics(\"service:app-web-${var.environment} @dashboard.tab:(submissions OR rates) -@page.load.abandoned:true\").rollup(\"avg\", \"@duration\").last(\"15m\") > ${var.dashboard_load_threshold_ms * 1000000}"
+
+  message = <<-EOT
+    The CMS dashboard is loading slowly in **${var.environment}**.
+
+    Triggered when the 15-minute average `page.load` duration for the Submissions / Rate reviews tabs exceeds ${var.dashboard_load_threshold_ms} ms.
+
+    - Review `page.load` spans in Datadog APM under service `app-web-${var.environment}` (filter on `@dashboard.tab`)
+    - Correlate with `@dashboard.row_count` — large result sets are the expected driver and point toward pagination/filtering work
+    - Check recent frontend deploys and `app-api-${var.environment}` for slow `indexContracts` / `indexRates` queries
+
+    ${var.notify_slack}
+  EOT
+
+  monitor_thresholds {
+    critical = var.dashboard_load_threshold_ms * 1000000
+  }
+
+  # A quiet dashboard (no loads in the window, e.g. off-hours) is normal, so
+  # absent data is not an outage signal here (mirrors the rare-event monitors).
+  notify_no_data    = false
+  evaluation_delay  = 60
+  renotify_interval = 60
+  include_tags      = true
+
+  tags = [
+    "env:${var.environment}",
+    "service:app-web-${var.environment}",
+    "managed-by:opentofu",
+    "team:${var.team}",
+  ]
+}

--- a/infra/datadog/monitors.tf
+++ b/infra/datadog/monitors.tf
@@ -231,18 +231,21 @@ resource "datadog_monitor" "dashboard_load_time" {
 
   # Rolling average duration of the `page.load` spans emitted by usePageLoadSpan
   # (services/app-web/src/hooks/usePageLoadSpan.ts) on the CMS dashboard tabs,
-  # which measure mount -> data-ready. @duration is reported in nanoseconds, so
-  # the millisecond threshold is converted with * 1,000,000. Abandoned loads
-  # (user navigated away before data arrived, tagged @page.load.abandoned) are
-  # excluded so partial timings don't drag the average down.
-  query = "trace-analytics(\"service:app-web-${var.environment} @dashboard.tab:(submissions OR rates) -@page.load.abandoned:true\").rollup(\"avg\", \"@duration\").last(\"15m\") > ${var.dashboard_load_threshold_ms * 1000000}"
+  # which measure mount -> data-ready. Spans are matched on the explicit
+  # `@page.name` rather than the route, because DASHBOARD_SUBMISSIONS is shared
+  # with the StateDashboard and so the route alone can't isolate the CMS
+  # dashboard. @duration is reported in nanoseconds, so the millisecond threshold
+  # is converted with * 1,000,000. Abandoned loads (user navigated away before
+  # data arrived, tagged @page.load.abandoned) are excluded so partial timings
+  # don't drag the average down.
+  query = "trace-analytics(\"service:app-web-${var.environment} @page.name:(cms-dashboard-submissions OR cms-dashboard-rates) -@page.load.abandoned:true\").rollup(\"avg\", \"@duration\").last(\"15m\") > ${var.dashboard_load_threshold_ms * 1000000}"
 
   message = <<-EOT
     The CMS dashboard is loading slowly in **${var.environment}**.
 
     Triggered when the 15-minute average `page.load` duration for the Submissions / Rate reviews tabs exceeds ${var.dashboard_load_threshold_ms} ms.
 
-    - Review `page.load` spans in Datadog APM under service `app-web-${var.environment}` (filter on `@dashboard.tab`)
+    - Review `page.load` spans in Datadog APM under service `app-web-${var.environment}` (filter on `@page.name`)
     - Correlate with `@dashboard.row_count` — large result sets are the expected driver and point toward pagination/filtering work
     - Check recent frontend deploys and `app-api-${var.environment}` for slow `indexContracts` / `indexRates` queries
 

--- a/infra/datadog/variables.tf
+++ b/infra/datadog/variables.tf
@@ -36,6 +36,12 @@ variable "web_error_threshold" {
   default     = 5
 }
 
+variable "dashboard_load_threshold_ms" {
+  type        = number
+  description = "Alert when the rolling average CMS dashboard page-load span duration (page.load, measuring mount -> data-ready) exceeds this many milliseconds. Observed baseline is a few hundred ms; the default leaves generous headroom — tune down as the metric stabilizes in prod."
+  default     = 5000
+}
+
 variable "large_payload_threshold" {
   type        = number
   description = "Alert when more than this many \"Large request payload detected\" error spans occur in 5 minutes. Default 0 means any single occurrence triggers the alert."

--- a/services/app-web/src/hooks/index.ts
+++ b/services/app-web/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useCurrentRoute } from './useCurrentRoute'
+export { usePageLoadSpan } from './usePageLoadSpan'
 export { useFocus } from './useFocus'
 export { useLocalStorage } from './useLocalStorage'
 export { usePrevious } from './usePrevious'

--- a/services/app-web/src/hooks/usePageLoadSpan.ts
+++ b/services/app-web/src/hooks/usePageLoadSpan.ts
@@ -6,6 +6,12 @@ import { useTracing } from '@mc-review/otel'
 import { useCurrentRoute } from './useCurrentRoute'
 
 interface PageLoadSpanArgs {
+    // Stable, explicit identifier for the page being measured (e.g.
+    // 'cms-dashboard-submissions'). Recorded as `page.name` so a trace reliably
+    // identifies its page even when the route is shared by more than one page —
+    // e.g. DASHBOARD_SUBMISSIONS serves the CMS SubmissionsDashboard and the
+    // StateDashboard depending on user type, so `page.route` alone is ambiguous.
+    pageName: string
     // True once the page's primary data has loaded and is ready to render.
     ready: boolean
     // Set if the load failed; ends the span with an error status.
@@ -17,9 +23,9 @@ interface PageLoadSpanArgs {
 
 /**
  * Measures how long a page takes to load its primary data and emits it as a
- * single `page.load` span whose duration is the load time, tagged with the
- * current route so it can be charted and alerted on per page in our telemetry
- * backend (Datadog).
+ * single `page.load` span whose duration is the load time, tagged with an
+ * explicit `page.name` (and the current route) so it can be charted and alerted
+ * on per page in our telemetry backend (Datadog).
  *
  * The span starts when the page mounts (the load begins) and ends the first time
  * `ready` becomes true — i.e. the user-perceived time to a usable page. This is
@@ -27,6 +33,7 @@ interface PageLoadSpanArgs {
  * (mount to unmount).
  */
 export const usePageLoadSpan = ({
+    pageName,
     ready,
     error,
     attributes,
@@ -41,6 +48,7 @@ export const usePageLoadSpan = ({
     useEffect(() => {
         endedRef.current = false
         spanRef.current = startSpan('page.load', {
+            'page.name': pageName,
             [SemanticAttributes.HTTP_ROUTE]: currentRoute.toString(),
             'page.route': currentRoute.toString(),
         })
@@ -60,7 +68,7 @@ export const usePageLoadSpan = ({
         // abandoned above and a new one starts for the new route. currentRoute is
         // a stable route-name string and startSpan is a stable callback, so this
         // only re-runs on an actual route change, not on every render.
-    }, [currentRoute, startSpan])
+    }, [currentRoute, startSpan, pageName])
 
     // End the span the first time the page is ready (or errors).
     useEffect(() => {

--- a/services/app-web/src/hooks/usePageLoadSpan.ts
+++ b/services/app-web/src/hooks/usePageLoadSpan.ts
@@ -55,10 +55,12 @@ export const usePageLoadSpan = ({
                 endedRef.current = true
             }
         }
-        // Only run on mount; currentRoute and startSpan are stable for the
-        // lifetime of a given page mount.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
+        // Restart the load timer if the route changes without unmounting (e.g. a
+        // shared layout reused across routes): the previous span is closed as
+        // abandoned above and a new one starts for the new route. currentRoute is
+        // a stable route-name string and startSpan is a stable callback, so this
+        // only re-runs on an actual route change, not on every render.
+    }, [currentRoute, startSpan])
 
     // End the span the first time the page is ready (or errors).
     useEffect(() => {

--- a/services/app-web/src/hooks/usePageLoadSpan.ts
+++ b/services/app-web/src/hooks/usePageLoadSpan.ts
@@ -1,0 +1,86 @@
+import { useEffect, useRef } from 'react'
+import { Attributes, Span, SpanStatusCode } from '@opentelemetry/api'
+import { SemanticAttributes } from '@opentelemetry/semantic-conventions'
+import { useTracing } from '@mc-review/otel'
+import { useCurrentRoute } from './useCurrentRoute'
+
+interface PageLoadSpanArgs {
+    // True once the page's primary data has loaded and is ready to render.
+    ready: boolean
+    // Set if the load failed; ends the span with an error status.
+    error?: Error
+    // Extra attributes recorded when the span ends, e.g. the number of rows
+    // returned, so load time can be correlated with result size.
+    attributes?: Attributes
+}
+
+/**
+ * Measures how long a page takes to load its primary data and emits it as a
+ * single `page.load` span whose duration is the load time, tagged with the
+ * current route so it can be charted and alerted on per page in our telemetry
+ * backend (Datadog).
+ *
+ * The span starts when the page mounts (the load begins) and ends the first time
+ * `ready` becomes true — i.e. the user-perceived time to a usable page. This is
+ * distinct from usePageTracing, which spans the page's entire lifetime
+ * (mount to unmount).
+ */
+export const usePageLoadSpan = ({
+    ready,
+    error,
+    attributes,
+}: PageLoadSpanArgs): void => {
+    const { currentRoute } = useCurrentRoute()
+    const { startSpan } = useTracing()
+
+    const spanRef = useRef<Span | undefined>(undefined)
+    const endedRef = useRef(false)
+
+    // Start the span once, when the page mounts and the load begins.
+    useEffect(() => {
+        endedRef.current = false
+        spanRef.current = startSpan('page.load', {
+            [SemanticAttributes.HTTP_ROUTE]: currentRoute.toString(),
+            'page.route': currentRoute.toString(),
+        })
+
+        // If the page unmounts before its data loaded, the user navigated away
+        // mid-load. Close the span so it isn't leaked, flagged as abandoned so
+        // these partial loads can be excluded from load-time aggregates.
+        return () => {
+            if (spanRef.current && !endedRef.current) {
+                spanRef.current.setAttribute('page.load.abandoned', true)
+                spanRef.current.end()
+                endedRef.current = true
+            }
+        }
+        // Only run on mount; currentRoute and startSpan are stable for the
+        // lifetime of a given page mount.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    // End the span the first time the page is ready (or errors).
+    useEffect(() => {
+        const span = spanRef.current
+        if (!span || endedRef.current) {
+            return
+        }
+
+        if (error) {
+            span.recordException(error)
+            span.setStatus({
+                code: SpanStatusCode.ERROR,
+                message: error.message,
+            })
+            span.end()
+            endedRef.current = true
+        } else if (ready) {
+            if (attributes) {
+                span.setAttributes(attributes)
+            }
+            span.setStatus({ code: SpanStatusCode.OK })
+            span.end()
+            endedRef.current = true
+        }
+    }, [ready, error, attributes])
+}

--- a/services/app-web/src/hooks/usePageLoadSpan.ts
+++ b/services/app-web/src/hooks/usePageLoadSpan.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
-import { Attributes, Span, SpanStatusCode } from '@opentelemetry/api'
+import { SpanStatusCode } from '@opentelemetry/api'
+import type { Attributes, Span } from '@opentelemetry/api'
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions'
 import { useTracing } from '@mc-review/otel'
 import { useCurrentRoute } from './useCurrentRoute'

--- a/services/app-web/src/hooks/usePageLoadSpan.ts
+++ b/services/app-web/src/hooks/usePageLoadSpan.ts
@@ -64,10 +64,10 @@ export const usePageLoadSpan = ({
             }
         }
         // Restart the load timer if the route changes without unmounting (e.g. a
-        // shared layout reused across routes): the previous span is closed as
-        // abandoned above and a new one starts for the new route. currentRoute is
-        // a stable route-name string and startSpan is a stable callback, so this
-        // only re-runs on an actual route change, not on every render.
+        // shared layout reused across routes). If the previous span hasn't ended
+        // yet, the cleanup above will close it (marking it as abandoned) and a new
+        // span starts for the new route. currentRoute is a stable route-name string
+        // and startSpan is a stable callback, so this only re-runs on an actual route change.
     }, [currentRoute, startSpan, pageName])
 
     // End the span the first time the page is ready (or errors).

--- a/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsDashboard.tsx
+++ b/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsDashboard.tsx
@@ -5,6 +5,7 @@ import { IndexRatesStrippedDocument } from '../../../gen/gqlClient'
 import { mostRecentDate } from '@mc-review/dates'
 import styles from '../../StateDashboard/StateDashboard.module.scss'
 import { recordJSException } from '@mc-review/otel'
+import { usePageLoadSpan } from '../../../hooks'
 import { Loading } from '../../../components'
 
 import { RateInDashboardType, RateReviewsTable } from './RateReviewsTable'
@@ -24,6 +25,16 @@ const RateReviewsDashboard = (): React.ReactElement => {
         },
         fetchPolicy: 'cache-and-network',
         pollInterval: 300000,
+    })
+
+    // Measure dashboard load time (mount -> data ready) for the Rate reviews tab.
+    usePageLoadSpan({
+        ready: !!data,
+        error,
+        attributes: {
+            'dashboard.tab': 'rates',
+            'dashboard.row_count': data?.indexRatesStripped.edges.length ?? 0,
+        },
     })
 
     // Handle loading and error states for fetching data while using cached data

--- a/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsDashboard.tsx
+++ b/services/app-web/src/pages/CMSDashboard/RateReviewsDashboard/RateReviewsDashboard.tsx
@@ -29,6 +29,9 @@ const RateReviewsDashboard = (): React.ReactElement => {
 
     // Measure dashboard load time (mount -> data ready) for the Rate reviews tab.
     usePageLoadSpan({
+        // Explicit id so the trace identifies this CMS dashboard tab regardless
+        // of route (see SubmissionsDashboard for why the route isn't sufficient).
+        pageName: 'cms-dashboard-rates',
         ready: !!data,
         error,
         attributes: {

--- a/services/app-web/src/pages/CMSDashboard/SubmissionsDashboard/SubmissionsDashboard.tsx
+++ b/services/app-web/src/pages/CMSDashboard/SubmissionsDashboard/SubmissionsDashboard.tsx
@@ -7,6 +7,7 @@ import { mostRecentDate } from '@mc-review/dates'
 import styles from '../../StateDashboard/StateDashboard.module.scss'
 import localStyles from './SubmissionsDashboard.module.scss'
 import { recordJSException } from '@mc-review/otel'
+import { usePageLoadSpan } from '../../../hooks'
 import {
     Loading,
     ContractTable,
@@ -20,6 +21,17 @@ const SubmissionsDashboard = (): React.ReactElement => {
     const { data, loading, error } = useQuery(IndexContractsStrippedDocument, {
         fetchPolicy: 'cache-and-network',
         pollInterval: 120000,
+    })
+
+    // Measure dashboard load time (mount -> data ready) for the Submissions tab.
+    usePageLoadSpan({
+        ready: !!data,
+        error,
+        attributes: {
+            'dashboard.tab': 'submissions',
+            'dashboard.row_count':
+                data?.indexContractsStripped.edges.length ?? 0,
+        },
     })
 
     if (!data && loading) {

--- a/services/app-web/src/pages/CMSDashboard/SubmissionsDashboard/SubmissionsDashboard.tsx
+++ b/services/app-web/src/pages/CMSDashboard/SubmissionsDashboard/SubmissionsDashboard.tsx
@@ -25,6 +25,9 @@ const SubmissionsDashboard = (): React.ReactElement => {
 
     // Measure dashboard load time (mount -> data ready) for the Submissions tab.
     usePageLoadSpan({
+        // Explicit id: DASHBOARD_SUBMISSIONS is also the StateDashboard route, so
+        // the route alone can't identify this as the CMS submissions dashboard.
+        pageName: 'cms-dashboard-submissions',
         ready: !!data,
         error,
         attributes: {


### PR DESCRIPTION
## Summary

Measures page load time from mount until primary data is ready for the dashboard tables, emitting a span tagged with route and result count for per-page charting and alerting in Datadog.

This was in an old ticket in an old epic that Pearl pointed out and I figured it was worth adding to our Datadog setup.

#### Related issues
https://jiraent.cms.gov/browse/MCR-2670
