### PR TITLE
MCR-6427-b Temporary hardcode includedInAnotherSubmission to false until MCR-6481 is implemented

### DIFF
--- a/services/app-api/src/postgres/revisionDiff/revisionDiffHelpers.test.ts
+++ b/services/app-api/src/postgres/revisionDiff/revisionDiffHelpers.test.ts
@@ -1269,7 +1269,7 @@ describe('revisionDiffHelpers', () => {
                     rateID: sharedRateID,
                     rateCertificationName:
                         addedRateRevision.formData.rateCertificationName,
-                    includedInAnotherSubmission: true,
+                    includedInAnotherSubmission: false,
                 },
             ],
             removed: [

--- a/services/app-api/src/postgres/revisionDiff/revisionDiffRates.ts
+++ b/services/app-api/src/postgres/revisionDiff/revisionDiffRates.ts
@@ -182,35 +182,12 @@ function buildRateDisplayName(
     return rateRevision.formData.rateCertificationName ?? undefined
 }
 
-function isIncludedInAnotherSubmission(
-    rateRevision: RateRevisionType,
-    newerSubmissionSubmittedAt: Date
-): boolean {
-    const sharedPackages =
-        rateRevision.formData.packagesWithSharedRateCerts ?? []
-
-    if (sharedPackages.length > 0) {
-        return true
-    }
-
-    return (
-        rateRevision.submitInfo?.updatedAt.getTime() !== undefined &&
-        rateRevision.submitInfo.updatedAt.getTime() <
-            newerSubmissionSubmittedAt.getTime()
-    )
-}
-
-function buildAddedRate(
-    rateRevision: RateRevisionType,
-    newerSubmissionSubmittedAt: Date
-): RevisionDiffAddedRate {
+function buildAddedRate(rateRevision: RateRevisionType): RevisionDiffAddedRate {
     return {
         rateID: rateRevision.rateID,
         rateCertificationName: buildRateDisplayName(rateRevision),
-        includedInAnotherSubmission: isIncludedInAnotherSubmission(
-            rateRevision,
-            newerSubmissionSubmittedAt
-        ),
+        // TODO(MCR-6481): identify when a rate on a submission diff is from another submission but linked to the current submission, e.g. a linked rate.
+        includedInAnotherSubmission: false,
     }
 }
 
@@ -346,12 +323,7 @@ function buildRateChanges(
             continue
         }
 
-        added.push(
-            buildAddedRate(
-                newerRateRevision,
-                newerSubmission.submitInfo.updatedAt
-            )
-        )
+        added.push(buildAddedRate(newerRateRevision))
     }
 
     const sortByName = <TItem extends { rateCertificationName?: string }>(

--- a/services/app-api/src/postgres/revisionDiff/revisionDiffRates.ts
+++ b/services/app-api/src/postgres/revisionDiff/revisionDiffRates.ts
@@ -302,19 +302,17 @@ function buildRateChanges(
             continue
         }
 
-        if (olderRateRevision.id !== newerRateRevision.id) {
-            const revisedRateResult = buildRevisedRate(
-                olderRateRevision,
-                newerRateRevision
-            )
+        const revisedRateResult = buildRevisedRate(
+            olderRateRevision,
+            newerRateRevision
+        )
 
-            if (revisedRateResult instanceof Error) {
-                return revisedRateResult
-            }
+        if (revisedRateResult instanceof Error) {
+            return revisedRateResult
+        }
 
-            if (revisedRateResult.hasChanges) {
-                revised.push(revisedRateResult.revisedRate)
-            }
+        if (revisedRateResult.hasChanges) {
+            revised.push(revisedRateResult.revisedRate)
         }
     }
 

--- a/services/app-api/src/resolvers/contract/fetchRevisionDiff.test.ts
+++ b/services/app-api/src/resolvers/contract/fetchRevisionDiff.test.ts
@@ -681,7 +681,7 @@ describe('fetchRevisionDiff', () => {
                 {
                     rateID: sharedRateID,
                     rateCertificationName: addedRateCertificationName,
-                    includedInAnotherSubmission: true,
+                    includedInAnotherSubmission: false,
                 },
             ],
             removed: [


### PR DESCRIPTION
… implementation is developed in MCR-6481

## Summary
Temporary hardcodes `includedInAnotherSubmission` to false until MCR-6481 is implemented
#### Related issues
This is a fix which belongs to [MCR-6427](https://jiraent.cms.gov/browse/MCR-6427). 
Implementation of [MCR-6481](https://jiraent.cms.gov/browse/MCR-6481) will create functionality to get correct value for includedInAnotherSubmission
#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed