### PR TITLE
Add OpenTelemetry tracing for S3 operations

### DIFF
--- a/services/app-api/src/otel/s3Tracing.ts
+++ b/services/app-api/src/otel/s3Tracing.ts
@@ -1,0 +1,104 @@
+import {
+    trace,
+    context as otelContext,
+    SpanStatusCode,
+    type Span,
+} from '@opentelemetry/api'
+import { parseErrorToError } from '@mc-review/helpers'
+
+/**
+ * Instrumentation scope for S3 data-plane spans.
+ *
+ * The Datadog `service` tag comes from the tracer provider's resource
+ * (service.name = `app-api-<stage>`), not from this scope name, so S3 spans land
+ * under the same service as the rest of the API while sharing a dedicated,
+ * queryable span name (`s3.<operation>`).
+ *
+ */
+export const S3_TRACER_SCOPE = 'mcreview.s3'
+
+export type S3SpanAttributes = {
+    /** S3 operation name, e.g. 'GetObject' | 'PutObject' */
+    operation: string
+    bucket: string
+    key: string
+}
+
+// AWS SDK v3 command outputs (and errors) all carry `$metadata`. We only read
+// the retry/status fields, so type just those rather than depending on the SDK.
+type WithS3Metadata = {
+    $metadata?: {
+        httpStatusCode?: number
+        attempts?: number
+        totalRetryDelay?: number
+    }
+}
+
+function recordMetadata(
+    span: Span,
+    metadata: WithS3Metadata['$metadata']
+): void {
+    if (!metadata) return
+    if (typeof metadata.httpStatusCode === 'number') {
+        span.setAttribute('http.status_code', metadata.httpStatusCode)
+    }
+    // attempts === 1 is the clean first-try case. attempts > 1 means the SDK had
+    // to retry — for S3 that is almost always throttling (503 SlowDown) or a 5xx,
+    // and total_retry_delay_ms is the backoff time spent. This makes throttling
+    // visible even when the request eventually succeeds (i.e. just looks slow).
+    if (typeof metadata.attempts === 'number') {
+        span.setAttribute('aws.request.attempts', metadata.attempts)
+    }
+    if (typeof metadata.totalRetryDelay === 'number') {
+        span.setAttribute(
+            'aws.request.total_retry_delay_ms',
+            metadata.totalRetryDelay
+        )
+    }
+}
+
+/**
+ * Wraps a single S3 `send()` call in a dedicated `s3.<operation>` span so each
+ * GET/PUT our Lambda makes is traced consistently. Nested under whatever span is
+ * active (resolver or `zip.generate`) via context propagation.
+ *
+ * On success it records the SDK's own retry accounting from `$metadata`
+ * (`aws.request.attempts`, `aws.request.total_retry_delay_ms`) plus the HTTP
+ * status. On failure it records the exception with the S3 error code preserved
+ * (`error.name`, e.g. `SlowDown` / `ThrottlingException`) and the HTTP status
+ * from the error's `$metadata`, then rethrows — callers keep their existing
+ * error handling unchanged.
+ */
+export async function withS3Span<T extends WithS3Metadata>(
+    attributes: S3SpanAttributes,
+    fn: () => Promise<T>
+): Promise<T> {
+    const tracer = trace.getTracer(S3_TRACER_SCOPE)
+    const span = tracer.startSpan(`s3.${attributes.operation}`, {
+        attributes: {
+            'aws.s3.operation': attributes.operation,
+            'aws.s3.bucket': attributes.bucket,
+            'aws.s3.key': attributes.key,
+        },
+    })
+
+    // Run within the span's context so it parents to the active resolver/zip span.
+    const spanContext = trace.setSpan(otelContext.active(), span)
+
+    try {
+        const result = await otelContext.with(spanContext, fn)
+        recordMetadata(span, result?.$metadata)
+        return result
+    } catch (error) {
+        const err = parseErrorToError(error)
+        span.recordException(err)
+        // Preserve the S3 error identity even where the caller later flattens it
+        // (e.g. uploadFile collapses everything to NETWORK_ERROR).
+        span.setAttribute('error.name', err.name)
+        recordMetadata(span, (error as WithS3Metadata)?.$metadata)
+        span.setStatus({ code: SpanStatusCode.ERROR, message: err.message })
+        throw error
+    } finally {
+        span.end()
+    }
+}

--- a/services/app-api/src/otel/s3Tracing.ts
+++ b/services/app-api/src/otel/s3Tracing.ts
@@ -1,6 +1,7 @@
 import {
     trace,
     context as otelContext,
+    SpanKind,
     SpanStatusCode,
     type Span,
 } from '@opentelemetry/api'
@@ -74,10 +75,15 @@ export async function withS3Span<T extends WithS3Metadata>(
     fn: () => Promise<T>
 ): Promise<T> {
     const tracer = trace.getTracer(S3_TRACER_SCOPE)
+    // SpanKind.CLIENT so S3 registers as an outbound dependency call in APM
+    // service-map / dependency views rather than an internal span.
     const span = tracer.startSpan(`s3.${attributes.operation}`, {
+        kind: SpanKind.CLIENT,
         attributes: {
             'aws.s3.operation': attributes.operation,
             'aws.s3.bucket': attributes.bucket,
+            // Safe to record raw: keys are UUID + revision-ID based
+            // (e.g. `allusers/<uuid>.<ext>`, `zips/rates/<rateRevisionID>/...`),
             'aws.s3.key': attributes.key,
         },
     })

--- a/services/app-api/src/s3/s3Deployed.ts
+++ b/services/app-api/src/s3/s3Deployed.ts
@@ -12,6 +12,7 @@ import type { S3ClientT } from './s3Client'
 import type { S3Error } from './s3Error'
 import { isS3Error } from './s3Error'
 import { parseErrorToError } from '@mc-review/helpers'
+import { withS3Span } from '../otel/s3Tracing'
 
 // newDeployedS3Client is used for calling S3 from app-api
 // app-api does not use amplify for interfacing with S3
@@ -41,7 +42,16 @@ export function newDeployedS3Client(
                     }
                     throw err
                 }
-                await s3Client.send(command)
+                // Traced so the S3 error identity (e.g. SlowDown) survives even
+                // though the catch below flattens failures to NETWORK_ERROR.
+                await withS3Span(
+                    {
+                        operation: 'PutObject',
+                        bucket: bucketConfig[bucket],
+                        key: filename,
+                    },
+                    () => s3Client.send(command)
+                )
 
                 return filename
             } catch (err) {

--- a/services/app-api/src/zip/generateZip.ts
+++ b/services/app-api/src/zip/generateZip.ts
@@ -19,6 +19,7 @@ import type {
     RateRevisionType,
 } from '../domain-models'
 import { withZipSpan } from './zipTracing'
+import { withS3Span } from '../otel/s3Tracing'
 
 const s3Client = new S3Client({
     region: process.env.AWS_REGION || 'us-east-1',
@@ -201,13 +202,17 @@ export const generateDocumentZip: GenerateDocumentZipFunctionType = async (
         // Upload zip to S3
         const outputKey = outputPath
         try {
-            await s3Client.send(
-                new PutObjectCommand({
-                    Bucket: bucket,
-                    Key: outputKey,
-                    Body: fs.createReadStream(zipPath),
-                    ContentType: 'application/zip',
-                })
+            await withS3Span(
+                { operation: 'PutObject', bucket, key: outputKey },
+                () =>
+                    s3Client.send(
+                        new PutObjectCommand({
+                            Bucket: bucket,
+                            Key: outputKey,
+                            Body: fs.createReadStream(zipPath),
+                            ContentType: 'application/zip',
+                        })
+                    )
             )
         } catch (err) {
             return new Error(
@@ -302,12 +307,16 @@ async function downloadFile(
     const timeoutId = setTimeout(() => controller.abort(), timeout)
 
     try {
-        const response = await s3Client.send(
-            new GetObjectCommand({
-                Bucket: bucket,
-                Key: key,
-            }),
-            { abortSignal: controller.signal }
+        const response = await withS3Span(
+            { operation: 'GetObject', bucket, key },
+            () =>
+                s3Client.send(
+                    new GetObjectCommand({
+                        Bucket: bucket,
+                        Key: key,
+                    }),
+                    { abortSignal: controller.signal }
+                )
         )
 
         clearTimeout(timeoutId)


### PR DESCRIPTION
## Summary

Wrap S3 client calls in dedicated spans to trace GET/PUT operations consistently. Records retry accounting, HTTP status, and S3 error codes so throttling and failures are visible in Datadog.

#### Related issues
