### PR TITLE
Vy 6326 add diff values to submission email part 1

### DIFF
--- a/services/app-api/src/emailer/emailer.ts
+++ b/services/app-api/src/emailer/emailer.ts
@@ -42,6 +42,7 @@ import { withEmailSpan } from './emailTracing'
 import { parseErrorToError } from '@mc-review/helpers'
 import type { RateForDisplayType } from './templateHelpers'
 import { newEQROContractCMSEmail } from './emails/newEQROContractCMSEmail'
+import type { ResubmitRevisionChanges } from './emails/resubmitRevisionChanges'
 
 // See more discussion of configuration in docs/Configuration.md
 type EmailConfiguration = {
@@ -130,7 +131,8 @@ type Emailer = {
         contract: ContractType,
         updateInfo: UpdateInfoType,
         stateAnalystsEmails: StateAnalystsEmails,
-        statePrograms: ProgramType[]
+        statePrograms: ProgramType[],
+        revisionChanges?: ResubmitRevisionChanges
     ) => Promise<void | Error>
     sendResubmittedEQROStateEmail: (
         contract: ContractType,
@@ -391,14 +393,16 @@ function emailer(
             contract,
             updateInfo,
             stateAnalystsEmails,
-            statePrograms
+            statePrograms,
+            revisionChanges
         ) {
             const emailData = await resubmitContractCMSEmail(
                 contract,
                 updateInfo,
                 config,
                 stateAnalystsEmails,
-                statePrograms
+                statePrograms,
+                revisionChanges
             )
             if (emailData instanceof Error) {
                 return emailData

--- a/services/app-api/src/emailer/emails/resubmitContractCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/resubmitContractCMSEmail.test.ts
@@ -32,6 +32,11 @@ describe('with rates', () => {
                         newValue: 'MCR-IL-0005-CHIP-CCCPLUS-FIDESNP-PCCME',
                     },
                     {
+                        label: 'Medicaid populations',
+                        oldValue: 'Medicaid and CHIP',
+                        newValue: 'CHIP-only',
+                    },
+                    {
                         label: 'Risk-based contract',
                         oldValue: 'No',
                         newValue: 'Yes',
@@ -278,6 +283,50 @@ describe('with rates', () => {
             'No changes made in the submission on 05/11/2027.'
         )
         expect(template.bodyHTML).toContain('<hr')
+    })
+    it('renders submission changes for CHIP-only CMS resubmission emails', async () => {
+        const chipOnlySubmission: ContractType = {
+            ...submission,
+            packageSubmissions: [
+                {
+                    ...submission.packageSubmissions[0],
+                    contractRevision: {
+                        ...submission.packageSubmissions[0].contractRevision,
+                        formData: {
+                            ...submission.packageSubmissions[0].contractRevision
+                                .formData,
+                            populationCovered: 'CHIP',
+                        },
+                    },
+                },
+            ],
+        }
+
+        const template = await resubmitContractCMSEmail(
+            chipOnlySubmission,
+            resubmitData,
+            testEmailConfig(),
+            testStateAnalystEmails,
+            defaultStatePrograms,
+            submissionTypeRevisionChanges
+        )
+
+        if (template instanceof Error) {
+            throw template
+        }
+
+        expect(template.subject).toContain(
+            'is not subject to DMCO review and validation.'
+        )
+        expect(template.bodyText).toContain('Submission changes: 05/01/2027')
+        expect(template.bodyText).toContain('SUBMISSION TYPE')
+        expect(template.bodyText).toContain(
+            'Medicaid populations: Medicaid and CHIP → CHIP-only'
+        )
+        expect(template.bodyText).toContain('Risk-based contract: No → Yes')
+        expect(template.bodyHTML).toContain(
+            '<strong>Medicaid populations:</strong> Medicaid and CHIP → CHIP-only'
+        )
     })
     it('renders submission type diff rows when revision changes are provided', async () => {
         const template = await resubmitContractCMSEmail(

--- a/services/app-api/src/emailer/emails/resubmitContractCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/resubmitContractCMSEmail.test.ts
@@ -9,6 +9,7 @@ import { resubmitContractCMSEmail } from './index'
 import type { ContractType } from '../../domain-models'
 import { packageName } from '@mc-review/submissions'
 import { ContractSubmissionTypeRecord } from '@mc-review/constants'
+import { emailColors } from '../styleConstants'
 
 describe('with rates', () => {
     const noDiffRevisionChanges = {
@@ -327,7 +328,9 @@ describe('with rates', () => {
         expect(template.bodyText).toContain(
             'Managed Care authorities: Title XXI Separate CHIP State Plan Authority\n→ 1932(a) State Plan Authority, 1115 Waiver Authority, Title XXI Separate CHIP State Plan Authority'
         )
-        expect(template.bodyHTML).toContain('NEW Associated with a D-SNP')
+        expect(template.bodyHTML).toContain(
+            `<span style="color: ${emailColors.revisionChangesNewIndicator}; font-family: Inter, Arial, sans-serif; font-size: 13px; font-style: normal; font-weight: 700; line-height: 150%;">NEW</span> Associated with a D-SNP`
+        )
         expect(template.bodyHTML).toContain(
             '<strong>Managed Care authorities:</strong> Title XXI Separate CHIP State Plan Authority<br />→ 1932(a) State Plan Authority, 1115 Waiver Authority, Title XXI Separate CHIP State Plan Authority'
         )
@@ -351,7 +354,9 @@ describe('with rates', () => {
             'In Lieu-of Services and Settings: No → Yes'
         )
         expect(template.bodyText).toContain('NEW CHIP beneficiaries: Yes')
-        expect(template.bodyHTML).toContain('NEW CHIP beneficiaries')
+        expect(template.bodyHTML).toContain(
+            `<span style="color: ${emailColors.revisionChangesNewIndicator}; font-family: Inter, Arial, sans-serif; font-size: 13px; font-style: normal; font-weight: 700; line-height: 150%;">NEW</span> CHIP beneficiaries`
+        )
     })
     it('includes expected data summary for a multi-rate contract and rates resubmission CMS email', async () => {
         const contract = mockContract()

--- a/services/app-api/src/emailer/emails/resubmitContractCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/resubmitContractCMSEmail.test.ts
@@ -39,6 +39,50 @@ describe('with rates', () => {
             },
         ],
     }
+    const contractDetailsRevisionChanges = {
+        previousSubmissionDate: '05/01/2027',
+        currentSubmissionDate: '05/11/2027',
+        hasChanges: true,
+        sections: [
+            {
+                title: 'CONTRACT DETAILS',
+                rows: [
+                    {
+                        label: 'Status',
+                        oldValue: 'Unexecuted by some or all parties',
+                        newValue: 'Fully executed',
+                    },
+                    {
+                        label: 'Associated with a D-SNP',
+                        newValue: 'Yes',
+                        isNew: true,
+                    },
+                ],
+            },
+        ],
+    }
+    const contractProvisionsRevisionChanges = {
+        previousSubmissionDate: '05/01/2027',
+        currentSubmissionDate: '05/11/2027',
+        hasChanges: true,
+        sections: [
+            {
+                title: 'CONTRACT PROVISIONS',
+                rows: [
+                    {
+                        label: 'In Lieu-of Services and Settings',
+                        oldValue: 'No',
+                        newValue: 'Yes',
+                    },
+                    {
+                        label: 'CHIP beneficiaries',
+                        newValue: 'Yes',
+                        isNew: true,
+                    },
+                ],
+            },
+        ],
+    }
     const resubmitData = {
         updatedBy: {
             email: 'bob@example.com',
@@ -240,6 +284,48 @@ describe('with rates', () => {
         )
         expect(template.bodyText).toContain('Risk-based contract: No → Yes')
         expect(template.bodyHTML).toContain('→')
+    })
+    it('renders contract details diff rows and NEW fields when revision changes are provided', async () => {
+        const template = await resubmitContractCMSEmail(
+            submission,
+            resubmitData,
+            testEmailConfig(),
+            testStateAnalystEmails,
+            defaultStatePrograms,
+            contractDetailsRevisionChanges
+        )
+
+        if (template instanceof Error) {
+            throw template
+        }
+
+        expect(template.bodyText).toContain('CONTRACT DETAILS')
+        expect(template.bodyText).toContain(
+            'Status: Unexecuted by some or all parties → Fully executed'
+        )
+        expect(template.bodyText).toContain('NEW Associated with a D-SNP: Yes')
+        expect(template.bodyHTML).toContain('NEW Associated with a D-SNP')
+    })
+    it('renders contract provisions diff rows and NEW fields when revision changes are provided', async () => {
+        const template = await resubmitContractCMSEmail(
+            submission,
+            resubmitData,
+            testEmailConfig(),
+            testStateAnalystEmails,
+            defaultStatePrograms,
+            contractProvisionsRevisionChanges
+        )
+
+        if (template instanceof Error) {
+            throw template
+        }
+
+        expect(template.bodyText).toContain('CONTRACT PROVISIONS')
+        expect(template.bodyText).toContain(
+            'In Lieu-of Services and Settings: No → Yes'
+        )
+        expect(template.bodyText).toContain('NEW CHIP beneficiaries: Yes')
+        expect(template.bodyHTML).toContain('NEW CHIP beneficiaries')
     })
     it('includes expected data summary for a multi-rate contract and rates resubmission CMS email', async () => {
         const contract = mockContract()

--- a/services/app-api/src/emailer/emails/resubmitContractCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/resubmitContractCMSEmail.test.ts
@@ -15,6 +15,29 @@ describe('with rates', () => {
         previousSubmissionDate: '05/01/2027',
         currentSubmissionDate: '05/11/2027',
         hasChanges: false,
+        sections: [],
+    }
+    const submissionTypeRevisionChanges = {
+        previousSubmissionDate: '05/01/2027',
+        currentSubmissionDate: '05/11/2027',
+        hasChanges: true,
+        sections: [
+            {
+                title: 'SUBMISSION TYPE',
+                rows: [
+                    {
+                        label: 'Submission ID',
+                        oldValue: 'MCR-IL-0005-CHIP-PCCME',
+                        newValue: 'MCR-IL-0005-CHIP-CCCPLUS-FIDESNP-PCCME',
+                    },
+                    {
+                        label: 'Risk-based contract',
+                        oldValue: 'No',
+                        newValue: 'Yes',
+                    },
+                ],
+            },
+        ],
     }
     const resubmitData = {
         updatedBy: {
@@ -190,12 +213,33 @@ describe('with rates', () => {
         }
 
         expect(template.bodyText).toContain(
-            'Submission changes: 05/01/2027 -> 05/11/2027'
+            'Submission changes: 05/01/2027 → 05/11/2027'
         )
         expect(template.bodyText).toContain(
             'No changes made in the submission on 05/11/2027.'
         )
         expect(template.bodyHTML).toContain('<hr')
+    })
+    it('renders submission type diff rows when revision changes are provided', async () => {
+        const template = await resubmitContractCMSEmail(
+            submission,
+            resubmitData,
+            testEmailConfig(),
+            testStateAnalystEmails,
+            defaultStatePrograms,
+            submissionTypeRevisionChanges
+        )
+
+        if (template instanceof Error) {
+            throw template
+        }
+
+        expect(template.bodyText).toContain('SUBMISSION TYPE')
+        expect(template.bodyText).toContain(
+            'Submission ID: MCR-IL-0005-CHIP-PCCME → MCR-IL-0005-CHIP-CCCPLUS-FIDESNP-PCCME'
+        )
+        expect(template.bodyText).toContain('Risk-based contract: No → Yes')
+        expect(template.bodyHTML).toContain('→')
     })
     it('includes expected data summary for a multi-rate contract and rates resubmission CMS email', async () => {
         const contract = mockContract()

--- a/services/app-api/src/emailer/emails/resubmitContractCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/resubmitContractCMSEmail.test.ts
@@ -11,6 +11,11 @@ import { packageName } from '@mc-review/submissions'
 import { ContractSubmissionTypeRecord } from '@mc-review/constants'
 
 describe('with rates', () => {
+    const noDiffRevisionChanges = {
+        previousSubmissionDate: '05/01/2027',
+        currentSubmissionDate: '05/11/2027',
+        hasChanges: false,
+    }
     const resubmitData = {
         updatedBy: {
             email: 'bob@example.com',
@@ -169,6 +174,28 @@ describe('with rates', () => {
                 ),
             })
         )
+    })
+    it('includes no-diff submission changes copy when revision changes are provided', async () => {
+        const template = await resubmitContractCMSEmail(
+            submission,
+            resubmitData,
+            testEmailConfig(),
+            testStateAnalystEmails,
+            defaultStatePrograms,
+            noDiffRevisionChanges
+        )
+
+        if (template instanceof Error) {
+            throw template
+        }
+
+        expect(template.bodyText).toContain(
+            'Submission changes: 05/01/2027 -> 05/11/2027'
+        )
+        expect(template.bodyText).toContain(
+            'No changes made in the submission on 05/11/2027.'
+        )
+        expect(template.bodyHTML).toContain('<hr')
     })
     it('includes expected data summary for a multi-rate contract and rates resubmission CMS email', async () => {
         const contract = mockContract()

--- a/services/app-api/src/emailer/emails/resubmitContractCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/resubmitContractCMSEmail.test.ts
@@ -35,6 +35,12 @@ describe('with rates', () => {
                         oldValue: 'No',
                         newValue: 'Yes',
                     },
+                    {
+                        label: 'Submission description',
+                        oldValue: 'Old description',
+                        newValue: 'New description',
+                        breakBeforeNewValue: true,
+                    },
                 ],
             },
         ],
@@ -56,6 +62,14 @@ describe('with rates', () => {
                         label: 'Associated with a D-SNP',
                         newValue: 'Yes',
                         isNew: true,
+                    },
+                    {
+                        label: 'Managed Care authorities',
+                        oldValue:
+                            'Title XXI Separate CHIP State Plan Authority',
+                        newValue:
+                            '1932(a) State Plan Authority, 1115 Waiver Authority, Title XXI Separate CHIP State Plan Authority',
+                        breakBeforeNewValue: true,
                     },
                 ],
             },
@@ -283,7 +297,13 @@ describe('with rates', () => {
             'Submission ID: MCR-IL-0005-CHIP-PCCME → MCR-IL-0005-CHIP-CCCPLUS-FIDESNP-PCCME'
         )
         expect(template.bodyText).toContain('Risk-based contract: No → Yes')
+        expect(template.bodyText).toContain(
+            'Submission description: Old description\n→ New description'
+        )
         expect(template.bodyHTML).toContain('→')
+        expect(template.bodyHTML).toContain(
+            '<strong>Submission description:</strong> Old description<br />→ New description'
+        )
     })
     it('renders contract details diff rows and NEW fields when revision changes are provided', async () => {
         const template = await resubmitContractCMSEmail(
@@ -304,7 +324,13 @@ describe('with rates', () => {
             'Status: Unexecuted by some or all parties → Fully executed'
         )
         expect(template.bodyText).toContain('NEW Associated with a D-SNP: Yes')
+        expect(template.bodyText).toContain(
+            'Managed Care authorities: Title XXI Separate CHIP State Plan Authority\n→ 1932(a) State Plan Authority, 1115 Waiver Authority, Title XXI Separate CHIP State Plan Authority'
+        )
         expect(template.bodyHTML).toContain('NEW Associated with a D-SNP')
+        expect(template.bodyHTML).toContain(
+            '<strong>Managed Care authorities:</strong> Title XXI Separate CHIP State Plan Authority<br />→ 1932(a) State Plan Authority, 1115 Waiver Authority, Title XXI Separate CHIP State Plan Authority'
+        )
     })
     it('renders contract provisions diff rows and NEW fields when revision changes are provided', async () => {
         const template = await resubmitContractCMSEmail(

--- a/services/app-api/src/emailer/emails/resubmitContractCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/resubmitContractCMSEmail.ts
@@ -14,13 +14,15 @@ import type {
     ContractType,
 } from '../../domain-models'
 import { submissionSummaryURL } from '../generateURLs'
+import type { ResubmitRevisionChanges } from './resubmitRevisionChanges'
 
 export const resubmitContractCMSEmail = async (
     contract: ContractType,
     updateInfo: UpdateInfoType,
     config: EmailConfiguration,
     stateAnalystsEmails: StateAnalystsEmails,
-    statePrograms: ProgramType[]
+    statePrograms: ProgramType[],
+    revisionChanges?: ResubmitRevisionChanges
 ): Promise<EmailData | Error> => {
     const reviewerEmails = generateCMSReviewerEmailsForSubmittedContract(
         config,
@@ -74,6 +76,7 @@ export const resubmitContractCMSEmail = async (
                 rateName: rate.formData.rateCertificationName,
             })),
         submissionURL: packageURL,
+        revisionChanges,
     }
 
     const emailTemplate = isChipOnly

--- a/services/app-api/src/emailer/emails/resubmitContractCMSEmail.ts
+++ b/services/app-api/src/emailer/emails/resubmitContractCMSEmail.ts
@@ -15,6 +15,7 @@ import type {
 } from '../../domain-models'
 import { submissionSummaryURL } from '../generateURLs'
 import type { ResubmitRevisionChanges } from './resubmitRevisionChanges'
+import { emailColors } from '../styleConstants'
 
 export const resubmitContractCMSEmail = async (
     contract: ContractType,
@@ -77,6 +78,8 @@ export const resubmitContractCMSEmail = async (
             })),
         submissionURL: packageURL,
         revisionChanges,
+        revisionChangesNewIndicatorColor:
+            emailColors.revisionChangesNewIndicator,
     }
 
     const emailTemplate = isChipOnly

--- a/services/app-api/src/emailer/emails/resubmitRevisionChanges.test.ts
+++ b/services/app-api/src/emailer/emails/resubmitRevisionChanges.test.ts
@@ -137,6 +137,7 @@ describe('buildResubmitRevisionChanges', () => {
                             label: 'Submission description',
                             oldValue: 'Original submission description',
                             newValue: 'Updated submission description',
+                            breakBeforeNewValue: true,
                         },
                     ],
                 },
@@ -225,6 +226,7 @@ describe('buildResubmitRevisionChanges', () => {
                                 'Title XXI Separate CHIP State Plan Authority',
                             newValue:
                                 '1932(a) State Plan Authority, 1115 Waiver Authority, Title XXI Separate CHIP State Plan Authority',
+                            breakBeforeNewValue: true,
                         },
                         {
                             label: 'Associated with a D-SNP',

--- a/services/app-api/src/emailer/emails/resubmitRevisionChanges.test.ts
+++ b/services/app-api/src/emailer/emails/resubmitRevisionChanges.test.ts
@@ -1,0 +1,146 @@
+import type { RevisionDiff } from '../../domain-models'
+import { buildResubmitRevisionChanges } from './resubmitRevisionChanges'
+import { mockMNState } from '../../testHelpers/emailerHelpers'
+
+describe('buildResubmitRevisionChanges', () => {
+    const statePrograms = mockMNState().programs
+
+    it('returns no-diff content when contract field changes are empty', () => {
+        const comparison: RevisionDiff = {
+            contractID: 'test-contract-id',
+            olderRevisionID: 'older-rev',
+            newerRevisionID: 'newer-rev',
+            olderSubmittedAt: new Date('2027-05-01T00:00:00.000Z'),
+            newerSubmittedAt: new Date('2027-05-11T00:00:00.000Z'),
+            fieldChanges: [],
+        }
+
+        expect(buildResubmitRevisionChanges(comparison, statePrograms)).toEqual(
+            {
+                previousSubmissionDate: '04/30/2027',
+                currentSubmissionDate: '05/10/2027',
+                hasChanges: false,
+                sections: [],
+            }
+        )
+    })
+
+    it('formats submission type field changes for CMS resubmit email', () => {
+        const comparison: RevisionDiff = {
+            contractID: 'test-contract-id',
+            olderRevisionID: 'older-rev',
+            newerRevisionID: 'newer-rev',
+            olderSubmittedAt: new Date('2027-05-01T00:00:00.000Z'),
+            newerSubmittedAt: new Date('2027-05-11T00:00:00.000Z'),
+            fieldChanges: [
+                {
+                    fieldPath: 'contractName',
+                    oldValue: 'MCR-IL-0005-CHIP-PCCME',
+                    newValue: 'MCR-IL-0005-CHIP-CCCPLUS-FIDESNP-PCCME',
+                },
+                {
+                    fieldPath: 'populationCovered',
+                    oldValue: 'MEDICAID',
+                    newValue: 'MEDICAID_AND_CHIP',
+                },
+                {
+                    fieldPath: 'submissionType',
+                    oldValue: 'CONTRACT_ONLY',
+                    newValue: 'CONTRACT_AND_RATES',
+                },
+                {
+                    fieldPath: 'contractType',
+                    oldValue: 'BASE',
+                    newValue: 'AMENDMENT',
+                },
+                {
+                    fieldPath: 'riskBasedContract',
+                    oldValue: false,
+                    newValue: true,
+                },
+                {
+                    fieldPath: 'programIDs',
+                    oldValue: [
+                        'abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce',
+                        'd95394e5-44d1-45df-8151-1cc1ee66f100',
+                    ],
+                    newValue: [
+                        '36c54daf-7611-4a15-8c3b-cdeb3fd7e25a',
+                        'abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce',
+                        'd95394e5-44d1-45df-8151-1cc1ee66f100',
+                        'ea16a6c0-5fc6-4df8-adac-c627e76660ab',
+                    ],
+                },
+                {
+                    fieldPath: 'submissionDescription',
+                    oldValue: 'Original submission description',
+                    newValue: 'Updated submission description',
+                },
+                {
+                    fieldPath: 'contractDateStart',
+                    oldValue: new Date('2027-01-01T00:00:00.000Z'),
+                    newValue: new Date('2027-05-15T00:00:00.000Z'),
+                },
+            ],
+        }
+
+        expect(
+            buildResubmitRevisionChanges(comparison, [
+                ...statePrograms,
+                {
+                    id: '36c54daf-7611-4a15-8c3b-cdeb3fd7e25a',
+                    name: 'CHIP',
+                    fullName: 'CHIP',
+                    isRateProgram: false,
+                    isDeprecated: false,
+                },
+            ])
+        ).toEqual({
+            previousSubmissionDate: '04/30/2027',
+            currentSubmissionDate: '05/10/2027',
+            hasChanges: true,
+            sections: [
+                {
+                    title: 'SUBMISSION TYPE',
+                    rows: [
+                        {
+                            label: 'Submission ID',
+                            oldValue: 'MCR-IL-0005-CHIP-PCCME',
+                            newValue: 'MCR-IL-0005-CHIP-CCCPLUS-FIDESNP-PCCME',
+                        },
+                        {
+                            label: 'Medicaid populations',
+                            oldValue: 'Medicaid',
+                            newValue: 'Medicaid and CHIP',
+                        },
+                        {
+                            label: 'Submission type',
+                            oldValue: 'Contract only',
+                            newValue: 'Contract and rate(s)',
+                        },
+                        {
+                            label: 'Contract action type',
+                            oldValue: 'Base',
+                            newValue: 'Amendment',
+                        },
+                        {
+                            label: 'Risk-based contract',
+                            oldValue: 'No',
+                            newValue: 'Yes',
+                        },
+                        {
+                            label: 'Programs',
+                            oldValue: 'SNBC, PMAP',
+                            newValue: 'CHIP, SNBC, PMAP, MSC+',
+                        },
+                        {
+                            label: 'Submission description',
+                            oldValue: 'Original submission description',
+                            newValue: 'Updated submission description',
+                        },
+                    ],
+                },
+            ],
+        })
+    })
+})

--- a/services/app-api/src/emailer/emails/resubmitRevisionChanges.test.ts
+++ b/services/app-api/src/emailer/emails/resubmitRevisionChanges.test.ts
@@ -1,9 +1,10 @@
-import type { RevisionDiff } from '../../domain-models'
+import type { ContractType, RevisionDiff } from '../../domain-models'
 import { buildResubmitRevisionChanges } from './resubmitRevisionChanges'
-import { mockMNState } from '../../testHelpers/emailerHelpers'
+import { mockContract, mockMNState } from '../../testHelpers/emailerHelpers'
 
 describe('buildResubmitRevisionChanges', () => {
     const statePrograms = mockMNState().programs
+    const currentContract = mockContract()
 
     it('returns no-diff content when contract field changes are empty', () => {
         const comparison: RevisionDiff = {
@@ -15,14 +16,18 @@ describe('buildResubmitRevisionChanges', () => {
             fieldChanges: [],
         }
 
-        expect(buildResubmitRevisionChanges(comparison, statePrograms)).toEqual(
-            {
-                previousSubmissionDate: '04/30/2027',
-                currentSubmissionDate: '05/10/2027',
-                hasChanges: false,
-                sections: [],
-            }
-        )
+        expect(
+            buildResubmitRevisionChanges(
+                currentContract,
+                comparison,
+                statePrograms
+            )
+        ).toEqual({
+            previousSubmissionDate: '04/30/2027',
+            currentSubmissionDate: '05/10/2027',
+            hasChanges: false,
+            sections: [],
+        })
     })
 
     it('formats submission type field changes for CMS resubmit email', () => {
@@ -76,16 +81,11 @@ describe('buildResubmitRevisionChanges', () => {
                     oldValue: 'Original submission description',
                     newValue: 'Updated submission description',
                 },
-                {
-                    fieldPath: 'contractDateStart',
-                    oldValue: new Date('2027-01-01T00:00:00.000Z'),
-                    newValue: new Date('2027-05-15T00:00:00.000Z'),
-                },
             ],
         }
 
         expect(
-            buildResubmitRevisionChanges(comparison, [
+            buildResubmitRevisionChanges(currentContract, comparison, [
                 ...statePrograms,
                 {
                     id: '36c54daf-7611-4a15-8c3b-cdeb3fd7e25a',
@@ -137,6 +137,308 @@ describe('buildResubmitRevisionChanges', () => {
                             label: 'Submission description',
                             oldValue: 'Original submission description',
                             newValue: 'Updated submission description',
+                        },
+                    ],
+                },
+            ],
+        })
+    })
+
+    it('formats contract details field changes for CMS resubmit email, including NEW fields', () => {
+        const comparison: RevisionDiff = {
+            contractID: 'test-contract-id',
+            olderRevisionID: 'older-rev',
+            newerRevisionID: 'newer-rev',
+            olderSubmittedAt: new Date('2027-05-01T00:00:00.000Z'),
+            newerSubmittedAt: new Date('2027-05-11T00:00:00.000Z'),
+            fieldChanges: [
+                {
+                    fieldPath: 'contractExecutionStatus',
+                    oldValue: 'UNEXECUTED',
+                    newValue: 'EXECUTED',
+                },
+                {
+                    fieldPath: 'contractDateStart',
+                    oldValue: new Date('2027-01-01T00:00:00.000Z'),
+                    newValue: new Date('2027-05-15T00:00:00.000Z'),
+                },
+                {
+                    fieldPath: 'contractDateEnd',
+                    oldValue: new Date('2028-01-01T00:00:00.000Z'),
+                    newValue: new Date('2028-05-15T00:00:00.000Z'),
+                },
+                {
+                    fieldPath: 'managedCareEntities',
+                    oldValue: ['MCO'],
+                    newValue: ['MCO', 'PIHP', 'PAHP', 'PCCM'],
+                },
+                {
+                    fieldPath: 'federalAuthorities',
+                    oldValue: ['TITLE_XXI'],
+                    newValue: ['STATE_PLAN', 'WAIVER_1115', 'TITLE_XXI'],
+                },
+                {
+                    fieldPath: 'dsnpContract',
+                    oldValue: undefined,
+                    newValue: true,
+                },
+            ],
+        }
+
+        expect(
+            buildResubmitRevisionChanges(
+                currentContract,
+                comparison,
+                statePrograms
+            )
+        ).toEqual({
+            previousSubmissionDate: '04/30/2027',
+            currentSubmissionDate: '05/10/2027',
+            hasChanges: true,
+            sections: [
+                {
+                    title: 'CONTRACT DETAILS',
+                    rows: [
+                        {
+                            label: 'Status',
+                            oldValue: 'Unexecuted by some or all parties',
+                            newValue: 'Fully executed',
+                        },
+                        {
+                            label: 'Start date',
+                            oldValue: '01/01/2027',
+                            newValue: '05/15/2027',
+                        },
+                        {
+                            label: 'End date',
+                            oldValue: '01/01/2028',
+                            newValue: '05/15/2028',
+                        },
+                        {
+                            label: 'Managed Care entities',
+                            oldValue: 'MCO',
+                            newValue: 'MCO, PIHP, PAHP, PCCM',
+                        },
+                        {
+                            label: 'Managed Care authorities',
+                            oldValue:
+                                'Title XXI Separate CHIP State Plan Authority',
+                            newValue:
+                                '1932(a) State Plan Authority, 1115 Waiver Authority, Title XXI Separate CHIP State Plan Authority',
+                        },
+                        {
+                            label: 'Associated with a D-SNP',
+                            newValue: 'Yes',
+                            isNew: true,
+                        },
+                    ],
+                },
+            ],
+        })
+    })
+
+    it('formats contract provisions field changes for CMS resubmit email, including NEW fields', () => {
+        const baseContract = mockContract()
+        const chipContract: ContractType = {
+            ...baseContract,
+            packageSubmissions: [
+                {
+                    ...baseContract.packageSubmissions[0],
+                    contractRevision: {
+                        ...baseContract.packageSubmissions[0].contractRevision,
+                        formData: {
+                            ...baseContract.packageSubmissions[0]
+                                .contractRevision.formData,
+                            populationCovered: 'CHIP',
+                            contractType: 'AMENDMENT',
+                        },
+                    },
+                },
+            ],
+        }
+        const comparison: RevisionDiff = {
+            contractID: 'test-contract-id',
+            olderRevisionID: 'older-rev',
+            newerRevisionID: 'newer-rev',
+            olderSubmittedAt: new Date('2027-05-01T00:00:00.000Z'),
+            newerSubmittedAt: new Date('2027-05-11T00:00:00.000Z'),
+            fieldChanges: [
+                {
+                    fieldPath: 'inLieuServicesAndSettings',
+                    oldValue: false,
+                    newValue: true,
+                },
+                {
+                    fieldPath: 'modifiedBenefitsProvided',
+                    oldValue: false,
+                    newValue: true,
+                },
+                {
+                    fieldPath: 'modifiedGeoAreaServed',
+                    oldValue: false,
+                    newValue: true,
+                },
+                {
+                    fieldPath: 'modifiedMedicaidBeneficiaries',
+                    oldValue: undefined,
+                    newValue: true,
+                },
+                {
+                    fieldPath: 'modifiedRiskSharingStrategy',
+                    oldValue: false,
+                    newValue: true,
+                },
+                {
+                    fieldPath: 'modifiedIncentiveArrangements',
+                    oldValue: false,
+                    newValue: true,
+                },
+                {
+                    fieldPath: 'modifiedWitholdAgreements',
+                    oldValue: false,
+                    newValue: true,
+                },
+                {
+                    fieldPath: 'modifiedStateDirectedPayments',
+                    oldValue: false,
+                    newValue: true,
+                },
+                {
+                    fieldPath: 'modifiedPassThroughPayments',
+                    oldValue: false,
+                    newValue: true,
+                },
+                {
+                    fieldPath: 'modifiedMedicalLossRatioStandards',
+                    oldValue: false,
+                    newValue: true,
+                },
+                {
+                    fieldPath: 'modifiedOtherFinancialPaymentIncentive',
+                    oldValue: false,
+                    newValue: true,
+                },
+                {
+                    fieldPath: 'modifiedGrevienceAndAppeal',
+                    oldValue: false,
+                    newValue: true,
+                },
+                {
+                    fieldPath: 'modifiedNetworkAdequacyStandards',
+                    oldValue: false,
+                    newValue: true,
+                },
+                {
+                    fieldPath: 'modifiedLengthOfContract',
+                    oldValue: false,
+                    newValue: true,
+                },
+                {
+                    fieldPath: 'modifiedNonRiskPaymentArrangements',
+                    oldValue: false,
+                    newValue: true,
+                },
+                {
+                    fieldPath: 'modifiedPaymentsForMentalDiseaseInstitutions',
+                    oldValue: false,
+                    newValue: true,
+                },
+            ],
+        }
+
+        expect(
+            buildResubmitRevisionChanges(
+                chipContract,
+                comparison,
+                statePrograms
+            )
+        ).toEqual({
+            previousSubmissionDate: '04/30/2027',
+            currentSubmissionDate: '05/10/2027',
+            hasChanges: true,
+            sections: [
+                {
+                    title: 'CONTRACT PROVISIONS',
+                    rows: [
+                        {
+                            label: 'In Lieu-of Services and Settings',
+                            oldValue: 'No',
+                            newValue: 'Yes',
+                        },
+                        {
+                            label: 'Benefits provided',
+                            oldValue: 'No',
+                            newValue: 'Yes',
+                        },
+                        {
+                            label: 'Geo area served',
+                            oldValue: 'No',
+                            newValue: 'Yes',
+                        },
+                        {
+                            label: 'CHIP beneficiaries',
+                            newValue: 'Yes',
+                            isNew: true,
+                        },
+                        {
+                            label: 'Risk-sharing strategy',
+                            oldValue: 'No',
+                            newValue: 'Yes',
+                        },
+                        {
+                            label: 'Incentive arrangements',
+                            oldValue: 'No',
+                            newValue: 'Yes',
+                        },
+                        {
+                            label: 'Withhold arrangements',
+                            oldValue: 'No',
+                            newValue: 'Yes',
+                        },
+                        {
+                            label: 'State directed payments',
+                            oldValue: 'No',
+                            newValue: 'Yes',
+                        },
+                        {
+                            label: 'Pass-through payments',
+                            oldValue: 'No',
+                            newValue: 'Yes',
+                        },
+                        {
+                            label: 'Medical loss ratio standards',
+                            oldValue: 'No',
+                            newValue: 'Yes',
+                        },
+                        {
+                            label: 'Other financial payment',
+                            oldValue: 'No',
+                            newValue: 'Yes',
+                        },
+                        {
+                            label: 'Grievance and appeal',
+                            oldValue: 'No',
+                            newValue: 'Yes',
+                        },
+                        {
+                            label: 'Network adequacy standards',
+                            oldValue: 'No',
+                            newValue: 'Yes',
+                        },
+                        {
+                            label: 'Length of the contract',
+                            oldValue: 'No',
+                            newValue: 'Yes',
+                        },
+                        {
+                            label: 'Non-risk payment arrangements',
+                            oldValue: 'No',
+                            newValue: 'Yes',
+                        },
+                        {
+                            label: 'Payments for mental disease institutions',
+                            oldValue: 'No',
+                            newValue: 'Yes',
                         },
                     ],
                 },

--- a/services/app-api/src/emailer/emails/resubmitRevisionChanges.test.ts
+++ b/services/app-api/src/emailer/emails/resubmitRevisionChanges.test.ts
@@ -202,8 +202,8 @@ describe('buildResubmitRevisionChanges', () => {
                     rows: [
                         {
                             label: 'Status',
-                            oldValue: 'Unexecuted by some or all parties',
-                            newValue: 'Fully executed',
+                            oldValue: 'Unexecuted',
+                            newValue: 'Executed',
                         },
                         {
                             label: 'Start date',
@@ -232,6 +232,47 @@ describe('buildResubmitRevisionChanges', () => {
                             label: 'Associated with a D-SNP',
                             newValue: 'Yes',
                             isNew: true,
+                        },
+                    ],
+                },
+            ],
+        })
+    })
+
+    it('formats removed contract detail values with a dash placeholder', () => {
+        const comparison: RevisionDiff = {
+            contractID: 'test-contract-id',
+            olderRevisionID: 'older-rev',
+            newerRevisionID: 'newer-rev',
+            olderSubmittedAt: new Date('2027-05-01T00:00:00.000Z'),
+            newerSubmittedAt: new Date('2027-05-11T00:00:00.000Z'),
+            fieldChanges: [
+                {
+                    fieldPath: 'dsnpContract',
+                    oldValue: false,
+                    newValue: undefined,
+                },
+            ],
+        }
+
+        expect(
+            buildResubmitRevisionChanges(
+                currentContract,
+                comparison,
+                statePrograms
+            )
+        ).toEqual({
+            previousSubmissionDate: '04/30/2027',
+            currentSubmissionDate: '05/10/2027',
+            hasChanges: true,
+            sections: [
+                {
+                    title: 'CONTRACT DETAILS',
+                    rows: [
+                        {
+                            label: 'Associated with a D-SNP',
+                            oldValue: 'No',
+                            newValue: '⎯',
                         },
                     ],
                 },
@@ -441,6 +482,47 @@ describe('buildResubmitRevisionChanges', () => {
                             label: 'Payments for mental disease institutions',
                             oldValue: 'No',
                             newValue: 'Yes',
+                        },
+                    ],
+                },
+            ],
+        })
+    })
+
+    it('formats removed contract provision values with a dash placeholder', () => {
+        const comparison: RevisionDiff = {
+            contractID: 'test-contract-id',
+            olderRevisionID: 'older-rev',
+            newerRevisionID: 'newer-rev',
+            olderSubmittedAt: new Date('2027-05-01T00:00:00.000Z'),
+            newerSubmittedAt: new Date('2027-05-11T00:00:00.000Z'),
+            fieldChanges: [
+                {
+                    fieldPath: 'modifiedBenefitsProvided',
+                    oldValue: false,
+                    newValue: undefined,
+                },
+            ],
+        }
+
+        expect(
+            buildResubmitRevisionChanges(
+                currentContract,
+                comparison,
+                statePrograms
+            )
+        ).toEqual({
+            previousSubmissionDate: '04/30/2027',
+            currentSubmissionDate: '05/10/2027',
+            hasChanges: true,
+            sections: [
+                {
+                    title: 'CONTRACT PROVISIONS',
+                    rows: [
+                        {
+                            label: 'Benefits provided',
+                            oldValue: 'No',
+                            newValue: '⎯',
                         },
                     ],
                 },

--- a/services/app-api/src/emailer/emails/resubmitRevisionChanges.ts
+++ b/services/app-api/src/emailer/emails/resubmitRevisionChanges.ts
@@ -1,14 +1,20 @@
 import { formatCalendarDate } from '@mc-review/dates'
-import type {
-    ProgramType,
-    RevisionDiff,
-    RevisionDiffFieldChange,
+import {
+    ContractExecutionStatusRecord,
+    FederalAuthorityRecord,
+} from '@mc-review/submissions'
+import {
+    type ContractType,
+    type ProgramType,
+    type RevisionDiff,
+    type RevisionDiffFieldChange,
 } from '../../domain-models'
 
 type ResubmitRevisionChangeRow = {
     label: string
-    oldValue: string
     newValue: string
+    oldValue?: string
+    isNew?: boolean
 }
 
 type ResubmitRevisionChangeSection = {
@@ -34,9 +40,48 @@ type SubmissionTypeFieldPath =
     | 'programIDs'
     | 'submissionDescription'
 
+type ContractDetailsFieldPath =
+    | 'contractExecutionStatus'
+    | 'contractDateStart'
+    | 'contractDateEnd'
+    | 'managedCareEntities'
+    | 'federalAuthorities'
+    | 'dsnpContract'
+
+type ContractProvisionsFieldPath =
+    | 'inLieuServicesAndSettings'
+    | 'modifiedBenefitsProvided'
+    | 'modifiedGeoAreaServed'
+    | 'modifiedMedicaidBeneficiaries'
+    | 'modifiedRiskSharingStrategy'
+    | 'modifiedIncentiveArrangements'
+    | 'modifiedWitholdAgreements'
+    | 'modifiedStateDirectedPayments'
+    | 'modifiedPassThroughPayments'
+    | 'modifiedMedicalLossRatioStandards'
+    | 'modifiedOtherFinancialPaymentIncentive'
+    | 'modifiedGrevienceAndAppeal'
+    | 'modifiedNetworkAdequacyStandards'
+    | 'modifiedLengthOfContract'
+    | 'modifiedNonRiskPaymentArrangements'
+    | 'modifiedPaymentsForMentalDiseaseInstitutions'
+
 type SubmissionTypeValue = 'CONTRACT_ONLY' | 'CONTRACT_AND_RATES'
 type PopulationCoveredValue = 'MEDICAID' | 'CHIP' | 'MEDICAID_AND_CHIP'
 type ContractActionTypeValue = 'BASE' | 'AMENDMENT'
+type ContractExecutionStatusValue = 'EXECUTED' | 'UNEXECUTED'
+type ManagedCareEntityValue = 'MCO' | 'PIHP' | 'PAHP' | 'PCCM'
+type FederalAuthorityValue =
+    | 'STATE_PLAN'
+    | 'WAIVER_1915B'
+    | 'WAIVER_1115'
+    | 'VOLUNTARY'
+    | 'BENCHMARK'
+    | 'TITLE_XXI'
+
+const isChipOnlyContract = (contract: ContractType): boolean =>
+    contract.packageSubmissions[0]?.contractRevision.formData
+        .populationCovered === 'CHIP'
 
 const submissionTypeValueRecord: Record<SubmissionTypeValue, string> = {
     CONTRACT_ONLY: 'Contract only',
@@ -84,8 +129,53 @@ const formatProgramsValue = (
     return names.length > 0 ? names.join(', ') : undefined
 }
 
+const formatStringArrayValue = <
+    TValue extends string,
+    TDictionary extends Record<TValue, string>,
+>(
+    value: unknown,
+    dictionary: TDictionary
+): string | undefined => {
+    if (!Array.isArray(value)) {
+        return undefined
+    }
+
+    const displayValues = value
+        .map((item) => dictionary[item as TValue])
+        .filter(Boolean)
+
+    return displayValues.length > 0 ? displayValues.join(', ') : undefined
+}
+
+const formatManagedCareEntitiesValue = (value: unknown): string | undefined => {
+    if (!Array.isArray(value)) {
+        return undefined
+    }
+
+    const displayValues = value.filter(
+        (item): item is ManagedCareEntityValue =>
+            item === 'MCO' ||
+            item === 'PIHP' ||
+            item === 'PAHP' ||
+            item === 'PCCM'
+    )
+
+    return displayValues.length > 0 ? displayValues.join(', ') : undefined
+}
+
+const formatDateValue = (value: unknown): string | undefined => {
+    if (!(value instanceof Date)) {
+        return undefined
+    }
+
+    return formatCalendarDate(value, 'UTC')
+}
+
 const formatFieldValue = (
-    fieldPath: SubmissionTypeFieldPath,
+    fieldPath:
+        | SubmissionTypeFieldPath
+        | ContractDetailsFieldPath
+        | ContractProvisionsFieldPath,
     value: unknown,
     statePrograms: ProgramType[]
 ): string | undefined => {
@@ -111,14 +201,54 @@ const formatFieldValue = (
         if (fieldPath === 'submissionDescription') {
             return value
         }
+
+        if (fieldPath === 'contractExecutionStatus') {
+            return ContractExecutionStatusRecord[
+                value as ContractExecutionStatusValue
+            ]
+        }
     }
 
-    if (fieldPath === 'riskBasedContract') {
+    if (
+        fieldPath === 'riskBasedContract' ||
+        fieldPath === 'dsnpContract' ||
+        fieldPath === 'inLieuServicesAndSettings' ||
+        fieldPath === 'modifiedBenefitsProvided' ||
+        fieldPath === 'modifiedGeoAreaServed' ||
+        fieldPath === 'modifiedMedicaidBeneficiaries' ||
+        fieldPath === 'modifiedRiskSharingStrategy' ||
+        fieldPath === 'modifiedIncentiveArrangements' ||
+        fieldPath === 'modifiedWitholdAgreements' ||
+        fieldPath === 'modifiedStateDirectedPayments' ||
+        fieldPath === 'modifiedPassThroughPayments' ||
+        fieldPath === 'modifiedMedicalLossRatioStandards' ||
+        fieldPath === 'modifiedOtherFinancialPaymentIncentive' ||
+        fieldPath === 'modifiedGrevienceAndAppeal' ||
+        fieldPath === 'modifiedNetworkAdequacyStandards' ||
+        fieldPath === 'modifiedLengthOfContract' ||
+        fieldPath === 'modifiedNonRiskPaymentArrangements' ||
+        fieldPath === 'modifiedPaymentsForMentalDiseaseInstitutions'
+    ) {
         return formatBooleanValue(value)
     }
 
     if (fieldPath === 'programIDs') {
         return formatProgramsValue(value, statePrograms)
+    }
+
+    if (fieldPath === 'contractDateStart' || fieldPath === 'contractDateEnd') {
+        return formatDateValue(value)
+    }
+
+    if (fieldPath === 'managedCareEntities') {
+        return formatManagedCareEntitiesValue(value)
+    }
+
+    if (fieldPath === 'federalAuthorities') {
+        return formatStringArrayValue<
+            FederalAuthorityValue,
+            typeof FederalAuthorityRecord
+        >(value, FederalAuthorityRecord)
     }
 
     return undefined
@@ -171,7 +301,149 @@ const buildSubmissionTypeRow = (
     }
 }
 
+const buildContractDetailsRow = (
+    fieldChange: RevisionDiffFieldChange,
+    statePrograms: ProgramType[]
+): ResubmitRevisionChangeRow | undefined => {
+    const rowConfig: Record<ContractDetailsFieldPath, string> = {
+        contractExecutionStatus: 'Status',
+        contractDateStart: 'Start date',
+        contractDateEnd: 'End date',
+        managedCareEntities: 'Managed Care entities',
+        federalAuthorities: 'Managed Care authorities',
+        dsnpContract: 'Associated with a D-SNP',
+    }
+
+    if (!(fieldChange.fieldPath in rowConfig)) {
+        return undefined
+    }
+
+    const typedFieldPath = fieldChange.fieldPath as ContractDetailsFieldPath
+    const label = rowConfig[typedFieldPath]
+    const oldValue = formatFieldValue(
+        typedFieldPath,
+        fieldChange.oldValue,
+        statePrograms
+    )
+    const newValue = formatFieldValue(
+        typedFieldPath,
+        fieldChange.newValue,
+        statePrograms
+    )
+
+    if (!newValue) {
+        return undefined
+    }
+
+    if (oldValue === undefined) {
+        return {
+            label,
+            newValue,
+            isNew: true,
+        }
+    }
+
+    return {
+        label,
+        oldValue,
+        newValue,
+    }
+}
+
+const getProvisionLabel = (
+    fieldPath: ContractProvisionsFieldPath,
+    currentContract: ContractType
+): string => {
+    const baseLabelConfig: Record<ContractProvisionsFieldPath, string> = {
+        inLieuServicesAndSettings: 'In Lieu-of Services and Settings',
+        modifiedBenefitsProvided: 'Benefits provided',
+        modifiedGeoAreaServed: 'Geo area served',
+        modifiedMedicaidBeneficiaries: isChipOnlyContract(currentContract)
+            ? 'CHIP beneficiaries'
+            : 'Medicaid beneficiaries',
+        modifiedRiskSharingStrategy: 'Risk-sharing strategy',
+        modifiedIncentiveArrangements: 'Incentive arrangements',
+        modifiedWitholdAgreements: 'Withhold arrangements',
+        modifiedStateDirectedPayments: 'State directed payments',
+        modifiedPassThroughPayments: 'Pass-through payments',
+        modifiedMedicalLossRatioStandards: 'Medical loss ratio standards',
+        modifiedOtherFinancialPaymentIncentive: 'Other financial payment',
+        modifiedGrevienceAndAppeal: 'Grievance and appeal',
+        modifiedNetworkAdequacyStandards: 'Network adequacy standards',
+        modifiedLengthOfContract: 'Length of the contract',
+        modifiedNonRiskPaymentArrangements: 'Non-risk payment arrangements',
+        modifiedPaymentsForMentalDiseaseInstitutions:
+            'Payments for mental disease institutions',
+    }
+
+    return baseLabelConfig[fieldPath]
+}
+
+const buildContractProvisionsRow = (
+    fieldChange: RevisionDiffFieldChange,
+    currentContract: ContractType,
+    statePrograms: ProgramType[]
+): ResubmitRevisionChangeRow | undefined => {
+    const rowOrder: ContractProvisionsFieldPath[] = [
+        'inLieuServicesAndSettings',
+        'modifiedBenefitsProvided',
+        'modifiedGeoAreaServed',
+        'modifiedMedicaidBeneficiaries',
+        'modifiedRiskSharingStrategy',
+        'modifiedIncentiveArrangements',
+        'modifiedWitholdAgreements',
+        'modifiedStateDirectedPayments',
+        'modifiedPassThroughPayments',
+        'modifiedMedicalLossRatioStandards',
+        'modifiedOtherFinancialPaymentIncentive',
+        'modifiedGrevienceAndAppeal',
+        'modifiedNetworkAdequacyStandards',
+        'modifiedLengthOfContract',
+        'modifiedNonRiskPaymentArrangements',
+        'modifiedPaymentsForMentalDiseaseInstitutions',
+    ]
+
+    if (
+        !rowOrder.includes(fieldChange.fieldPath as ContractProvisionsFieldPath)
+    ) {
+        return undefined
+    }
+
+    const typedFieldPath = fieldChange.fieldPath as ContractProvisionsFieldPath
+    const oldValue = formatFieldValue(
+        typedFieldPath,
+        fieldChange.oldValue,
+        statePrograms
+    )
+    const newValue = formatFieldValue(
+        typedFieldPath,
+        fieldChange.newValue,
+        statePrograms
+    )
+
+    if (!newValue) {
+        return undefined
+    }
+
+    const label = getProvisionLabel(typedFieldPath, currentContract)
+
+    if (oldValue === undefined) {
+        return {
+            label,
+            newValue,
+            isNew: true,
+        }
+    }
+
+    return {
+        label,
+        oldValue,
+        newValue,
+    }
+}
+
 const buildResubmitRevisionChanges = (
+    currentContract: ContractType,
     comparison: RevisionDiff,
     statePrograms: ProgramType[]
 ): ResubmitRevisionChanges => {
@@ -180,16 +452,43 @@ const buildResubmitRevisionChanges = (
             buildSubmissionTypeRow(fieldChange, statePrograms)
         )
         .filter((row): row is ResubmitRevisionChangeRow => row !== undefined)
+    const contractDetailsRows = comparison.fieldChanges
+        .map((fieldChange) =>
+            buildContractDetailsRow(fieldChange, statePrograms)
+        )
+        .filter((row): row is ResubmitRevisionChangeRow => row !== undefined)
+    const contractProvisionsRows = comparison.fieldChanges
+        .map((fieldChange) =>
+            buildContractProvisionsRow(
+                fieldChange,
+                currentContract,
+                statePrograms
+            )
+        )
+        .filter((row): row is ResubmitRevisionChangeRow => row !== undefined)
 
-    const sections: ResubmitRevisionChangeSection[] =
-        submissionTypeRows.length > 0
-            ? [
-                  {
-                      title: 'SUBMISSION TYPE',
-                      rows: submissionTypeRows,
-                  },
-              ]
-            : []
+    const sections: ResubmitRevisionChangeSection[] = []
+
+    if (submissionTypeRows.length > 0) {
+        sections.push({
+            title: 'SUBMISSION TYPE',
+            rows: submissionTypeRows,
+        })
+    }
+
+    if (contractDetailsRows.length > 0) {
+        sections.push({
+            title: 'CONTRACT DETAILS',
+            rows: contractDetailsRows,
+        })
+    }
+
+    if (contractProvisionsRows.length > 0) {
+        sections.push({
+            title: 'CONTRACT PROVISIONS',
+            rows: contractProvisionsRows,
+        })
+    }
 
     return {
         previousSubmissionDate: formatCalendarDate(

--- a/services/app-api/src/emailer/emails/resubmitRevisionChanges.ts
+++ b/services/app-api/src/emailer/emails/resubmitRevisionChanges.ts
@@ -1,8 +1,5 @@
 import { formatCalendarDate } from '@mc-review/dates'
-import {
-    ContractExecutionStatusRecord,
-    FederalAuthorityRecord,
-} from '@mc-review/submissions'
+import { FederalAuthorityRecord } from '@mc-review/submissions'
 import {
     type ContractType,
     type ProgramType,
@@ -31,6 +28,7 @@ type ResubmitRevisionChanges = {
 }
 
 const EMAIL_TIMEZONE = 'America/Los_Angeles'
+const MISSING_VALUE_PLACEHOLDER = '⎯'
 
 type SubmissionTypeFieldPath =
     | 'contractName'
@@ -52,6 +50,7 @@ type ContractDetailsFieldPath =
 type ContractProvisionsFieldPath =
     | 'inLieuServicesAndSettings'
     | 'modifiedBenefitsProvided'
+    | 'modifiedEnrollmentProcess'
     | 'modifiedGeoAreaServed'
     | 'modifiedMedicaidBeneficiaries'
     | 'modifiedRiskSharingStrategy'
@@ -117,6 +116,14 @@ const populationCoveredValueRecord: Record<PopulationCoveredValue, string> = {
 const contractActionTypeValueRecord: Record<ContractActionTypeValue, string> = {
     BASE: 'Base',
     AMENDMENT: 'Amendment',
+}
+
+const contractExecutionStatusValueRecord: Record<
+    ContractExecutionStatusValue,
+    string
+> = {
+    EXECUTED: 'Executed',
+    UNEXECUTED: 'Unexecuted',
 }
 
 const formatBooleanValue = (value: unknown): string | undefined => {
@@ -223,7 +230,7 @@ const formatFieldValue = (
         }
 
         if (fieldPath === 'contractExecutionStatus') {
-            return ContractExecutionStatusRecord[
+            return contractExecutionStatusValueRecord[
                 value as ContractExecutionStatusValue
             ]
         }
@@ -234,6 +241,7 @@ const formatFieldValue = (
         fieldPath === 'dsnpContract' ||
         fieldPath === 'inLieuServicesAndSettings' ||
         fieldPath === 'modifiedBenefitsProvided' ||
+        fieldPath === 'modifiedEnrollmentProcess' ||
         fieldPath === 'modifiedGeoAreaServed' ||
         fieldPath === 'modifiedMedicaidBeneficiaries' ||
         fieldPath === 'modifiedRiskSharingStrategy' ||
@@ -310,14 +318,14 @@ const buildSubmissionTypeRow = (
         statePrograms
     )
 
-    if (!oldValue || !newValue) {
+    if (oldValue === undefined) {
         return undefined
     }
 
     return {
         label,
         oldValue,
-        newValue,
+        newValue: newValue ?? MISSING_VALUE_PLACEHOLDER,
         ...(typedFieldPath === 'submissionDescription'
             ? { breakBeforeNewValue: true }
             : {}),
@@ -354,11 +362,11 @@ const buildContractDetailsRow = (
         statePrograms
     )
 
-    if (!newValue) {
-        return undefined
-    }
-
     if (oldValue === undefined) {
+        if (newValue === undefined) {
+            return undefined
+        }
+
         return {
             label,
             newValue,
@@ -369,7 +377,7 @@ const buildContractDetailsRow = (
     return {
         label,
         oldValue,
-        newValue,
+        newValue: newValue ?? MISSING_VALUE_PLACEHOLDER,
         ...(typedFieldPath === 'federalAuthorities'
             ? { breakBeforeNewValue: true }
             : {}),
@@ -383,6 +391,7 @@ const getProvisionLabel = (
     const baseLabelConfig: Record<ContractProvisionsFieldPath, string> = {
         inLieuServicesAndSettings: 'In Lieu-of Services and Settings',
         modifiedBenefitsProvided: 'Benefits provided',
+        modifiedEnrollmentProcess: 'Enrollment/disenrolment process',
         modifiedGeoAreaServed: 'Geo area served',
         modifiedMedicaidBeneficiaries: isChipOnlyContract(currentContract)
             ? 'CHIP beneficiaries'
@@ -413,6 +422,7 @@ const buildContractProvisionsRow = (
     const rowOrder: ContractProvisionsFieldPath[] = [
         'inLieuServicesAndSettings',
         'modifiedBenefitsProvided',
+        'modifiedEnrollmentProcess',
         'modifiedGeoAreaServed',
         'modifiedMedicaidBeneficiaries',
         'modifiedRiskSharingStrategy',
@@ -447,13 +457,13 @@ const buildContractProvisionsRow = (
         statePrograms
     )
 
-    if (!newValue) {
-        return undefined
-    }
-
     const label = getProvisionLabel(typedFieldPath, currentContract)
 
     if (oldValue === undefined) {
+        if (newValue === undefined) {
+            return undefined
+        }
+
         return {
             label,
             newValue,
@@ -464,7 +474,7 @@ const buildContractProvisionsRow = (
     return {
         label,
         oldValue,
-        newValue,
+        newValue: newValue ?? MISSING_VALUE_PLACEHOLDER,
     }
 }
 

--- a/services/app-api/src/emailer/emails/resubmitRevisionChanges.ts
+++ b/services/app-api/src/emailer/emails/resubmitRevisionChanges.ts
@@ -109,7 +109,7 @@ const submissionTypeValueRecord: Record<SubmissionTypeValue, string> = {
 
 const populationCoveredValueRecord: Record<PopulationCoveredValue, string> = {
     MEDICAID: 'Medicaid',
-    CHIP: 'CHIP',
+    CHIP: 'CHIP-only',
     MEDICAID_AND_CHIP: 'Medicaid and CHIP',
 }
 

--- a/services/app-api/src/emailer/emails/resubmitRevisionChanges.ts
+++ b/services/app-api/src/emailer/emails/resubmitRevisionChanges.ts
@@ -1,0 +1,32 @@
+import { formatCalendarDate } from '@mc-review/dates'
+import type { RevisionDiff } from '../../domain-models'
+
+type ResubmitRevisionChanges = {
+    previousSubmissionDate: string
+    currentSubmissionDate: string
+    hasChanges: boolean
+}
+
+const EMAIL_TIMEZONE = 'America/Los_Angeles'
+
+const buildResubmitRevisionChanges = (
+    comparison: RevisionDiff
+): ResubmitRevisionChanges | undefined => {
+    if (comparison.fieldChanges.length > 0) {
+        return undefined
+    }
+
+    return {
+        previousSubmissionDate: formatCalendarDate(
+            comparison.olderSubmittedAt,
+            EMAIL_TIMEZONE
+        ),
+        currentSubmissionDate: formatCalendarDate(
+            comparison.newerSubmittedAt,
+            EMAIL_TIMEZONE
+        ),
+        hasChanges: false,
+    }
+}
+
+export { buildResubmitRevisionChanges, type ResubmitRevisionChanges }

--- a/services/app-api/src/emailer/emails/resubmitRevisionChanges.ts
+++ b/services/app-api/src/emailer/emails/resubmitRevisionChanges.ts
@@ -15,6 +15,7 @@ type ResubmitRevisionChangeRow = {
     newValue: string
     oldValue?: string
     isNew?: boolean
+    breakBeforeNewValue?: boolean
 }
 
 type ResubmitRevisionChangeSection = {
@@ -298,6 +299,9 @@ const buildSubmissionTypeRow = (
         label,
         oldValue,
         newValue,
+        ...(typedFieldPath === 'submissionDescription'
+            ? { breakBeforeNewValue: true }
+            : {}),
     }
 }
 
@@ -347,6 +351,9 @@ const buildContractDetailsRow = (
         label,
         oldValue,
         newValue,
+        ...(typedFieldPath === 'federalAuthorities'
+            ? { breakBeforeNewValue: true }
+            : {}),
     }
 }
 

--- a/services/app-api/src/emailer/emails/resubmitRevisionChanges.ts
+++ b/services/app-api/src/emailer/emails/resubmitRevisionChanges.ts
@@ -1,20 +1,195 @@
 import { formatCalendarDate } from '@mc-review/dates'
-import type { RevisionDiff } from '../../domain-models'
+import type {
+    ProgramType,
+    RevisionDiff,
+    RevisionDiffFieldChange,
+} from '../../domain-models'
+
+type ResubmitRevisionChangeRow = {
+    label: string
+    oldValue: string
+    newValue: string
+}
+
+type ResubmitRevisionChangeSection = {
+    title: string
+    rows: ResubmitRevisionChangeRow[]
+}
 
 type ResubmitRevisionChanges = {
     previousSubmissionDate: string
     currentSubmissionDate: string
     hasChanges: boolean
+    sections: ResubmitRevisionChangeSection[]
 }
 
 const EMAIL_TIMEZONE = 'America/Los_Angeles'
 
-const buildResubmitRevisionChanges = (
-    comparison: RevisionDiff
-): ResubmitRevisionChanges | undefined => {
-    if (comparison.fieldChanges.length > 0) {
+type SubmissionTypeFieldPath =
+    | 'contractName'
+    | 'populationCovered'
+    | 'submissionType'
+    | 'contractType'
+    | 'riskBasedContract'
+    | 'programIDs'
+    | 'submissionDescription'
+
+type SubmissionTypeValue = 'CONTRACT_ONLY' | 'CONTRACT_AND_RATES'
+type PopulationCoveredValue = 'MEDICAID' | 'CHIP' | 'MEDICAID_AND_CHIP'
+type ContractActionTypeValue = 'BASE' | 'AMENDMENT'
+
+const submissionTypeValueRecord: Record<SubmissionTypeValue, string> = {
+    CONTRACT_ONLY: 'Contract only',
+    CONTRACT_AND_RATES: 'Contract and rate(s)',
+}
+
+const populationCoveredValueRecord: Record<PopulationCoveredValue, string> = {
+    MEDICAID: 'Medicaid',
+    CHIP: 'CHIP',
+    MEDICAID_AND_CHIP: 'Medicaid and CHIP',
+}
+
+const contractActionTypeValueRecord: Record<ContractActionTypeValue, string> = {
+    BASE: 'Base',
+    AMENDMENT: 'Amendment',
+}
+
+const formatBooleanValue = (value: unknown): string | undefined => {
+    if (value === true) {
+        return 'Yes'
+    }
+
+    if (value === false) {
+        return 'No'
+    }
+
+    return undefined
+}
+
+const formatProgramsValue = (
+    value: unknown,
+    statePrograms: ProgramType[]
+): string | undefined => {
+    if (!Array.isArray(value)) {
         return undefined
     }
+
+    const names = value
+        .map((programID) =>
+            statePrograms.find((program) => program.id === String(programID))
+        )
+        .filter((program): program is ProgramType => Boolean(program))
+        .map((program) => program.name)
+
+    return names.length > 0 ? names.join(', ') : undefined
+}
+
+const formatFieldValue = (
+    fieldPath: SubmissionTypeFieldPath,
+    value: unknown,
+    statePrograms: ProgramType[]
+): string | undefined => {
+    if (typeof value === 'string') {
+        if (fieldPath === 'contractName') {
+            return value
+        }
+
+        if (fieldPath === 'populationCovered') {
+            return populationCoveredValueRecord[value as PopulationCoveredValue]
+        }
+
+        if (fieldPath === 'submissionType') {
+            return submissionTypeValueRecord[value as SubmissionTypeValue]
+        }
+
+        if (fieldPath === 'contractType') {
+            return contractActionTypeValueRecord[
+                value as ContractActionTypeValue
+            ]
+        }
+
+        if (fieldPath === 'submissionDescription') {
+            return value
+        }
+    }
+
+    if (fieldPath === 'riskBasedContract') {
+        return formatBooleanValue(value)
+    }
+
+    if (fieldPath === 'programIDs') {
+        return formatProgramsValue(value, statePrograms)
+    }
+
+    return undefined
+}
+
+const buildSubmissionTypeRow = (
+    fieldChange: RevisionDiffFieldChange,
+    statePrograms: ProgramType[]
+): ResubmitRevisionChangeRow | undefined => {
+    const rowConfig: Record<SubmissionTypeFieldPath, string> = {
+        contractName: 'Submission ID',
+        populationCovered: 'Medicaid populations',
+        submissionType: 'Submission type',
+        contractType: 'Contract action type',
+        riskBasedContract: 'Risk-based contract',
+        programIDs: 'Programs',
+        submissionDescription: 'Submission description',
+    }
+
+    if (!(fieldChange.fieldPath in rowConfig)) {
+        return undefined
+    }
+
+    const typedFieldPath = fieldChange.fieldPath as SubmissionTypeFieldPath
+    const label = rowConfig[typedFieldPath]
+
+    if (!label) {
+        return undefined
+    }
+
+    const oldValue = formatFieldValue(
+        typedFieldPath,
+        fieldChange.oldValue,
+        statePrograms
+    )
+    const newValue = formatFieldValue(
+        typedFieldPath,
+        fieldChange.newValue,
+        statePrograms
+    )
+
+    if (!oldValue || !newValue) {
+        return undefined
+    }
+
+    return {
+        label,
+        oldValue,
+        newValue,
+    }
+}
+
+const buildResubmitRevisionChanges = (
+    comparison: RevisionDiff,
+    statePrograms: ProgramType[]
+): ResubmitRevisionChanges => {
+    const submissionTypeRows = comparison.fieldChanges
+        .map((fieldChange) =>
+            buildSubmissionTypeRow(fieldChange, statePrograms)
+        )
+        .filter((row): row is ResubmitRevisionChangeRow => row !== undefined)
+
+    const sections: ResubmitRevisionChangeSection[] =
+        submissionTypeRows.length > 0
+            ? [
+                  {
+                      title: 'SUBMISSION TYPE',
+                      rows: submissionTypeRows,
+                  },
+              ]
+            : []
 
     return {
         previousSubmissionDate: formatCalendarDate(
@@ -25,7 +200,8 @@ const buildResubmitRevisionChanges = (
             comparison.newerSubmittedAt,
             EMAIL_TIMEZONE
         ),
-        hasChanges: false,
+        hasChanges: comparison.fieldChanges.length > 0,
+        sections,
     }
 }
 

--- a/services/app-api/src/emailer/emails/resubmitRevisionChanges.ts
+++ b/services/app-api/src/emailer/emails/resubmitRevisionChanges.ts
@@ -80,6 +80,25 @@ type FederalAuthorityValue =
     | 'BENCHMARK'
     | 'TITLE_XXI'
 
+const submissionTypeFieldOrder: SubmissionTypeFieldPath[] = [
+    'contractName',
+    'populationCovered',
+    'submissionType',
+    'contractType',
+    'riskBasedContract',
+    'programIDs',
+    'submissionDescription',
+]
+
+const contractDetailsFieldOrder: ContractDetailsFieldPath[] = [
+    'contractExecutionStatus',
+    'contractDateStart',
+    'contractDateEnd',
+    'managedCareEntities',
+    'federalAuthorities',
+    'dsnpContract',
+]
+
 const isChipOnlyContract = (contract: ContractType): boolean =>
     contract.packageSubmissions[0]?.contractRevision.formData
         .populationCovered === 'CHIP'
@@ -455,15 +474,45 @@ const buildResubmitRevisionChanges = (
     statePrograms: ProgramType[]
 ): ResubmitRevisionChanges => {
     const submissionTypeRows = comparison.fieldChanges
-        .map((fieldChange) =>
-            buildSubmissionTypeRow(fieldChange, statePrograms)
+        .flatMap((fieldChange) => {
+            const row = buildSubmissionTypeRow(fieldChange, statePrograms)
+
+            return row
+                ? [
+                      {
+                          row,
+                          fieldPath:
+                              fieldChange.fieldPath as SubmissionTypeFieldPath,
+                      },
+                  ]
+                : []
+        })
+        .sort(
+            (left, right) =>
+                submissionTypeFieldOrder.indexOf(left.fieldPath) -
+                submissionTypeFieldOrder.indexOf(right.fieldPath)
         )
-        .filter((row): row is ResubmitRevisionChangeRow => row !== undefined)
+        .map(({ row }) => row)
     const contractDetailsRows = comparison.fieldChanges
-        .map((fieldChange) =>
-            buildContractDetailsRow(fieldChange, statePrograms)
+        .flatMap((fieldChange) => {
+            const row = buildContractDetailsRow(fieldChange, statePrograms)
+
+            return row
+                ? [
+                      {
+                          row,
+                          fieldPath:
+                              fieldChange.fieldPath as ContractDetailsFieldPath,
+                      },
+                  ]
+                : []
+        })
+        .sort(
+            (left, right) =>
+                contractDetailsFieldOrder.indexOf(left.fieldPath) -
+                contractDetailsFieldOrder.indexOf(right.fieldPath)
         )
-        .filter((row): row is ResubmitRevisionChangeRow => row !== undefined)
+        .map(({ row }) => row)
     const contractProvisionsRows = comparison.fieldChanges
         .map((fieldChange) =>
             buildContractProvisionsRow(

--- a/services/app-api/src/emailer/etaTemplates/resubmitChipOnlyCMSEmail.eta
+++ b/services/app-api/src/emailer/etaTemplates/resubmitChipOnlyCMSEmail.eta
@@ -8,3 +8,6 @@ Submission <%= it.packageName %> is not subject to DMCO review and validation.<b
 <b>Summary of changes</b>: <%= it.resubmissionReason %><br />
 <br />
 <a href="<%= it.submissionURL%>">View submission</a><br />
+<% if (it.revisionChanges) { %>
+<%~ includeFile('./reusableTemplates/resubmitRevisionChanges', it) %>
+<% } %>

--- a/services/app-api/src/emailer/etaTemplates/resubmitContractCMSEmail.eta
+++ b/services/app-api/src/emailer/etaTemplates/resubmitContractCMSEmail.eta
@@ -3,3 +3,7 @@ The state completed their edits on submission <%= it.packageName %><br />
 <%~ includeFile('./resubmitContractSummary', it) %>
 <br />
 <a href="<%= it.submissionURL %>">View the full submission</a>
+<% if (it.revisionChanges) { %>
+<br />
+<%~ includeFile('./reusableTemplates/resubmitRevisionChanges', it) %>
+<% } %>

--- a/services/app-api/src/emailer/etaTemplates/resubmitContractCMSEmail.eta
+++ b/services/app-api/src/emailer/etaTemplates/resubmitContractCMSEmail.eta
@@ -4,6 +4,5 @@ The state completed their edits on submission <%= it.packageName %><br />
 <br />
 <a href="<%= it.submissionURL %>">View the full submission</a>
 <% if (it.revisionChanges) { %>
-<br />
 <%~ includeFile('./reusableTemplates/resubmitRevisionChanges', it) %>
 <% } %>

--- a/services/app-api/src/emailer/etaTemplates/reusableTemplates/resubmitRevisionChanges.eta
+++ b/services/app-api/src/emailer/etaTemplates/reusableTemplates/resubmitRevisionChanges.eta
@@ -1,5 +1,6 @@
 <hr />
-<br />
+<div style="height: 32px; line-height: 32px;">&nbsp;</div>
+<div style="height: 32px; line-height: 32px;">&nbsp;</div>
 <div style="padding: 4px 0;">
     <strong>Submission changes: <%= it.revisionChanges.previousSubmissionDate %> → <%= it.revisionChanges.currentSubmissionDate %></strong>
 </div>
@@ -9,14 +10,18 @@
 </div>
 <% } %>
 <% if (it.revisionChanges.hasChanges) { %>
-<% it.revisionChanges.sections.forEach(function(section) { %>
+<div style="height: 16px; line-height: 16px;">&nbsp;</div>
+<% it.revisionChanges.sections.forEach(function(section, index) { %>
+<% if (index > 0) { %>
+<div style="height: 32px; line-height: 32px;">&nbsp;</div>
+<% } %>
 <div style="padding: 4px 0;">
     <strong><%= section.title %></strong>
 </div>
 <% section.rows.forEach(function(row) { %>
 <% if (row.isNew) { %>
 <div style="padding: 4px 0;">
-    <strong>NEW <%= row.label %>:</strong> <%= row.newValue %>
+    <strong><span style="color: <%= it.revisionChangesNewIndicatorColor %>; font-family: Inter, Arial, sans-serif; font-size: 13px; font-style: normal; font-weight: 700; line-height: 150%;">NEW</span> <%= row.label %>:</strong> <%= row.newValue %>
 </div>
 <% } else { %>
 <div style="padding: 4px 0;">

--- a/services/app-api/src/emailer/etaTemplates/reusableTemplates/resubmitRevisionChanges.eta
+++ b/services/app-api/src/emailer/etaTemplates/reusableTemplates/resubmitRevisionChanges.eta
@@ -1,0 +1,7 @@
+<hr />
+<br />
+<strong>Submission changes: <%= it.revisionChanges.previousSubmissionDate %> -> <%= it.revisionChanges.currentSubmissionDate %></strong><br />
+<br />
+<% if (!it.revisionChanges.hasChanges) { %>
+No changes made in the submission on <%= it.revisionChanges.currentSubmissionDate %>.<br />
+<% } %>

--- a/services/app-api/src/emailer/etaTemplates/reusableTemplates/resubmitRevisionChanges.eta
+++ b/services/app-api/src/emailer/etaTemplates/reusableTemplates/resubmitRevisionChanges.eta
@@ -10,8 +10,13 @@ No changes made in the submission on <%= it.revisionChanges.currentSubmissionDat
 <strong><%= section.title %></strong><br />
 <br />
 <% section.rows.forEach(function(row) { %>
+<% if (row.isNew) { %>
+<strong>NEW <%= row.label %>:</strong> <%= row.newValue %><br />
+<br />
+<% } else { %>
 <strong><%= row.label %>:</strong> <%= row.oldValue %> → <%= row.newValue %><br />
 <br />
+<% } %>
 <% }) %>
 <% }) %>
 <% } %>

--- a/services/app-api/src/emailer/etaTemplates/reusableTemplates/resubmitRevisionChanges.eta
+++ b/services/app-api/src/emailer/etaTemplates/reusableTemplates/resubmitRevisionChanges.eta
@@ -1,7 +1,17 @@
 <hr />
 <br />
-<strong>Submission changes: <%= it.revisionChanges.previousSubmissionDate %> -> <%= it.revisionChanges.currentSubmissionDate %></strong><br />
+<strong>Submission changes: <%= it.revisionChanges.previousSubmissionDate %> → <%= it.revisionChanges.currentSubmissionDate %></strong><br />
 <br />
 <% if (!it.revisionChanges.hasChanges) { %>
 No changes made in the submission on <%= it.revisionChanges.currentSubmissionDate %>.<br />
+<% } %>
+<% if (it.revisionChanges.hasChanges) { %>
+<% it.revisionChanges.sections.forEach(function(section) { %>
+<strong><%= section.title %></strong><br />
+<br />
+<% section.rows.forEach(function(row) { %>
+<strong><%= row.label %>:</strong> <%= row.oldValue %> → <%= row.newValue %><br />
+<br />
+<% }) %>
+<% }) %>
 <% } %>

--- a/services/app-api/src/emailer/etaTemplates/reusableTemplates/resubmitRevisionChanges.eta
+++ b/services/app-api/src/emailer/etaTemplates/reusableTemplates/resubmitRevisionChanges.eta
@@ -1,21 +1,27 @@
 <hr />
 <br />
-<strong>Submission changes: <%= it.revisionChanges.previousSubmissionDate %> → <%= it.revisionChanges.currentSubmissionDate %></strong><br />
-<br />
+<div style="padding: 4px 0;">
+    <strong>Submission changes: <%= it.revisionChanges.previousSubmissionDate %> → <%= it.revisionChanges.currentSubmissionDate %></strong>
+</div>
 <% if (!it.revisionChanges.hasChanges) { %>
-No changes made in the submission on <%= it.revisionChanges.currentSubmissionDate %>.<br />
+<div style="padding: 4px 0;">
+    No changes made in the submission on <%= it.revisionChanges.currentSubmissionDate %>.
+</div>
 <% } %>
 <% if (it.revisionChanges.hasChanges) { %>
 <% it.revisionChanges.sections.forEach(function(section) { %>
-<strong><%= section.title %></strong><br />
-<br />
+<div style="padding: 4px 0;">
+    <strong><%= section.title %></strong>
+</div>
 <% section.rows.forEach(function(row) { %>
 <% if (row.isNew) { %>
-<strong>NEW <%= row.label %>:</strong> <%= row.newValue %><br />
-<br />
+<div style="padding: 4px 0;">
+    <strong>NEW <%= row.label %>:</strong> <%= row.newValue %>
+</div>
 <% } else { %>
-<strong><%= row.label %>:</strong> <%= row.oldValue %> → <%= row.newValue %><br />
-<br />
+<div style="padding: 4px 0;">
+    <strong><%= row.label %>:</strong> <%= row.oldValue %><% if (row.breakBeforeNewValue) { %><br />→ <%= row.newValue %><% } else { %> → <%= row.newValue %><% } %>
+</div>
 <% } %>
 <% }) %>
 <% }) %>

--- a/services/app-api/src/emailer/etaTemplates/reusableTemplates/resubmitRevisionChanges.eta
+++ b/services/app-api/src/emailer/etaTemplates/reusableTemplates/resubmitRevisionChanges.eta
@@ -1,6 +1,4 @@
 <hr />
-<div style="height: 32px; line-height: 32px;">&nbsp;</div>
-<div style="height: 32px; line-height: 32px;">&nbsp;</div>
 <div style="padding: 4px 0;">
     <strong>Submission changes: <%= it.revisionChanges.previousSubmissionDate %> → <%= it.revisionChanges.currentSubmissionDate %></strong>
 </div>
@@ -10,10 +8,11 @@
 </div>
 <% } %>
 <% if (it.revisionChanges.hasChanges) { %>
-<div style="height: 16px; line-height: 16px;">&nbsp;</div>
+<br />
 <% it.revisionChanges.sections.forEach(function(section, index) { %>
 <% if (index > 0) { %>
-<div style="height: 32px; line-height: 32px;">&nbsp;</div>
+<br />
+<br />
 <% } %>
 <div style="padding: 4px 0;">
     <strong><%= section.title %></strong>

--- a/services/app-api/src/emailer/styleConstants.ts
+++ b/services/app-api/src/emailer/styleConstants.ts
@@ -1,0 +1,8 @@
+// Mirror email-safe design tokens used by app-api templates.
+// Keep these aligned with shared UI tokens where possible.
+
+const emailColors = {
+    revisionChangesNewIndicator: '#0D600A',
+} as const
+
+export { emailColors }

--- a/services/app-api/src/resolvers/contract/submitContract.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.ts
@@ -1,5 +1,8 @@
 import type { Emailer } from '../../emailer'
-import type { LDService } from '../../launchDarkly/launchDarkly'
+import {
+    defaultFeatureFlags,
+    type LDService,
+} from '../../launchDarkly/launchDarkly'
 import type { Store } from '../../postgres'
 import { NotFoundError } from '../../postgres'
 import { logError, logResolverError, logResolverSuccess } from '../../logger'
@@ -34,6 +37,7 @@ import {
 import type { GeneralizedProvisionType } from '@mc-review/submissions'
 import { canWrite } from '../../oauth/oauthAuthorization'
 import type { DocumentZipService } from '../../zip/generateZip'
+import { buildResubmitRevisionChanges } from '../../emailer/emails/resubmitRevisionChanges'
 
 const validateStatusAndUpdateInfo = (
     status: PackageStatusType,
@@ -74,9 +78,10 @@ export function submitContract(
             async (span) => {
                 setResolverDetails(span, user)
 
-                const featureFlags = await launchDarkly.allFlags({
-                    key: context.user.email,
-                })
+                const featureFlags =
+                    (await launchDarkly.allFlags({
+                        key: context.user.email,
+                    })) ?? defaultFeatureFlags()
 
                 // Check OAuth client read permissions
                 if (!canWrite(context)) {
@@ -571,6 +576,30 @@ export function submitContract(
                 let stateContractEmailResult
 
                 if (status === 'RESUBMITTED') {
+                    let revisionChanges
+
+                    if (
+                        featureFlags['revision-history-enhancements'] &&
+                        !isEQRO
+                    ) {
+                        const revisionDiff =
+                            await store.findRevisionDiffByContractID({
+                                contractID: submitContractResult.id,
+                            })
+
+                        if (revisionDiff instanceof Error) {
+                            logResolverError(
+                                'submitContract - revision diff lookup failed',
+                                revisionDiff,
+                                context
+                            )
+                            recordResolverError(span, revisionDiff)
+                        } else {
+                            revisionChanges =
+                                buildResubmitRevisionChanges(revisionDiff)
+                        }
+                    }
+
                     cmsContractEmailResult = isEQRO
                         ? await emailer.sendResubmittedEQROCMSEmail(
                               submitContractResult,
@@ -581,7 +610,8 @@ export function submitContract(
                               submitContractResult,
                               updateInfo,
                               stateAnalystsEmails,
-                              statePrograms
+                              statePrograms,
+                              revisionChanges
                           )
                     stateContractEmailResult = isEQRO
                         ? await emailer.sendResubmittedEQROStateEmail(

--- a/services/app-api/src/resolvers/contract/submitContract.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.ts
@@ -595,8 +595,10 @@ export function submitContract(
                             )
                             recordResolverError(span, revisionDiff)
                         } else {
-                            revisionChanges =
-                                buildResubmitRevisionChanges(revisionDiff)
+                            revisionChanges = buildResubmitRevisionChanges(
+                                revisionDiff,
+                                statePrograms
+                            )
                         }
                     }
 

--- a/services/app-api/src/resolvers/contract/submitContract.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.ts
@@ -596,6 +596,7 @@ export function submitContract(
                             recordResolverError(span, revisionDiff)
                         } else {
                             revisionChanges = buildResubmitRevisionChanges(
+                                submitContractResult,
                                 revisionDiff,
                                 statePrograms
                             )


### PR DESCRIPTION
## Summary
Surface Contract DIFF values in the CMS Resubmit email. Part 1: Submission Type, Contract Details, Contract Provisions

#### Related issues
[MCR-6326](https://jiraent.cms.gov/browse/MCR-6326)
#### Screenshots
<img width="528" height="571" alt="Screenshot 2026-08-03 at 2 45 28 PM" src="https://github.com/user-attachments/assets/1bd82d01-e4c4-4e9f-aac1-3322b99a1e75" />
<img width="411" height="550" alt="Screenshot 2026-08-03 at 2 45 51 PM" src="https://github.com/user-attachments/assets/32c5b87e-8524-41aa-bd48-31f3f8522b36" />

#### Test cases covered
resubmitRevisionChanges.test.ts
resubmitContractCMSEmail.test.ts

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
Locally, log in as a State user, submit Health Plan contract. 
As a CMS Approver user, unlock this record. 
As a State user re-open the contract record, make edits and re-submit. 
Use MC-Review Local Dev Console to examine the content of the CMS Re-submit email, compare the result with data changes and [Figma design](https://www.figma.com/design/frKNnm6lkcpdjJ2eVJE8Bj/Managed-Care-Review?node-id=28705-5195&p=f&m=dev).
<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed