### PR TITLE
MCR-6096 & MCR-6097: Banner fixes

### DIFF
--- a/services/app-web/src/components/Banner/AccessibleAlertBanner/AccessibleAlertBanner.module.scss
+++ b/services/app-web/src/components/Banner/AccessibleAlertBanner/AccessibleAlertBanner.module.scss
@@ -5,6 +5,10 @@
     h4[class*='usa-alert__heading'] {
         @include custom.mcr-h4-bold-style;
         margin: -0.125rem 0 0.5rem 0;
+
+        &:last-child {
+            margin-bottom: 0;
+        }
     }
 
     [class*='usa-alert--emergency']:before,

--- a/services/app-web/src/components/Banner/QuestionResponseSubmitBanner/QuestionResponseSubmitBanner.tsx
+++ b/services/app-web/src/components/Banner/QuestionResponseSubmitBanner/QuestionResponseSubmitBanner.tsx
@@ -1,15 +1,17 @@
+import React from 'react'
 import { AccessibleAlertBanner } from '../AccessibleAlertBanner/AccessibleAlertBanner'
 
 type SubmitType = 'question' | 'response'
 export type QuestionResponseSubmitBannerProps = {
     submitType: string
-}
+} & React.HTMLAttributes<HTMLDivElement>
 function isSubmitType(type: SubmitType | string): type is SubmitType {
     return type === 'question' || type === 'response'
 }
 
 const QuestionResponseSubmitBanner = ({
     submitType,
+    className,
 }: QuestionResponseSubmitBannerProps) => {
     if (!isSubmitType(submitType)) return null
     const cmsQuestion = submitType === 'question'
@@ -23,8 +25,9 @@ const QuestionResponseSubmitBanner = ({
             type="success"
             headingLevel="h4"
             heading={heading}
+            className={className}
         >
-            <p>{message}</p>
+            {message}
         </AccessibleAlertBanner>
     )
 }

--- a/services/app-web/src/components/Banner/UserAccountWarningBanner/UserAccountWarningBanner.tsx
+++ b/services/app-web/src/components/Banner/UserAccountWarningBanner/UserAccountWarningBanner.tsx
@@ -7,7 +7,7 @@ import { AccessibleAlertBanner } from '../AccessibleAlertBanner/AccessibleAlertB
 export type AccountWarningBannerProps = {
     header?: string
     message?: React.ReactNode
-}
+} & React.HTMLAttributes<HTMLDivElement>
 
 const MissingDivisionMessage = () => {
     return (
@@ -24,6 +24,7 @@ const MissingDivisionMessage = () => {
 const UserAccountWarningBanner = ({
     header = 'Missing division',
     message = <MissingDivisionMessage />,
+    className,
 }: AccountWarningBannerProps) => {
     const { logAlertImpressionEvent } = useTealium()
 
@@ -35,12 +36,14 @@ const UserAccountWarningBanner = ({
             extension: 'react-uswds',
         })
     }, [logAlertImpressionEvent, message])
+
     return (
         <AccessibleAlertBanner
             role="alert"
             type="warning"
             headingLevel="h4"
             heading={header}
+            className={className}
         >
             {message}
         </AccessibleAlertBanner>

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponse.module.scss
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponse.module.scss
@@ -6,6 +6,10 @@
     width: 100%;
 }
 
+.banner {
+    margin: uswds.units(3) auto uswds.units(4) auto;
+}
+
 // Matches the Required/Optional indicator used by FieldTextarea in the state
 // submission forms, for required fields on the plain-state admin Q&A form.
 .requiredOptionalText {
@@ -15,7 +19,7 @@
 
 .container {
     max-width: custom.$mcr-container-standard-width-fixed;
-    padding-bottom: 2rem;
+    padding: 0 0 2rem 0;
 
     h1 {
         margin-top: 34px;
@@ -59,7 +63,6 @@
 
 .questionSection {
     @extend %questionSection;
-    margin-top: 0px;
     [class*='summarySectionHeader'] {
         padding-bottom: 0;
         margin-bottom: 0;

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/ContractQuestionResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/ContractQuestionResponse.tsx
@@ -92,10 +92,15 @@ export const ContractQuestionResponse = () => {
             <GridContainer className={styles.container}>
                 <h1>Contract questions</h1>
 
-                {hasCMSPermissions && !division && <UserAccountWarningBanner />}
+                {hasCMSPermissions && !division && (
+                    <UserAccountWarningBanner className={styles.banner} />
+                )}
 
                 {submitType && (
-                    <QuestionResponseSubmitBanner submitType={submitType} />
+                    <QuestionResponseSubmitBanner
+                        submitType={submitType}
+                        className={styles.banner}
+                    />
                 )}
 
                 {hasCMSPermissions ? (


### PR DESCRIPTION
## Summary
[MCR-6096](https://jiraent.cms.gov/browse/MCR-6096): Correct QuestionResponseBanner spacing
Acceptance criteria
- Changes apply to all QuestionResponseBanner variants
- The body text has 0px top and bottom margin
- Spacing between alert heading and body text is 8px
- No unintended spacing changes to other alert variants

[MCR-6097](https://jiraent.cms.gov/browse/MCR-6097): SubmissionSuccessBanner margin fix
Acceptance criteria
- With no contract type h4 has 0px bottom margin.
   - Validate using storybook

Other work
- Fixed left and right padding on Q&A page to match the summary page
- Fixed top and bottom spacing on Q&A page banners to match other pages.
   - State user: Banner and "Outstanding questions" section had no spacing
   - CMS user: Banner spacing did not match other pages.

#### Related issues

#### Screenshots
No Contract type submission banner
<img width="500" alt="Screenshot 2026-07-06 at 6 33 15 PM" src="https://github.com/user-attachments/assets/ea1bc49a-a887-428f-8c01-1a178483fbe1" />

Q&A Submit banner
<img width="500" alt="Screenshot 2026-07-06 at 6 34 21 PM" src="https://github.com/user-attachments/assets/9ddf4f00-f6a0-48a9-a5e7-4bcef6a157d4" />

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
- Validate both using [storybook](https://d143lsylj4zn45.cloudfront.net/).

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed