### PR TITLE
Refactor OAuth2: require form-urlencoded, fix error handling

### DIFF
--- a/services/app-api/src/oauth/__tests__/oauth2Server.test.ts
+++ b/services/app-api/src/oauth/__tests__/oauth2Server.test.ts
@@ -2,123 +2,120 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { CustomOAuth2Server } from '../oauth2Server'
 import type { ExtendedPrismaClient } from '../../postgres/prismaClient'
 import type { APIGatewayProxyEvent } from 'aws-lambda'
-import type { Client, Token, User } from '@node-oauth/oauth2-server'
 
-// Mock OAuth2 server
-vi.mock('@node-oauth/oauth2-server', () => {
-    class UnauthorizedClientError extends Error {
-        constructor(message: string) {
-            super(message)
-            this.name = 'UnauthorizedClientError'
+// These tests run against the real @node-oauth/oauth2-server library with only
+// Prisma mocked, so they exercise the library's own request validation
+// (method, content-type, required params) alongside our model methods.
+
+const mockJwtSecret = 'abcd1234abcd1234abcd1234abcd1234' // pragma: allowlist secret
+const mockOauthIssuer = 'mcreview-oauth'
+
+const validClientId = 'oauth-client-abc'
+const validClientSecret = 'super-secret-value' // pragma: allowlist secret
+
+const adminUser = {
+    id: 'user-123',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    role: 'ADMIN_USER',
+    givenName: 'Ada',
+    familyName: 'Admin',
+    email: 'ada@example.com',
+    divisionAssignment: null,
+    stateCode: null,
+    stateAssignments: [],
+}
+
+const oauthClientRow = {
+    id: 'oauth-row-1',
+    clientId: validClientId,
+    clientSecret: validClientSecret,
+    grants: ['client_credentials'],
+    description: null,
+    userID: adminUser.id,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastUsedAt: null,
+    user: adminUser,
+}
+
+function tokenEvent(overrides?: {
+    body?: string | null
+    contentType?: string
+    method?: string
+}): APIGatewayProxyEvent {
+    const headers: Record<string, string> = {}
+    if (overrides?.contentType !== undefined) {
+        if (overrides.contentType !== '') {
+            headers['Content-Type'] = overrides.contentType
         }
+    } else {
+        headers['Content-Type'] = 'application/x-www-form-urlencoded'
     }
 
-    class InvalidRequestError extends Error {
-        constructor(message: string) {
-            super(message)
-            this.name = 'InvalidRequestError'
-        }
-    }
-
-    class InvalidClientError extends Error {
-        constructor(message: string) {
-            super(message)
-            this.name = 'InvalidClientError'
-        }
-    }
-
-    class Request {
-        body: Record<string, unknown>
-        headers: Record<string, string>
-        method: string
-        query: Record<string, string>
-        constructor(options: {
-            body: Record<string, unknown>
-            headers: Record<string, string>
-            method: string
-            query: Record<string, string>
-        }) {
-            this.body = options.body
-            this.headers = options.headers
-            this.method = options.method
-            this.query = options.query
-        }
-    }
-
-    class Response {
-        body: Record<string, unknown>
-        headers: Record<string, string>
-        constructor() {
-            this.body = {}
-            this.headers = {}
-        }
-    }
-
-    interface OAuth2ServerModel {
-        getClient: (clientId: string, clientSecret: string) => Promise<Client>
-        validateScope: (
-            user: User,
-            client: Client,
-            scope: string
-        ) => Promise<boolean>
-        saveToken: (token: Token, client: Client, user: User) => Promise<Token>
-        getAccessToken: (accessToken: string) => Promise<Token | null>
-    }
-
-    class OAuth2Server {
-        private model: OAuth2ServerModel
-
-        constructor(options: { model: OAuth2ServerModel }) {
-            this.model = options.model
-        }
-
-        async token(request: Request, response: Response) {
-            if (!request.body) {
-                throw new InvalidRequestError('Missing request body')
-            }
-
-            if (!request.body.client_id || !request.body.client_secret) {
-                throw new InvalidRequestError('Missing client credentials')
-            }
-
-            // pragma: allowlist nextline secret
-            if (request.body.client_secret === 'invalid') {
-                throw new InvalidClientError('Invalid client credentials')
-            }
-
-            return {
-                grantType: 'client_credentials',
-                client: {
-                    id: request.body.client_id,
-                    grants: ['client_credentials'],
-                } as Client,
-                accessToken: 'mock.access.token', // pragma: allowlist secret
-                user: { id: 'system' } as User,
-            } as Token
-        }
-    }
+    const defaultBody = new URLSearchParams({
+        grant_type: 'client_credentials',
+        client_id: validClientId,
+        client_secret: validClientSecret,
+    }).toString()
 
     return {
-        default: OAuth2Server,
-        OAuth2Server,
-        UnauthorizedClientError,
-        InvalidRequestError,
-        InvalidClientError,
-        Request,
-        Response,
-    }
-})
+        body: overrides?.body !== undefined ? overrides.body : defaultBody,
+        headers,
+        httpMethod: overrides?.method ?? 'POST',
+        queryStringParameters: null,
+        multiValueHeaders: {},
+        multiValueQueryStringParameters: null,
+        isBase64Encoded: false,
+        path: '/oauth/token',
+        pathParameters: null,
+        stageVariables: null,
+        requestContext: {
+            accountId: '',
+            apiId: '',
+            authorizer: null,
+            protocol: '',
+            httpMethod: overrides?.method ?? 'POST',
+            identity: {
+                accessKey: null,
+                accountId: null,
+                apiKey: null,
+                apiKeyId: null,
+                caller: null,
+                clientCert: null,
+                cognitoAuthenticationProvider: null,
+                cognitoAuthenticationType: null,
+                cognitoIdentityId: null,
+                cognitoIdentityPoolId: null,
+                principalOrgId: null,
+                sourceIp: '',
+                user: null,
+                userAgent: null,
+                userArn: null,
+            },
+            path: '/oauth/token',
+            stage: '',
+            requestId: '',
+            requestTimeEpoch: 0,
+            resourceId: '',
+            resourcePath: '',
+        },
+        resource: '',
+    } as APIGatewayProxyEvent
+}
 
 describe('CustomOAuth2Server', () => {
     let oauth2Server: CustomOAuth2Server
-    let mockPrisma: ExtendedPrismaClient
-    const mockJwtSecret = 'test-secret' // pragma: allowlist secret
-    const mockOauthIssuer = 'mcreview-oauth'
+    let findUnique: ReturnType<typeof vi.fn>
+    let update: ReturnType<typeof vi.fn>
 
     beforeEach(() => {
-        mockPrisma = {
+        findUnique = vi.fn().mockResolvedValue(oauthClientRow)
+        update = vi.fn().mockResolvedValue(oauthClientRow)
+        const mockPrisma = {
             oAuthClient: {
-                findUnique: vi.fn(),
+                findUnique,
+                update,
             },
         } as unknown as ExtendedPrismaClient
 
@@ -130,170 +127,121 @@ describe('CustomOAuth2Server', () => {
     })
 
     describe('token', () => {
-        it('should return 400 for invalid JSON payload', async () => {
-            const event = {
-                body: '{invalid json',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                httpMethod: 'POST',
-                queryStringParameters: null,
-                multiValueHeaders: {},
-                multiValueQueryStringParameters: null,
-                isBase64Encoded: false,
-                path: '/token',
-                pathParameters: null,
-                stageVariables: null,
-                requestContext: {
-                    accountId: '',
-                    apiId: '',
-                    authorizer: null,
-                    protocol: '',
-                    httpMethod: 'POST',
-                    identity: {
-                        accessKey: null,
-                        accountId: null,
-                        apiKey: null,
-                        apiKeyId: null,
-                        caller: null,
-                        clientCert: null,
-                        cognitoAuthenticationProvider: null,
-                        cognitoAuthenticationType: null,
-                        cognitoIdentityId: null,
-                        cognitoIdentityPoolId: null,
-                        principalOrgId: null,
-                        sourceIp: '',
-                        user: null,
-                        userAgent: null,
-                        userArn: null,
-                    },
-                    path: '/token',
-                    stage: '',
-                    requestId: '',
-                    requestTimeEpoch: 0,
-                    resourceId: '',
-                    resourcePath: '',
-                },
-                resource: '',
-            } as APIGatewayProxyEvent
+        it('returns a JWT for valid form-urlencoded credentials', async () => {
+            const result = await oauth2Server.token(tokenEvent())
 
-            const result = await oauth2Server.token(event)
+            expect(result.statusCode).toBe(200)
+            const response = JSON.parse(result.body)
+            expect(response).toHaveProperty('token_type', 'Bearer')
+            expect(response).toHaveProperty('expires_in', 1800)
+            // access_token should be a signed JWT carrying our client
+            const [, payloadB64] = response.access_token.split('.')
+            const payload = JSON.parse(
+                Buffer.from(payloadB64, 'base64url').toString()
+            )
+            expect(payload.client_id).toBe(validClientId)
+            expect(payload.user_id).toBe(adminUser.id)
+            expect(payload.grants).toEqual(['client_credentials'])
+        })
+
+        it('accepts a content-type with a charset parameter', async () => {
+            const result = await oauth2Server.token(
+                tokenEvent({
+                    contentType:
+                        'application/x-www-form-urlencoded; charset=UTF-8',
+                })
+            )
+
+            expect(result.statusCode).toBe(200)
+        })
+
+        it('accepts camelCase parameter names in the form body', async () => {
+            const result = await oauth2Server.token(
+                tokenEvent({
+                    body: new URLSearchParams({
+                        grantType: 'client_credentials',
+                        clientId: validClientId,
+                        clientSecret: validClientSecret,
+                    }).toString(),
+                })
+            )
+
+            expect(result.statusCode).toBe(200)
+        })
+
+        it('returns 400 for application/json content, per RFC 6749', async () => {
+            const result = await oauth2Server.token(
+                tokenEvent({
+                    body: JSON.stringify({
+                        grant_type: 'client_credentials',
+                        client_id: validClientId,
+                        client_secret: validClientSecret,
+                    }),
+                    contentType: 'application/json',
+                })
+            )
 
             expect(result.statusCode).toBe(400)
             expect(JSON.parse(result.body)).toEqual({
                 error: 'invalid_request',
-                error_description: 'Invalid JSON payload',
+                error_description:
+                    'Content-Type must be application/x-www-form-urlencoded',
             })
         })
 
-        it('should return 400 for invalid request', async () => {
-            const event = {
-                body: JSON.stringify({}),
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                httpMethod: 'POST',
-                queryStringParameters: null,
-                multiValueHeaders: {},
-                multiValueQueryStringParameters: null,
-                isBase64Encoded: false,
-                path: '/token',
-                pathParameters: null,
-                stageVariables: null,
-                requestContext: {
-                    accountId: '',
-                    apiId: '',
-                    authorizer: null,
-                    protocol: '',
-                    httpMethod: 'POST',
-                    identity: {
-                        accessKey: null,
-                        accountId: null,
-                        apiKey: null,
-                        apiKeyId: null,
-                        caller: null,
-                        clientCert: null,
-                        cognitoAuthenticationProvider: null,
-                        cognitoAuthenticationType: null,
-                        cognitoIdentityId: null,
-                        cognitoIdentityPoolId: null,
-                        principalOrgId: null,
-                        sourceIp: '',
-                        user: null,
-                        userAgent: null,
-                        userArn: null,
-                    },
-                    path: '/token',
-                    stage: '',
-                    requestId: '',
-                    requestTimeEpoch: 0,
-                    resourceId: '',
-                    resourcePath: '',
-                },
-                resource: '',
-            } as APIGatewayProxyEvent
-
-            const result = await oauth2Server.token(event)
+        it('returns 400 when content-type is missing', async () => {
+            const result = await oauth2Server.token(
+                tokenEvent({ contentType: '' })
+            )
 
             expect(result.statusCode).toBe(400)
             expect(JSON.parse(result.body)).toEqual({
                 error: 'invalid_request',
+                error_description:
+                    'Content-Type must be application/x-www-form-urlencoded',
+            })
+        })
+
+        it('returns 400 when grant_type is missing', async () => {
+            const result = await oauth2Server.token(
+                tokenEvent({
+                    body: new URLSearchParams({
+                        client_id: validClientId,
+                        client_secret: validClientSecret,
+                    }).toString(),
+                })
+            )
+
+            expect(result.statusCode).toBe(400)
+            expect(JSON.parse(result.body)).toEqual({
+                error: 'invalid_request',
+                error_description: expect.stringContaining('grant_type'),
+            })
+        })
+
+        it('returns 401 for a wrong client secret and does not mark the client used', async () => {
+            const result = await oauth2Server.token(
+                tokenEvent({
+                    body: new URLSearchParams({
+                        grant_type: 'client_credentials',
+                        client_id: validClientId,
+                        client_secret: 'wrong-secret', // pragma: allowlist secret
+                    }).toString(),
+                })
+            )
+
+            expect(result.statusCode).toBe(401)
+            expect(JSON.parse(result.body)).toEqual({
+                error: 'invalid_client',
                 error_description: expect.any(String),
             })
+            expect(update).not.toHaveBeenCalled()
         })
 
-        it('should return 401 for invalid client credentials', async () => {
-            const event = {
-                body: JSON.stringify({
-                    grant_type: 'client_credentials',
-                    client_id: 'invalid',
-                    client_secret: 'invalid', // pragma: allowlist secret
-                }),
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                httpMethod: 'POST',
-                queryStringParameters: null,
-                multiValueHeaders: {},
-                multiValueQueryStringParameters: null,
-                isBase64Encoded: false,
-                path: '/token',
-                pathParameters: null,
-                stageVariables: null,
-                requestContext: {
-                    accountId: '',
-                    apiId: '',
-                    authorizer: null,
-                    protocol: '',
-                    httpMethod: 'POST',
-                    identity: {
-                        accessKey: null,
-                        accountId: null,
-                        apiKey: null,
-                        apiKeyId: null,
-                        caller: null,
-                        clientCert: null,
-                        cognitoAuthenticationProvider: null,
-                        cognitoAuthenticationType: null,
-                        cognitoIdentityId: null,
-                        cognitoIdentityPoolId: null,
-                        principalOrgId: null,
-                        sourceIp: '',
-                        user: null,
-                        userAgent: null,
-                        userArn: null,
-                    },
-                    path: '/token',
-                    stage: '',
-                    requestId: '',
-                    requestTimeEpoch: 0,
-                    resourceId: '',
-                    resourcePath: '',
-                },
-                resource: '',
-            } as APIGatewayProxyEvent
+        it('returns 401 for an unknown client', async () => {
+            findUnique.mockResolvedValue(null)
 
-            const result = await oauth2Server.token(event)
+            const result = await oauth2Server.token(tokenEvent())
 
             expect(result.statusCode).toBe(401)
             expect(JSON.parse(result.body)).toEqual({
@@ -302,64 +250,14 @@ describe('CustomOAuth2Server', () => {
             })
         })
 
-        it('should return JWT token for valid client credentials', async () => {
-            const event = {
-                body: JSON.stringify({
-                    grant_type: 'client_credentials',
-                    client_id: 'valid', // pragma: allowlist secret
-                    client_secret: 'valid', // pragma: allowlist secret
-                }),
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                httpMethod: 'POST',
-                queryStringParameters: null,
-                multiValueHeaders: {},
-                multiValueQueryStringParameters: null,
-                isBase64Encoded: false,
-                path: '/token',
-                pathParameters: null,
-                stageVariables: null,
-                requestContext: {
-                    accountId: '',
-                    apiId: '',
-                    authorizer: null,
-                    protocol: '',
-                    httpMethod: 'POST',
-                    identity: {
-                        accessKey: null,
-                        accountId: null,
-                        apiKey: null,
-                        apiKeyId: null,
-                        caller: null,
-                        clientCert: null,
-                        cognitoAuthenticationProvider: null,
-                        cognitoAuthenticationType: null,
-                        cognitoIdentityId: null,
-                        cognitoIdentityPoolId: null,
-                        principalOrgId: null,
-                        sourceIp: '',
-                        user: null,
-                        userAgent: null,
-                        userArn: null,
-                    },
-                    path: '/token',
-                    stage: '',
-                    requestId: '',
-                    requestTimeEpoch: 0,
-                    resourceId: '',
-                    resourcePath: '',
-                },
-                resource: '',
-            } as APIGatewayProxyEvent
+        it('returns 500, not 401, when the database fails during verification', async () => {
+            findUnique.mockRejectedValue(new Error('connection refused'))
 
-            const result = await oauth2Server.token(event)
+            const result = await oauth2Server.token(tokenEvent())
 
-            expect(result.statusCode).toBe(200)
+            expect(result.statusCode).toBe(500)
             const response = JSON.parse(result.body)
-            expect(response).toHaveProperty('access_token')
-            expect(response).toHaveProperty('token_type', 'Bearer')
-            expect(response).toHaveProperty('expires_in', 1800)
+            expect(response.error).toBe('server_error')
         })
     })
 })

--- a/services/app-api/src/oauth/__tests__/oauth2Server.test.ts
+++ b/services/app-api/src/oauth/__tests__/oauth2Server.test.ts
@@ -287,5 +287,15 @@ describe('CustomOAuth2Server', () => {
             const response = JSON.parse(result.body)
             expect(response.error).toBe('server_error')
         })
+
+        it('returns 500 when the store throws a non-Error value', async () => {
+            findUnique.mockRejectedValue('connection refused')
+
+            const result = await oauth2Server.token(tokenEvent())
+
+            expect(result.statusCode).toBe(500)
+            const response = JSON.parse(result.body)
+            expect(response.error).toBe('server_error')
+        })
     })
 })

--- a/services/app-api/src/oauth/__tests__/oauth2Server.test.ts
+++ b/services/app-api/src/oauth/__tests__/oauth2Server.test.ts
@@ -43,6 +43,7 @@ function tokenEvent(overrides?: {
     body?: string | null
     contentType?: string
     method?: string
+    isBase64Encoded?: boolean
 }): APIGatewayProxyEvent {
     const headers: Record<string, string> = {}
     if (overrides?.contentType !== undefined) {
@@ -66,7 +67,7 @@ function tokenEvent(overrides?: {
         queryStringParameters: null,
         multiValueHeaders: {},
         multiValueQueryStringParameters: null,
-        isBase64Encoded: false,
+        isBase64Encoded: overrides?.isBase64Encoded ?? false,
         path: '/oauth/token',
         pathParameters: null,
         stageVariables: null,
@@ -149,6 +150,33 @@ describe('CustomOAuth2Server', () => {
                 tokenEvent({
                     contentType:
                         'application/x-www-form-urlencoded; charset=UTF-8',
+                })
+            )
+
+            expect(result.statusCode).toBe(200)
+        })
+
+        it('accepts a mixed-case content-type header value', async () => {
+            const result = await oauth2Server.token(
+                tokenEvent({
+                    contentType: 'Application/X-WWW-Form-Urlencoded',
+                })
+            )
+
+            expect(result.statusCode).toBe(200)
+        })
+
+        it('decodes a base64-encoded form body', async () => {
+            const formBody = new URLSearchParams({
+                grant_type: 'client_credentials',
+                client_id: validClientId,
+                client_secret: validClientSecret,
+            }).toString()
+
+            const result = await oauth2Server.token(
+                tokenEvent({
+                    body: Buffer.from(formBody).toString('base64'),
+                    isBase64Encoded: true,
                 })
             )
 

--- a/services/app-api/src/oauth/oauth2Server.ts
+++ b/services/app-api/src/oauth/oauth2Server.ts
@@ -4,6 +4,7 @@ import OAuth2Server, {
     InvalidRequestError,
     InvalidClientError,
     UnauthorizedClientError,
+    ServerError,
     type Token,
     type Client,
     type User,
@@ -56,6 +57,16 @@ export class CustomOAuth2Server {
             clientId,
             clientSecret
         )
+        // A store error is not an auth result: report it as a server error
+        // rather than letting a DB failure read as valid (truthy) credentials
+        if (isValid instanceof Error) {
+            recordException(
+                isValid,
+                OTEL_SERVICE_NAME,
+                'oauth2Server.getClient.verifyClientCredentials'
+            )
+            throw new ServerError('Error verifying client credentials')
+        }
         if (!isValid) {
             throw new InvalidClientError('Invalid client credentials')
         }
@@ -143,7 +154,15 @@ export class CustomOAuth2Server {
             this.prisma,
             clientId
         )
-        if (clientResult instanceof Error || !clientResult) {
+        if (clientResult instanceof Error) {
+            recordException(
+                clientResult,
+                OTEL_SERVICE_NAME,
+                'oauth2Server.generateJWT.getOAuthClientByClientId'
+            )
+            throw new ServerError('Error fetching client')
+        }
+        if (!clientResult) {
             throw new InvalidClientError('Client not found')
         }
 
@@ -158,33 +177,13 @@ export class CustomOAuth2Server {
 
     // Main method to handle token requests
     async token(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
-        let body: Record<string, unknown> = {}
         const contentType =
             event.headers['Content-Type'] || event.headers['content-type']
 
         try {
-            if (contentType?.includes('application/json')) {
-                try {
-                    body = event.body ? JSON.parse(event.body) : {}
-                } catch {
-                    return {
-                        statusCode: 400,
-                        headers: {
-                            'Content-Type': 'application/json',
-                        },
-                        body: JSON.stringify({
-                            error: 'invalid_request',
-                            error_description: 'Invalid JSON payload',
-                        }),
-                    }
-                }
-            } else if (
-                contentType?.includes('application/x-www-form-urlencoded')
-            ) {
-                // Parse form-urlencoded data
-                const params = new URLSearchParams(event.body || '')
-                body = Object.fromEntries(params.entries())
-            } else {
+            // RFC 6749 requires token requests be application/x-www-form-urlencoded,
+            // and the underlying oauth2-server library rejects anything else
+            if (!contentType?.includes('application/x-www-form-urlencoded')) {
                 return {
                     statusCode: 400,
                     headers: {
@@ -193,10 +192,15 @@ export class CustomOAuth2Server {
                     body: JSON.stringify({
                         error: 'invalid_request',
                         error_description:
-                            'Content-Type must be application/json or application/x-www-form-urlencoded',
+                            'Content-Type must be application/x-www-form-urlencoded',
                     }),
                 }
             }
+
+            const params = new URLSearchParams(event.body || '')
+            const body: Record<string, unknown> = Object.fromEntries(
+                params.entries()
+            )
 
             // Transform the body to match OAuth2 expected format
             const transformedBody = {
@@ -325,6 +329,11 @@ export class CustomOAuth2Server {
                 }
             }
         } catch (error) {
+            recordException(
+                parseErrorToError(error),
+                OTEL_SERVICE_NAME,
+                'oauth2Server.token.requestParsing'
+            )
             return {
                 statusCode: 400,
                 headers: {

--- a/services/app-api/src/oauth/oauth2Server.ts
+++ b/services/app-api/src/oauth/oauth2Server.ts
@@ -183,7 +183,11 @@ export class CustomOAuth2Server {
         try {
             // RFC 6749 requires token requests be application/x-www-form-urlencoded,
             // and the underlying oauth2-server library rejects anything else
-            if (!contentType?.includes('application/x-www-form-urlencoded')) {
+            if (
+                !contentType
+                    ?.toLowerCase()
+                    .includes('application/x-www-form-urlencoded')
+            ) {
                 return {
                     statusCode: 400,
                     headers: {
@@ -197,7 +201,11 @@ export class CustomOAuth2Server {
                 }
             }
 
-            const params = new URLSearchParams(event.body || '')
+            const raw =
+                event.isBase64Encoded && event.body
+                    ? Buffer.from(event.body, 'base64').toString('utf-8')
+                    : event.body || ''
+            const params = new URLSearchParams(raw)
             const body: Record<string, unknown> = Object.fromEntries(
                 params.entries()
             )

--- a/services/app-api/src/postgres/oauth/oauthClientStore.ts
+++ b/services/app-api/src/postgres/oauth/oauthClientStore.ts
@@ -4,6 +4,7 @@ import type { OAuthScope } from '../../generated/enums'
 import type { UserType } from '../../domain-models'
 import { v4 as uuidv4 } from 'uuid'
 import { randomBytes, timingSafeEqual } from 'crypto'
+import { parseErrorToError } from '@mc-review/helpers'
 import { domainUserFromPrismaUser } from '../user/prismaDomainUser'
 
 type OAuthClientWithUser = Omit<
@@ -56,7 +57,7 @@ export async function createOAuthClient(
             user: domainUser,
         }
     } catch (error) {
-        return error as Error
+        return parseErrorToError(error)
     }
 }
 
@@ -84,7 +85,7 @@ export async function getOAuthClientById(
             user: domainUser,
         }
     } catch (error) {
-        return error as Error
+        return parseErrorToError(error)
     }
 }
 
@@ -111,7 +112,7 @@ export async function getOAuthClientByClientId(
             user: domainUser,
         }
     } catch (error) {
-        return error as Error
+        return parseErrorToError(error)
     }
 }
 
@@ -148,7 +149,7 @@ export async function verifyClientCredentials(
 
         return true
     } catch (error) {
-        return error as Error
+        return parseErrorToError(error)
     }
 }
 
@@ -181,7 +182,7 @@ export async function updateOAuthClient(
             user: domainUser,
         }
     } catch (error) {
-        return error as Error
+        return parseErrorToError(error)
     }
 }
 
@@ -215,7 +216,7 @@ export async function deleteOAuthClient(
             user: domainUser,
         }
     } catch (error) {
-        return error as Error
+        return parseErrorToError(error)
     }
 }
 
@@ -242,7 +243,7 @@ export async function listOAuthClients(
 
         return domainResults
     } catch (error) {
-        return error as Error
+        return parseErrorToError(error)
     }
 }
 
@@ -271,7 +272,7 @@ export async function getOAuthClientsByUserId(
 
         return domainResults
     } catch (error) {
-        return error as Error
+        return parseErrorToError(error)
     }
 }
 

--- a/services/app-api/src/postgres/oauth/oauthClientStore.ts
+++ b/services/app-api/src/postgres/oauth/oauthClientStore.ts
@@ -3,7 +3,7 @@ import type { Prisma } from '../../generated/client'
 import type { OAuthScope } from '../../generated/enums'
 import type { UserType } from '../../domain-models'
 import { v4 as uuidv4 } from 'uuid'
-import { randomBytes } from 'crypto'
+import { randomBytes, timingSafeEqual } from 'crypto'
 import { domainUserFromPrismaUser } from '../user/prismaDomainUser'
 
 type OAuthClientWithUser = Omit<
@@ -130,13 +130,23 @@ export async function verifyClientCredentials(
             return false
         }
 
-        // Update last used timestamp
+        const provided = Buffer.from(clientSecret)
+        const stored = Buffer.from(oauthClient.clientSecret)
+        const secretMatches =
+            provided.length === stored.length &&
+            timingSafeEqual(provided, stored)
+
+        if (!secretMatches) {
+            return false
+        }
+
+        // Update last used timestamp, only after successful verification
         await client.oAuthClient.update({
             where: { id: oauthClient.id },
             data: { lastUsedAt: new Date() },
         })
 
-        return clientSecret === oauthClient.clientSecret
+        return true
     } catch (error) {
         return error as Error
     }


### PR DESCRIPTION
## Summary

While troubleshooting failed token requests from the Mule team, I found that our `/oauth/token handler` accepts `application/json` and parses it — but the underlying `@node-oauth/oauth2-server` library then rejects any non-form-urlencoded request per RFC 6749 (§4.4.2), so every JSON token request has always returned 400. The JSON path was unreachable-success code, and our error messages incorrectly advertised JSON as supported.

Changes

- Token requests must be `application/x-www-form-urlencoded` (RFC 6749). The JSON parsing branch is removed and the 400 error message now states the actual requirement. No working client is affected — JSON requests could never succeed.
- DB failures during client verification now return 500, not 401. `verifyClientCredentials` returns `boolean | Error`, but `getClient` checked if (!isValid) — an Error object is truthy, so a store failure skipped the credential rejection path and surfaced downstream as invalid_client. Store errors now record an OTEL exception and throw `ServerError`. Same fix in `generateJWT`.
- `verifyClientCredentials` hardening: secret comparison uses `crypto.timingSafeEqual`, and `astUsedAt` is only updated after successful verification (previously it was bumped even for failed attempts).
- Unexpected request-parsing errors now record an OTEL exception instead of failing silently.
- Tests rewritten against the real oauth2-server library (only Prisma mocked). The previous whole-library mock skipped the library's content-type validation, which is how the dead JSON path went unnoticed. New coverage: charset-suffixed content types, camelCase params, JSON/missing content-type rejection, wrong secret leaves lastUsedAt untouched, and DB failure → 500.

#### Related Tickets
https://jiraent.cms.gov/browse/MCR-6430