### PR TITLE
MCR-6483: provisions display incorrectly on past submissions

### DIFF
--- a/packages/submissions/src/contract/healthPlanFormDataValidtions.ts
+++ b/packages/submissions/src/contract/healthPlanFormDataValidtions.ts
@@ -102,16 +102,20 @@ const isMedicaidAmendmentProvision = (
 
 // Returns the list of provision keys that apply for given submission variant
 const generateApplicableProvisionsList = (
-    draftSubmission: Contract | UnlockedContract
+    formData: ContractFormData
 ):
     | CHIPProvisionType[]
     | MedicaidBaseProvisionType[]
     | MedicaidAmendmentProvisionType[] => {
-    if (isCHIPOnly(draftSubmission)) {
-        return isContractAmendment(draftSubmission)
+    const chipOnly = formData.populationCovered === 'CHIP'
+    const contractAmendment = formData.contractType === 'AMENDMENT'
+    const baseContract = formData.contractType === 'BASE'
+
+    if (chipOnly) {
+        return contractAmendment
             ? (provisionCHIPKeys as unknown as CHIPProvisionType[])
             : [] // there are no applicable provisions for CHIP base contract
-    } else if (isBaseContract(draftSubmission)) {
+    } else if (baseContract) {
         return modifiedProvisionMedicaidBaseKeys as unknown as MedicaidBaseProvisionType[]
     } else {
         return modifiedProvisionMedicaidAmendmentKeys as unknown as MedicaidAmendmentProvisionType[]
@@ -120,20 +124,18 @@ const generateApplicableProvisionsList = (
 
 // Returns user-friendly label text for the provision based on the given submission variant
 const generateProvisionLabel = (
-    draftSubmission: Contract | UnlockedContract,
+    formData: ContractFormData,
     provision: GeneralizedProvisionType
 ): string => {
-    if (isCHIPOnly(draftSubmission) && isCHIPProvision(provision)) {
+    const isChipOnly = formData.populationCovered === 'CHIP'
+    const isBaseContract = formData.contractType === 'BASE'
+    const isContractAmendment = formData.contractType === 'AMENDMENT'
+
+    if (isChipOnly && isCHIPProvision(provision)) {
         return ModifiedProvisionsCHIPRecord[provision]
-    } else if (
-        isBaseContract(draftSubmission) &&
-        isMedicaidBaseProvision(provision)
-    ) {
+    } else if (isBaseContract && isMedicaidBaseProvision(provision)) {
         return ModifiedProvisionsBaseContractRecord[provision]
-    } else if (
-        isContractAmendment(draftSubmission) &&
-        isMedicaidAmendmentProvision(provision)
-    ) {
+    } else if (isContractAmendment && isMedicaidAmendmentProvision(provision)) {
         return ModifiedProvisionsAmendmentRecord[provision]
     } else {
         console.warn('Coding Error: This is a fallback case and is unexpected.')
@@ -147,44 +149,41 @@ const generateProvisionLabel = (
     That functionality needed for unlocked contracts which can be edited in a non-linear fashion)
 */
 const sortModifiedProvisions = (
-    contract: Contract | UnlockedContract
+    formData: ContractFormData
 ): [GeneralizedProvisionType[], GeneralizedProvisionType[]] => {
-    const contractFormData =
-        contract.draftRevision?.formData ||
-        getLastContractSubmission(contract)?.contractRevision.formData
     const initialProvisions = {
-        inLieuServicesAndSettings: contractFormData?.inLieuServicesAndSettings,
-        modifiedBenefitsProvided: contractFormData?.modifiedBenefitsProvided,
-        modifiedGeoAreaServed: contractFormData?.modifiedGeoAreaServed,
+        inLieuServicesAndSettings: formData.inLieuServicesAndSettings,
+        modifiedBenefitsProvided: formData.modifiedBenefitsProvided,
+        modifiedGeoAreaServed: formData.modifiedGeoAreaServed,
         modifiedMedicaidBeneficiaries:
-            contractFormData?.modifiedMedicaidBeneficiaries,
+            formData.modifiedMedicaidBeneficiaries,
         modifiedRiskSharingStrategy:
-            contractFormData?.modifiedRiskSharingStrategy,
+            formData.modifiedRiskSharingStrategy,
         modifiedIncentiveArrangements:
-            contractFormData?.modifiedIncentiveArrangements,
-        modifiedWitholdAgreements: contractFormData?.modifiedWitholdAgreements,
+            formData.modifiedIncentiveArrangements,
+        modifiedWitholdAgreements: formData.modifiedWitholdAgreements,
         modifiedStateDirectedPayments:
-            contractFormData?.modifiedStateDirectedPayments,
+            formData.modifiedStateDirectedPayments,
         modifiedPassThroughPayments:
-            contractFormData?.modifiedPassThroughPayments,
+            formData.modifiedPassThroughPayments,
         modifiedPaymentsForMentalDiseaseInstitutions:
-            contractFormData?.modifiedPaymentsForMentalDiseaseInstitutions,
+            formData.modifiedPaymentsForMentalDiseaseInstitutions,
         modifiedMedicalLossRatioStandards:
-            contractFormData?.modifiedMedicalLossRatioStandards,
+            formData.modifiedMedicalLossRatioStandards,
         modifiedOtherFinancialPaymentIncentive:
-            contractFormData?.modifiedOtherFinancialPaymentIncentive,
-        modifiedEnrollmentProcess: contractFormData?.modifiedEnrollmentProcess,
+            formData.modifiedOtherFinancialPaymentIncentive,
+        modifiedEnrollmentProcess: formData.modifiedEnrollmentProcess,
         modifiedGrevienceAndAppeal:
-            contractFormData?.modifiedGrevienceAndAppeal,
+            formData.modifiedGrevienceAndAppeal,
         modifiedNetworkAdequacyStandards:
-            contractFormData?.modifiedNetworkAdequacyStandards,
-        modifiedLengthOfContract: contractFormData?.modifiedLengthOfContract,
+            formData.modifiedNetworkAdequacyStandards,
+        modifiedLengthOfContract: formData.modifiedLengthOfContract,
         modifiedNonRiskPaymentArrangements:
-            contractFormData?.modifiedNonRiskPaymentArrangements,
+            formData.modifiedNonRiskPaymentArrangements,
         statutoryRegulatoryAttestation:
-            contractFormData?.statutoryRegulatoryAttestation,
+            formData.statutoryRegulatoryAttestation,
         statutoryRegulatoryAttestationDescription:
-            contractFormData?.statutoryRegulatoryAttestationDescription,
+            formData.statutoryRegulatoryAttestationDescription,
     }
     const hasInitialProvisions = Object.values(initialProvisions).some(
         (val) => val !== undefined
@@ -192,8 +191,13 @@ const sortModifiedProvisions = (
     const modifiedProvisions: GeneralizedProvisionType[] = []
     const unmodifiedProvisions: GeneralizedProvisionType[] = []
 
-    if (hasInitialProvisions && isContractWithProvisions(contract)) {
-        const applicableProvisions = generateApplicableProvisionsList(contract)
+    const isContractWithProvisions =
+        formData.contractType === 'AMENDMENT' ||
+        (formData.contractType === 'BASE' &&
+            formData.populationCovered !== 'CHIP')
+
+    if (hasInitialProvisions && isContractWithProvisions) {
+        const applicableProvisions = generateApplicableProvisionsList(formData)
 
         for (const provisionKey of applicableProvisions) {
             const value = initialProvisions[provisionKey]
@@ -213,11 +217,11 @@ const sortModifiedProvisions = (
     This is used to determine if we display the missing data warning on review and submit
 */
 const isMissingProvisions = (
-    contract: Contract | UnlockedContract
+    formData: ContractFormData
 ): boolean => {
-    const requiredProvisions = generateApplicableProvisionsList(contract)
+    const requiredProvisions = generateApplicableProvisionsList(formData)
     const [modifiedProvisions, unmodifiedProvisions] =
-        sortModifiedProvisions(contract)
+        sortModifiedProvisions(formData)
 
     return (
         modifiedProvisions.length + unmodifiedProvisions.length <
@@ -241,14 +245,14 @@ const healthPlanReviewDetermination = (formData: ContractFormData): boolean => {
     Returns lang string dictionary for variant
 */
 const getProvisionDictionary = (
-    contract: Contract | UnlockedContract
+    formData: ContractFormData
 ):
     | typeof ModifiedProvisionsCHIPRecord
     | typeof ModifiedProvisionsBaseContractRecord
     | typeof ModifiedProvisionsAmendmentRecord => {
-    if (isCHIPOnly(contract)) {
+    if (formData.populationCovered === 'CHIP') {
         return ModifiedProvisionsCHIPRecord
-    } else if (isBaseContract(contract)) {
+    } else if (formData.contractType === 'BASE') {
         return ModifiedProvisionsBaseContractRecord
     } else {
         return ModifiedProvisionsAmendmentRecord

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -20,7 +20,6 @@ import {
     getLastContractSubmission,
     getPackageSubmissionAtIndex,
     getVisibleLatestContractFormData,
-    isContractWithProvisions,
 } from '@mc-review/submissions'
 import styles from '../SubmissionSummarySection.module.scss'
 import {
@@ -103,13 +102,19 @@ export const ContractDetailsSummarySection = ({
         featureFlags.CHIP_SUBMISSION_AUTOMATION.defaultValue
     )
 
-    const contractSupportingDocuments = contractFormData?.supportingDocuments
-    const contractDocs = contractFormData?.contractDocuments
+    const contractSupportingDocuments = contractFormData.supportingDocuments
+    const contractDocs = contractFormData.contractDocuments
     const contractDocumentCount =
         contractSupportingDocuments &&
         contractDocs &&
         contractFormData.supportingDocuments.length +
             contractFormData.contractDocuments.length
+
+    const isChipOnly = contractFormData.populationCovered === 'CHIP'
+    const isContractAmendment = contractFormData.contractType === 'AMENDMENT'
+    const isBaseContract = contractFormData.contractType === 'BASE'
+    const isContractWithProvisions =
+        isContractAmendment || (isBaseContract && !isChipOnly)
 
     const currentRevision = getCurrentRevForZipLink(
         contract,
@@ -177,16 +182,16 @@ export const ContractDetailsSummarySection = ({
                             />
                         </MultiColumnGrid>
                     )}
-                {isContractWithProvisions(contract) && (
+                {isContractWithProvisions && (
                     <MultiColumnGrid columns={2}>
                         <ModifiedProvisionSummary
-                            contract={contract}
+                            formData={contractFormData}
                             isEditing={isEditing}
                             explainMissingData={explainMissingData}
                         />
 
                         <UnmodifiedProvisionSummary
-                            contract={contract}
+                            formData={contractFormData}
                             isEditing={isEditing}
                             explainMissingData={explainMissingData}
                         />

--- a/services/app-web/src/components/SubmissionSummarySection/SummarySectionFields/SummarySectionFields.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SummarySectionFields/SummarySectionFields.tsx
@@ -1,8 +1,4 @@
-import {
-    Contract,
-    ContractFormData,
-    UnlockedContract,
-} from '../../../gen/gqlClient'
+import { ContractFormData } from '../../../gen/gqlClient'
 import {
     DataDetail,
     DataDetailCheckboxList,
@@ -16,7 +12,6 @@ import {
     federalAuthorityKeysForCHIP,
     FederalAuthorityRecord,
     getProvisionDictionary,
-    isBaseContract,
     isMissingProvisions,
     ManagedCareEntityRecord,
     PopulationCoveredRecord,
@@ -429,23 +424,23 @@ export const DsnpSummary = ({
 }
 
 export const ModifiedProvisionSummary = ({
-    contract,
+    formData,
     isEditing,
     explainMissingData,
     label,
 }: {
-    contract: Contract | UnlockedContract
+    formData: ContractFormData
     isEditing?: boolean
     explainMissingData?: boolean
     label?: string
 }) => {
-    const provisionsAreInvalid = isMissingProvisions(contract) && isEditing
+    const provisionsAreInvalid = isMissingProvisions(formData) && isEditing
     const dynamicLabel = label
         ? label
-        : isBaseContract(contract)
+        : formData.contractType === 'BASE'
           ? 'This contract action includes provisions related to the following'
           : 'This contract action includes new or modified provisions related to the following'
-    const [modifiedProvisions] = sortModifiedProvisions(contract)
+    const [modifiedProvisions] = sortModifiedProvisions(formData)
 
     return (
         <DataDetail
@@ -456,7 +451,7 @@ export const ModifiedProvisionSummary = ({
             {provisionsAreInvalid ? null : (
                 <DataDetailCheckboxList
                     list={modifiedProvisions}
-                    dict={getProvisionDictionary(contract)}
+                    dict={getProvisionDictionary(formData)}
                     displayEmptyList
                 />
             )}
@@ -465,23 +460,23 @@ export const ModifiedProvisionSummary = ({
 }
 
 export const UnmodifiedProvisionSummary = ({
-    contract,
+    formData,
     isEditing,
     explainMissingData,
     label,
 }: {
-    contract: Contract | UnlockedContract
+    formData: ContractFormData
     isEditing?: boolean
     explainMissingData?: boolean
     label?: string
 }) => {
-    const provisionsAreInvalid = isMissingProvisions(contract) && isEditing
+    const provisionsAreInvalid = isMissingProvisions(formData) && isEditing
     const dynamicLabel = label
         ? label
-        : isBaseContract(contract)
+        : formData.contractType === 'BASE'
           ? 'This contract action does NOT include provisions related to the following'
           : 'This contract action does NOT include new or modified provisions related to the following'
-    const unmodifiedProvisions = sortModifiedProvisions(contract)[1]
+    const unmodifiedProvisions = sortModifiedProvisions(formData)[1]
 
     return (
         <DataDetail
@@ -492,7 +487,7 @@ export const UnmodifiedProvisionSummary = ({
             {provisionsAreInvalid ? null : (
                 <DataDetailCheckboxList
                     list={unmodifiedProvisions}
-                    dict={getProvisionDictionary(contract)}
+                    dict={getProvisionDictionary(formData)}
                     displayEmptyList
                 />
             )}

--- a/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/HealthPlanSubmission/ContractDetails/ContractDetails.tsx
@@ -50,10 +50,6 @@ import {
     ManagedCareEntityRecord,
     FederalAuthorityRecord,
     dsnpTriggers,
-    isBaseContract,
-    isCHIPOnly,
-    isContractAmendment,
-    isContractWithProvisions,
     generateProvisionLabel,
     generateApplicableProvisionsList,
 } from '@mc-review/submissions'
@@ -169,22 +165,18 @@ export const ContractDetails = ({
     if (interimState || !draftSubmission)
         return <ErrorOrLoadingPage state={interimState || 'GENERIC_ERROR'} />
 
-    const fileItemsFromDraftSubmission = (
-        docType: string
-    ): FileItemT[] | undefined => {
-        if (
-            (draftSubmission &&
-                docType === 'contract' &&
-                !draftSubmission.draftRevision.formData.contractDocuments) ||
-            (draftSubmission &&
-                docType === 'supporting' &&
-                !draftSubmission.draftRevision.formData.supportingDocuments)
-        )
-            return undefined
+    // Get the draft revision form data
+    const formData = draftSubmission.draftRevision?.formData
+
+    if (!formData) {
+        return <ErrorOrLoadingPage state={'GENERIC_ERROR'} />
+    }
+
+    const fileItemsFromDraftSubmission = (docType: string): FileItemT[] => {
         const docs =
             docType === 'contract'
-                ? draftSubmission.draftRevision.formData.contractDocuments
-                : draftSubmission.draftRevision.formData.supportingDocuments
+                ? formData.contractDocuments
+                : formData.supportingDocuments
         return docs.map((doc) => {
             const key = getKey(doc.s3URL)
             if (!key) {
@@ -207,136 +199,90 @@ export const ContractDetails = ({
             }
         })
     }
-    const applicableProvisions =
-        generateApplicableProvisionsList(draftSubmission)
 
-    const applicableFederalAuthorities = isCHIPOnly(draftSubmission)
+    const applicableProvisions = generateApplicableProvisionsList(formData)
+    const isChipOnly = formData.populationCovered === 'CHIP'
+    const isContractAmendment = formData.contractType === 'AMENDMENT'
+    const isBaseContract = formData.contractType === 'BASE'
+    const isContractWithProvisions =
+        isContractAmendment || (isBaseContract && !isChipOnly)
+
+    const applicableFederalAuthorities = isChipOnly
         ? federalAuthorityKeysForCHIP
         : federalAuthorityKeys
-    const hideDsnpForChipOnly =
-        chipSubmissionAutomation && isCHIPOnly(draftSubmission)
+    const hideDsnpForChipOnly = chipSubmissionAutomation && isChipOnly
 
     const contractDetailsInitialValues: ContractDetailsFormValues = {
         contractDocuments: formatDocumentsForForm({
-            documents: draftSubmission.draftRevision.formData.contractDocuments,
+            documents: formData.contractDocuments,
             getKey: getKey,
         }),
         supportingDocuments: formatDocumentsForForm({
-            documents:
-                draftSubmission.draftRevision.formData.supportingDocuments,
+            documents: formData.supportingDocuments,
             getKey: getKey,
         }),
-        contractExecutionStatus:
-            draftSubmission.draftRevision.formData.contractExecutionStatus ??
-            undefined,
+        contractExecutionStatus: formData.contractExecutionStatus ?? undefined,
         contractDateStart:
-            (draftSubmission &&
-                formatForForm(
-                    draftSubmission.draftRevision.formData.contractDateStart
-                )) ??
+            (draftSubmission && formatForForm(formData.contractDateStart)) ??
             '',
         contractDateEnd:
-            (draftSubmission &&
-                formatForForm(
-                    draftSubmission.draftRevision.formData.contractDateEnd
-                )) ??
-            '',
+            (draftSubmission && formatForForm(formData.contractDateEnd)) ?? '',
         managedCareEntities:
-            (draftSubmission.draftRevision.formData
-                .managedCareEntities as ManagedCareEntity[]) ?? [],
-        federalAuthorities:
-            draftSubmission.draftRevision.formData.federalAuthorities ?? [],
-        dsnpContract:
-            booleanAsYesNoFormValue(
-                draftSubmission.draftRevision.formData.dsnpContract
-            ) ?? '',
+            (formData.managedCareEntities as ManagedCareEntity[]) ?? [],
+        federalAuthorities: formData.federalAuthorities ?? [],
+        dsnpContract: booleanAsYesNoFormValue(formData.dsnpContract) ?? '',
         inLieuServicesAndSettings:
-            booleanAsYesNoFormValue(
-                draftSubmission.draftRevision.formData.inLieuServicesAndSettings
-            ) ?? '',
+            booleanAsYesNoFormValue(formData.inLieuServicesAndSettings) ?? '',
         modifiedBenefitsProvided:
-            booleanAsYesNoFormValue(
-                draftSubmission.draftRevision.formData.modifiedBenefitsProvided
-            ) ?? '',
+            booleanAsYesNoFormValue(formData.modifiedBenefitsProvided) ?? '',
         modifiedGeoAreaServed:
-            booleanAsYesNoFormValue(
-                draftSubmission.draftRevision.formData.modifiedGeoAreaServed
-            ) ?? '',
+            booleanAsYesNoFormValue(formData.modifiedGeoAreaServed) ?? '',
         modifiedMedicaidBeneficiaries:
-            booleanAsYesNoFormValue(
-                draftSubmission.draftRevision.formData
-                    .modifiedMedicaidBeneficiaries
-            ) ?? '',
+            booleanAsYesNoFormValue(formData.modifiedMedicaidBeneficiaries) ??
+            '',
         modifiedRiskSharingStrategy:
-            booleanAsYesNoFormValue(
-                draftSubmission.draftRevision.formData
-                    .modifiedRiskSharingStrategy
-            ) ?? '',
+            booleanAsYesNoFormValue(formData.modifiedRiskSharingStrategy) ?? '',
         modifiedIncentiveArrangements:
-            booleanAsYesNoFormValue(
-                draftSubmission.draftRevision.formData
-                    .modifiedIncentiveArrangements
-            ) ?? '',
+            booleanAsYesNoFormValue(formData.modifiedIncentiveArrangements) ??
+            '',
         modifiedWitholdAgreements:
-            booleanAsYesNoFormValue(
-                draftSubmission.draftRevision.formData.modifiedWitholdAgreements
-            ) ?? '',
+            booleanAsYesNoFormValue(formData.modifiedWitholdAgreements) ?? '',
         modifiedStateDirectedPayments:
-            booleanAsYesNoFormValue(
-                draftSubmission.draftRevision.formData
-                    .modifiedStateDirectedPayments
-            ) ?? '',
+            booleanAsYesNoFormValue(formData.modifiedStateDirectedPayments) ??
+            '',
         modifiedPassThroughPayments:
-            booleanAsYesNoFormValue(
-                draftSubmission.draftRevision.formData
-                    .modifiedPassThroughPayments
-            ) ?? '',
+            booleanAsYesNoFormValue(formData.modifiedPassThroughPayments) ?? '',
         modifiedPaymentsForMentalDiseaseInstitutions:
             booleanAsYesNoFormValue(
-                draftSubmission.draftRevision.formData
-                    .modifiedPaymentsForMentalDiseaseInstitutions
+                formData.modifiedPaymentsForMentalDiseaseInstitutions
             ) ?? '',
         modifiedMedicalLossRatioStandards:
             booleanAsYesNoFormValue(
-                draftSubmission.draftRevision.formData
-                    .modifiedMedicalLossRatioStandards
+                formData.modifiedMedicalLossRatioStandards
             ) ?? '',
         modifiedOtherFinancialPaymentIncentive:
             booleanAsYesNoFormValue(
-                draftSubmission.draftRevision.formData
-                    .modifiedOtherFinancialPaymentIncentive
+                formData.modifiedOtherFinancialPaymentIncentive
             ) ?? '',
         modifiedEnrollmentProcess:
-            booleanAsYesNoFormValue(
-                draftSubmission.draftRevision.formData.modifiedEnrollmentProcess
-            ) ?? '',
+            booleanAsYesNoFormValue(formData.modifiedEnrollmentProcess) ?? '',
         modifiedGrevienceAndAppeal:
-            booleanAsYesNoFormValue(
-                draftSubmission.draftRevision.formData
-                    .modifiedGrevienceAndAppeal
-            ) ?? '',
+            booleanAsYesNoFormValue(formData.modifiedGrevienceAndAppeal) ?? '',
         modifiedNetworkAdequacyStandards:
             booleanAsYesNoFormValue(
-                draftSubmission.draftRevision.formData
-                    .modifiedNetworkAdequacyStandards
+                formData.modifiedNetworkAdequacyStandards
             ) ?? '',
         modifiedLengthOfContract:
-            booleanAsYesNoFormValue(
-                draftSubmission.draftRevision.formData.modifiedLengthOfContract
-            ) ?? '',
+            booleanAsYesNoFormValue(formData.modifiedLengthOfContract) ?? '',
         modifiedNonRiskPaymentArrangements:
             booleanAsYesNoFormValue(
-                draftSubmission.draftRevision.formData
-                    .modifiedNonRiskPaymentArrangements
+                formData.modifiedNonRiskPaymentArrangements
             ) ?? '',
         statutoryRegulatoryAttestation:
-            booleanAsYesNoFormValue(
-                draftSubmission.draftRevision.formData
-                    .statutoryRegulatoryAttestation
-            ) ?? '',
+            booleanAsYesNoFormValue(formData.statutoryRegulatoryAttestation) ??
+            '',
         statutoryRegulatoryAttestationDescription:
-            draftSubmission.draftRevision.formData
-                .statutoryRegulatoryAttestationDescription ?? '',
+            formData.statutoryRegulatoryAttestationDescription ?? '',
     }
 
     const showFieldErrors = (
@@ -406,14 +352,10 @@ export const ContractDetails = ({
                     values.contractDateStart
                 ),
                 contractDateEnd: formatFormDateForGQL(values.contractDateEnd),
-                riskBasedContract:
-                    draftSubmission.draftRevision.formData.riskBasedContract,
-                populationCovered:
-                    draftSubmission.draftRevision.formData.populationCovered,
-                programIDs:
-                    draftSubmission.draftRevision.formData.programIDs || [],
-                stateContacts:
-                    draftSubmission.draftRevision.formData.stateContacts || [],
+                riskBasedContract: formData.riskBasedContract,
+                populationCovered: formData.populationCovered,
+                programIDs: formData.programIDs || [],
+                stateContacts: formData.stateContacts || [],
                 contractDocuments:
                     formatDocumentsForGQL(values.contractDocuments) || [],
                 supportingDocuments:
@@ -425,8 +367,7 @@ export const ContractDetails = ({
                     values.dsnpContract && dsnpTrigger && !hideDsnpForChipOnly
                         ? yesNoFormValueAsBoolean(values.dsnpContract)
                         : undefined,
-                submissionType:
-                    draftSubmission.draftRevision.formData.submissionType,
+                submissionType: formData.submissionType,
                 statutoryRegulatoryAttestation: yesNoFormValueAsBoolean(
                     values.statutoryRegulatoryAttestation
                 ),
@@ -446,7 +387,7 @@ export const ContractDetails = ({
             )
             return
         }
-        if (isContractWithProvisions(draftSubmission)) {
+        if (isContractWithProvisions) {
             updatedDraftSubmissionFormData.inLieuServicesAndSettings =
                 yesNoFormValueAsBoolean(values.inLieuServicesAndSettings)
             updatedDraftSubmissionFormData.modifiedBenefitsProvided =
@@ -552,10 +493,7 @@ export const ContractDetails = ({
         <div id={activeMainContentId}>
             <FormNotificationContainer>
                 <DynamicStepIndicator
-                    formPages={activeFormPages(
-                        draftSubmission.draftRevision.formData,
-                        hideSupportingDocs
-                    )}
+                    formPages={activeFormPages(formData, hideSupportingDocs)}
                     currentFormPage={currentRoute}
                 />
                 <PageBannerAlerts
@@ -572,8 +510,7 @@ export const ContractDetails = ({
                         return handleFormSubmit(values, setSubmitting, {
                             type: 'CONTINUE',
                             redirectPath:
-                                draftSubmission.draftRevision.formData
-                                    .submissionType === 'CONTRACT_ONLY'
+                                formData.submissionType === 'CONTRACT_ONLY'
                                     ? 'SUBMISSIONS_CONTACTS'
                                     : 'SUBMISSIONS_RATE_DETAILS',
                         })
@@ -983,9 +920,7 @@ export const ContractDetails = ({
                                     <FormGroup>
                                         <Fieldset
                                             legend={
-                                                isContractAmendment(
-                                                    draftSubmission
-                                                )
+                                                isContractAmendment
                                                     ? 'Amendment effective dates'
                                                     : 'Contract effective dates'
                                             }
@@ -1274,15 +1209,11 @@ export const ContractDetails = ({
                                                 </Fieldset>
                                             </FormGroup>
                                         )}
-                                    {isContractWithProvisions(
-                                        draftSubmission
-                                    ) && (
+                                    {isContractWithProvisions && (
                                         <FormGroup data-testid="yes-no-group">
                                             <Fieldset
                                                 legend={
-                                                    isBaseContract(
-                                                        draftSubmission
-                                                    )
+                                                    isBaseContract
                                                         ? 'Does this contract action include provisions related to any of the following'
                                                         : 'Does this contract action include new or modified provisions related to any of the following'
                                                 }
@@ -1307,7 +1238,7 @@ export const ContractDetails = ({
                                                                 modifiedProvisionName
                                                             }
                                                             label={generateProvisionLabel(
-                                                                draftSubmission,
+                                                                formData,
                                                                 modifiedProvisionName
                                                             )}
                                                             showError={Boolean(
@@ -1367,8 +1298,8 @@ export const ContractDetails = ({
                                         }
                                     )}
                                     continueOnClickUrl={
-                                        draftSubmission.draftRevision.formData
-                                            .submissionType === 'CONTRACT_ONLY'
+                                        formData.submissionType ===
+                                        'CONTRACT_ONLY'
                                             ? generatePath(
                                                   RoutesRecord.SUBMISSIONS_RATE_DETAILS,
                                                   {

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.test.tsx
@@ -215,6 +215,81 @@ describe('SubmissionRevisionSummary', () => {
                 ).toHaveTextContent('Submission 1')
             })
 
+            it('renders modified provisions from the revision being viewed, not the latest revision', async () => {
+                const mockContract = mockContractPackageSubmittedWithRevisions({
+                    id: '15',
+                    contractSubmissionType: 'HEALTH_PLAN',
+                })
+
+                // Revision versions are numbered oldest first, so /revisions/1 is the
+                // earliest submission - the last of the three newest first packageSubmissions
+                const earliestFormData =
+                    mockContract.packageSubmissions[2].contractRevision.formData
+                earliestFormData.modifiedBenefitsProvided = false
+                earliestFormData.modifiedGeoAreaServed = true
+
+                // Flip the provisions on the latest revision so reading the wrong one fails this test
+                const latestFormData =
+                    mockContract.packageSubmissions[0].contractRevision.formData
+                latestFormData.modifiedBenefitsProvided = true
+                latestFormData.modifiedGeoAreaServed = false
+
+                renderWithProviders(
+                    <Routes>
+                        <Route
+                            path={RoutesRecord.SUBMISSIONS_REVISION}
+                            element={<SubmissionRevisionSummary />}
+                        />
+                    </Routes>,
+                    {
+                        apolloProvider: {
+                            mocks: [
+                                fetchCurrentUserMock({
+                                    user: mockUser(),
+                                    statusCode: 200,
+                                }),
+                                fetchContractMockSuccess({
+                                    contract: mockContract,
+                                }),
+                            ],
+                        },
+                        routerProvider: {
+                            route: '/submissions/health-plan/15/revisions/1',
+                        },
+                        featureFlags: {},
+                    }
+                )
+
+                const modifiedProvisions = await screen.findByLabelText(
+                    'This contract action includes new or modified provisions related to the following'
+                )
+                const unmodifiedProvisions = await screen.findByLabelText(
+                    'This contract action does NOT include new or modified provisions related to the following'
+                )
+
+                expect(
+                    within(modifiedProvisions).getByText(
+                        'Geographic areas served by the managed care plans'
+                    )
+                ).toBeInTheDocument()
+                expect(
+                    within(unmodifiedProvisions).getByText(
+                        'Benefits provided by the managed care plans'
+                    )
+                ).toBeInTheDocument()
+
+                expect(
+                    within(modifiedProvisions).queryByText(
+                        'Benefits provided by the managed care plans'
+                    )
+                ).toBeNull()
+                expect(
+                    within(unmodifiedProvisions).queryByText(
+                        'Geographic areas served by the managed care plans'
+                    )
+                ).toBeNull()
+            })
+
             it('renders the right indexed version 3', async () => {
                 renderWithProviders(
                     <Routes>


### PR DESCRIPTION
## Summary
[MCR-6483](https://jiraent.cms.gov/browse/MCR-6483)

The issue here was that the components that render the provision data took the entire `contract` data as a prop and then parsing out the latest revision's form data to then display the provisions.

The issue comes when viewing a past submission, we cannot use the latest revision we have to use the revision being viewied. So when viewing a past submission the component was being passed the full `contract` data and not the specific past revision's data. This resulted in past submissions always showing the latest submission provisions.

The fix is was to refactor the provision components to take in a `ContractFormData` instead of the full contract, so that it can be targeted with the data we want to render. This refactor touched other parts of the app, but was pretty minimal.

Current behavior:
- When comparing the current and previous versions of a submission in the UI, the previous version's provisions selections match the current version's selections instead of 
- The resubmit email for this same submission generates the correct diff, confirming the underlying data is accurate and that the defect lies in how the comparison UI reads or displays it.

Expected behavior:
- The previous version's provision selections should reflect what was actually selected at that point in time.

#### Related issues

#### Screenshots

#### Test cases covered
- SubmissionRevisionSummary.test.tsx
   - `'renders modified provisions from the revision being viewed, not the latest revision'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

- This work updates the component that displays provisions, so it's worth while to take a close look to make sure we do no introduce more regressions.
   - Make sure latest submission summary displays correct provisions
   - Make sure Contract Details page, on health plan submissions, display provisions correctly. While it may not be using the provision components it did used a lot of the shared helper functions that use to take `Contract` as a parameter and now it takes `ContractFormData`.

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed