### PR TITLE
[MCR-6482] Review decision is not displayed for submissions with populations other than CHIP-only

### DIFF
--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.test.tsx
@@ -436,29 +436,37 @@ describe('SubmissionTypeSummarySection', () => {
         expect(screen.queryByText(/\(retired\)/)).not.toBeInTheDocument()
     })
 
-    it('renders CHIP-only Review decision with DMCO override text when NOT_SUBJECT_TO_REVIEW', async () => {
-        const contract = mockContractPackageSubmitted({
-            consolidatedStatus: 'NOT_SUBJECT_TO_REVIEW',
-            reviewStatus: 'NOT_SUBJECT_TO_REVIEW',
-        })
-        contract.packageSubmissions[0].contractRevision.formData.populationCovered =
-            'CHIP'
-        renderWithProviders(
-            <SubmissionTypeSummarySection
-                contract={contract}
-                editNavigateTo="submission-type"
-                submissionName="MN-MSHO-0003"
-                isStateUser={true}
-                initiallySubmittedAt={contract.initiallySubmittedAt}
-            />
-        )
-        const reviewDecision = await screen.findByRole('definition', {
-            name: 'Review decision',
-        })
-        expect(reviewDecision).toHaveTextContent(
-            'Not subject to DMCO review and validation'
-        )
-    })
+    it.each([
+        'NOT_SUBJECT_TO_REVIEW',
+        'SUBMITTED',
+        'RESUBMITTED',
+        'APPROVED',
+        'WITHDRAWN',
+    ] as const)(
+        'renders CHIP-only Review decision as not subject to review when consolidated status is %s',
+        async (consolidatedStatus) => {
+            const contract = mockContractPackageSubmitted({
+                consolidatedStatus,
+            })
+            contract.packageSubmissions[0].contractRevision.formData.populationCovered =
+                'CHIP'
+            renderWithProviders(
+                <SubmissionTypeSummarySection
+                    contract={contract}
+                    editNavigateTo="submission-type"
+                    submissionName="MN-MSHO-0003"
+                    isStateUser={true}
+                    initiallySubmittedAt={contract.initiallySubmittedAt}
+                />
+            )
+            const reviewDecision = await screen.findByRole('definition', {
+                name: 'Review decision',
+            })
+            expect(reviewDecision).toHaveTextContent(
+                'Not subject to DMCO review and validation'
+            )
+        }
+    )
 
     it('does not render Review decision when not CHIP-only', async () => {
         const contract = mockContractPackageSubmitted({

--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.test.tsx
@@ -436,7 +436,7 @@ describe('SubmissionTypeSummarySection', () => {
         expect(screen.queryByText(/\(retired\)/)).not.toBeInTheDocument()
     })
 
-    it('renders CHIP-only Review decision with DMCO override text when NOT_SUBJECT_TO_REVIEW', () => {
+    it('renders CHIP-only Review decision with DMCO override text when NOT_SUBJECT_TO_REVIEW', async () => {
         const contract = mockContractPackageSubmitted({
             consolidatedStatus: 'NOT_SUBJECT_TO_REVIEW',
             reviewStatus: 'NOT_SUBJECT_TO_REVIEW',
@@ -452,7 +452,7 @@ describe('SubmissionTypeSummarySection', () => {
                 initiallySubmittedAt={contract.initiallySubmittedAt}
             />
         )
-        const reviewDecision = screen.getByRole('definition', {
+        const reviewDecision = await screen.findByRole('definition', {
             name: 'Review decision',
         })
         expect(reviewDecision).toHaveTextContent(
@@ -460,10 +460,12 @@ describe('SubmissionTypeSummarySection', () => {
         )
     })
 
-    it('renders Review decision with normalized status text when not CHIP-only', () => {
+    it('does not render Review decision when not CHIP-only', async () => {
         const contract = mockContractPackageSubmitted({
             consolidatedStatus: 'SUBMITTED',
         })
+        contract.packageSubmissions[0].contractRevision.formData.populationCovered =
+            'MEDICAID'
         renderWithProviders(
             <SubmissionTypeSummarySection
                 contract={contract}
@@ -473,10 +475,36 @@ describe('SubmissionTypeSummarySection', () => {
                 initiallySubmittedAt={contract.initiallySubmittedAt}
             />
         )
-        const reviewDecision = screen.getByRole('definition', {
-            name: 'Review decision',
+        await screen.findByRole('definition', {
+            name: 'Which populations does this contract action cover?',
         })
-        expect(reviewDecision).toHaveTextContent('Submitted')
+        expect(
+            screen.queryByRole('definition', { name: 'Review decision' })
+        ).not.toBeInTheDocument()
+    })
+
+    it('does not render Review decision on a past version that is no longer CHIP-only', async () => {
+        const contract = mockContractPackageSubmitted({
+            consolidatedStatus: 'RESUBMITTED',
+        })
+        const contractRev = contract.packageSubmissions[0].contractRevision
+        contractRev.formData.populationCovered = 'MEDICAID'
+        renderWithProviders(
+            <SubmissionTypeSummarySection
+                contract={contract}
+                contractRev={contractRev}
+                editNavigateTo="submission-type"
+                submissionName="MN-MSHO-0003"
+                isStateUser={true}
+                initiallySubmittedAt={contract.initiallySubmittedAt}
+            />
+        )
+        await screen.findByRole('definition', {
+            name: 'Which populations does this contract action cover?',
+        })
+        expect(
+            screen.queryByRole('definition', { name: 'Review decision' })
+        ).not.toBeInTheDocument()
     })
 
     it('does not render fields with missing fields for submitted package on submission summary', () => {

--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.tsx
@@ -26,6 +26,8 @@ import {
 } from '../SummarySectionFields'
 import { formattedProgramNames } from '../../../formHelpers'
 import { getConsolidatedContractStatusText } from '../../ContractTable'
+import { useLDClient } from 'launchdarkly-react-client-sdk'
+import { featureFlags } from '@mc-review/common-code'
 
 export type SubmissionTypeSummarySectionProps = {
     contract: Contract | UnlockedContract
@@ -51,12 +53,18 @@ export const SubmissionTypeSummarySection = ({
     explainMissingData,
 }: SubmissionTypeSummarySectionProps): React.ReactElement => {
     const contractOrRev = contractRev ? contractRev : contract
+    const ldClient = useLDClient()
     const contractFormData = getVisibleLatestContractFormData(
         contractOrRev,
         isStateUser
     )
 
     if (!contractFormData) return <GenericErrorPage />
+
+    const chipSubmissionAutomation = ldClient?.variation(
+        featureFlags.CHIP_SUBMISSION_AUTOMATION.flag,
+        featureFlags.CHIP_SUBMISSION_AUTOMATION.defaultValue
+    )
 
     const programIDs = contractFormData?.programIDs ?? []
     const programNames = formattedProgramNames(
@@ -86,20 +94,22 @@ export const SubmissionTypeSummarySection = ({
                 {headerChildComponent && headerChildComponent}
             </SectionHeader>
             <dl>
-                {contract.consolidatedStatus && isSubmitted && (
-                    <ReviewDecisionSummary
-                        reviewDecision={
-                            contract.consolidatedStatus ===
-                                'NOT_SUBJECT_TO_REVIEW' &&
-                            contractFormData.populationCovered === 'CHIP'
-                                ? 'Not subject to DMCO review and validation'
-                                : getConsolidatedContractStatusText(
-                                      contract.consolidatedStatus
-                                  )
-                        }
-                        explainMissingData={explainMissingData}
-                    />
-                )}
+                {contract.consolidatedStatus &&
+                    isSubmitted &&
+                    chipSubmissionAutomation &&
+                    contractFormData.populationCovered === 'CHIP' && (
+                        <ReviewDecisionSummary
+                            reviewDecision={
+                                contract.consolidatedStatus ===
+                                'NOT_SUBJECT_TO_REVIEW'
+                                    ? 'Not subject to DMCO review and validation'
+                                    : getConsolidatedContractStatusText(
+                                          contract.consolidatedStatus
+                                      )
+                            }
+                            explainMissingData={explainMissingData}
+                        />
+                    )}
                 <MultiColumnGrid columns={2}>
                     {initiallySubmittedAt &&
                         (isSubmitted || (!isStateUser && isUnlocked)) && (

--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.tsx
@@ -25,7 +25,6 @@ import {
     UpdatedAtSummary,
 } from '../SummarySectionFields'
 import { formattedProgramNames } from '../../../formHelpers'
-import { getConsolidatedContractStatusText } from '../../ContractTable'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { featureFlags } from '@mc-review/common-code'
 
@@ -94,19 +93,11 @@ export const SubmissionTypeSummarySection = ({
                 {headerChildComponent && headerChildComponent}
             </SectionHeader>
             <dl>
-                {contract.consolidatedStatus &&
-                    isSubmitted &&
+                {isSubmitted &&
                     chipSubmissionAutomation &&
                     contractFormData.populationCovered === 'CHIP' && (
                         <ReviewDecisionSummary
-                            reviewDecision={
-                                contract.consolidatedStatus ===
-                                'NOT_SUBJECT_TO_REVIEW'
-                                    ? 'Not subject to DMCO review and validation'
-                                    : getConsolidatedContractStatusText(
-                                          contract.consolidatedStatus
-                                      )
-                            }
+                            reviewDecision="Not subject to DMCO review and validation"
                             explainMissingData={explainMissingData}
                         />
                     )}


### PR DESCRIPTION
## Summary
Bug discovered on submission [MCR-FL-0135-MMA](https://mc-review-dev.onemac.cms.gov/submissions/health-plan/fd6ff171-76ff-4a1c-9076-871b7781ce25) 

**Current behavior:**
- Managed Care Plan (MCP) (health plan) submissions that should NOT have a review decision displayed (submissions with populations other than CHIP-only) in the submitted status, display "Review decision: Submitted" on the submission summary
- Review decision submitted is visible on previous submission versions

**Expected behavior:**
- Review decision is not displayed

**Steps to reproduce:**
- Log in as a state user
- Find an unlocked MCP (health plan submission) that was previously submitted with Medicaid and CHIP populations
- While unlocked, change the populations to Medicaid
- Resubmit
- View the resubmitted submission as a state user
- View past submission version

#### Related issues
[MCR-6482](https://jiraent.cms.gov/browse/MCR-6482)
#### Screenshots
Non-CHIP only:
<img width="804" height="691" alt="image" src="https://github.com/user-attachments/assets/abc2b796-116c-4759-83de-a1c77afe74da" />

CHIP-only:
<img width="803" height="542" alt="image" src="https://github.com/user-attachments/assets/fc118276-7234-4cba-9cff-833363e48202" />

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
1. Log in as a state user and open a Medicaid (non-CHIP) health plan submission that's been submitted -> no "Review decision" row in the Submission type section
2. On that submission, open Change history -> View past submission version -> still no "Review decision" row
3. Open a CHIP-only submission -> "Review decision: Not subject to DMCO review and validation" still shows
4. Log in as a CMS user, repeat step 1 -> no "Review decision" row
<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed