### PR TITLE
[MCR-6401] Undo Unlock status banner

### DIFF
--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -1828,6 +1828,111 @@ describe('SubmissionSummary', () => {
                     ).toBeInTheDocument()
                 })
             })
+
+            it('renders status update banner and clears the url flag on undo unlock', async () => {
+                let testLocation: Location
+                const contract = mockContractPackageSubmittedWithQuestions(
+                    'test-abc-123',
+                    { contractSubmissionType: 'HEALTH_PLAN' }
+                )
+
+                renderWithProviders(
+                    <Routes>
+                        <Route element={<SubmissionSideNav />}>
+                            <Route
+                                path={RoutesRecord.SUBMISSIONS_SUMMARY}
+                                element={<SubmissionSummary />}
+                            />
+                        </Route>
+                    </Routes>,
+                    {
+                        apolloProvider: {
+                            mocks: [
+                                fetchCurrentUserMock({
+                                    user: mockUser(),
+                                    statusCode: 200,
+                                }),
+                                fetchContractWithQuestionsMockSuccess({
+                                    contract,
+                                }),
+                                fetchContractWithQuestionsMockSuccess({
+                                    contract,
+                                }),
+                            ],
+                        },
+                        routerProvider: {
+                            route: '/submissions/health-plan/test-abc-123?showTempUndoUnlockBanner=true',
+                        },
+                        location: (location) => (testLocation = location),
+                    }
+                )
+
+                await waitFor(() => {
+                    expect(
+                        screen.getByTestId('statusUpdatedBanner')
+                    ).toBeInTheDocument()
+                    expect(
+                        screen.getByRole('heading', {
+                            level: 4,
+                            name: /Status updated/,
+                        })
+                    ).toBeInTheDocument()
+                })
+
+                // flag is consumed once so the banner does not survive a refresh
+                await waitFor(() => {
+                    expect(testLocation.search).toBe('')
+                })
+            })
+
+            it('does not render status update banner without the undo unlock url flag', async () => {
+                const contract = mockContractPackageSubmittedWithQuestions(
+                    'test-abc-123',
+                    { contractSubmissionType: 'HEALTH_PLAN' }
+                )
+
+                renderWithProviders(
+                    <Routes>
+                        <Route element={<SubmissionSideNav />}>
+                            <Route
+                                path={RoutesRecord.SUBMISSIONS_SUMMARY}
+                                element={<SubmissionSummary />}
+                            />
+                        </Route>
+                    </Routes>,
+                    {
+                        apolloProvider: {
+                            mocks: [
+                                fetchCurrentUserMock({
+                                    user: mockUser(),
+                                    statusCode: 200,
+                                }),
+                                fetchContractWithQuestionsMockSuccess({
+                                    contract,
+                                }),
+                                fetchContractWithQuestionsMockSuccess({
+                                    contract,
+                                }),
+                            ],
+                        },
+                        routerProvider: {
+                            route: '/submissions/health-plan/test-abc-123',
+                        },
+                    }
+                )
+
+                await waitFor(() => {
+                    expect(
+                        screen.getByRole('heading', {
+                            level: 1,
+                            name: 'Submission summary',
+                        })
+                    ).toBeInTheDocument()
+                })
+                expect(
+                    screen.queryByTestId('statusUpdatedBanner')
+                ).not.toBeInTheDocument()
+            })
         }
     )
 

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -61,6 +61,8 @@ export const SubmissionSummary = (): React.ReactElement => {
     const [documentError, setDocumentError] = useState(false)
     const [showTempUndoWithdrawBanner, setShowTempUndoWithdrawBanner] =
         useState<boolean>(false)
+    const [showTempUndoUnlockBanner, setShowTempUndoUnlockBanner] =
+        useState<boolean>(false)
     const [searchParams, setSearchParams] = useSearchParams()
     const { loggedInUser } = useAuth()
     const { id } = useRouteParams()
@@ -126,11 +128,20 @@ export const SubmissionSummary = (): React.ReactElement => {
     })
 
     useEffect(() => {
+        //Undo Withdraw
         if (searchParams.get('showTempUndoWithdrawBanner') === 'true') {
             setShowTempUndoWithdrawBanner(true)
 
             //This ensures the banner goes away upon refresh or navigation
             searchParams.delete('showTempUndoWithdrawBanner')
+            setSearchParams(searchParams, { replace: true })
+        }
+        //Undo Unlock
+        if (searchParams.get('showTempUndoUnlockBanner') === 'true') {
+            setShowTempUndoUnlockBanner(true)
+
+            //This ensures the banner goes away upon refresh or navigation
+            searchParams.delete('showTempUndoUnlockBanner')
             setSearchParams(searchParams, { replace: true })
         }
     }, [searchParams, setSearchParams])
@@ -307,6 +318,10 @@ export const SubmissionSummary = (): React.ReactElement => {
 
         if (showTempUndoWithdrawBanner) {
             return <StatusUpdatedBanner className={styles.banner} />
+        }
+
+        if (showTempUndoUnlockBanner) {
+            return <StatusUpdatedBanner className={styles.banner} message="" />
         }
 
         if (showWithdrawnBanner && latestContractAction.updatedBy) {

--- a/services/app-web/src/pages/UndoSubmissionUnlock/UndoSubmissionUnlock.test.tsx
+++ b/services/app-web/src/pages/UndoSubmissionUnlock/UndoSubmissionUnlock.test.tsx
@@ -332,6 +332,8 @@ describe('UndoSubmissionUnlock', () => {
             expect(testLocation.pathname).toBe(
                 `/submissions/health-plan/${contract.id}`
             )
+            // flag tells the summary page to show the temporary status banner
+            expect(testLocation.search).toBe('?showTempUndoUnlockBanner=true')
         })
 
         await waitFor(() => {

--- a/services/app-web/src/pages/UndoSubmissionUnlock/UndoSubmissionUnlock.tsx
+++ b/services/app-web/src/pages/UndoSubmissionUnlock/UndoSubmissionUnlock.tsx
@@ -125,7 +125,9 @@ export const UndoSubmissionUnlock = (): React.ReactElement => {
                     },
                 },
             })
-            navigate(`/submissions/${contractSubmissionType}/${id}`)
+            navigate(
+                `/submissions/${contractSubmissionType}/${id}?showTempUndoUnlockBanner=true`
+            )
         } catch (err) {
             recordJSException(
                 `UndoSubmissionUnlock: GraphQL error reported. Error message: ${err}`
@@ -213,7 +215,7 @@ export const UndoSubmissionUnlock = (): React.ReactElement => {
                                     variant="default"
                                     data-testid="page-actions-right-primary"
                                     parent_component_type="page body"
-                                    link_url={`/submissions/${contractSubmissionType}/${id}`}
+                                    link_url={`/submissions/${contractSubmissionType}/${id}?showTempUndoUnlockBanner=true`}
                                     animationTimeout={1000}
                                     disabled={showFieldErrors(
                                         errors.undoSubmissionUnlockReason


### PR DESCRIPTION
## Summary
As a CMS user, I want the temporary "Status updated" success banner to be displayed when I complete the undo unlock action so that I can receive visual confirmation that the action was successfully completed.

**Acceptance Criteria:**
- When the CMS user provides a reason for completing the "Undo unlock" on the Undo unlock screen and the confirmation button is clicked, then:
- The CMS user will be returned to the submission summary page
- The temporary "Status updated" success banner will be displayed, confirming that the action was completed
#### Related issues
[MCR-6401](https://jiraent.cms.gov/browse/MCR-6401)
#### Screenshots

https://github.com/user-attachments/assets/9b4c7caf-a92b-4210-930a-25ff0a31dcdd


#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed