### PR TITLE
MCR-6230: Use h4 instead of h3 in eqro summary banner

### DIFF
--- a/services/app-web/src/components/Banner/AccessibleAlertBanner/AccessibleAlertBanner.module.scss
+++ b/services/app-web/src/components/Banner/AccessibleAlertBanner/AccessibleAlertBanner.module.scss
@@ -4,7 +4,7 @@
 .accessibleAlertBanner {
     h4[class*='usa-alert__heading'] {
         @include custom.mcr-h4-bold-style;
-        margin: 0 0 0.5rem 0;
+        margin: -0.125rem 0 0.5rem 0;
     }
 
     [class*='usa-alert--emergency']:before,

--- a/services/app-web/src/components/Banner/EQROSummaryBanner/eqroSummaryBanners.tsx
+++ b/services/app-web/src/components/Banner/EQROSummaryBanner/eqroSummaryBanners.tsx
@@ -186,7 +186,7 @@ export const EqroReviewDeterminationBanners = ({
             role="status"
             type="info"
             heading={heading}
-            headingLevel="h3"
+            headingLevel="h4"
             data-testid="eqroSummaryBanner"
             className={className}
             validation


### PR DESCRIPTION
## Summary

This PR  uses the h4 instead of h3 in the EQRO summary banner

#### Related issues

https://jiraent.cms.gov/browse/MCR-6230

#### Screenshots

<img width="856" height="201" alt="Screenshot 2026-06-26 at 12 08 26 PM" src="https://github.com/user-attachments/assets/e55ccda6-3421-46f6-a593-8694701b34a0" />



#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed