### PR TITLE
MCR-6113: Effective dates error UI

### DIFF
--- a/services/app-web/src/components/Form/FieldYesNo/FieldYesNo.tsx
+++ b/services/app-web/src/components/Form/FieldYesNo/FieldYesNo.tsx
@@ -54,7 +54,6 @@ export const FieldYesNo = ({
     return (
         <Fieldset
             role="radiogroup"
-            aria-required={isRequired}
             id={id}
             legend={label}
             className={classes}

--- a/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
+++ b/services/app-web/src/pages/LinkYourRates/LinkYourRates.tsx
@@ -66,7 +66,6 @@ export const LinkYourRates = ({
             <Fieldset
                 role="radiogroup"
                 className={styles.radioGroup}
-                aria-required
                 legend={
                     'Was this rate certification included with another submission?'
                 }

--- a/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROContractDetails/EQROContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROContractDetails/EQROContractDetails.tsx
@@ -587,90 +587,92 @@ export const EQROContractDetails = ({
                                             />
                                         </FormGroup>
 
-                                        <Fieldset
-                                            aria-required
-                                            legend={
-                                                isContractAmendment(
-                                                    draftSubmission
-                                                )
-                                                    ? 'Amendment effective dates'
-                                                    : 'Contract effective dates'
-                                            }
-                                        >
-                                            <span
-                                                className={
-                                                    styles.requiredOptionalText
+                                        <FormGroup>
+                                            <Fieldset
+                                                aria-required
+                                                legend={
+                                                    isContractAmendment(
+                                                        draftSubmission
+                                                    )
+                                                        ? 'Amendment effective dates'
+                                                        : 'Contract effective dates'
                                                 }
                                             >
-                                                Required
-                                            </span>
+                                                <span
+                                                    className={
+                                                        styles.requiredOptionalText
+                                                    }
+                                                >
+                                                    Required
+                                                </span>
 
-                                            <LinkWithLogging
-                                                aria-label="Effective date guidance (opens in new window)"
-                                                href={
-                                                    '/resources/help#effective-date-guidance'
-                                                }
-                                                variant="external"
-                                                target="_blank"
-                                            >
-                                                Effective date guidance
-                                            </LinkWithLogging>
-                                            <CustomDateRangePicker
-                                                className={
-                                                    styles.dateRangePicker
-                                                }
-                                                startDateHint="mm/dd/yyyy"
-                                                startDateLabel="Start date"
-                                                startDateError={showFieldErrors(
-                                                    'contractDateStart',
-                                                    errors
-                                                )}
-                                                startDatePickerProps={{
-                                                    id: 'contractDateStart',
-                                                    name: 'contractDateStart',
-                                                    'aria-required': true,
-                                                    disabled: false,
-                                                    defaultValue:
-                                                        values.contractDateStart,
-                                                    maxDate:
-                                                        formattedDateMinusOneDay(
-                                                            values.contractDateEnd
-                                                        ),
-                                                    onChange: (val) =>
-                                                        setFieldValue(
-                                                            'contractDateStart',
-                                                            formatUserInputDate(
-                                                                val
-                                                            )
-                                                        ),
-                                                }}
-                                                endDateHint="mm/dd/yyyy"
-                                                endDateLabel="End date"
-                                                endDateError={showFieldErrors(
-                                                    'contractDateEnd',
-                                                    errors
-                                                )}
-                                                endDatePickerProps={{
-                                                    disabled: false,
-                                                    id: 'contractDateEnd',
-                                                    name: 'contractDateEnd',
-                                                    'aria-required': true,
-                                                    defaultValue:
-                                                        values.contractDateEnd,
-                                                    minDate:
-                                                        formattedDatePlusOneDay(
-                                                            values.contractDateStart
-                                                        ),
-                                                    onChange: (val) =>
-                                                        setFieldValue(
-                                                            'contractDateEnd',
-                                                            formatUserInputDate(
-                                                                val
-                                                            )
-                                                        ),
-                                                }}
-                                            />
-                                        </Fieldset>
+                                                <LinkWithLogging
+                                                    aria-label="Effective date guidance (opens in new window)"
+                                                    href={
+                                                        '/resources/help#effective-date-guidance'
+                                                    }
+                                                    variant="external"
+                                                    target="_blank"
+                                                >
+                                                    Effective date guidance
+                                                </LinkWithLogging>
+                                                <CustomDateRangePicker
+                                                    className={
+                                                        styles.dateRangePicker
+                                                    }
+                                                    startDateHint="mm/dd/yyyy"
+                                                    startDateLabel="Start date"
+                                                    startDateError={showFieldErrors(
+                                                        'contractDateStart',
+                                                        errors
+                                                    )}
+                                                    startDatePickerProps={{
+                                                        id: 'contractDateStart',
+                                                        name: 'contractDateStart',
+                                                        'aria-required': true,
+                                                        disabled: false,
+                                                        defaultValue:
+                                                            values.contractDateStart,
+                                                        maxDate:
+                                                            formattedDateMinusOneDay(
+                                                                values.contractDateEnd
+                                                            ),
+                                                        onChange: (val) =>
+                                                            setFieldValue(
+                                                                'contractDateStart',
+                                                                formatUserInputDate(
+                                                                    val
+                                                                )
+                                                            ),
+                                                    }}
+                                                    endDateHint="mm/dd/yyyy"
+                                                    endDateLabel="End date"
+                                                    endDateError={showFieldErrors(
+                                                        'contractDateEnd',
+                                                        errors
+                                                    )}
+                                                    endDatePickerProps={{
+                                                        disabled: false,
+                                                        id: 'contractDateEnd',
+                                                        name: 'contractDateEnd',
+                                                        'aria-required': true,
+                                                        defaultValue:
+                                                            values.contractDateEnd,
+                                                        minDate:
+                                                            formattedDatePlusOneDay(
+                                                                values.contractDateStart
+                                                            ),
+                                                        onChange: (val) =>
+                                                            setFieldValue(
+                                                                'contractDateEnd',
+                                                                formatUserInputDate(
+                                                                    val
+                                                                )
+                                                            ),
+                                                    }}
+                                                />
+                                            </Fieldset>
+                                        </FormGroup>
 
                                         {isBaseContract && isMCO && (
                                             <FormGroup

--- a/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROContractDetails/EQROContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROContractDetails/EQROContractDetails.tsx
@@ -589,7 +589,6 @@ export const EQROContractDetails = ({
 
                                         <FormGroup>
                                             <Fieldset
-                                                aria-required
                                                 legend={
                                                     isContractAmendment(
                                                         draftSubmission
@@ -684,7 +683,6 @@ export const EQROContractDetails = ({
                                                 )}
                                             >
                                                 <Fieldset
-                                                    aria-required
                                                     id="eqroNewContractor"
                                                     legend="Is this contract with a new EQRO contractor?"
                                                 >
@@ -747,7 +745,6 @@ export const EQROContractDetails = ({
                                                         )}
                                                     >
                                                         <Fieldset
-                                                            aria-required
                                                             id="eqroProvisionMcoEqrOrRelatedActivities"
                                                             legend="EQR or EQR-related activities performed on MCOs"
                                                         >
@@ -789,7 +786,6 @@ export const EQROContractDetails = ({
                                                         )}
                                                     >
                                                         <Fieldset
-                                                            aria-required
                                                             id="eqroProvisionMcoNewOptionalActivity"
                                                             legend="New optional activities to be performed on MCO in accordance with 42 CFR $ 438.358(c)"
                                                         >
@@ -831,7 +827,6 @@ export const EQROContractDetails = ({
                                                         )}
                                                     >
                                                         <Fieldset
-                                                            aria-required
                                                             id="eqroProvisionNewMcoEqrRelatedActivities"
                                                             legend="EQR-related activities for a new MCO managed care program"
                                                         >
@@ -868,7 +863,6 @@ export const EQROContractDetails = ({
                                                         )}
                                                     >
                                                         <Fieldset
-                                                            aria-required
                                                             id="eqroProvisionChipEqrRelatedActivities"
                                                             legend="EQR-related activities performed on the CHIP population"
                                                         >

--- a/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROContractDetails/EQROContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROContractDetails/EQROContractDetails.tsx
@@ -587,92 +587,90 @@ export const EQROContractDetails = ({
                                             />
                                         </FormGroup>
 
-                                        <FormGroup>
-                                            <Fieldset
-                                                aria-required
-                                                legend={
-                                                    isContractAmendment(
-                                                        draftSubmission
-                                                    )
-                                                        ? 'Amendment effective dates'
-                                                        : 'Contract effective dates'
+                                        <Fieldset
+                                            aria-required
+                                            legend={
+                                                isContractAmendment(
+                                                    draftSubmission
+                                                )
+                                                    ? 'Amendment effective dates'
+                                                    : 'Contract effective dates'
+                                            }
+                                        >
+                                            <span
+                                                className={
+                                                    styles.requiredOptionalText
                                                 }
                                             >
-                                                <span
-                                                    className={
-                                                        styles.requiredOptionalText
-                                                    }
-                                                >
-                                                    Required
-                                                </span>
+                                                Required
+                                            </span>
 
-                                                <LinkWithLogging
-                                                    aria-label="Effective date guidance (opens in new window)"
-                                                    href={
-                                                        '/resources/help#effective-date-guidance'
-                                                    }
-                                                    variant="external"
-                                                    target="_blank"
-                                                >
-                                                    Effective date guidance
-                                                </LinkWithLogging>
-                                                <CustomDateRangePicker
-                                                    className={
-                                                        styles.dateRangePicker
-                                                    }
-                                                    startDateHint="mm/dd/yyyy"
-                                                    startDateLabel="Start date"
-                                                    startDateError={showFieldErrors(
-                                                        'contractDateStart',
-                                                        errors
-                                                    )}
-                                                    startDatePickerProps={{
-                                                        id: 'contractDateStart',
-                                                        name: 'contractDateStart',
-                                                        'aria-required': true,
-                                                        disabled: false,
-                                                        defaultValue:
-                                                            values.contractDateStart,
-                                                        maxDate:
-                                                            formattedDateMinusOneDay(
-                                                                values.contractDateEnd
-                                                            ),
-                                                        onChange: (val) =>
-                                                            setFieldValue(
-                                                                'contractDateStart',
-                                                                formatUserInputDate(
-                                                                    val
-                                                                )
-                                                            ),
-                                                    }}
-                                                    endDateHint="mm/dd/yyyy"
-                                                    endDateLabel="End date"
-                                                    endDateError={showFieldErrors(
-                                                        'contractDateEnd',
-                                                        errors
-                                                    )}
-                                                    endDatePickerProps={{
-                                                        disabled: false,
-                                                        id: 'contractDateEnd',
-                                                        name: 'contractDateEnd',
-                                                        'aria-required': true,
-                                                        defaultValue:
-                                                            values.contractDateEnd,
-                                                        minDate:
-                                                            formattedDatePlusOneDay(
-                                                                values.contractDateStart
-                                                            ),
-                                                        onChange: (val) =>
-                                                            setFieldValue(
-                                                                'contractDateEnd',
-                                                                formatUserInputDate(
-                                                                    val
-                                                                )
-                                                            ),
-                                                    }}
-                                                />
-                                            </Fieldset>
-                                        </FormGroup>
+                                            <LinkWithLogging
+                                                aria-label="Effective date guidance (opens in new window)"
+                                                href={
+                                                    '/resources/help#effective-date-guidance'
+                                                }
+                                                variant="external"
+                                                target="_blank"
+                                            >
+                                                Effective date guidance
+                                            </LinkWithLogging>
+                                            <CustomDateRangePicker
+                                                className={
+                                                    styles.dateRangePicker
+                                                }
+                                                startDateHint="mm/dd/yyyy"
+                                                startDateLabel="Start date"
+                                                startDateError={showFieldErrors(
+                                                    'contractDateStart',
+                                                    errors
+                                                )}
+                                                startDatePickerProps={{
+                                                    id: 'contractDateStart',
+                                                    name: 'contractDateStart',
+                                                    'aria-required': true,
+                                                    disabled: false,
+                                                    defaultValue:
+                                                        values.contractDateStart,
+                                                    maxDate:
+                                                        formattedDateMinusOneDay(
+                                                            values.contractDateEnd
+                                                        ),
+                                                    onChange: (val) =>
+                                                        setFieldValue(
+                                                            'contractDateStart',
+                                                            formatUserInputDate(
+                                                                val
+                                                            )
+                                                        ),
+                                                }}
+                                                endDateHint="mm/dd/yyyy"
+                                                endDateLabel="End date"
+                                                endDateError={showFieldErrors(
+                                                    'contractDateEnd',
+                                                    errors
+                                                )}
+                                                endDatePickerProps={{
+                                                    disabled: false,
+                                                    id: 'contractDateEnd',
+                                                    name: 'contractDateEnd',
+                                                    'aria-required': true,
+                                                    defaultValue:
+                                                        values.contractDateEnd,
+                                                    minDate:
+                                                        formattedDatePlusOneDay(
+                                                            values.contractDateStart
+                                                        ),
+                                                    onChange: (val) =>
+                                                        setFieldValue(
+                                                            'contractDateEnd',
+                                                            formatUserInputDate(
+                                                                val
+                                                            )
+                                                        ),
+                                                }}
+                                            />
+                                        </Fieldset>
 
                                         {isBaseContract && isMCO && (
                                             <FormGroup

--- a/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROSubmissionDetails/EQROSubmissionDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROSubmissionDetails/EQROSubmissionDetails.tsx
@@ -297,7 +297,6 @@ export const EQROSubmissionDetails = (): React.ReactElement => {
                                     <Fieldset
                                         className={styles.radioGroup}
                                         role="radiogroup"
-                                        aria-required
                                         legend="Populations included in EQRO activities"
                                     >
                                         <span
@@ -406,10 +405,7 @@ export const EQROSubmissionDetails = (): React.ReactElement => {
                                         )
                                     )}
                                 >
-                                    <Fieldset
-                                        aria-required
-                                        legend="Managed Care entities reviewed by this EQRO"
-                                    >
+                                    <Fieldset legend="Managed Care entities reviewed by this EQRO">
                                         <span
                                             className={
                                                 styles.requiredOptionalText
@@ -483,7 +479,6 @@ export const EQROSubmissionDetails = (): React.ReactElement => {
                                 >
                                     <Fieldset
                                         role="radiogroup"
-                                        aria-required
                                         className={styles.radioGroup}
                                         legend="Contract action type"
                                         id="contractType"

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ContractDetails/ContractDetails.tsx
@@ -787,7 +787,6 @@ export const ContractDetails = ({
                                         >
                                             <Fieldset
                                                 role="radiogroup"
-                                                aria-required
                                                 className={
                                                     styles.contractAttestation
                                                 }
@@ -935,7 +934,6 @@ export const ContractDetails = ({
                                     >
                                         <Fieldset
                                             role="radiogroup"
-                                            aria-required
                                             className={styles.radioGroup}
                                             legend="Contract status"
                                         >
@@ -984,7 +982,6 @@ export const ContractDetails = ({
                                     </FormGroup>
                                     <FormGroup>
                                         <Fieldset
-                                            aria-required
                                             legend={
                                                 isContractAmendment(
                                                     draftSubmission
@@ -1075,10 +1072,7 @@ export const ContractDetails = ({
                                             )
                                         )}
                                     >
-                                        <Fieldset
-                                            aria-required
-                                            legend="Managed Care entities"
-                                        >
+                                        <Fieldset legend="Managed Care entities">
                                             <span
                                                 className={
                                                     styles.requiredOptionalText
@@ -1169,10 +1163,7 @@ export const ContractDetails = ({
                                             )
                                         )}
                                     >
-                                        <Fieldset
-                                            aria-required
-                                            legend="Active federal operating authority"
-                                        >
+                                        <Fieldset legend="Active federal operating authority">
                                             <span
                                                 className={
                                                     styles.requiredOptionalText
@@ -1240,7 +1231,6 @@ export const ContractDetails = ({
                                                 )}
                                             >
                                                 <Fieldset
-                                                    aria-required
                                                     id="dsnpContract"
                                                     legend="Is this contract associated with a Dual-Eligible Special Needs Plan (D-SNP) that covers Medicaid benefits?"
                                                 >
@@ -1289,7 +1279,6 @@ export const ContractDetails = ({
                                     ) && (
                                         <FormGroup data-testid="yes-no-group">
                                             <Fieldset
-                                                aria-required
                                                 legend={
                                                     isBaseContract(
                                                         draftSubmission

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ContractDetails/ContractDetails.tsx
@@ -982,216 +982,257 @@ export const ContractDetails = ({
                                             />
                                         </Fieldset>
                                     </FormGroup>
-                                    {
-                                        <>
-                                            <FormGroup
-                                                error={
-                                                    Boolean(
-                                                        showFieldErrors(
-                                                            'contractDateStart',
-                                                            errors
-                                                        )
-                                                    ) ||
-                                                    Boolean(
-                                                        showFieldErrors(
-                                                            'contractDateEnd',
-                                                            errors
-                                                        )
-                                                    )
+                                    <Fieldset
+                                        aria-required
+                                        legend={
+                                            isContractAmendment(draftSubmission)
+                                                ? 'Amendment effective dates'
+                                                : 'Contract effective dates'
+                                        }
+                                    >
+                                        <span
+                                            className={
+                                                styles.requiredOptionalText
+                                            }
+                                        >
+                                            Required
+                                        </span>
+                                        <LinkWithLogging
+                                            aria-label="Effective date guidance (opens in new window)"
+                                            href={
+                                                '/resources/help#effective-date-guidance'
+                                            }
+                                            variant="external"
+                                            target="_blank"
+                                        >
+                                            Effective date guidance
+                                        </LinkWithLogging>
+                                        <CustomDateRangePicker
+                                            className={styles.dateRangePicker}
+                                            startDateHint="mm/dd/yyyy"
+                                            startDateLabel="Start date"
+                                            startDateError={showFieldErrors(
+                                                'contractDateStart',
+                                                errors
+                                            )}
+                                            startDatePickerProps={{
+                                                id: 'contractDateStart',
+                                                name: 'contractDateStart',
+                                                'aria-required': true,
+                                                disabled: false,
+                                                defaultValue:
+                                                    values.contractDateStart,
+                                                maxDate:
+                                                    formattedDateMinusOneDay(
+                                                        values.contractDateEnd
+                                                    ),
+                                                onChange: (val) =>
+                                                    setFieldValue(
+                                                        'contractDateStart',
+                                                        formatUserInputDate(val)
+                                                    ),
+                                            }}
+                                            endDateHint="mm/dd/yyyy"
+                                            endDateLabel="End date"
+                                            endDateError={showFieldErrors(
+                                                'contractDateEnd',
+                                                errors
+                                            )}
+                                            endDatePickerProps={{
+                                                disabled: false,
+                                                id: 'contractDateEnd',
+                                                name: 'contractDateEnd',
+                                                'aria-required': true,
+                                                defaultValue:
+                                                    values.contractDateEnd,
+                                                minDate:
+                                                    formattedDatePlusOneDay(
+                                                        values.contractDateStart
+                                                    ),
+                                                onChange: (val) =>
+                                                    setFieldValue(
+                                                        'contractDateEnd',
+                                                        formatUserInputDate(val)
+                                                    ),
+                                            }}
+                                        />
+                                    </Fieldset>
+                                    <FormGroup
+                                        error={Boolean(
+                                            showFieldErrors(
+                                                'managedCareEntities',
+                                                errors
+                                            )
+                                        )}
+                                    >
+                                        <Fieldset
+                                            aria-required
+                                            legend="Managed Care entities"
+                                        >
+                                            <span
+                                                className={
+                                                    styles.requiredOptionalText
                                                 }
                                             >
-                                                <Fieldset
-                                                    aria-required
-                                                    legend={
-                                                        isContractAmendment(
-                                                            draftSubmission
-                                                        )
-                                                            ? 'Amendment effective dates'
-                                                            : 'Contract effective dates'
-                                                    }
-                                                >
-                                                    <span
-                                                        className={
-                                                            styles.requiredOptionalText
-                                                        }
-                                                    >
-                                                        Required
-                                                    </span>
-                                                    <LinkWithLogging
-                                                        aria-label="Effective date guidance (opens in new window)"
-                                                        href={
-                                                            '/resources/help#effective-date-guidance'
-                                                        }
-                                                        variant="external"
-                                                        target="_blank"
-                                                    >
-                                                        Effective date guidance
-                                                    </LinkWithLogging>
-                                                    <CustomDateRangePicker
-                                                        className={
-                                                            styles.dateRangePicker
-                                                        }
-                                                        startDateHint="mm/dd/yyyy"
-                                                        startDateLabel="Start date"
-                                                        startDateError={showFieldErrors(
-                                                            'contractDateStart',
-                                                            errors
-                                                        )}
-                                                        startDatePickerProps={{
-                                                            id: 'contractDateStart',
-                                                            name: 'contractDateStart',
-                                                            'aria-required': true,
-                                                            disabled: false,
-                                                            defaultValue:
-                                                                values.contractDateStart,
-                                                            maxDate:
-                                                                formattedDateMinusOneDay(
-                                                                    values.contractDateEnd
-                                                                ),
-                                                            onChange: (val) =>
-                                                                setFieldValue(
-                                                                    'contractDateStart',
-                                                                    formatUserInputDate(
-                                                                        val
-                                                                    )
-                                                                ),
-                                                        }}
-                                                        endDateHint="mm/dd/yyyy"
-                                                        endDateLabel="End date"
-                                                        endDateError={showFieldErrors(
-                                                            'contractDateEnd',
-                                                            errors
-                                                        )}
-                                                        endDatePickerProps={{
-                                                            disabled: false,
-                                                            id: 'contractDateEnd',
-                                                            name: 'contractDateEnd',
-                                                            'aria-required': true,
-                                                            defaultValue:
-                                                                values.contractDateEnd,
-                                                            minDate:
-                                                                formattedDatePlusOneDay(
-                                                                    values.contractDateStart
-                                                                ),
-                                                            onChange: (val) =>
-                                                                setFieldValue(
-                                                                    'contractDateEnd',
-                                                                    formatUserInputDate(
-                                                                        val
-                                                                    )
-                                                                ),
-                                                        }}
-                                                    />
-                                                </Fieldset>
-                                            </FormGroup>
-                                            <FormGroup
-                                                error={Boolean(
-                                                    showFieldErrors(
-                                                        'managedCareEntities',
-                                                        errors
-                                                    )
-                                                )}
+                                                Required
+                                            </span>
+                                            <Link
+                                                variant="external"
+                                                href={
+                                                    'https://www.medicaid.gov/medicaid/managed-care/managed-care-entities/index.html'
+                                                }
+                                                target="_blank"
                                             >
-                                                <Fieldset
-                                                    aria-required
-                                                    legend="Managed Care entities"
-                                                >
-                                                    <span
-                                                        className={
-                                                            styles.requiredOptionalText
-                                                        }
-                                                    >
-                                                        Required
-                                                    </span>
-                                                    <Link
-                                                        variant="external"
-                                                        href={
-                                                            'https://www.medicaid.gov/medicaid/managed-care/managed-care-entities/index.html'
-                                                        }
-                                                        target="_blank"
-                                                    >
-                                                        Managed Care entity
-                                                        definitions
-                                                    </Link>
-                                                    <div className="usa-hint">
-                                                        <span>
-                                                            Check all that apply
-                                                        </span>
-                                                    </div>
-                                                    {Boolean(
-                                                        showFieldErrors(
-                                                            'managedCareEntities',
-                                                            errors
-                                                        )
-                                                    ) && (
-                                                        <PoliteErrorMessage formFieldLabel="Managed Care entities">
-                                                            {
-                                                                errors.managedCareEntities
-                                                            }
-                                                        </PoliteErrorMessage>
-                                                    )}
-                                                    <FieldCheckbox
-                                                        id="managedCareOrganization"
-                                                        name="managedCareEntities"
-                                                        label={
-                                                            ManagedCareEntityRecord.MCO
-                                                        }
-                                                        value="MCO"
-                                                        heading="Managed Care entities"
-                                                        parent_component_heading={
-                                                            formHeading
-                                                        }
-                                                    />
-                                                    <FieldCheckbox
-                                                        id="prepaidInpatientHealthPlan"
-                                                        name="managedCareEntities"
-                                                        label={
-                                                            ManagedCareEntityRecord.PIHP
-                                                        }
-                                                        value="PIHP"
-                                                        heading="Managed Care entities"
-                                                        parent_component_heading={
-                                                            formHeading
-                                                        }
-                                                    />
-                                                    <FieldCheckbox
-                                                        id="prepaidAmbulatoryHealthPlans"
-                                                        name="managedCareEntities"
-                                                        label={
-                                                            ManagedCareEntityRecord.PAHP
-                                                        }
-                                                        value="PAHP"
-                                                        heading="Managed Care entities"
-                                                        parent_component_heading={
-                                                            formHeading
-                                                        }
-                                                    />
-                                                    <FieldCheckbox
-                                                        id="primaryCareCaseManagementEntity"
-                                                        name="managedCareEntities"
-                                                        label={
-                                                            ManagedCareEntityRecord.PCCM
-                                                        }
-                                                        value="PCCM"
-                                                        heading="Managed Care entities"
-                                                        parent_component_heading={
-                                                            formHeading
-                                                        }
-                                                    />
-                                                </Fieldset>
-                                            </FormGroup>
+                                                Managed Care entity definitions
+                                            </Link>
+                                            <div className="usa-hint">
+                                                <span>
+                                                    Check all that apply
+                                                </span>
+                                            </div>
+                                            {Boolean(
+                                                showFieldErrors(
+                                                    'managedCareEntities',
+                                                    errors
+                                                )
+                                            ) && (
+                                                <PoliteErrorMessage formFieldLabel="Managed Care entities">
+                                                    {errors.managedCareEntities}
+                                                </PoliteErrorMessage>
+                                            )}
+                                            <FieldCheckbox
+                                                id="managedCareOrganization"
+                                                name="managedCareEntities"
+                                                label={
+                                                    ManagedCareEntityRecord.MCO
+                                                }
+                                                value="MCO"
+                                                heading="Managed Care entities"
+                                                parent_component_heading={
+                                                    formHeading
+                                                }
+                                            />
+                                            <FieldCheckbox
+                                                id="prepaidInpatientHealthPlan"
+                                                name="managedCareEntities"
+                                                label={
+                                                    ManagedCareEntityRecord.PIHP
+                                                }
+                                                value="PIHP"
+                                                heading="Managed Care entities"
+                                                parent_component_heading={
+                                                    formHeading
+                                                }
+                                            />
+                                            <FieldCheckbox
+                                                id="prepaidAmbulatoryHealthPlans"
+                                                name="managedCareEntities"
+                                                label={
+                                                    ManagedCareEntityRecord.PAHP
+                                                }
+                                                value="PAHP"
+                                                heading="Managed Care entities"
+                                                parent_component_heading={
+                                                    formHeading
+                                                }
+                                            />
+                                            <FieldCheckbox
+                                                id="primaryCareCaseManagementEntity"
+                                                name="managedCareEntities"
+                                                label={
+                                                    ManagedCareEntityRecord.PCCM
+                                                }
+                                                value="PCCM"
+                                                heading="Managed Care entities"
+                                                parent_component_heading={
+                                                    formHeading
+                                                }
+                                            />
+                                        </Fieldset>
+                                    </FormGroup>
 
+                                    <FormGroup
+                                        error={Boolean(
+                                            showFieldErrors(
+                                                'federalAuthorities',
+                                                errors
+                                            )
+                                        )}
+                                    >
+                                        <Fieldset
+                                            aria-required
+                                            legend="Active federal operating authority"
+                                        >
+                                            <span
+                                                className={
+                                                    styles.requiredOptionalText
+                                                }
+                                            >
+                                                Required
+                                            </span>
+                                            <Link
+                                                variant="external"
+                                                href={
+                                                    'https://www.medicaid.gov/medicaid/managed-care/managed-care-authorities/index.html'
+                                                }
+                                                target="_blank"
+                                            >
+                                                Managed Care authority
+                                                definitions
+                                            </Link>
+                                            <div className="usa-hint">
+                                                <span>
+                                                    Check all that apply
+                                                </span>
+                                            </div>
+                                            {Boolean(
+                                                showFieldErrors(
+                                                    'federalAuthorities',
+                                                    errors
+                                                )
+                                            ) && (
+                                                <PoliteErrorMessage formFieldLabel="Active federal operating authority">
+                                                    {errors.federalAuthorities}
+                                                </PoliteErrorMessage>
+                                            )}
+                                            {applicableFederalAuthorities.map(
+                                                (federalAuthority) => (
+                                                    <FieldCheckbox
+                                                        id={federalAuthority.toLowerCase()}
+                                                        key={federalAuthority.toLowerCase()}
+                                                        name="federalAuthorities"
+                                                        label={
+                                                            FederalAuthorityRecord[
+                                                                federalAuthority
+                                                            ]
+                                                        }
+                                                        value={federalAuthority}
+                                                        heading="Managed Care entities"
+                                                        parent_component_heading={
+                                                            formHeading
+                                                        }
+                                                    />
+                                                )
+                                            )}
+                                        </Fieldset>
+                                    </FormGroup>
+                                    {enableDSNPs &&
+                                        !hideDsnpForChipOnly &&
+                                        values.federalAuthorities.some((type) =>
+                                            dsnpTriggers.includes(type)
+                                        ) && (
                                             <FormGroup
                                                 error={Boolean(
                                                     showFieldErrors(
-                                                        'federalAuthorities',
+                                                        'dsnpContract',
                                                         errors
                                                     )
                                                 )}
                                             >
                                                 <Fieldset
                                                     aria-required
-                                                    legend="Active federal operating authority"
+                                                    id="dsnpContract"
+                                                    legend="Is this contract associated with a Dual-Eligible Special Needs Plan (D-SNP) that covers Medicaid benefits?"
                                                 >
                                                     <span
                                                         className={
@@ -1200,172 +1241,89 @@ export const ContractDetails = ({
                                                     >
                                                         Required
                                                     </span>
-                                                    <Link
+                                                    <div
+                                                        role="note"
+                                                        aria-labelledby="dsnpContract"
+                                                        className="mcr-note margin-top-1"
+                                                    >
+                                                        See 42 CFR § 422.2
+                                                    </div>
+                                                    <LinkWithLogging
                                                         variant="external"
                                                         href={
-                                                            'https://www.medicaid.gov/medicaid/managed-care/managed-care-authorities/index.html'
+                                                            '/resources/help#dual-eligible-special-needs-plans'
                                                         }
                                                         target="_blank"
+                                                        data-testid="dsnpGuidanceLink"
+                                                        aria-label="D-SNP guidance (opens in new window)"
                                                     >
-                                                        Managed Care authority
-                                                        definitions
-                                                    </Link>
-                                                    <div className="usa-hint">
-                                                        <span>
-                                                            Check all that apply
-                                                        </span>
-                                                    </div>
-                                                    {Boolean(
-                                                        showFieldErrors(
-                                                            'federalAuthorities',
-                                                            errors
-                                                        )
-                                                    ) && (
-                                                        <PoliteErrorMessage formFieldLabel="Active federal operating authority">
-                                                            {
-                                                                errors.federalAuthorities
-                                                            }
-                                                        </PoliteErrorMessage>
-                                                    )}
-                                                    {applicableFederalAuthorities.map(
-                                                        (federalAuthority) => (
-                                                            <FieldCheckbox
-                                                                id={federalAuthority.toLowerCase()}
-                                                                key={federalAuthority.toLowerCase()}
-                                                                name="federalAuthorities"
-                                                                label={
-                                                                    FederalAuthorityRecord[
-                                                                        federalAuthority
-                                                                    ]
-                                                                }
-                                                                value={
-                                                                    federalAuthority
-                                                                }
-                                                                heading="Managed Care entities"
-                                                                parent_component_heading={
-                                                                    formHeading
-                                                                }
-                                                            />
-                                                        )
-                                                    )}
-                                                </Fieldset>
-                                            </FormGroup>
-                                            {enableDSNPs &&
-                                                !hideDsnpForChipOnly &&
-                                                values.federalAuthorities.some(
-                                                    (type) =>
-                                                        dsnpTriggers.includes(
-                                                            type
-                                                        )
-                                                ) && (
-                                                    <FormGroup
-                                                        error={Boolean(
+                                                        D-SNP guidance
+                                                    </LinkWithLogging>
+                                                    <FieldYesNo
+                                                        id="dsnpContract"
+                                                        name="dsnpContract"
+                                                        label="Is this contract associated with a Dual-Eligible Special Needs Plan (D-SNP) that covers Medicaid benefits?"
+                                                        showError={Boolean(
                                                             showFieldErrors(
                                                                 'dsnpContract',
                                                                 errors
                                                             )
                                                         )}
-                                                    >
-                                                        <Fieldset
-                                                            aria-required
-                                                            id="dsnpContract"
-                                                            legend="Is this contract associated with a Dual-Eligible Special Needs Plan (D-SNP) that covers Medicaid benefits?"
-                                                        >
-                                                            <span
-                                                                className={
-                                                                    styles.requiredOptionalText
-                                                                }
-                                                            >
-                                                                Required
-                                                            </span>
-                                                            <div
-                                                                role="note"
-                                                                aria-labelledby="dsnpContract"
-                                                                className="mcr-note margin-top-1"
-                                                            >
-                                                                See 42 CFR §
-                                                                422.2
-                                                            </div>
-                                                            <LinkWithLogging
-                                                                variant="external"
-                                                                href={
-                                                                    '/resources/help#dual-eligible-special-needs-plans'
-                                                                }
-                                                                target="_blank"
-                                                                data-testid="dsnpGuidanceLink"
-                                                                aria-label="D-SNP guidance (opens in new window)"
-                                                            >
-                                                                D-SNP guidance
-                                                            </LinkWithLogging>
-                                                            <FieldYesNo
-                                                                id="dsnpContract"
-                                                                name="dsnpContract"
-                                                                label="Is this contract associated with a Dual-Eligible Special Needs Plan (D-SNP) that covers Medicaid benefits?"
-                                                                showError={Boolean(
-                                                                    showFieldErrors(
-                                                                        'dsnpContract',
-                                                                        errors
-                                                                    )
-                                                                )}
-                                                                legendStyle="srOnly"
-                                                            />
-                                                        </Fieldset>
-                                                    </FormGroup>
-                                                )}
-                                            {isContractWithProvisions(
-                                                draftSubmission
-                                            ) && (
-                                                <FormGroup data-testid="yes-no-group">
-                                                    <Fieldset
-                                                        aria-required
-                                                        legend={
-                                                            isBaseContract(
-                                                                draftSubmission
-                                                            )
-                                                                ? 'Does this contract action include provisions related to any of the following'
-                                                                : 'Does this contract action include new or modified provisions related to any of the following'
-                                                        }
-                                                    >
-                                                        <span
-                                                            className={
-                                                                styles.requiredOptionalText
-                                                            }
-                                                        >
-                                                            Required
-                                                        </span>
-                                                        {applicableProvisions.map(
-                                                            (
+                                                        legendStyle="srOnly"
+                                                    />
+                                                </Fieldset>
+                                            </FormGroup>
+                                        )}
+                                    {isContractWithProvisions(
+                                        draftSubmission
+                                    ) && (
+                                        <FormGroup data-testid="yes-no-group">
+                                            <Fieldset
+                                                aria-required
+                                                legend={
+                                                    isBaseContract(
+                                                        draftSubmission
+                                                    )
+                                                        ? 'Does this contract action include provisions related to any of the following'
+                                                        : 'Does this contract action include new or modified provisions related to any of the following'
+                                                }
+                                            >
+                                                <span
+                                                    className={
+                                                        styles.requiredOptionalText
+                                                    }
+                                                >
+                                                    Required
+                                                </span>
+                                                {applicableProvisions.map(
+                                                    (modifiedProvisionName) => (
+                                                        <FieldYesNo
+                                                            id={
                                                                 modifiedProvisionName
-                                                            ) => (
-                                                                <FieldYesNo
-                                                                    id={
-                                                                        modifiedProvisionName
-                                                                    }
-                                                                    key={
-                                                                        modifiedProvisionName
-                                                                    }
-                                                                    name={
-                                                                        modifiedProvisionName
-                                                                    }
-                                                                    label={generateProvisionLabel(
-                                                                        draftSubmission,
-                                                                        modifiedProvisionName
-                                                                    )}
-                                                                    showError={Boolean(
-                                                                        showFieldErrors(
-                                                                            modifiedProvisionName,
-                                                                            errors
-                                                                        )
-                                                                    )}
-                                                                    variant="SUBHEAD"
-                                                                />
-                                                            )
-                                                        )}
-                                                    </Fieldset>
-                                                </FormGroup>
-                                            )}
-                                        </>
-                                    }
+                                                            }
+                                                            key={
+                                                                modifiedProvisionName
+                                                            }
+                                                            name={
+                                                                modifiedProvisionName
+                                                            }
+                                                            label={generateProvisionLabel(
+                                                                draftSubmission,
+                                                                modifiedProvisionName
+                                                            )}
+                                                            showError={Boolean(
+                                                                showFieldErrors(
+                                                                    modifiedProvisionName,
+                                                                    errors
+                                                                )
+                                                            )}
+                                                            variant="SUBHEAD"
+                                                        />
+                                                    )
+                                                )}
+                                            </Fieldset>
+                                        </FormGroup>
+                                    )}
                                 </fieldset>
 
                                 <PageActions

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ContractDetails/ContractDetails.tsx
@@ -982,81 +982,91 @@ export const ContractDetails = ({
                                             />
                                         </Fieldset>
                                     </FormGroup>
-                                    <Fieldset
-                                        aria-required
-                                        legend={
-                                            isContractAmendment(draftSubmission)
-                                                ? 'Amendment effective dates'
-                                                : 'Contract effective dates'
-                                        }
-                                    >
-                                        <span
-                                            className={
-                                                styles.requiredOptionalText
+                                    <FormGroup>
+                                        <Fieldset
+                                            aria-required
+                                            legend={
+                                                isContractAmendment(
+                                                    draftSubmission
+                                                )
+                                                    ? 'Amendment effective dates'
+                                                    : 'Contract effective dates'
                                             }
                                         >
-                                            Required
-                                        </span>
-                                        <LinkWithLogging
-                                            aria-label="Effective date guidance (opens in new window)"
-                                            href={
-                                                '/resources/help#effective-date-guidance'
-                                            }
-                                            variant="external"
-                                            target="_blank"
-                                        >
-                                            Effective date guidance
-                                        </LinkWithLogging>
-                                        <CustomDateRangePicker
-                                            className={styles.dateRangePicker}
-                                            startDateHint="mm/dd/yyyy"
-                                            startDateLabel="Start date"
-                                            startDateError={showFieldErrors(
-                                                'contractDateStart',
-                                                errors
-                                            )}
-                                            startDatePickerProps={{
-                                                id: 'contractDateStart',
-                                                name: 'contractDateStart',
-                                                'aria-required': true,
-                                                disabled: false,
-                                                defaultValue:
-                                                    values.contractDateStart,
-                                                maxDate:
-                                                    formattedDateMinusOneDay(
-                                                        values.contractDateEnd
-                                                    ),
-                                                onChange: (val) =>
-                                                    setFieldValue(
-                                                        'contractDateStart',
-                                                        formatUserInputDate(val)
-                                                    ),
-                                            }}
-                                            endDateHint="mm/dd/yyyy"
-                                            endDateLabel="End date"
-                                            endDateError={showFieldErrors(
-                                                'contractDateEnd',
-                                                errors
-                                            )}
-                                            endDatePickerProps={{
-                                                disabled: false,
-                                                id: 'contractDateEnd',
-                                                name: 'contractDateEnd',
-                                                'aria-required': true,
-                                                defaultValue:
-                                                    values.contractDateEnd,
-                                                minDate:
-                                                    formattedDatePlusOneDay(
-                                                        values.contractDateStart
-                                                    ),
-                                                onChange: (val) =>
-                                                    setFieldValue(
-                                                        'contractDateEnd',
-                                                        formatUserInputDate(val)
-                                                    ),
-                                            }}
-                                        />
-                                    </Fieldset>
+                                            <span
+                                                className={
+                                                    styles.requiredOptionalText
+                                                }
+                                            >
+                                                Required
+                                            </span>
+                                            <LinkWithLogging
+                                                aria-label="Effective date guidance (opens in new window)"
+                                                href={
+                                                    '/resources/help#effective-date-guidance'
+                                                }
+                                                variant="external"
+                                                target="_blank"
+                                            >
+                                                Effective date guidance
+                                            </LinkWithLogging>
+                                            <CustomDateRangePicker
+                                                className={
+                                                    styles.dateRangePicker
+                                                }
+                                                startDateHint="mm/dd/yyyy"
+                                                startDateLabel="Start date"
+                                                startDateError={showFieldErrors(
+                                                    'contractDateStart',
+                                                    errors
+                                                )}
+                                                startDatePickerProps={{
+                                                    id: 'contractDateStart',
+                                                    name: 'contractDateStart',
+                                                    'aria-required': true,
+                                                    disabled: false,
+                                                    defaultValue:
+                                                        values.contractDateStart,
+                                                    maxDate:
+                                                        formattedDateMinusOneDay(
+                                                            values.contractDateEnd
+                                                        ),
+                                                    onChange: (val) =>
+                                                        setFieldValue(
+                                                            'contractDateStart',
+                                                            formatUserInputDate(
+                                                                val
+                                                            )
+                                                        ),
+                                                }}
+                                                endDateHint="mm/dd/yyyy"
+                                                endDateLabel="End date"
+                                                endDateError={showFieldErrors(
+                                                    'contractDateEnd',
+                                                    errors
+                                                )}
+                                                endDatePickerProps={{
+                                                    disabled: false,
+                                                    id: 'contractDateEnd',
+                                                    name: 'contractDateEnd',
+                                                    'aria-required': true,
+                                                    defaultValue:
+                                                        values.contractDateEnd,
+                                                    minDate:
+                                                        formattedDatePlusOneDay(
+                                                            values.contractDateStart
+                                                        ),
+                                                    onChange: (val) =>
+                                                        setFieldValue(
+                                                            'contractDateEnd',
+                                                            formatUserInputDate(
+                                                                val
+                                                            )
+                                                        ),
+                                                }}
+                                            />
+                                        </Fieldset>
+                                    </FormGroup>
                                     <FormGroup
                                         error={Boolean(
                                             showFieldErrors(

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/RateDetails/SingleRateCert.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/RateDetails/SingleRateCert.tsx
@@ -260,7 +260,6 @@ export const SingleRateCert = ({
                         className={styles.radioGroup}
                         legend="Rate certification type"
                         role="radiogroup"
-                        aria-required
                     >
                         <span className={styles.requiredOptionalText}>
                             Required
@@ -367,7 +366,6 @@ export const SingleRateCert = ({
                             )}
                         >
                             <Fieldset
-                                aria-required
                                 legend={
                                     isRateTypeAmendment(rateInfo)
                                         ? 'Rating period of original rate certification'
@@ -436,16 +434,8 @@ export const SingleRateCert = ({
 
                         {isRateTypeAmendment(rateInfo) && (
                             <>
-                                <FormGroup
-                                    error={Boolean(
-                                        showFieldErrors('effectiveDateStart') ??
-                                        showFieldErrors('effectiveDateEnd')
-                                    )}
-                                >
-                                    <Fieldset
-                                        aria-required
-                                        legend="Effective dates of rate amendment"
-                                    >
+                                <FormGroup>
+                                    <Fieldset legend="Effective dates of rate amendment">
                                         <span
                                             className={
                                                 styles.requiredOptionalText
@@ -618,7 +608,6 @@ export const SingleRateCert = ({
                         className={styles.radioGroup}
                         legend="Actuaries' communication preference"
                         role="radiogroup"
-                        aria-required
                     >
                         <span
                             className={styles.requiredOptionalText}

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/RateDetails/SingleRateFormFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/RateDetails/SingleRateFormFields.tsx
@@ -228,7 +228,6 @@ export const SingleRateFormFields = ({
                 >
                     <Fieldset
                         legend="Which Medicaid populations are included in this rate certification?"
-                        aria-required
                         id={`${fieldNamePrefix}.rateMedicaidPopulations`}
                     >
                         <span className={styles.requiredOptionalText}>
@@ -301,7 +300,6 @@ export const SingleRateFormFields = ({
                     className={styles.radioGroup}
                     legend="Rate certification type"
                     role="radiogroup"
-                    aria-required
                 >
                     <span className={styles.requiredOptionalText}>
                         Required
@@ -401,7 +399,6 @@ export const SingleRateFormFields = ({
                 <>
                     <FormGroup>
                         <Fieldset
-                            aria-required
                             legend={
                                 isRateTypeAmendment(rateForm)
                                     ? 'Rating period of original rate certification'
@@ -453,10 +450,7 @@ export const SingleRateFormFields = ({
                     {isRateTypeAmendment(rateForm) && (
                         <>
                             <FormGroup>
-                                <Fieldset
-                                    aria-required
-                                    legend="Effective dates of rate amendment"
-                                >
+                                <Fieldset legend="Effective dates of rate amendment">
                                     <span
                                         className={styles.requiredOptionalText}
                                     >
@@ -619,7 +613,6 @@ export const SingleRateFormFields = ({
                     className={styles.radioGroup}
                     legend="Actuaries' communication preference"
                     role="radiogroup"
-                    aria-required
                 >
                     <span
                         className={styles.requiredOptionalText}

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/RateDetails/SingleRateFormFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/RateDetails/SingleRateFormFields.tsx
@@ -399,12 +399,7 @@ export const SingleRateFormFields = ({
 
             {!isRateTypeEmpty(rateForm) && (
                 <>
-                    <FormGroup
-                        error={Boolean(
-                            showFieldErrors('rateDateStart') ??
-                            showFieldErrors('rateDateEnd')
-                        )}
-                    >
+                    <FormGroup>
                         <Fieldset
                             aria-required
                             legend={
@@ -457,12 +452,7 @@ export const SingleRateFormFields = ({
 
                     {isRateTypeAmendment(rateForm) && (
                         <>
-                            <FormGroup
-                                error={Boolean(
-                                    showFieldErrors('effectiveDateStart') ??
-                                    showFieldErrors('effectiveDateEnd')
-                                )}
-                            >
+                            <FormGroup>
                                 <Fieldset
                                     aria-required
                                     legend="Effective dates of rate amendment"

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/SubmissionType/SubmissionType.tsx
@@ -410,7 +410,6 @@ export const SubmissionType = ({
                                         <Fieldset
                                             className={styles.radioGroup}
                                             role="radiogroup"
-                                            aria-required
                                             legend="Which populations does this contract action cover?"
                                         >
                                             <span
@@ -560,9 +559,6 @@ export const SubmissionType = ({
                                         <Fieldset
                                             className={styles.radioGroup}
                                             role="radiogroup"
-                                            aria-required={
-                                                !hasPreviouslySubmittedRates
-                                            }
                                             defaultValue={values.submissionType}
                                             legend="Choose a submission type"
                                             id="submissionType"
@@ -656,7 +652,6 @@ export const SubmissionType = ({
                                     >
                                         <Fieldset
                                             role="radiogroup"
-                                            aria-required
                                             className={styles.radioGroup}
                                             legend="Contract action type"
                                             id="contractType"

--- a/services/app-web/src/pages/StateSubmission/SharedSubmissionComponents/NewSubmissionForm/NewSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmission/SharedSubmissionComponents/NewSubmissionForm/NewSubmissionForm.tsx
@@ -123,7 +123,6 @@ export const NewSubmission = () => {
                             >
                                 <Fieldset
                                     role="radiogroup"
-                                    aria-required
                                     className={styles.radioGroup}
                                     legend="Submission type"
                                 >


### PR DESCRIPTION
## Summary
[MCR-6113](https://jiraent.cms.gov/browse/MCR-6113)

When both effective date fields have errors there is an accent line that spans both fields and amendment date label.

The fix was to remove the `error` prop in the `FormGroup` component wrapping the date range pickers. Made this fix on the following pages:
- Health plan contract details
- EQRO contract details
- Rate details

Expected behavior:
- Only the input fields have an accent line
- There is no additional padding to the left of the smaller accent borders
- The bold label is in line with labels not in error

Other work:
- Fixed accessibility issues found by axe DevTools
   - `Ensure an element's role supports its ARIA attributes`
  ```
   <fieldset data-testid="fieldset" class="usa-fieldset" aria-required="true">
   ```
   - Fieldset component cannot have the aria-required role.
   - Removed `aria-required` on all usages of `Fieldset`

#### Related issues

#### Screenshots
Health plan contract details
<img width="500" alt="Screenshot 2026-07-07 at 10 53 09 AM" src="https://github.com/user-attachments/assets/45d23686-db3b-4104-9c20-03d0531a2fc5" />

EQRO contract details
<img width="500" alt="Screenshot 2026-07-07 at 10 53 46 AM" src="https://github.com/user-attachments/assets/6e52cb7a-c01e-44d1-87a3-acc528cd7f9b" />

Rate details
<img width="500" alt="Screenshot 2026-07-07 at 10 52 29 AM" src="https://github.com/user-attachments/assets/17870297-7344-4ec0-b228-52deb150c1cf" />

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [x] Checked accessibility with ANDI and Wave tools as needed