### PR TITLE
Fix local OTEL via Jaeger container

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -33,7 +33,8 @@ export OKTA_OAUTH_ISSUER='okta-oauth-local'
 export LOCAL_DEV_SERVICE_URL='http://localhost:3031'
 
 export VITE_APP_OTEL_COLLECTOR_URL='http://localhost:3030/local/otel'
-export DD_API_KEY='local' # pragma: allowlist secret
+# Send local traces to the Jaeger container instead of Datadog (UI: http://localhost:16686)
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT='http://localhost:4318/v1/traces'
 export VITE_APP_LD_CLIENT_ID='this-value-can-be-set-in-local-if-desired'
 export VITE_APP_SDP_PORTAL_URL='this-value-can-be-set-in-local-if-desired'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,24 +38,14 @@ services:
       timeout: 5s
       retries: 3
 
-  # Jaeger for OpenTelemetry tracing
+  # Jaeger v2 for OpenTelemetry tracing (built on the OTel Collector, OTLP-native)
   jaeger-all-in-one:
-    image: jaegertracing/all-in-one:latest
+    image: jaegertracing/jaeger:2.19.0
     container_name: mcr-jaeger
-    environment:
-      - COLLECTOR_OTLP_ENABLED=true
-      - COLLECTOR_ZIPKIN_HOST_PORT=:9411
     ports:
-      - 6831:6831/udp
-      - 6832:6832/udp
-      - 5778:5778
-      - 16686:16686
-      - 14268:14268
-      - 14269:14269
-      - 14250:14250
-      - 9411:9411
-      - 4317:4317
-      - 4318:4318
+      - 16686:16686 # UI
+      - 4317:4317 # OTLP gRPC
+      - 4318:4318 # OTLP HTTP
 
 volumes:
   postgres_data:

--- a/services/app-api/src/handlers/otel_proxy.ts
+++ b/services/app-api/src/handlers/otel_proxy.ts
@@ -16,16 +16,34 @@ const main: APIGatewayProxyHandler = async (event) => {
         `otel_proxy: received trace payload, body=${bodyBytes} bytes, content-type=${contentType}`
     )
 
-    // Local dev sets OTEL_EXPORTER_OTLP_TRACES_ENDPOINT (in .envrc) to point
-    // at the local Jaeger container's OTLP port. Deployed environments leave
-    // it unset and forward directly to Datadog.
-    const localEndpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-    const tracesUrl = localEndpoint ?? DD_TRACES_URL
-
+    // Local dev (stage === 'local') forwards traces to the local Jaeger
+    // container's OTLP port, set via OTEL_EXPORTER_OTLP_TRACES_ENDPOINT in
+    // .envrc. All other environments forward directly to Datadog; the
+    // endpoint override is ignored there so a stray env var can't redirect
+    // traces.
+    let tracesUrl: string
     const headers: Record<string, string> = {
         'content-type': contentType,
     }
-    if (!localEndpoint) {
+    if (process.env.stage === 'local') {
+        const localEndpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+        if (!localEndpoint) {
+            console.error(
+                'otel_proxy: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is not set'
+            )
+            return {
+                statusCode: 500,
+                body: JSON.stringify(
+                    'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is required for local tracing'
+                ),
+                headers: {
+                    'Access-Control-Allow-Origin': '*',
+                    'Access-Control-Allow-Credentials': true,
+                },
+            }
+        }
+        tracesUrl = localEndpoint
+    } else {
         if (!process.env.DD_API_KEY) {
             console.error('otel_proxy: DD_API_KEY is not set')
             return {
@@ -37,6 +55,7 @@ const main: APIGatewayProxyHandler = async (event) => {
                 },
             }
         }
+        tracesUrl = DD_TRACES_URL
         headers['dd-api-key'] = process.env.DD_API_KEY
         headers['dd-otlp-source'] = 'datadog'
         headers['dd-otel-span-mapping'] = '{span_name_as_resource_name: false}'

--- a/services/app-api/src/handlers/otel_proxy.ts
+++ b/services/app-api/src/handlers/otel_proxy.ts
@@ -16,34 +16,42 @@ const main: APIGatewayProxyHandler = async (event) => {
         `otel_proxy: received trace payload, body=${bodyBytes} bytes, content-type=${contentType}`
     )
 
-    if (!process.env.DD_API_KEY) {
-        console.error('otel_proxy: DD_API_KEY is not set')
-        return {
-            statusCode: 500,
-            body: JSON.stringify('DD_API_KEY is required'),
-            headers: {
-                'Access-Control-Allow-Origin': '*',
-                'Access-Control-Allow-Credentials': true,
-            },
+    // Local dev sets OTEL_EXPORTER_OTLP_TRACES_ENDPOINT (in .envrc) to point
+    // at the local Jaeger container's OTLP port. Deployed environments leave
+    // it unset and forward directly to Datadog.
+    const localEndpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+    const tracesUrl = localEndpoint ?? DD_TRACES_URL
+
+    const headers: Record<string, string> = {
+        'content-type': contentType,
+    }
+    if (!localEndpoint) {
+        if (!process.env.DD_API_KEY) {
+            console.error('otel_proxy: DD_API_KEY is not set')
+            return {
+                statusCode: 500,
+                body: JSON.stringify('DD_API_KEY is required'),
+                headers: {
+                    'Access-Control-Allow-Origin': '*',
+                    'Access-Control-Allow-Credentials': true,
+                },
+            }
         }
+        headers['dd-api-key'] = process.env.DD_API_KEY
+        headers['dd-otlp-source'] = 'datadog'
+        headers['dd-otel-span-mapping'] = '{span_name_as_resource_name: false}'
     }
 
-    const options = {
-        headers: {
-            'content-type': contentType,
-            'dd-api-key': process.env.DD_API_KEY,
-            'dd-otlp-source': 'datadog',
-            'dd-otel-span-mapping': '{span_name_as_resource_name: false}',
-        },
-    }
+    const options = { headers }
 
     const body = event.isBase64Encoded
         ? Buffer.from(event.body ?? '', 'base64')
         : event.body
 
     try {
-        const response = await axios.post(DD_TRACES_URL, body, options)
-        console.info(`otel_proxy: forwarded to datadog`, {
+        const response = await axios.post(tracesUrl, body, options)
+        console.info(`otel_proxy: forwarded traces`, {
+            url: tracesUrl,
             status: response.status,
             responseData: response.data,
         })
@@ -53,9 +61,9 @@ const main: APIGatewayProxyHandler = async (event) => {
             response?: { status: number; data: unknown }
             code?: string
         }
-        console.error('otel_proxy: failed to forward to datadog', {
+        console.error('otel_proxy: failed to forward traces', {
             message: parsed.message,
-            url: DD_TRACES_URL,
+            url: tracesUrl,
             httpStatus: axiosErr.response?.status,
             responseData: axiosErr.response?.data,
             code: axiosErr.code,

--- a/services/app-api/src/otel/otel_handler.ts
+++ b/services/app-api/src/otel/otel_handler.ts
@@ -31,6 +31,17 @@ function getDDHeaders() {
     }
 }
 
+// Local dev sets OTEL_EXPORTER_OTLP_TRACES_ENDPOINT (in .envrc) to point at
+// the local Jaeger container's OTLP port. Deployed environments leave it
+// unset and export directly to Datadog.
+function getExporterConfig() {
+    const localEndpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+    if (localEndpoint) {
+        return { url: localEndpoint, headers: {} }
+    }
+    return { url: DD_TRACES_URL, headers: getDDHeaders() }
+}
+
 export function initTracer(serviceName: string) {
     // Skip OTEL setup under unit tests (setupTests.ts sets stage='test'). This
     // keeps tests hermetic: without a registered provider, recordException/
@@ -57,10 +68,7 @@ export function initTracer(serviceName: string) {
         })
     )
 
-    const exporter = new OTLPTraceExporter({
-        url: DD_TRACES_URL,
-        headers: getDDHeaders(),
-    })
+    const exporter = new OTLPTraceExporter(getExporterConfig())
     const provider = new NodeTracerProvider({
         resource,
         spanProcessors: [new BatchSpanProcessor(exporter)],

--- a/services/app-api/src/otel/otel_handler.ts
+++ b/services/app-api/src/otel/otel_handler.ts
@@ -31,12 +31,18 @@ function getDDHeaders() {
     }
 }
 
-// Local dev sets OTEL_EXPORTER_OTLP_TRACES_ENDPOINT (in .envrc) to point at
-// the local Jaeger container's OTLP port. Deployed environments leave it
-// unset and export directly to Datadog.
+// Local dev (stage === 'local') exports traces to the local Jaeger
+// container's OTLP port, set via OTEL_EXPORTER_OTLP_TRACES_ENDPOINT in
+// .envrc. All other environments export directly to Datadog; the endpoint
+// override is ignored there so a stray env var can't redirect traces.
 function getExporterConfig() {
-    const localEndpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-    if (localEndpoint) {
+    if (process.env.stage === 'local') {
+        const localEndpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+        if (!localEndpoint) {
+            throw new Error(
+                'Configuration error: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT environment variable is required for local OpenTelemetry'
+            )
+        }
         return { url: localEndpoint, headers: {} }
     }
     return { url: DD_TRACES_URL, headers: getDDHeaders() }


### PR DESCRIPTION
## Summary

When I migrated us to Datadog I missed some errors in the local OTEL setup. This PR updates Jaeger (the local OTEL container) and fixes up some of the configs for local init to send traces to the local OTEL setup.

#### Related issues
https://jiraent.cms.gov/browse/MCR-6424
