### PR TITLE
[MCR-6480] Undo unlock twice in succession drops rates on third unlock

### DIFF
--- a/services/app-api/src/postgres/contractAndRates/submitContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/submitContract.ts
@@ -49,16 +49,9 @@ async function submitContractInsideTransaction(
             if (rate.draftRevision) {
                 unsubmittedChildRevs.push(rate.draftRevision)
             } else {
-                console.info(
-                    'Strange, a child rate is not in a draft state. Shouldnt be true while we are unlocking child rates with contracts.'
-                )
-                const latestSubmittedRate = rate.revisions[0]
-                if (!latestSubmittedRate) {
-                    return new Error(
-                        `Attempted to submit a contract connected to an unsubmitted child-rate. ContractID: ${contractID}`
-                    )
-                }
-                linkedRateRevs.push(latestSubmittedRate)
+                const msg = `Cannot submit contract ${contractID}: child rate ${rate.id} has no active draft revision`
+                console.error(msg)
+                return new Error(msg)
             }
         } else {
             // non-child rate

--- a/services/app-api/src/postgres/contractAndRates/unlockContract.ts
+++ b/services/app-api/src/postgres/contractAndRates/unlockContract.ts
@@ -114,6 +114,17 @@ async function unlockContractInsideTransaction(
             // return data only queries data we need.
             id: true,
             revisions: {
+                // Only the revision that was last submitted with a contract
+                // tells us who the current parent is. Undo unlock preserves
+                // reversed unlocked revisions for audit history. Matches how
+                // getParentContractID selects the parent-defining revision.
+                where: {
+                    submitInfo: {
+                        submittedContracts: {
+                            some: {},
+                        },
+                    },
+                },
                 orderBy: {
                     createdAt: 'desc',
                 },
@@ -129,7 +140,7 @@ async function unlockContractInsideTransaction(
                     },
                     unlockInfo: true,
                 },
-                take: 2, // Only two revision states are possible: mutually unlocked or submitted
+                take: 1,
             },
             reviewStatusActions: {
                 orderBy: {

--- a/services/app-api/src/resolvers/contract/undoUnlockContract.test.ts
+++ b/services/app-api/src/resolvers/contract/undoUnlockContract.test.ts
@@ -632,6 +632,104 @@ describe('undoUnlockContract', () => {
         ).toBe('Initial submission')
     })
 
+    it('unlocks child rates on a third unlock after two reverse-unlock cycles', async () => {
+        const cmsServer = await constructTestPostgresServer({
+            s3Client: mockS3,
+            emailer: mockEmailer,
+            context: {
+                user: testCMSUser(),
+            },
+        })
+
+        const stateServer = await constructTestPostgresServer({
+            s3Client: mockS3,
+            emailer: mockEmailer,
+        })
+
+        const submittedContract =
+            await createAndSubmitTestContractWithRate(stateServer)
+        const childRateID =
+            submittedContract.packageSubmissions[0].rateRevisions[0].rateID
+        const initialRateRevisionID =
+            submittedContract.packageSubmissions[0].rateRevisions[0].id
+
+        await unlockTestContract(
+            cmsServer,
+            submittedContract.id,
+            'First unlock'
+        )
+        await undoUnlockTestContract(
+            cmsServer,
+            submittedContract.id,
+            'First reverse'
+        )
+        await unlockTestContract(
+            cmsServer,
+            submittedContract.id,
+            'Second unlock'
+        )
+        await undoUnlockTestContract(
+            cmsServer,
+            submittedContract.id,
+            'Second reverse'
+        )
+
+        const thirdUnlock = await unlockTestContract(
+            cmsServer,
+            submittedContract.id,
+            'Third unlock'
+        )
+
+        expect(thirdUnlock.draftRates).toHaveLength(1)
+
+        const unlockedChildRate = thirdUnlock.draftRates?.[0]
+
+        expect(unlockedChildRate?.id).toBe(childRateID)
+        expect(unlockedChildRate?.parentContractID).toBe(submittedContract.id)
+        expect(unlockedChildRate?.draftRevision).not.toBeNull()
+        expect(unlockedChildRate?.draftRevision?.id).not.toBe(
+            initialRateRevisionID
+        )
+        // The child rate draft is created by the same unlock event as the contract draft
+        expect(
+            unlockedChildRate?.draftRevision?.unlockInfo?.updatedReason
+        ).toBe('Third unlock')
+        expect(thirdUnlock.draftRevision?.unlockInfo?.updatedReason).toBe(
+            'Third unlock'
+        )
+
+        const resubmitted = await resubmitTestContract(
+            stateServer,
+            submittedContract.id,
+            'Resubmit after third unlock'
+        )
+
+        const resubmittedRateRevision =
+            resubmitted.packageSubmissions[0].rateRevisions[0]
+
+        expect(resubmitted.packageSubmissions[0].cause).toBe(
+            'CONTRACT_SUBMISSION'
+        )
+        expect(resubmittedRateRevision.rateID).toBe(childRateID)
+        // The child rate must be stamped with a new revision rather than
+        // reusing the revision from the initial submission.
+        expect(resubmittedRateRevision.id).not.toBe(initialRateRevisionID)
+
+        const fetchedChildRate = await fetchTestRateById(
+            stateServer,
+            childRateID
+        )
+
+        expect(fetchedChildRate.status).toBe('RESUBMITTED')
+        expect(fetchedChildRate.parentContractID).toBe(submittedContract.id)
+        expect(fetchedChildRate.packageSubmissions?.[0]?.rateRevision.id).toBe(
+            resubmittedRateRevision.id
+        )
+        expect(
+            fetchedChildRate.packageSubmissions?.[0]?.submitInfo.updatedReason
+        ).toBe('Resubmit after third unlock')
+    })
+
     it('errors if contract is not UNLOCKED', async () => {
         const stateServer = await constructTestPostgresServer({
             s3Client: mockS3,

--- a/services/app-api/src/resolvers/contract/undoUnlockContract.test.ts
+++ b/services/app-api/src/resolvers/contract/undoUnlockContract.test.ts
@@ -730,6 +730,98 @@ describe('undoUnlockContract', () => {
         ).toBe('Resubmit after third unlock')
     })
 
+    it('withdraws and undo withdraws with child rates intact after two reverse-unlock cycles', async () => {
+        const cmsServer = await constructTestPostgresServer({
+            s3Client: mockS3,
+            emailer: mockEmailer,
+            context: {
+                user: testCMSUser(),
+            },
+        })
+
+        const stateServer = await constructTestPostgresServer({
+            s3Client: mockS3,
+            emailer: mockEmailer,
+        })
+
+        const submittedContract =
+            await createAndSubmitTestContractWithRate(stateServer)
+        const childRateID =
+            submittedContract.packageSubmissions[0].rateRevisions[0].rateID
+
+        await unlockTestContract(
+            cmsServer,
+            submittedContract.id,
+            'First unlock before withdraw'
+        )
+        await undoUnlockTestContract(
+            cmsServer,
+            submittedContract.id,
+            'First reverse before withdraw'
+        )
+        await unlockTestContract(
+            cmsServer,
+            submittedContract.id,
+            'Second unlock before withdraw'
+        )
+        await undoUnlockTestContract(
+            cmsServer,
+            submittedContract.id,
+            'Second reverse before withdraw'
+        )
+
+        // Withdraw unlocks and resubmits the contract internally, so it relies
+        // on the same child rate lookup as a plain unlock.
+        const withdrawnContract = await withdrawTestContract(
+            cmsServer,
+            submittedContract.id,
+            'Withdrawing after two reversed unlocks'
+        )
+
+        expect(withdrawnContract.consolidatedStatus).toBe('WITHDRAWN')
+
+        const withdrawnChildRate = await fetchTestRateById(
+            cmsServer,
+            childRateID
+        )
+
+        expect(withdrawnChildRate.consolidatedStatus).toBe('WITHDRAWN')
+
+        const undoWithdrawnContract = await undoWithdrawTestContract(
+            cmsServer,
+            submittedContract.id,
+            'Undo withdrawal after two reversed unlocks'
+        )
+
+        expect(undoWithdrawnContract.consolidatedStatus).toBe('RESUBMITTED')
+        expect(
+            undoWithdrawnContract.packageSubmissions[0].rateRevisions.map(
+                (rateRev) => rateRev.rateID
+            )
+        ).toContain(childRateID)
+
+        const restoredChildRate = await fetchTestRateById(
+            stateServer,
+            childRateID
+        )
+
+        expect(restoredChildRate.consolidatedStatus).toBe('RESUBMITTED')
+        expect(restoredChildRate.parentContractID).toBe(submittedContract.id)
+
+        // The child rate must still unlock with its contract afterwards
+        const unlockedAfterUndoWithdraw = await unlockTestContract(
+            cmsServer,
+            submittedContract.id,
+            'Unlock after undo withdraw'
+        )
+
+        expect(unlockedAfterUndoWithdraw.draftRates).toHaveLength(1)
+        expect(unlockedAfterUndoWithdraw.draftRates?.[0].id).toBe(childRateID)
+        expect(
+            unlockedAfterUndoWithdraw.draftRates?.[0].draftRevision
+        ).not.toBeNull()
+    })
+
     it('errors if contract is not UNLOCKED', async () => {
         const stateServer = await constructTestPostgresServer({
             s3Client: mockS3,


### PR DESCRIPTION
## Summary
When a submission is unlocked then undo unlock twice in succession, rates are dropped on the submission summary page.

**Current Behavior:**
Unlock then undo unlock twice in succession drops rates from submission when unlocked a third time.

**Expected Behavior:**
Unlock then undo unlock twice or more in succession retains existing rates on the submission.

**Reproduction Steps:**
- Make a contract and rate submission and submit it
- Unlock and undo unlock twice in succession.
- Unlock a third time and view submission as the state user.
- Rates are no longer existing on the submission

**Eng Notes:**
Console errors suggest an issue with unlocking the rate at the third unlock, without undoing unlock. `Programming Error: A child rate is not a draft`. Likely missing some logic in the unlock API code that needs to unlock when two undo unlocks happen in a row.

#### Related issues
[MCR-6480](https://jiraent.cms.gov/browse/MCR-6480)
#### Screenshots

#### Test cases covered
  - After the third unlock: the child rate is still attached to the contract and gets a fresh draft revision from that same unlock event.
  - After the resubmit: the new package stamps a new child rate revision rather than reusing the one from the initial submission.
<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
- As a state user, create and submit a contract with at least one rate.
- Cycle twice as a CMS user, unlock then undo unlock; repeat a second time.
- Third unlock, unlock again as CMS.
- Check the state view, open the unlocked submission as the state user and go to review & submit; rates should still be listed, with no "A child rate is not a draft" console error.
- submit as the state user; the rate should appear in the new submission with its data intact.
<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed