### PR TITLE
MCR-6196: create read only user 

### DIFF
--- a/packages/helpers/src/gql/userHelpers.ts
+++ b/packages/helpers/src/gql/userHelpers.ts
@@ -5,6 +5,7 @@ import {
     AdminUser,
     BusinessOwnerUser,
     HelpdeskUser,
+    ReadOnlyUser,
     UpdatedBy,
 } from '../gen/gqlClient'
 const hasCMSUserPermissions = (
@@ -31,6 +32,24 @@ const hasAdminUserPermissions = (
     return validRoles.includes(user.role)
 }
 
+const hasReadOnlyUserPermissions = (user?: User): user is ReadOnlyUser => {
+    if (!user) {
+        return false
+    }
+
+    return user.role === 'READONLY_USER'
+}
+
+// Users who view CMS-side data (all submissions, questions, etc.). This
+// includes read-only users, who can see everything a CMS reviewer sees but
+// cannot trigger any mutation. Use hasCMSUserPermissions (not this helper) to
+// gate write/action affordances.
+const canViewCMSData = (
+    user?: User
+): user is CmsUser | CmsApproverUser | ReadOnlyUser => {
+    return hasCMSUserPermissions(user) || hasReadOnlyUserPermissions(user)
+}
+
 // process user that made the change history event.
 const getUpdatedByDisplayName = (updatedBy?: UpdatedBy): string | undefined => {
     if (!updatedBy) {
@@ -45,5 +64,7 @@ const getUpdatedByDisplayName = (updatedBy?: UpdatedBy): string | undefined => {
 export {
     hasCMSUserPermissions,
     hasAdminUserPermissions,
+    hasReadOnlyUserPermissions,
+    canViewCMSData,
     getUpdatedByDisplayName,
 }

--- a/scripts/add_cypress_test_users_cdk.ts
+++ b/scripts/add_cypress_test_users_cdk.ts
@@ -50,6 +50,7 @@ type UserRole =
     | 'HELPDESK_USER'
     | 'BUSINESSOWNER_USER'
     | 'CMS_APPROVER_USER'
+    | 'READONLY_USER'
 
 // these are the exact roles as they are set by IDM
 function IDMRole(role: UserRole): string {
@@ -66,6 +67,8 @@ function IDMRole(role: UserRole): string {
             return 'macmcrrs-bo'
         case 'CMS_APPROVER_USER':
             return 'macmcrrs-cms-approver'
+        case 'READONLY_USER':
+            return 'macmcrrs-ro-user'
         case 'UNKNOWN_USER':
             return 'foo-bar-user'
     }
@@ -263,6 +266,13 @@ async function main() {
             familyName: 'Hotman',
             email: 'azula@example.com',
             role: 'CMS_APPROVER_USER' as const,
+            state: undefined,
+        },
+        {
+            name: 'Gyatso',
+            familyName: 'Monk',
+            email: 'gyatso@example.com',
+            role: 'READONLY_USER' as const,
             state: undefined,
         },
     ]

--- a/services/app-api/prisma/schema.prisma
+++ b/services/app-api/prisma/schema.prisma
@@ -791,6 +791,7 @@ enum Role {
   HELPDESK_USER
   BUSINESSOWNER_USER
   CMS_APPROVER_USER
+  READONLY_USER
 }
 
 enum ContractActionType {

--- a/services/app-api/src/authn/cognitoAuthn.test.ts
+++ b/services/app-api/src/authn/cognitoAuthn.test.ts
@@ -146,6 +146,21 @@ describe('cognitoAuthn', () => {
                 },
                 {
                     attributes: {
+                        'custom:role': 'macmcrrs-ro-user',
+                        given_name: 'Generic',
+                        family_name: 'Person',
+                        email: 'gp@example.com',
+                    },
+                    expectedResult: {
+                        id: testID,
+                        role: 'READONLY_USER',
+                        email: 'gp@example.com',
+                        familyName: 'Person',
+                        givenName: 'Generic',
+                    },
+                },
+                {
+                    attributes: {
                         'custom:role':
                             'SOME_OPE User,neid-lame-user,smacfi-enduser,twoell-mmc-user,wefoi-mmc-ab-auth-user,POSS_ENDUSER,strongweak-user,macmcrrs-state-user',
                         'custom:state_code': 'FL',

--- a/services/app-api/src/authn/cognitoAuthn.ts
+++ b/services/app-api/src/authn/cognitoAuthn.ts
@@ -106,6 +106,7 @@ const ADMIN_ROLE_ATTRIBUTE = 'macmcrrs-approver'
 const HELPDESK_ROLE_ATTRIBUTE = 'macmcrrs-helpdesk'
 const BUSINESSOWNER_ROLE_ATTRIBUTE = 'macmcrrs-bo'
 const CMS_APPROVER_ROLE_ATTRIBUTE = 'macmcrrs-cms-approver'
+const READONLY_ROLE_ATTRIBUTE = 'macmcrrs-ro-user'
 
 export function userTypeFromAttributes(
     id: string,
@@ -203,6 +204,16 @@ export function userTypeFromAttributes(
         return {
             id,
             role: 'BUSINESSOWNER_USER',
+            email: attributes.email,
+            givenName: attributes.given_name,
+            familyName: attributes.family_name,
+        }
+    }
+
+    if (roles.includes(READONLY_ROLE_ATTRIBUTE)) {
+        return {
+            id,
+            role: 'READONLY_USER',
             email: attributes.email,
             givenName: attributes.given_name,
             familyName: attributes.family_name,

--- a/services/app-api/src/domain-models/UserType.ts
+++ b/services/app-api/src/domain-models/UserType.ts
@@ -9,6 +9,7 @@ type UserType =
     | HelpdeskUserType
     | BusinessOwnerUserType
     | CMSApproverUserType
+    | ReadOnlyUserType
 
 const userRolesSchema = z.enum([
     'STATE_USER',
@@ -17,6 +18,7 @@ const userRolesSchema = z.enum([
     'ADMIN_USER',
     'HELPDESK_USER',
     'BUSINESSOWNER_USER',
+    'READONLY_USER',
 ])
 
 const baseUserSchema = z.object({
@@ -64,6 +66,12 @@ const businessOwnerUserSchema = baseUserSchema.extend({
     role: z.literal(userRolesSchema.enum.BUSINESSOWNER_USER),
 })
 
+// Read-only users can view all submissions and non-admin data but cannot
+// trigger any mutation. They are not scoped to a state or division.
+const readOnlyUserSchema = baseUserSchema.extend({
+    role: z.literal(userRolesSchema.enum.READONLY_USER),
+})
+
 type StateUserType = z.infer<typeof stateUserSchema>
 
 type AdminUserType = z.infer<typeof adminUserSchema>
@@ -71,6 +79,8 @@ type AdminUserType = z.infer<typeof adminUserSchema>
 type HelpdeskUserType = z.infer<typeof helpdeskUserSchema>
 
 type BusinessOwnerUserType = z.infer<typeof businessOwnerUserSchema>
+
+type ReadOnlyUserType = z.infer<typeof readOnlyUserSchema>
 
 type CMSUserType = z.infer<typeof cmsUserSchema>
 
@@ -89,6 +99,7 @@ export type {
     HelpdeskUserType,
     BusinessOwnerUserType,
     CMSApproverUserType,
+    ReadOnlyUserType,
     UserType,
     UserRoles,
     CMSUsersUnionType,
@@ -102,4 +113,5 @@ export {
     baseUserSchema,
     cmsUsersUnionSchema,
     adminUserSchema,
+    readOnlyUserSchema,
 }

--- a/services/app-api/src/domain-models/index.ts
+++ b/services/app-api/src/domain-models/index.ts
@@ -8,6 +8,7 @@ export type {
     BaseUserType,
     BusinessOwnerUserType,
     HelpdeskUserType,
+    ReadOnlyUserType,
 } from './UserType'
 export type { StateType } from './StateType'
 
@@ -23,8 +24,10 @@ export {
     toDomainUser,
     isBusinessOwnerUser,
     isHelpdeskUser,
+    isReadOnlyUser,
     hasAdminPermissions,
     hasCMSPermissions,
+    hasReadPermissions,
 } from './user'
 
 export {

--- a/services/app-api/src/domain-models/user.ts
+++ b/services/app-api/src/domain-models/user.ts
@@ -6,6 +6,7 @@ import type {
     HelpdeskUserType,
     BusinessOwnerUserType,
     CMSApproverUserType,
+    ReadOnlyUserType,
     UserRoles,
 } from './UserType'
 import type { User as PrismaUser } from '../generated/client'
@@ -52,6 +53,10 @@ function isBusinessOwnerUser(user: UserType): user is BusinessOwnerUserType {
     return user.role === 'BUSINESSOWNER_USER'
 }
 
+function isReadOnlyUser(user: UserType): user is ReadOnlyUserType {
+    return user.role === 'READONLY_USER'
+}
+
 function toDomainUser(user: PrismaUser): UserType {
     switch (user.role) {
         case 'ADMIN_USER':
@@ -60,6 +65,8 @@ function toDomainUser(user: PrismaUser): UserType {
             return user as HelpdeskUserType
         case 'BUSINESSOWNER_USER':
             return user as BusinessOwnerUserType
+        case 'READONLY_USER':
+            return user as ReadOnlyUserType
         case 'CMS_USER':
             return {
                 id: user.id,
@@ -107,6 +114,19 @@ function hasAdminPermissions(
     return authorizedAdmins.includes(user.role)
 }
 
+// Users allowed to view (read) submissions and other non-admin data.
+// This is the CMS-level read surface plus the dedicated read-only role.
+// It intentionally does NOT grant any mutation ability — mutations gate on
+// hasCMSPermissions / hasAdminPermissions / isStateUser, none of which
+// include READONLY_USER.
+function hasReadPermissions(user: UserType): boolean {
+    return (
+        hasCMSPermissions(user) ||
+        hasAdminPermissions(user) ||
+        isReadOnlyUser(user)
+    )
+}
+
 export {
     isUser,
     isCMSUser,
@@ -116,6 +136,8 @@ export {
     toDomainUser,
     isHelpdeskUser,
     isBusinessOwnerUser,
+    isReadOnlyUser,
     hasAdminPermissions,
     hasCMSPermissions,
+    hasReadPermissions,
 }

--- a/services/app-api/src/postgres/user/prismaDomainUser.ts
+++ b/services/app-api/src/postgres/user/prismaDomainUser.ts
@@ -92,6 +92,16 @@ function domainUserFromPrismaUser(
                 familyName: prismaUser.familyName,
                 email: prismaUser.email,
             }
+        case 'READONLY_USER':
+            return {
+                id: prismaUser.id,
+                createdAt: prismaUser.createdAt,
+                updatedAt: prismaUser.updatedAt,
+                role: 'READONLY_USER',
+                givenName: prismaUser.givenName,
+                familyName: prismaUser.familyName,
+                email: prismaUser.email,
+            }
     }
 }
 

--- a/services/app-api/src/resolvers/configureResolvers.ts
+++ b/services/app-api/src/resolvers/configureResolvers.ts
@@ -197,6 +197,8 @@ export function configureResolvers(
                     return 'HelpdeskUser'
                 } else if (obj.role === 'BUSINESSOWNER_USER') {
                     return 'BusinessOwnerUser'
+                } else if (obj.role === 'READONLY_USER') {
+                    return 'ReadOnlyUser'
                 } else {
                     return 'StateUser'
                 }

--- a/services/app-api/src/resolvers/contract/fetchContract.ts
+++ b/services/app-api/src/resolvers/contract/fetchContract.ts
@@ -2,11 +2,7 @@ import { GraphQLError } from 'graphql'
 import type { QueryResolvers } from '../../gen/gqlServer'
 import { NotFoundError, type Store } from '../../postgres'
 import { withResolverSpan, setResolverDetails } from '../attributeHelper'
-import {
-    isStateUser,
-    hasCMSPermissions,
-    hasAdminPermissions,
-} from '../../domain-models'
+import { isStateUser, hasReadPermissions } from '../../domain-models'
 import { canRead } from '../../oauth/oauthAuthorization'
 import { logResolverError, logResolverSuccess } from '../../logger'
 
@@ -76,10 +72,7 @@ export function fetchContractResolver(
                             },
                         })
                     }
-                } else if (
-                    !hasCMSPermissions(user) &&
-                    !hasAdminPermissions(user)
-                ) {
+                } else if (!hasReadPermissions(user)) {
                     const errMessage = 'User not allowed to access contract'
                     logResolverError('fetchContract', errMessage, context)
                     throw new GraphQLError(errMessage, {

--- a/services/app-api/src/resolvers/contract/fetchSubmissionHistory.ts
+++ b/services/app-api/src/resolvers/contract/fetchSubmissionHistory.ts
@@ -2,11 +2,7 @@ import { GraphQLError } from 'graphql'
 import type { QueryResolvers } from '../../gen/gqlServer'
 import { NotFoundError, type Store } from '../../postgres'
 import { canRead } from '../../oauth/oauthAuthorization'
-import {
-    hasAdminPermissions,
-    hasCMSPermissions,
-    isStateUser,
-} from '../../domain-models'
+import { hasReadPermissions, isStateUser } from '../../domain-models'
 import { logResolverError, logResolverSuccess } from '../../logger'
 import { setResolverDetails, withResolverSpan } from '../attributeHelper'
 
@@ -88,10 +84,7 @@ export function fetchSubmissionHistoryResolver(
                             },
                         })
                     }
-                } else if (
-                    !hasCMSPermissions(user) &&
-                    !hasAdminPermissions(user)
-                ) {
+                } else if (!hasReadPermissions(user)) {
                     const errMessage = 'User not allowed to access contract'
                     logResolverError(
                         'fetchSubmissionHistory',

--- a/services/app-api/src/resolvers/contract/indexContracts.ts
+++ b/services/app-api/src/resolvers/contract/indexContracts.ts
@@ -1,10 +1,6 @@
 import type { Span } from '@opentelemetry/api'
 import { createForbiddenError } from '../errorUtils'
-import {
-    isStateUser,
-    hasAdminPermissions,
-    hasCMSPermissions,
-} from '../../domain-models'
+import { isStateUser, hasReadPermissions } from '../../domain-models'
 import type { ContractType } from '../../domain-models'
 import type {
     QueryResolvers,
@@ -272,7 +268,7 @@ export function indexContractsResolver(
 
                 // CMS/Admin users do not need draft freshness, so the flagged path can
                 // push updatedWithin into the DB using the stored lastActionDate.
-                if (hasAdminPermissions(user) || hasCMSPermissions(user)) {
+                if (hasReadPermissions(user)) {
                     const cleanedStatuses =
                         input?.statusesToExclude?.filter(
                             (s): s is ConsolidatedContractStatus => s != null

--- a/services/app-api/src/resolvers/contract/indexContractsStripped.ts
+++ b/services/app-api/src/resolvers/contract/indexContractsStripped.ts
@@ -8,6 +8,7 @@ import {
 import {
     hasAdminPermissions,
     hasCMSPermissions,
+    isReadOnlyUser,
     isStateUser,
 } from '../../domain-models'
 import { NotFoundError } from '../../postgres'
@@ -65,8 +66,9 @@ export function indexContractsStripped(
                 const adminPermissions = hasAdminPermissions(user)
                 const cmsUser = hasCMSPermissions(user)
                 const stateUser = isStateUser(user)
+                const readOnlyUser = isReadOnlyUser(user)
 
-                if (adminPermissions || cmsUser || stateUser) {
+                if (adminPermissions || cmsUser || stateUser || readOnlyUser) {
                     let contractsWithHistory
                     if (stateUser) {
                         contractsWithHistory =

--- a/services/app-api/src/resolvers/rate/fetchRate.ts
+++ b/services/app-api/src/resolvers/rate/fetchRate.ts
@@ -3,11 +3,7 @@ import { NotFoundError } from '../../postgres'
 import type { QueryResolvers } from '../../gen/gqlServer'
 import type { Store } from '../../postgres'
 import { GraphQLError } from 'graphql'
-import {
-    isStateUser,
-    hasCMSPermissions,
-    hasAdminPermissions,
-} from '../../domain-models'
+import { isStateUser, hasReadPermissions } from '../../domain-models'
 import { logResolverError, logResolverSuccess } from '../../logger'
 import { createForbiddenError } from '../errorUtils'
 import { canRead } from '../../oauth/oauthAuthorization'
@@ -62,10 +58,7 @@ export function fetchRateResolver(store: Store): QueryResolvers['fetchRate'] {
                         logResolverError('fetchRate', errMessage, context)
                         throw createForbiddenError(errMessage)
                     }
-                } else if (
-                    !hasCMSPermissions(user) &&
-                    !hasAdminPermissions(user)
-                ) {
+                } else if (!hasReadPermissions(user)) {
                     const errMessage = 'User not authorized to fetch rate data'
                     logResolverError('fetchRate', errMessage, context)
                     throw createForbiddenError(errMessage)

--- a/services/app-api/src/resolvers/rate/indexRates.ts
+++ b/services/app-api/src/resolvers/rate/indexRates.ts
@@ -8,6 +8,7 @@ import {
 import {
     hasAdminPermissions,
     hasCMSPermissions,
+    isReadOnlyUser,
     isStateUser,
 } from '../../domain-models'
 import { NotFoundError } from '../../postgres'
@@ -68,8 +69,9 @@ export function indexRatesResolver(store: Store): QueryResolvers['indexRates'] {
                 const adminPermissions = hasAdminPermissions(user)
                 const cmsUser = hasCMSPermissions(user)
                 const stateUser = isStateUser(user)
+                const readOnlyUser = isReadOnlyUser(user)
 
-                if (adminPermissions || cmsUser || stateUser) {
+                if (adminPermissions || cmsUser || stateUser || readOnlyUser) {
                     let ratesWithHistory
                     if (stateUser) {
                         ratesWithHistory =

--- a/services/app-api/src/resolvers/rate/indexRatesPaginated.ts
+++ b/services/app-api/src/resolvers/rate/indexRatesPaginated.ts
@@ -8,6 +8,7 @@ import {
 import {
     hasAdminPermissions,
     hasCMSPermissions,
+    isReadOnlyUser,
     isStateUser,
 } from '../../domain-models'
 import type { QueryResolvers } from '../../gen/gqlServer'
@@ -151,8 +152,9 @@ export function indexRatesPaginatedResolver(
                 const adminPermissions = hasAdminPermissions(user)
                 const cmsUser = hasCMSPermissions(user)
                 const stateUser = isStateUser(user)
+                const readOnlyUser = isReadOnlyUser(user)
 
-                if (adminPermissions || cmsUser || stateUser) {
+                if (adminPermissions || cmsUser || stateUser || readOnlyUser) {
                     const pageSize = normalizeIndexRatesPageSize(
                         pageSizeInput ?? undefined
                     )

--- a/services/app-api/src/resolvers/rate/indexRatesStripped.ts
+++ b/services/app-api/src/resolvers/rate/indexRatesStripped.ts
@@ -8,6 +8,7 @@ import {
 import {
     hasAdminPermissions,
     hasCMSPermissions,
+    isReadOnlyUser,
     isStateUser,
 } from '../../domain-models'
 import { NotFoundError } from '../../postgres'
@@ -63,8 +64,9 @@ export function indexRatesStripped(
                 const adminPermissions = hasAdminPermissions(user)
                 const cmsUser = hasCMSPermissions(user)
                 const stateUser = isStateUser(user)
+                const readOnlyUser = isReadOnlyUser(user)
 
-                if (adminPermissions || cmsUser || stateUser) {
+                if (adminPermissions || cmsUser || stateUser || readOnlyUser) {
                     let ratesWithHistory
                     if (stateUser) {
                         ratesWithHistory = await store.findAllRatesStripped({

--- a/services/app-api/src/resolvers/settings/fetchMcReviewSettings.ts
+++ b/services/app-api/src/resolvers/settings/fetchMcReviewSettings.ts
@@ -2,7 +2,7 @@ import type { Store } from '../../postgres'
 import type { QueryResolvers } from '../../gen/gqlServer'
 import { setResolverDetails, withResolverSpan } from '../attributeHelper'
 import { logResolverError, logResolverSuccess } from '../../logger'
-import { hasAdminPermissions, hasCMSPermissions } from '../../domain-models'
+import { hasReadPermissions } from '../../domain-models'
 import { createForbiddenError } from '../errorUtils'
 import { GraphQLError } from 'graphql'
 import type { Emailer } from '../../emailer'
@@ -29,7 +29,7 @@ export function fetchMcReviewSettings(
                     throw createForbiddenError(oauthErr)
                 }
 
-                if (!hasCMSPermissions(user) && !hasAdminPermissions(user)) {
+                if (!hasReadPermissions(user)) {
                     const msg =
                         'user not authorized to fetch mc review settings'
                     logResolverError('fetchMcReviewSettings', msg, context)

--- a/services/app-api/src/resolvers/user/indexUsers.ts
+++ b/services/app-api/src/resolvers/user/indexUsers.ts
@@ -1,5 +1,5 @@
 import { createForbiddenError } from '../errorUtils'
-import { hasAdminPermissions, hasCMSPermissions } from '../../domain-models'
+import { hasReadPermissions } from '../../domain-models'
 import type { QueryResolvers } from '../../gen/gqlServer'
 import { logResolverError } from '../../logger'
 import type { Store } from '../../postgres'
@@ -17,10 +17,7 @@ export function indexUsersResolver(store: Store): QueryResolvers['indexUsers'] {
             async (span) => {
                 setResolverDetails(span, currentUser)
 
-                if (
-                    !hasAdminPermissions(currentUser) &&
-                    !hasCMSPermissions(currentUser)
-                ) {
+                if (!hasReadPermissions(currentUser)) {
                     const errMsg = 'user not authorized to fetch users'
                     logResolverError('indexUsers', errMsg, context)
                     throw createForbiddenError(errMsg)

--- a/services/app-api/src/testHelpers/userHelpers.ts
+++ b/services/app-api/src/testHelpers/userHelpers.ts
@@ -7,6 +7,7 @@ import type {
     UserType,
     BusinessOwnerUserType,
     HelpdeskUserType,
+    ReadOnlyUserType,
 } from '../domain-models'
 import { sharedTestPrismaClient } from './storeHelpers'
 import { v4 as uuidv4 } from 'uuid'
@@ -73,6 +74,17 @@ const testHelpdeskUser = (
     email: 'iroh@example.com',
     familyName: 'Iroh',
     givenName: 'Uncle',
+    ...userData,
+})
+
+const testReadOnlyUser = (
+    userData?: Partial<ReadOnlyUserType>
+): ReadOnlyUserType => ({
+    id: uuidv4(),
+    role: 'READONLY_USER',
+    email: 'gyatso@example.com',
+    familyName: 'Monk',
+    givenName: 'Gyatso',
     ...userData,
 })
 
@@ -158,4 +170,5 @@ export {
     testCMSApproverUser,
     testBusinessOwnerUser,
     testHelpdeskUser,
+    testReadOnlyUser,
 }

--- a/services/app-graphql/package.json
+++ b/services/app-graphql/package.json
@@ -6,8 +6,8 @@
     "license": "MIT",
     "scripts": {
         "generate": "pnpm gqlgen",
-        "gqlgen": "graphql-codegen",
-        "gqlgen:watch": "graphql-codegen --watch",
+        "gqlgen": "graphql-codegen-cjs",
+        "gqlgen:watch": "graphql-codegen-cjs --watch",
         "prettier": "npx prettier -u --write \"**/*.+(ts|tsx|json)\""
     },
     "devDependencies": {

--- a/services/app-graphql/src/fragments/userFragments.graphql
+++ b/services/app-graphql/src/fragments/userFragments.graphql
@@ -83,3 +83,11 @@ fragment businessUserFragment on BusinessOwnerUser {
     familyName
     givenName
 }
+
+fragment readOnlyUserFragment on ReadOnlyUser {
+    id
+    email
+    role
+    familyName
+    givenName
+}

--- a/services/app-graphql/src/queries/fetchCurrentUser.graphql
+++ b/services/app-graphql/src/queries/fetchCurrentUser.graphql
@@ -18,5 +18,8 @@ query fetchCurrentUser {
         ... on BusinessOwnerUser {
             ...businessUserFragment
         }
+        ... on ReadOnlyUser {
+            ...readOnlyUserFragment
+        }
     }
 }

--- a/services/app-graphql/src/queries/indexUsers.graphql
+++ b/services/app-graphql/src/queries/indexUsers.graphql
@@ -21,6 +21,9 @@ query indexUsers {
                 ...on HelpdeskUser {
                     ...helpdeskUserFragment
                 }
+                ...on ReadOnlyUser {
+                    ...readOnlyUserFragment
+                }
             }
         }
     }

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -1232,6 +1232,7 @@ union User =
     | HelpdeskUser
     | BusinessOwnerUser
     | CMSApproverUser
+    | ReadOnlyUser
 
 "StateUser is a user that works for a state, submitting packages to be reviewed by CMSUsers"
 type StateUser {
@@ -1306,6 +1307,16 @@ type HelpdeskUser {
 type BusinessOwnerUser {
     id: ID!
     "will always be 'BUSINESSOWNER_USER'"
+    role: String!
+    email: String!
+    givenName: String!
+    familyName: String!
+}
+
+"ReadOnlyUser can view all submissions and non-admin data but cannot trigger any mutation"
+type ReadOnlyUser {
+    id: ID!
+    "will always be 'READONLY_USER'"
     role: String!
     email: String!
     givenName: String!

--- a/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.tsx
+++ b/services/app-web/src/components/Header/PageHeadingRow/PageHeadingRow.tsx
@@ -7,9 +7,17 @@ import { User, StateUser } from '../../../gen/gqlClient'
 import {
     hasAdminUserPermissions,
     hasCMSUserPermissions,
+    hasReadOnlyUserPermissions,
 } from '@mc-review/helpers'
 
-const CMSUserRow = ({ heading }: { heading?: string | React.ReactElement }) => {
+const CMSUserRow = ({
+    heading,
+    hideOrgLabel = false,
+}: {
+    heading?: string | React.ReactElement
+    // Read-only users don't get the "CMS" organization label.
+    hideOrgLabel?: boolean
+}) => {
     return (
         <div className={styles.dashboardHeading}>
             <GridContainer>
@@ -18,7 +26,7 @@ const CMSUserRow = ({ heading }: { heading?: string | React.ReactElement }) => {
                 ) : (
                     <Grid row className="flex-align-center">
                         <PageHeading>
-                            <span>CMS</span>
+                            {!hideOrgLabel && <span>CMS</span>}
                             {heading && (
                                 <span
                                     className="font-heading-lg text-light"
@@ -119,7 +127,15 @@ export const PageHeadingRow = ({
         }
     }
 
-    if (
+    if (hasReadOnlyUserPermissions(loggedInUser)) {
+        // Read-only users see the CMS-side pages but without the "CMS" org
+        // label. On pages with no heading of their own (e.g. the dashboard),
+        // render nothing rather than an empty header.
+        if (!heading) {
+            return null
+        }
+        return <CMSUserRow heading={heading} hideOrgLabel />
+    } else if (
         hasCMSUserPermissions(loggedInUser) ||
         hasAdminUserPermissions(loggedInUser)
     ) {

--- a/services/app-web/src/localAuth/AddLocalUser.tsx
+++ b/services/app-web/src/localAuth/AddLocalUser.tsx
@@ -36,6 +36,7 @@ const roleOptions = [
     { value: 'HELPDESK_USER', label: 'Helpdesk User' },
     { value: 'BUSINESSOWNER_USER', label: 'Business Owner' },
     { value: 'ADMIN_USER', label: 'Admin User' },
+    { value: 'READONLY_USER', label: 'Read Only User' },
 ]
 
 interface AddLocalUserFromValueType {

--- a/services/app-web/src/localAuth/LocalLogin.tsx
+++ b/services/app-web/src/localAuth/LocalLogin.tsx
@@ -100,6 +100,13 @@ const localUsers: LocalUserType[] = [
         role: 'CMS_APPROVER_USER',
         stateAssignments: [],
     },
+    {
+        id: 'user10',
+        email: 'gyatso@example.com',
+        givenName: 'Gyatso',
+        familyName: 'Monk',
+        role: 'READONLY_USER',
+    },
 ]
 
 const userAvatars: { [key: string]: string } = {
@@ -156,6 +163,7 @@ export function LocalLogin(): React.ReactElement {
                             BUSINESSOWNER_USER: 'CMS (Business Owner)',
                             HELPDESK_USER: 'CMS (Helpdesk)',
                             CMS_USER: 'CMS',
+                            READONLY_USER: 'Read Only',
                             STATE_USER:
                                 user.role === 'STATE_USER'
                                     ? user.stateCode

--- a/services/app-web/src/localAuth/LocalUserType.ts
+++ b/services/app-web/src/localAuth/LocalUserType.ts
@@ -8,6 +8,7 @@ type LocalUserType =
     | LocalHelpdeskUserType
     | LocalBusinessOwnerUserType
     | LocalCMSApproverType
+    | LocalReadOnlyUserType
 
 type LocalStateUserType = {
     id: string
@@ -62,6 +63,14 @@ type LocalCMSApproverType = {
     divisionAssignment?: Division
 }
 
+type LocalReadOnlyUserType = {
+    id: string
+    role: 'READONLY_USER'
+    email: string
+    givenName: string
+    familyName: string
+}
+
 function isLocalUser(user: unknown): user is LocalUserType {
     if (user && typeof user === 'object') {
         if ('role' in user) {
@@ -73,7 +82,8 @@ function isLocalUser(user: unknown): user is LocalUserType {
                     roleUser.role === 'ADMIN_USER' ||
                     roleUser.role === 'HELPDESK_USER' ||
                     roleUser.role === 'BUSINESSOWNER_USER' ||
-                    roleUser.role === 'CMS_APPROVER_USER'
+                    roleUser.role === 'CMS_APPROVER_USER' ||
+                    roleUser.role === 'READONLY_USER'
                 ) {
                     return true
                 }

--- a/services/app-web/src/pages/Auth/Auth.test.tsx
+++ b/services/app-web/src/pages/Auth/Auth.test.tsx
@@ -211,10 +211,16 @@ describe('Auth', () => {
             ).toBeInTheDocument()
 
             expect(
+                screen.getByRole('img', {
+                    name: /Gyatso/i,
+                })
+            ).toBeInTheDocument()
+
+            expect(
                 screen.getAllByRole('button', {
                     name: /Login/i,
                 })
-            ).toHaveLength(9)
+            ).toHaveLength(10)
         })
 
         it('when login is successful, redirect to dashboard', async () => {

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/ContractQuestionResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/ContractQuestionResponse.tsx
@@ -15,7 +15,7 @@ import {
     FetchContractWithQuestionsDocument,
 } from '../../../gen/gqlClient'
 import { GenericErrorPage } from '../../Errors/GenericErrorPage'
-import { hasCMSUserPermissions } from '@mc-review/helpers'
+import { hasCMSUserPermissions, canViewCMSData } from '@mc-review/helpers'
 import {
     allQuestionsAnswered,
     getUserDivision,
@@ -35,6 +35,9 @@ export const ContractQuestionResponse = () => {
     const { updateHeading, updateActiveMainContent } = usePage()
     const { loggedInUser } = useAuth()
     const hasCMSPermissions = hasCMSUserPermissions(loggedInUser)
+    // Read-only users see the CMS (review) view of Q&A, but without any write
+    // affordances, which remain gated by hasCMSPermissions.
+    const showCMSView = canViewCMSData(loggedInUser)
 
     const { data, loading, error } = useQuery(
         FetchContractWithQuestionsDocument,
@@ -103,7 +106,7 @@ export const ContractQuestionResponse = () => {
                     />
                 )}
 
-                {hasCMSPermissions ? (
+                {showCMSView ? (
                     <CMSQuestionResponseTable
                         indexQuestions={contract.questions}
                         questionType="contract"

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/RateQuestionResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponseSummary/RateQuestionResponse.tsx
@@ -10,7 +10,7 @@ import { useParams, matchPath, useLocation } from 'react-router-dom'
 import { GridContainer } from '@trussworks/react-uswds'
 import { QuestionResponseSubmitBanner } from '../../../components'
 import { GenericErrorPage } from '../../Errors/GenericErrorPage'
-import { hasCMSUserPermissions } from '@mc-review/helpers'
+import { hasCMSUserPermissions, canViewCMSData } from '@mc-review/helpers'
 import {
     allQuestionsAnswered,
     getUserDivision,
@@ -35,6 +35,9 @@ export const RateQuestionResponse = () => {
     const { pathname } = useLocation()
     const { updateHeading, updateActiveMainContent } = usePage()
     const hasCMSPermissions = hasCMSUserPermissions(loggedInUser)
+    // Read-only users see the CMS (review) view of Q&A, but without any write
+    // affordances, which remain gated by hasCMSPermissions.
+    const showCMSView = canViewCMSData(loggedInUser)
     let division: Division | undefined = undefined
 
     // Check current path, use rateID if we are viewing as state user since path is nested in summary path.
@@ -100,7 +103,7 @@ export const RateQuestionResponse = () => {
                     <QuestionResponseSubmitBanner submitType={submitType} />
                 )}
 
-                {hasCMSPermissions ? (
+                {showCMSView ? (
                     <CMSQuestionResponseTable
                         indexQuestions={rate.questions}
                         questionType="rate"

--- a/services/app-web/src/pages/Settings/SettingsTables/StateAssignmentTable.tsx
+++ b/services/app-web/src/pages/Settings/SettingsTables/StateAssignmentTable.tsx
@@ -30,6 +30,8 @@ import { EditLink, formatUserNamesFromUsers } from '../'
 import { SettingsErrorAlert } from '../SettingsErrorAlert'
 import { getTealiumFiltersChanged } from '../../../tealium/tealiumHelpers'
 import { usePage } from '../../../contexts/PageContext'
+import { useAuth } from '../../../contexts/AuthContext'
+import { hasReadOnlyUserPermissions } from '@mc-review/helpers'
 
 type AnalystDisplayType = {
     email: string
@@ -104,6 +106,8 @@ const StateAssignmentTable = () => {
     const { updateActiveMainContent } = usePage()
     const { stateAnalysts: analysts } =
         useOutletContext<MCReviewSettingsContextType>()
+    const { loggedInUser } = useAuth()
+    const isReadOnlyUser = hasReadOnlyUserPermissions(loggedInUser)
 
     const activeMainContentId = 'stateAssignmentPageMainContent'
     // Set the active main content to focus when click the Skip to main content button.
@@ -129,19 +133,23 @@ const StateAssignmentTable = () => {
                 cell: (info) => formatUserNamesFromUsers(info.getValue()),
                 filterFn: 'analystFilter',
             }),
-            columnHelper.accessor('editLink', {
-                id: 'editLink',
-                header: 'Edit state assignment',
-                cell: (info) => (
-                    <EditLink
-                        rowID={info.row.original.stateCode}
-                        url={info.getValue()}
-                        fieldName={info.row.original.stateName}
-                    />
-                ),
-            }),
+            ...(isReadOnlyUser
+                ? []
+                : [
+                      columnHelper.accessor('editLink', {
+                          id: 'editLink',
+                          header: 'Edit state assignment',
+                          cell: (info) => (
+                              <EditLink
+                                  rowID={info.row.original.stateCode}
+                                  url={info.getValue()}
+                                  fieldName={info.row.original.stateName}
+                              />
+                          ),
+                      }),
+                  ]),
         ],
-        []
+        [isReadOnlyUser]
     )
 
     const reactTable = useReactTable({
@@ -264,8 +272,9 @@ const StateAssignmentTable = () => {
         <div id={activeMainContentId}>
             <h1>State assignments</h1>
             <p>
-                Below is a list of the DMCO staff assigned to states. To edit
-                the assigned staff click on the edit link below.
+                {isReadOnlyUser
+                    ? 'Below is a list of the DMCO staff assigned to states.'
+                    : 'Below is a list of the DMCO staff assigned to states. To edit the assigned staff click on the edit link below.'}
             </p>
             <FilterAccordion
                 onClearFilters={clearFilters}


### PR DESCRIPTION
## Summary

This PR creates a new user role for a Read Only user. This user type isn't able to view any draft data, any oauth client settings data or take any actions

- A read only user account type is created in the system for all environments
- The read only user account type will differ from the Help Desk account type
- The account type should have the ability to review submission records
- The account type should not have any write capabilites
- The account type should not be able to take any actions within the application

#### Related issues

https://jiraent.cms.gov/browse/MCR-6196 

#### Screenshots

#### Test cases covered

1. Backend — auth entrypoint (cognitoAuthn.test.ts)

Added a case to the table-driven userTypeFromAttributes test asserting that the IDM attribute macmcrrs-ro-user parses into a READONLY_USER domain user (id, email, given/family name). This directly covers the original bug — the entrypoint no longer throws "Unsupported user role."
2. Frontend — local login (Auth.test.tsx)

Updated the "displays local users when logged out" test to expect 10 login buttons (was 9) and assert the Gyatso read-only card renders — covering that the new local sign-in user shows up.

## QA guidance

In the ephemeral review environment sign in as gyatso@example.com (same 1password password as Zuko and Aang) and confirm that the read only user has the correct permissions (no ability to submit any action or see restricted info such as oauth client settings)

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed