### PR TITLE
MCR-6384 & MCR-6385: Add and update feature flags

### DIFF
--- a/packages/common-code/src/featureFlags/flags.ts
+++ b/packages/common-code/src/featureFlags/flags.ts
@@ -3,6 +3,8 @@
  * Ensures some type safety around flag names when we're enabling/disabling features in our code.
  *
  * This file also used to generate types for our Jest unit tests, Cypress tests, and for Yup validation logic.
+ *
+ * Default values are set to match PROD.
  */
 
 const featureFlags = {
@@ -16,7 +18,7 @@ const featureFlags = {
      */
     HIDE_SUPPORTING_DOCS_PAGE: {
         flag: 'hide-supporting-docs-page',
-        defaultValue: false,
+        defaultValue: true,
     },
     /**
      * Enables state and CMS rate edit, unlock, resubmit functionality
@@ -37,42 +39,34 @@ const featureFlags = {
      */
     DSNP: {
         flag: 'dsnp',
-        defaultValue: false,
+        defaultValue: true,
     },
     /**
      * Enables undo withdraw rate feature
      */
     UNDO_WITHDRAW_RATE: {
         flag: 'undo-withdraw-rate',
-        defaultValue: false,
+        defaultValue: true,
     },
     /**
      * Remove parameter store. False: use parameter store for email config. True: use database.
      */
     REMOVE_PARAMETER_STORE: {
         flag: 'remove-parameter-store',
-        defaultValue: false,
+        defaultValue: true,
     },
     /**
      * Enables withdraw submission features
      */
     WITHDRAW_SUBMISSION: {
         flag: 'withdraw-submission',
-        defaultValue: false,
+        defaultValue: true,
     },
     /**
      * Enables undo withdraw submission features
      */
     UNDO_WITHDRAW_SUBMISSION: {
         flag: 'undo-withdraw-submission',
-        defaultValue: false,
-    },
-    // PERMANENT FLAGS
-    /**
-     Enables the modal that alerts the user to an expiring session
-    */
-    SESSION_EXPIRING_MODAL: {
-        flag: 'session-expiring-modal',
         defaultValue: true,
     },
     /**
@@ -87,7 +81,7 @@ const featureFlags = {
      */
     CHIP_SUBMISSION_AUTOMATION: {
         flag: 'chip-submission-automation',
-        defaultValue: false,
+        defaultValue: true,
     },
     /**
      * Uses stored contract action dates for contract lastUpdatedForDisplay and updatedWithin filtering.
@@ -101,13 +95,21 @@ const featureFlags = {
      */
     RESOURCES_NAV_PAGES: {
         flag: 'resources-nav-pages',
-        defaultValue: false,
+        defaultValue: true,
     },
+    // PERMANENT FLAGS for utilities not flagging features
     /**
      * This flag toggles the ability for external API users to send write requests.
      */
     EXTERNAL_API_WRITE_REQUEST: {
         flag: 'external-api-write-request',
+        defaultValue: false,
+    },
+    /**
+     Enables the modal that alerts the user to an expiring session
+    */
+    SESSION_EXPIRING_MODAL: {
+        flag: 'session-expiring-modal',
         defaultValue: true,
     },
     MINUTES_UNTIL_SESSION_EXPIRES: {

--- a/packages/common-code/src/featureFlags/flags.ts
+++ b/packages/common-code/src/featureFlags/flags.ts
@@ -97,13 +97,27 @@ const featureFlags = {
         flag: 'resources-nav-pages',
         defaultValue: true,
     },
-    // PERMANENT FLAGS for utilities not flagging features
+    /**
+     * Feature flag to toggle undo unlock feature for submissions. This flag should only gate CMS users ability to undo unlock and leave the feature available for admin users.
+     */
+    CMS_USER_UNDO_UNLOCK: {
+        flag: 'cms-user-undo-unlock',
+        defaultValue: false,
+    },
+    /**
+     * This flag toggles on or off enhanced revision history features for emails and state portal web app.
+     */
+    REVISION_HISTORY_ENHANCEMENTS: {
+        flag: 'revision-history-enhancements',
+        defaultValue: false,
+    },
+    // PERMANENT FLAGS for utilities features
     /**
      * This flag toggles the ability for external API users to send write requests.
      */
     EXTERNAL_API_WRITE_REQUEST: {
         flag: 'external-api-write-request',
-        defaultValue: false,
+        defaultValue: true,
     },
     /**
      Enables the modal that alerts the user to an expiring session

--- a/services/app-api/src/domain-models/contractAndRates/dataValidatorHelpers.test.ts
+++ b/services/app-api/src/domain-models/contractAndRates/dataValidatorHelpers.test.ts
@@ -413,7 +413,6 @@ describe('Health plan parsing and validation', () => {
                         populationCovered: 'CHIP',
                         submissionType: 'CONTRACT_AND_RATES',
                         riskBasedContract: true,
-                        dsnpContract: true,
                         submissionDescription: 'A real submission',
                         supportingDocuments: [
                             {
@@ -535,6 +534,7 @@ describe('Health plan parsing and validation', () => {
                 {
                     '438-attestation': true,
                     dsnp: true,
+                    'chip-submission-automation': true,
                 }
             )
             if (!(parsedContract instanceof Error)) {
@@ -542,7 +542,7 @@ describe('Health plan parsing and validation', () => {
                     'Unexpected error: Was expecting validateContractDraftRevisionInput to return and error'
                 )
             }
-            expect(parsedContract.issues).toHaveLength(6)
+            expect(parsedContract.issues).toHaveLength(5)
             const errMessages = parsedContract.issues.map((err) => err.message)
             expect(errMessages[0]).toContain(
                 'Too small: expected array to have >=1 items'
@@ -556,16 +556,49 @@ describe('Health plan parsing and validation', () => {
             expect(errMessages[3]).toContain(
                 'statutoryRegulatoryAttestationDescription is required when 438-attestation feature flag is on'
             )
-            expect(errMessages[4]).toContain(
-                'rateMedicaidPopulations is required when dsnpContract is true'
-            )
             // The rate is linked (parentContractID !== contract.id), so its rateProgramIDs
             // are excluded from this contract's program validation. Only the contract's own
             // 'fake-id' should surface in the error.
-            expect(errMessages[5]).toContain(
+            expect(errMessages[4]).toContain(
                 'Program(s) in [fake-id] are not valid FL programs'
             )
-            expect(errMessages[5]).not.toContain('fakerateprogramid')
+            expect(errMessages[4]).not.toContain('fakerateprogramid')
+        })
+        it('return error if rateMedicaidPopulations is missing when dsnpContract is true', async () => {
+            const prismaClient = await sharedTestPrismaClient()
+            const postgresStore = NewPostgresStore(prismaClient)
+            // dsnpContract is only valid on non-CHIP populations, so this rule
+            // is exercised on the default MEDICAID mock (dsnpContract: true)
+            const contract = mockSubmittableHealthPlanContract()
+            if (!contract.draftRates?.[0]?.draftRevision) {
+                throw new Error('Unexpected error: missing draft rate revision')
+            }
+            contract.draftRates[0].draftRevision.formData.rateMedicaidPopulations =
+                []
+
+            const parsedContract = parseContract(
+                contract,
+                'KY',
+                postgresStore,
+                {
+                    '438-attestation': true,
+                    dsnp: true,
+                    'chip-submission-automation': true,
+                }
+            )
+            if (!(parsedContract instanceof Error)) {
+                throw new Error(
+                    'Expected parseContract to return an error for missing rateMedicaidPopulations'
+                )
+            }
+            const errMessages = parsedContract.issues.map((err) => err.message)
+            expect(
+                errMessages.some((m) =>
+                    m.includes(
+                        'rateMedicaidPopulations is required when dsnpContract is true'
+                    )
+                )
+            ).toBe(true)
         })
         it('return error if dnspContract is required but not populated', async () => {
             const prismaClient = await sharedTestPrismaClient()

--- a/services/app-api/src/emailer/emails/sendQuestionResponseStateEmail.test.ts
+++ b/services/app-api/src/emailer/emails/sendQuestionResponseStateEmail.test.ts
@@ -51,7 +51,8 @@ const formData: ContractFormDataType = {
     populationCovered: 'CHIP',
     submissionType: 'CONTRACT_AND_RATES',
     riskBasedContract: false,
-    dsnpContract: false,
+    // CHIP-only submissions cannot carry a dsnpContract value
+    dsnpContract: undefined,
     submissionDescription: 'A submitted submission',
     supportingDocuments: [
         {

--- a/services/app-api/src/emailer/emails/sendQuestionStateEmail.test.ts
+++ b/services/app-api/src/emailer/emails/sendQuestionStateEmail.test.ts
@@ -48,7 +48,8 @@ const formData: ContractFormDataType = {
     populationCovered: 'CHIP',
     submissionType: 'CONTRACT_AND_RATES',
     riskBasedContract: false,
-    dsnpContract: false,
+    // CHIP-only submissions cannot carry a dsnpContract value
+    dsnpContract: undefined,
     submissionDescription: 'A submitted submission',
     supportingDocuments: [
         {

--- a/services/app-api/src/postgres/submissionHistoryHelpers.test.ts
+++ b/services/app-api/src/postgres/submissionHistoryHelpers.test.ts
@@ -1632,6 +1632,7 @@ describe('buildCompleteHistory', () => {
         expect(completeHistory.map((entry) => entry.actionType)).toEqual([
             'CONTRACT_QUESTION_RESPONSE',
             'CONTRACT_QUESTION',
+            'UNDER_REVIEW',
             'CONTRACT_SUBMISSION',
         ])
         expect(

--- a/services/app-api/src/resolvers/contract/approveContract.test.ts
+++ b/services/app-api/src/resolvers/contract/approveContract.test.ts
@@ -35,17 +35,23 @@ describe('approveContract', () => {
             cmsServer,
             contract.id
         )
-        expect(approvedContract.reviewStatusActions).toHaveLength(1)
+        // chip-submission-automation is on by default, so submitting the
+        // HEALTH_PLAN contract records an UNDER_REVIEW determination action, and
+        // approving appends a MARK_AS_APPROVED action, so both are present.
+        expect(approvedContract.reviewStatusActions).toHaveLength(2)
         expect(approvedContract.contractSubmissionType).toBe('HEALTH_PLAN')
-        expect(approvedContract.reviewStatusActions![0]?.contractID).toBe(
-            approvedContract.id
+
+        const submitReviewAction = approvedContract.reviewStatusActions?.find(
+            (action) => action.actionType === 'UNDER_REVIEW'
         )
-        expect(
-            approvedContract.reviewStatusActions![0]?.updatedReason
-        ).toBeNull()
-        expect(approvedContract.reviewStatusActions![0]?.actionType).toBe(
-            'MARK_AS_APPROVED'
+        const approvalAction = approvedContract.reviewStatusActions?.find(
+            (action) => action.actionType === 'MARK_AS_APPROVED'
         )
+
+        expect(submitReviewAction).toBeDefined()
+        expect(approvalAction).toBeDefined()
+        expect(approvalAction?.contractID).toBe(approvedContract.id)
+        expect(approvalAction?.updatedReason).toBeNull()
         expect(approvedContract.reviewStatus).toBe('APPROVED')
 
         const contractTableRow = await client.contractTable.findUniqueOrThrow({
@@ -53,10 +59,10 @@ describe('approveContract', () => {
             select: { lastActionDate: true },
         })
 
-        // Approval is a review action, so the stored action date should match
-        // the approval action timestamp.
+        // Approval is the latest review action, so the stored action date should
+        // match the approval action timestamp.
         expect(contractTableRow.lastActionDate).toEqual(
-            approvedContract.reviewStatusActions![0]?.updatedAt
+            approvalAction?.updatedAt
         )
     })
 

--- a/services/app-api/src/resolvers/contract/submitContract.test.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.test.ts
@@ -186,6 +186,21 @@ describe('submitContract', () => {
                 s3Client: mockS3,
             })
 
+            // chip-submission-automation is on by default, so every HEALTH_PLAN
+            // submit appends a review determination action after the submit that
+            // becomes the contract's stored lastActionDate. The child rate is not
+            // touched by that action, so it keeps the submit date.
+            const latestReviewActionDate = (contract: {
+                reviewStatusActions?: { updatedAt: Date }[] | null
+            }): Date =>
+                new Date(
+                    Math.max(
+                        ...(contract.reviewStatusActions ?? []).map((action) =>
+                            action.updatedAt.getTime()
+                        )
+                    )
+                )
+
             const parentDraft =
                 await createAndUpdateTestContractWithoutRates(stateServer)
             const parentDraftWithRate = await addNewRateToTestContract(
@@ -213,8 +228,11 @@ describe('submitContract', () => {
             })
 
             // Initial submit writes the action date for the submitted contract
-            // and for the child rate submitted with that contract.
-            expect(parentContractRow.lastActionDate).toEqual(initialSubmitDate)
+            // and for the child rate submitted with that contract. The contract's
+            // date advances to the post-submit review determination action.
+            expect(parentContractRow.lastActionDate).toEqual(
+                latestReviewActionDate(initialSubmit)
+            )
             expect(childRateRow.lastActionDate).toEqual(initialSubmitDate)
 
             await unlockTestContract(
@@ -240,8 +258,11 @@ describe('submitContract', () => {
             })
 
             // Resubmit writes a new action date for the contract and for the
-            // child rate whose own revision was resubmitted with it.
-            expect(parentContractRow.lastActionDate).toEqual(parentResubmitDate)
+            // child rate whose own revision was resubmitted with it. The contract's
+            // date advances to the post-resubmit review determination action.
+            expect(parentContractRow.lastActionDate).toEqual(
+                latestReviewActionDate(parentResubmit)
+            )
             expect(childRateRow.lastActionDate).toEqual(parentResubmitDate)
 
             const linkedContractDraft =
@@ -280,8 +301,9 @@ describe('submitContract', () => {
 
             // Submitting the linked contract makes the link part of submission
             // history, so both the linked contract and linked rate action dates move.
+            // The contract's date advances to its post-submit review determination.
             expect(linkedContractRow.lastActionDate).toEqual(
-                linkedContractSubmitDate
+                latestReviewActionDate(linkedContractSubmit)
             )
             expect(childRateRow.lastActionDate).toEqual(
                 linkedContractSubmitDate
@@ -336,8 +358,9 @@ describe('submitContract', () => {
 
             // Submitting the unlink removes the rate from the contract's
             // submission package, which is a material rate relationship action.
+            // The contract's date advances to its post-submit review determination.
             expect(linkedContractRow.lastActionDate).toEqual(
-                linkedContractUnlinkSubmitDate
+                latestReviewActionDate(linkedContractUnlinkSubmit)
             )
             expect(childRateRow.lastActionDate).toEqual(
                 linkedContractUnlinkSubmitDate
@@ -2817,28 +2840,6 @@ describe('submitContract', () => {
             resubmitted.reviewStatusActions?.forEach((a) => {
                 expect(a.actionType).toBe('NOT_SUBJECT_TO_REVIEW')
             })
-        })
-
-        it('does not add a review action when chip-submission-automation flag is off', async () => {
-            const stateServer = await constructTestPostgresServer({
-                s3Client: mockS3,
-            })
-
-            const draft = await createAndUpdateTestContractWithoutRates(
-                stateServer,
-                undefined,
-                {
-                    submissionType: 'CONTRACT_ONLY',
-                    populationCovered: 'CHIP',
-                    federalAuthorities: ['TITLE_XXI'],
-                }
-            )
-
-            const contract = await submitTestContract(stateServer, draft.id)
-
-            expect(contract.contractSubmissionType).toBe('HEALTH_PLAN')
-            expect(contract.consolidatedStatus).toBe('SUBMITTED')
-            expect(contract.reviewStatusActions ?? []).toHaveLength(0)
         })
     })
 })

--- a/services/app-api/src/testHelpers/gqlContractHelpers.ts
+++ b/services/app-api/src/testHelpers/gqlContractHelpers.ts
@@ -501,6 +501,9 @@ const createAndUpdateTestContractWithoutRates = async (
     formData.modifiedLengthOfContract = false
     formData.statutoryRegulatoryAttestation = false
     formData.statutoryRegulatoryAttestationDescription = 'No compliance'
+    // dsnp flag is on by default, and STATE_PLAN is a dsnp-triggering federal
+    // authority, so dsnpContract must be answered for the submit to validate
+    formData.dsnpContract = false
 
     Object.assign(formData, contractFormDataOverrides)
 

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
@@ -22,18 +22,29 @@ describe('ContractDetailsSummarySection', () => {
     }
 
     it('can render draft submission without errors (review and submit behavior)', async () => {
-        const testContract = {
-            ...mockContractPackageDraft(),
-            documents: [
+        const testContract = mockContractPackageDraft()
+        if (!testContract.draftRevision)
+            throw new Error('Unexpected error: no draftRevision')
+        testContract.draftRevision.formData = {
+            ...testContract.draftRevision.formData,
+            supportingDocuments: [
                 {
+                    __typename: 'GenericDocument',
+                    id: 'supporting1',
                     s3URL: 's3://bucketname/key/test1',
                     name: 'supporting docs test 1',
                     sha256: 'fakesha',
+                    dateAdded: new Date(),
+                    downloadURL: s3DlUrl,
                 },
                 {
+                    __typename: 'GenericDocument',
+                    id: 'supporting3',
                     s3URL: 's3://bucketname/key/test3',
                     name: 'supporting docs test 3',
                     sha256: 'fakesha',
+                    dateAdded: new Date(),
+                    downloadURL: s3DlUrl,
                 },
             ],
         }
@@ -49,6 +60,7 @@ describe('ContractDetailsSummarySection', () => {
             }
         )
 
+        // Section heading and edit link render (review and submit behavior)
         expect(
             await screen.findByRole('heading', {
                 level: 2,
@@ -58,13 +70,74 @@ describe('ContractDetailsSummarySection', () => {
         expect(
             screen.getByRole('link', { name: 'Edit Contract details' })
         ).toHaveAttribute('href', '/contract-details')
+
+        // While editing there is no zip download link (that's submission
+        // summary behavior, covered by the next test)
+        expect(screen.queryByTestId('zipDownloadLink')).toBeNull()
+
+        // Contract detail fields render from the draft form data
         expect(
-            screen.getByRole('link', {
-                name: /Edit Contract supporting documents/,
+            within(screen.getByTestId('contractExecutionStatus')).getByText(
+                'Fully executed'
+            )
+        ).toBeInTheDocument()
+        expect(
+            screen.getByRole('definition', {
+                name: 'Contract amendment effective dates',
             })
-        ).toHaveAttribute('href', '/documents')
-        const link = await screen.queryByTestId('zipDownloadLink')
-        expect(link).toBeNull()
+        ).toBeInTheDocument()
+        expect(
+            within(screen.getByTestId('managedCareEntities')).getByText(
+                'Managed Care Organization (MCO)'
+            )
+        ).toBeInTheDocument()
+        expect(
+            within(screen.getByTestId('federalAuthorities')).getByText(
+                '1932(a) State Plan Authority'
+            )
+        ).toBeInTheDocument()
+
+        // Provisions render for this contract-with-provisions submission
+        expect(
+            screen.getByRole('definition', {
+                name: 'This contract action includes new or modified provisions related to the following',
+            })
+        ).toBeInTheDocument()
+        expect(
+            screen.getByRole('definition', {
+                name: 'This contract action does NOT include new or modified provisions related to the following',
+            })
+        ).toBeInTheDocument()
+
+        // Contract documents section header
+        expect(
+            screen.getByRole('heading', {
+                level: 3,
+                name: 'Contract documents',
+            })
+        ).toBeInTheDocument()
+
+        // Contract documents table shows the contract doc from the mock form data
+        const contractDocsTable = await screen.findByRole('table', {
+            name: 'Contract',
+        })
+        expect(
+            within(contractDocsTable).getByText('contract document')
+        ).toBeInTheDocument()
+
+        // Supporting documents table shows both supporting docs and their category
+        const supportingDocsTable = await screen.findByRole('table', {
+            name: /Contract supporting documents/,
+        })
+        expect(
+            within(supportingDocsTable).getByText('supporting docs test 1')
+        ).toBeInTheDocument()
+        expect(
+            within(supportingDocsTable).getByText('supporting docs test 3')
+        ).toBeInTheDocument()
+        expect(
+            within(supportingDocsTable).getAllByText('Contract-supporting')
+        ).toHaveLength(2)
     })
 
     it('can render state submission on summary page without errors (submission summary behavior)', async () => {

--- a/services/app-web/src/pages/RateWithdraw/RateWithdraw.test.tsx
+++ b/services/app-web/src/pages/RateWithdraw/RateWithdraw.test.tsx
@@ -107,11 +107,7 @@ describe('RateWithdraw', () => {
             expect(screen.getByTestId('rateWithdrawBanner')).toBeInTheDocument()
         })
 
-        expect(
-            screen.getByText(
-                'No action can be taken on this submission in its current status.'
-            )
-        ).toBeInTheDocument()
+        expect(screen.getByText('Undo withdraw')).toBeInTheDocument()
     })
 
     it('renders generic API error on failed withdraw', async () => {

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ContractDetails/ContractDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ContractDetails/ContractDetails.test.tsx
@@ -734,7 +734,6 @@ describe('ContractDetails', () => {
                     routerProvider: {
                         route: '/submissions/health-plan/15/edit/contract-details',
                     },
-                    featureFlags: { dsnp: true },
                 }
             )
 
@@ -744,15 +743,14 @@ describe('ContractDetails', () => {
                     'Does this contract action include provisions related to any of the following'
                 )
             ).toBeNull()
-            expect(
-                screen.queryAllByTestId('yes-no-radio-fieldset')
-            ).toHaveLength(1) //Should only find the d-snp question
         })
 
         it('can set provisions for CHIP only amendment', async () => {
             const draftContract = mockContractPackageUnlockedWithUnlockedType()
             draftContract.draftRevision.formData.populationCovered = 'CHIP'
             draftContract.draftRevision.formData.contractType = 'AMENDMENT'
+            draftContract.draftRevision.formData.submissionType =
+                'CONTRACT_ONLY'
 
             renderWithProviders(
                 <Routes>
@@ -777,7 +775,6 @@ describe('ContractDetails', () => {
                     routerProvider: {
                         route: '/submissions/health-plan/15/edit/contract-details',
                     },
-                    featureFlags: { dsnp: true },
                 }
             )
 
@@ -808,7 +805,7 @@ describe('ContractDetails', () => {
 
             // overall number of provisions should be correct
             expect(screen.getAllByTestId('yes-no-radio-fieldset')).toHaveLength(
-                provisionCHIPKeys.length + 1 //+1 to account for the unrelated dsnp question
+                provisionCHIPKeys.length
             )
         })
 

--- a/services/app-web/src/pages/SubmissionWithdraw/SubmissionWithdraw.test.tsx
+++ b/services/app-web/src/pages/SubmissionWithdraw/SubmissionWithdraw.test.tsx
@@ -253,9 +253,7 @@ describe('SubmissionWithdraw', () => {
             ).toBeInTheDocument()
         })
         expect(
-            screen.getByText(
-                'No action can be taken on this submission in its current status.'
-            )
+            screen.getByRole('button', { name: 'Undo submission withdraw' })
         ).toBeInTheDocument()
     })
 


### PR DESCRIPTION
## Summary
[MCR-6384](https://jiraent.cms.gov/browse/MCR-6384):
- Add a feature flag to LaunchDarkly
- Add the feature flag into the codebase
- Name the feature flag something like "revision-diff" to ensure that there is no confusion with the actual revision history functionality
   - NOTE: Naming this flag the same as the epic name `revision-history-enhancements`. I think it should suffice since there is a description for the flag.

[MCR-6385](https://jiraent.cms.gov/browse/MCR-6385):
- Add a feature flag to LaunchDarkly
- Add the feature flag into the codebase

Update default feature flag values:
- This updates our default feature flags in the codebase to match production settings. This is a fallback in case LaunchDarkly servers are down we can still preserve the flag settings in prod.
- Unit tests have been updated to test based on new flag values. Some have been deleted if testing with flag off.
- We will be removing flags for features that are permanent, but for now this is a light lift fallback.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
- Mainly the unit tests pass.
- Check for typos in flags.ts