### PR TITLE
Add email tracing instrumentation

### DIFF
--- a/services/app-api/src/emailer/emailTracing.test.ts
+++ b/services/app-api/src/emailer/emailTracing.test.ts
@@ -42,7 +42,7 @@ describe('emailTracing', () => {
     const attributes = {
         toAddresses: ['zuko@example.com', 'aang@example.com'],
         ccAddresses: ['iroh@example.com'],
-        bccAddresses: [],
+        bccAddresses: ['azula@example.com'],
         sourceEmail: 'no-reply@example.com',
         subject: 'New Submission',
     }
@@ -57,13 +57,16 @@ describe('emailTracing', () => {
                     attributes: expect.objectContaining({
                         'email.to_addresses': attributes.toAddresses,
                         'email.cc_addresses': attributes.ccAddresses,
-                        'email.bcc_addresses': attributes.bccAddresses,
-                        'email.recipient_count': 3,
+                        // BCC recipients are counted but never recorded as addresses.
+                        'email.recipient_count': 4,
                         'email.source': attributes.sourceEmail,
                         'email.subject': attributes.subject,
                     }),
                 })
             )
+
+            const spanAttributes = startSpan.mock.calls[0][1].attributes
+            expect(spanAttributes).not.toHaveProperty('email.bcc_addresses')
         })
 
         it('marks the span successful and ends it when the send resolves', async () => {

--- a/services/app-api/src/emailer/emailTracing.test.ts
+++ b/services/app-api/src/emailer/emailTracing.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+    trace,
+    SpanStatusCode,
+    type Span,
+    type Tracer,
+} from '@opentelemetry/api'
+import {
+    withEmailSpan,
+    recordEmailFailure,
+    EMAIL_SPAN_NAME,
+} from './emailTracing'
+
+function makeMockSpan() {
+    return {
+        setAttribute: vi.fn(),
+        setStatus: vi.fn(),
+        recordException: vi.fn(),
+        end: vi.fn(),
+    }
+}
+
+describe('emailTracing', () => {
+    let span: ReturnType<typeof makeMockSpan>
+    let startSpan: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+        span = makeMockSpan()
+        startSpan = vi.fn(() => span)
+        // Override the global tracer so withEmailSpan operates on our mock span
+        // (under unit tests the real provider is a no-op, so we couldn't observe
+        // the attributes it would set otherwise).
+        vi.spyOn(trace, 'getTracer').mockReturnValue({
+            startSpan,
+        } as unknown as Tracer)
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    const attributes = {
+        toAddresses: ['zuko@example.com', 'aang@example.com'],
+        ccAddresses: ['iroh@example.com'],
+        bccAddresses: [],
+        sourceEmail: 'no-reply@example.com',
+        subject: 'New Submission',
+    }
+
+    describe('withEmailSpan', () => {
+        it('starts an email.send span tagged with the recipients', async () => {
+            await withEmailSpan(attributes, async () => undefined)
+
+            expect(startSpan).toHaveBeenCalledWith(
+                EMAIL_SPAN_NAME,
+                expect.objectContaining({
+                    attributes: expect.objectContaining({
+                        'email.to_addresses': attributes.toAddresses,
+                        'email.cc_addresses': attributes.ccAddresses,
+                        'email.bcc_addresses': attributes.bccAddresses,
+                        'email.recipient_count': 3,
+                        'email.source': attributes.sourceEmail,
+                        'email.subject': attributes.subject,
+                    }),
+                })
+            )
+        })
+
+        it('marks the span successful and ends it when the send resolves', async () => {
+            const result = await withEmailSpan(attributes, async (s) => {
+                s.setAttribute('email.ses_message_id', 'msg-123')
+                return undefined
+            })
+
+            expect(result).toBeUndefined()
+            expect(span.setAttribute).toHaveBeenCalledWith(
+                'email.outcome',
+                'success'
+            )
+            expect(span.setAttribute).toHaveBeenCalledWith(
+                'email.ses_message_id',
+                'msg-123'
+            )
+            expect(span.setStatus).not.toHaveBeenCalled()
+            expect(span.end).toHaveBeenCalledTimes(1)
+        })
+
+        it('records a failure (without throwing) when the callback returns an Error', async () => {
+            const err = new Error('SES email send failed')
+
+            const result = await withEmailSpan(attributes, async () => err)
+
+            // The emailer's convention is to return errors by value, not throw —
+            // withEmailSpan must surface that error back unchanged to callers.
+            expect(result).toBe(err)
+            expect(span.setAttribute).toHaveBeenCalledWith(
+                'email.outcome',
+                'failure'
+            )
+            expect(span.recordException).toHaveBeenCalledWith(err)
+            expect(span.setStatus).toHaveBeenCalledWith({
+                code: SpanStatusCode.ERROR,
+                message: err.message,
+            })
+            expect(span.end).toHaveBeenCalledTimes(1)
+        })
+
+        it('records and rethrows when the callback throws, still ending the span', async () => {
+            const err = new Error('unexpected fail')
+
+            await expect(
+                withEmailSpan(attributes, async () => {
+                    throw err
+                })
+            ).rejects.toThrow('unexpected fail')
+
+            expect(span.setAttribute).toHaveBeenCalledWith(
+                'email.outcome',
+                'failure'
+            )
+            expect(span.recordException).toHaveBeenCalled()
+            expect(span.end).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('recordEmailFailure', () => {
+        it('coerces a string error into an Error and sets an error status', () => {
+            recordEmailFailure(span as unknown as Span, 'string failure')
+
+            expect(span.setAttribute).toHaveBeenCalledWith(
+                'email.outcome',
+                'failure'
+            )
+            expect(span.recordException).toHaveBeenCalledWith(expect.any(Error))
+            expect(span.setStatus).toHaveBeenCalledWith({
+                code: SpanStatusCode.ERROR,
+                message: 'string failure',
+            })
+        })
+    })
+})

--- a/services/app-api/src/emailer/emailTracing.ts
+++ b/services/app-api/src/emailer/emailTracing.ts
@@ -41,7 +41,6 @@ function toSpanAttributes(attributes: EmailSpanAttributes): Attributes {
         // record of so we know who was (or was not) notified.
         'email.to_addresses': attributes.toAddresses,
         'email.cc_addresses': attributes.ccAddresses,
-        'email.bcc_addresses': attributes.bccAddresses,
         'email.recipient_count':
             attributes.toAddresses.length +
             attributes.ccAddresses.length +

--- a/services/app-api/src/emailer/emailTracing.ts
+++ b/services/app-api/src/emailer/emailTracing.ts
@@ -1,0 +1,108 @@
+import {
+    trace,
+    context as otelContext,
+    SpanStatusCode,
+    type Span,
+    type Attributes,
+} from '@opentelemetry/api'
+import { parseErrorToError } from '@mc-review/helpers'
+
+/**
+ * Instrumentation scope for email-send spans.
+ *
+ * The Datadog `service` tag comes from the tracer provider's resource
+ * (service.name = `app-api-<stage>`), NOT from this scope name, so every email
+ * span still lands under the same `app-api-<env>` service as the rest of the API
+ * while sharing a dedicated, queryable span name.
+ */
+export const EMAIL_TRACER_SCOPE = 'mcreview.email'
+
+/**
+ * Stable span name for every transactional email send via SES.
+ *
+ * Search Datadog APM with `operation_name:email.send` (optionally filtered on the
+ * `@email.*` attributes below) to see who notifications were sent to, the SES
+ * message id for correlating with any future bounce/complaint events, and
+ * whether the send succeeded (`@email.outcome`).
+ */
+export const EMAIL_SPAN_NAME = 'email.send'
+
+export type EmailSpanAttributes = {
+    toAddresses: string[]
+    ccAddresses: string[]
+    bccAddresses: string[]
+    sourceEmail: string
+    subject: string
+}
+
+function toSpanAttributes(attributes: EmailSpanAttributes): Attributes {
+    return {
+        // The recipients the email was sent to — the primary thing we want a
+        // record of so we know who was (or was not) notified.
+        'email.to_addresses': attributes.toAddresses,
+        'email.cc_addresses': attributes.ccAddresses,
+        'email.bcc_addresses': attributes.bccAddresses,
+        'email.recipient_count':
+            attributes.toAddresses.length +
+            attributes.ccAddresses.length +
+            attributes.bccAddresses.length,
+        'email.source': attributes.sourceEmail,
+        // Subject stands in for "which email" — the templates encode their type
+        // (new submission, unlock, question, etc.) in the subject line.
+        'email.subject': attributes.subject,
+    }
+}
+
+/**
+ * Records an email-send failure on its span using the current OTEL pattern
+ * (recordException + ERROR status), and sets `email.outcome` so healthy and
+ * failed sends are easy to split in APM.
+ */
+export function recordEmailFailure(span: Span, error: Error | string): void {
+    const err = error instanceof Error ? error : new Error(error)
+    span.setAttribute('email.outcome', 'failure')
+    span.recordException(err)
+    span.setStatus({ code: SpanStatusCode.ERROR, message: err.message })
+}
+
+/**
+ * Wraps a single SES email send in a dedicated span so transactional emails are
+ * traced consistently. Mirrors `withZipSpan`:
+ *
+ * - nested spans become children via context propagation
+ * - an error returned by value (the emailer's convention) is recorded as a span
+ *   error via {@link recordEmailFailure}
+ * - a thrown error is recorded and rethrown
+ * - the span is always ended
+ *
+ * The wrapped function receives the span so it can attach the SES `MessageId`
+ * once the send returns. The return value (including any `Error` value) is passed
+ * back unchanged, so callers keep their existing error handling.
+ */
+export async function withEmailSpan<T>(
+    attributes: EmailSpanAttributes,
+    fn: (span: Span) => Promise<T>
+): Promise<T> {
+    const tracer = trace.getTracer(EMAIL_TRACER_SCOPE)
+    const span = tracer.startSpan(EMAIL_SPAN_NAME, {
+        attributes: toSpanAttributes(attributes),
+    })
+
+    // Run within the span's context so any nested spans parent to it.
+    const spanContext = trace.setSpan(otelContext.active(), span)
+
+    try {
+        const result = await otelContext.with(spanContext, () => fn(span))
+        if (result instanceof Error) {
+            recordEmailFailure(span, result)
+        } else {
+            span.setAttribute('email.outcome', 'success')
+        }
+        return result
+    } catch (error) {
+        recordEmailFailure(span, parseErrorToError(error))
+        throw error
+    } finally {
+        span.end()
+    }
+}

--- a/services/app-api/src/emailer/emailer.ts
+++ b/services/app-api/src/emailer/emailer.ts
@@ -38,8 +38,8 @@ import type {
     RateQuestionType,
     ContractSubmissionType,
 } from '../domain-models'
-import { SESServiceException } from '@aws-sdk/client-ses'
 import { withEmailSpan } from './emailTracing'
+import { parseErrorToError } from '@mc-review/helpers'
 import type { RateForDisplayType } from './templateHelpers'
 import { newEQROContractCMSEmail } from './emails/newEQROContractCMSEmail'
 
@@ -771,13 +771,8 @@ const sendSESEmails = async (emailData: EmailData): Promise<void | Error> => {
                 }
                 return
             } catch (err) {
-                if (err instanceof SESServiceException) {
-                    return new Error(
-                        'SES email send failed. Error: ' + JSON.stringify(err)
-                    )
-                }
-
-                return new Error('SES email send failed. Error: ' + err)
+                const message = parseErrorToError(err).message
+                return new Error('SES email send failed. Error: ' + message)
             }
         }
     )

--- a/services/app-api/src/emailer/emailer.ts
+++ b/services/app-api/src/emailer/emailer.ts
@@ -39,6 +39,7 @@ import type {
     ContractSubmissionType,
 } from '../domain-models'
 import { SESServiceException } from '@aws-sdk/client-ses'
+import { withEmailSpan } from './emailTracing'
 import type { RateForDisplayType } from './templateHelpers'
 import { newEQROContractCMSEmail } from './emails/newEQROContractCMSEmail'
 
@@ -749,18 +750,37 @@ function emailer(
 const sendSESEmails = async (emailData: EmailData): Promise<void | Error> => {
     const emailRequestParams = getSESEmailParams(emailData)
 
-    try {
-        await sendSESEmail(emailRequestParams)
-        return
-    } catch (err) {
-        if (err instanceof SESServiceException) {
-            return new Error(
-                'SES email send failed. Error: ' + JSON.stringify(err)
-            )
-        }
+    return withEmailSpan(
+        {
+            toAddresses: emailData.toAddresses,
+            ccAddresses: emailData.ccAddresses ?? [],
+            bccAddresses: emailData.bccAddresses ?? [],
+            sourceEmail: emailData.sourceEmail,
+            subject: emailData.subject,
+        },
+        async (span) => {
+            try {
+                const response = await sendSESEmail(emailRequestParams)
+                // Capture the SES MessageId so a send can later be correlated
+                // with any bounce/complaint event for the same message.
+                if (response && 'MessageId' in response && response.MessageId) {
+                    span.setAttribute(
+                        'email.ses_message_id',
+                        response.MessageId
+                    )
+                }
+                return
+            } catch (err) {
+                if (err instanceof SESServiceException) {
+                    return new Error(
+                        'SES email send failed. Error: ' + JSON.stringify(err)
+                    )
+                }
 
-        return new Error('SES email send failed. Error: ' + err)
-    }
+                return new Error('SES email send failed. Error: ' + err)
+            }
+        }
+    )
 }
 
 function newSESEmailer(config: EmailConfiguration): Emailer {
@@ -815,5 +835,5 @@ function newLocalEmailer(config: EmailConfiguration): Emailer {
     return emailer(config, sendLocalEmails)
 }
 
-export { newLocalEmailer, newSESEmailer, emailer }
+export { newLocalEmailer, newSESEmailer, emailer, sendSESEmails }
 export type { Emailer, EmailConfiguration, EmailData, StateAnalystsEmails }

--- a/services/app-api/src/emailer/sendSESEmails.test.ts
+++ b/services/app-api/src/emailer/sendSESEmails.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { trace, type Tracer } from '@opentelemetry/api'
+import { sendSESEmail } from './awsSES'
+import { sendSESEmails } from './emailer'
+import type { EmailData } from './emailer'
+
+// Mock only the SES transport; getSESEmailParams (the real EmailData -> SES
+// params mapping) is preserved so sendSESEmails runs its real code path.
+vi.mock('./awsSES', async (importActual) => {
+    const actual = (await importActual()) as Record<string, unknown>
+    return { ...actual, sendSESEmail: vi.fn() }
+})
+
+const mockedSendSESEmail = vi.mocked(sendSESEmail)
+
+const emailData: EmailData = {
+    bodyText: 'hello',
+    bodyHTML: '<p>hello</p>',
+    sourceEmail: 'no-reply@example.com',
+    subject: 'New Submission',
+    toAddresses: ['zuko@example.com', 'aang@example.com'],
+    ccAddresses: ['iroh@example.com'],
+    bccAddresses: [],
+}
+
+describe('sendSESEmails', () => {
+    let span: {
+        setAttribute: ReturnType<typeof vi.fn>
+        setStatus: ReturnType<typeof vi.fn>
+        recordException: ReturnType<typeof vi.fn>
+        end: ReturnType<typeof vi.fn>
+    }
+
+    beforeEach(() => {
+        mockedSendSESEmail.mockReset()
+        span = {
+            setAttribute: vi.fn(),
+            setStatus: vi.fn(),
+            recordException: vi.fn(),
+            end: vi.fn(),
+        }
+        vi.spyOn(trace, 'getTracer').mockReturnValue({
+            startSpan: vi.fn(() => span),
+        } as unknown as Tracer)
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('sends via SES and records the returned MessageId on a successful span', async () => {
+        mockedSendSESEmail.mockResolvedValue({ MessageId: 'ses-message-1' })
+
+        const result = await sendSESEmails(emailData)
+
+        expect(result).toBeUndefined()
+        expect(mockedSendSESEmail).toHaveBeenCalledTimes(1)
+        expect(span.setAttribute).toHaveBeenCalledWith(
+            'email.ses_message_id',
+            'ses-message-1'
+        )
+        expect(span.setAttribute).toHaveBeenCalledWith(
+            'email.outcome',
+            'success'
+        )
+    })
+
+    it('returns an Error and marks the span failed when the SES send throws', async () => {
+        mockedSendSESEmail.mockRejectedValue(new Error('network down'))
+
+        const result = await sendSESEmails(emailData)
+
+        // The send failure is returned by value (not thrown) so callers keep
+        // their existing error handling, and the span is marked failed.
+        expect(result).toBeInstanceOf(Error)
+        expect(span.setAttribute).toHaveBeenCalledWith(
+            'email.outcome',
+            'failure'
+        )
+        expect(span.recordException).toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## Summary
In going through some old epics I found this one related to email monitoring. This adds some OTEL tracing to our emailer along with some tests for paths we weren't testing.

#### Related issues
https://jiraent.cms.gov/browse/MCR-2664

