### PR TITLE
MCR-6516: Add contract execution status field to EQRO contract details form

### DIFF
--- a/packages/mocks/src/apollo/contractPackageDataMock.ts
+++ b/packages/mocks/src/apollo/contractPackageDataMock.ts
@@ -3313,7 +3313,7 @@ function mockEqroContractSubmittedUnderReview(
                             ],
                             supportingDocuments: [],
                             contractType: 'BASE',
-                            contractExecutionStatus: null,
+                            contractExecutionStatus: 'EXECUTED',
                             contractDocuments: [
                                 {
                                     __typename: 'GenericDocument',
@@ -3410,7 +3410,7 @@ function mockEqroContractSubmittedUnderReview(
                         ],
                         supportingDocuments: [],
                         contractType: 'BASE',
-                        contractExecutionStatus: null,
+                        contractExecutionStatus: 'EXECUTED',
                         contractDocuments: [
                             {
                                 __typename: 'GenericDocument',
@@ -3570,7 +3570,7 @@ function mockEqroContractSubmittedNotSubjectToReview(
                             ],
                             supportingDocuments: [],
                             contractType: 'BASE',
-                            contractExecutionStatus: null,
+                            contractExecutionStatus: 'EXECUTED',
                             contractDocuments: [
                                 {
                                     __typename: 'GenericDocument',
@@ -3668,7 +3668,7 @@ function mockEqroContractSubmittedNotSubjectToReview(
                         ],
                         supportingDocuments: [],
                         contractType: 'BASE',
-                        contractExecutionStatus: null,
+                        contractExecutionStatus: 'EXECUTED',
                         contractDocuments: [
                             {
                                 __typename: 'GenericDocument',
@@ -3851,7 +3851,7 @@ function mockEqroContractResubmittedWithReviewStatusChange(
                             ],
                             supportingDocuments: [],
                             contractType: 'BASE',
-                            contractExecutionStatus: null,
+                            contractExecutionStatus: 'EXECUTED',
                             contractDocuments: [
                                 {
                                     __typename: 'GenericDocument',
@@ -3962,7 +3962,7 @@ function mockEqroContractResubmittedWithReviewStatusChange(
                         ],
                         supportingDocuments: [],
                         contractType: 'BASE',
-                        contractExecutionStatus: null,
+                        contractExecutionStatus: 'EXECUTED',
                         contractDocuments: [
                             {
                                 __typename: 'GenericDocument',
@@ -4079,7 +4079,7 @@ function mockEqroContractResubmittedWithReviewStatusChange(
                             ],
                             supportingDocuments: [],
                             contractType: 'BASE',
-                            contractExecutionStatus: null,
+                            contractExecutionStatus: 'EXECUTED',
                             contractDocuments: [
                                 {
                                     __typename: 'GenericDocument',
@@ -4177,7 +4177,7 @@ function mockEqroContractResubmittedWithReviewStatusChange(
                         ],
                         supportingDocuments: [],
                         contractType: 'BASE',
-                        contractExecutionStatus: null,
+                        contractExecutionStatus: 'EXECUTED',
                         contractDocuments: [
                             {
                                 __typename: 'GenericDocument',

--- a/services/app-api/src/domain-models/contractAndRates/dataValidatorHelpers.test.ts
+++ b/services/app-api/src/domain-models/contractAndRates/dataValidatorHelpers.test.ts
@@ -1122,6 +1122,7 @@ describe('EQRO parsing and validation', () => {
             },
         ],
         contractType: 'BASE',
+        contractExecutionStatus: 'EXECUTED',
         contractDocuments: [
             {
                 s3URL: 's3://bucketname/key/contractdoc1',
@@ -1811,7 +1812,38 @@ describe('EQRO parsing and validation', () => {
             )
         })
 
-        it('should succeed with optional fields omitted', async () => {
+        it('should return an error if contract execution status is omitted', async () => {
+            const prismaClient = await sharedTestPrismaClient()
+            const postgresStore = NewPostgresStore(prismaClient)
+            const contract = createValidEQROContract({
+                contractExecutionStatus: undefined,
+            })
+
+            const parsedContract = parseEQROContract(
+                contract,
+                'FL',
+                postgresStore
+            )
+
+            expect(parsedContract).toBeInstanceOf(z.ZodError)
+            if (!(parsedContract instanceof z.ZodError)) {
+                throw new Error('Expected parseEQROContract to return an error')
+            }
+
+            expect(parsedContract.issues).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        path: [
+                            'draftRevision',
+                            'formData',
+                            'contractExecutionStatus',
+                        ],
+                    }),
+                ])
+            )
+        })
+
+        it('should succeed with other optional fields omitted', async () => {
             const prismaClient = await sharedTestPrismaClient()
             const postgresStore = NewPostgresStore(prismaClient)
             const stateCode = 'FL'
@@ -1819,7 +1851,6 @@ describe('EQRO parsing and validation', () => {
                 // Ensure optional fields are not set
                 federalAuthorities: [],
                 riskBasedContract: undefined,
-                contractExecutionStatus: undefined,
                 modifiedBenefitsProvided: undefined,
                 modifiedGeoAreaServed: undefined,
                 modifiedRiskSharingStrategy: undefined,

--- a/services/app-api/src/domain-models/contractAndRates/formDataTypes.ts
+++ b/services/app-api/src/domain-models/contractAndRates/formDataTypes.ts
@@ -286,11 +286,12 @@ const eqroContractFormDataSchema = genericContractFormDataSchema.extend({
     contractDateEnd: preprocessNulls(
         genericContractFormDataSchema.shape.contractDateEnd.optional()
     ),
-    // Fields not applicable to EQRO submissions
-    // following values should be undefined for a EQRO contract
+    contractExecutionStatus: preprocessNulls(
+        genericContractFormDataSchema.shape.contractExecutionStatus.optional()
+    ),
+    // Fields not applicable to EQRO submissions should be undefined.
     riskBasedContract: preprocessNulls(z.undefined().optional()),
     dsnpContract: preprocessNulls(z.undefined().optional()),
-    contractExecutionStatus: preprocessNulls(z.undefined().optional()),
     inLieuServicesAndSettings: preprocessNulls(z.undefined().optional()),
     modifiedBenefitsProvided: preprocessNulls(z.undefined().optional()),
     modifiedGeoAreaServed: preprocessNulls(z.undefined().optional()),
@@ -363,6 +364,8 @@ const submittableEQROContractFormDataSchema = eqroContractFormDataSchema.extend(
             genericContractFormDataSchema.shape.stateContacts.nonempty(),
         contractDocuments:
             genericContractFormDataSchema.shape.contractDocuments.nonempty(),
+        contractExecutionStatus:
+            genericContractFormDataSchema.shape.contractExecutionStatus,
         submissionType: z.literal('CONTRACT_ONLY'),
     }
 )

--- a/services/app-api/src/resolvers/contract/submitContract.test.ts
+++ b/services/app-api/src/resolvers/contract/submitContract.test.ts
@@ -2897,6 +2897,34 @@ describe('submitContract', () => {
             ])
         })
 
+        it('returns an error if EQRO contract execution status is not populated', async () => {
+            const stateServer = await constructTestPostgresServer({
+                s3Client: mockS3,
+            })
+            const draftWithoutContractStatus =
+                await createAndUpdateTestEQROContract(stateServer, undefined, {
+                    contractExecutionStatus: undefined,
+                })
+            const response = await executeGraphQLOperation(stateServer, {
+                query: SubmitContractDocument,
+                variables: {
+                    input: {
+                        contractID: draftWithoutContractStatus.id,
+                    },
+                },
+            })
+
+            expect(response.errors).toEqual([
+                expect.objectContaining({
+                    message: expect.stringContaining('contractExecutionStatus'),
+                    extensions: expect.objectContaining({
+                        code: 'BAD_USER_INPUT',
+                        argumentName: 'contractID',
+                    }),
+                }),
+            ])
+        })
+
         it('send EQRO submission CMS email on successful submit', async () => {
             const config = testEmailConfig()
             const mockEmailer = testEmailer(config)

--- a/services/app-api/src/resolvers/contract/updateContractDraftRevision.test.ts
+++ b/services/app-api/src/resolvers/contract/updateContractDraftRevision.test.ts
@@ -543,6 +543,7 @@ describe(`Tests UpdateContractDraftRevision`, () => {
 
             expect(updatedFormData).toEqual(
                 expect.objectContaining({
+                    contractExecutionStatus: 'EXECUTED',
                     eqroNewContractor: true,
                     eqroProvisionMcoNewOptionalActivity: true,
                     eqroProvisionNewMcoEqrRelatedActivities: true,

--- a/services/app-api/src/testHelpers/gqlContractHelpers.ts
+++ b/services/app-api/src/testHelpers/gqlContractHelpers.ts
@@ -428,7 +428,7 @@ const createAndUpdateTestEQROContract = async (
             eqroProvisionMcoNewOptionalActivity: true,
             riskBasedContract: undefined,
             dsnpContract: undefined,
-            contractExecutionStatus: undefined,
+            contractExecutionStatus: 'EXECUTED',
             inLieuServicesAndSettings: undefined,
             modifiedBenefitsProvided: undefined,
             modifiedGeoAreaServed: undefined,

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/EQROContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/EQROContractDetailsSummarySection.tsx
@@ -22,6 +22,7 @@ import {
 import styles from '../SubmissionSummarySection.module.scss'
 import {
     ContractEffectiveDateSummary,
+    ContractExecutionSummary,
     EQROModifiedProvisionSummary,
     NewEQROContractorSummary,
 } from '../SummarySectionFields'
@@ -101,6 +102,10 @@ export const EQROContractDetailsSummarySection = ({
             />
             <dl>
                 <MultiColumnGrid columns={2}>
+                    <ContractExecutionSummary
+                        contractFormData={contractFormData}
+                        explainMissingData={explainMissingData}
+                    />
                     <ContractEffectiveDateSummary
                         contractFormData={contractFormData}
                         explainMissingData={explainMissingData}

--- a/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROContractDetails/EQROContractDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROContractDetails/EQROContractDetails.test.tsx
@@ -122,6 +122,95 @@ describe('EQROContractDetails', () => {
         })
     })
 
+    describe('Contract status', () => {
+        it('displays the saved contract execution status', async () => {
+            const draftContract = mockContractPackageUnlockedWithUnlockedType()
+            draftContract.draftRevision.formData.contractExecutionStatus =
+                'UNEXECUTED'
+
+            renderWithProviders(
+                <Routes>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_CONTRACT_DETAILS}
+                        element={<EQROContractDetails />}
+                    />
+                </Routes>,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({ statusCode: 200 }),
+                            fetchContractMockSuccess({
+                                contract: {
+                                    ...draftContract,
+                                    id: '15',
+                                    contractSubmissionType: 'EQRO',
+                                },
+                            }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: '/submissions/eqro/15/edit/contract-details',
+                    },
+                }
+            )
+
+            const contractStatus = await screen.findByRole('radiogroup', {
+                name: 'Contract status',
+            })
+
+            expect(
+                within(contractStatus).getByRole('radio', {
+                    name: 'Unexecuted by some or all parties',
+                })
+            ).toBeChecked()
+        })
+
+        it('requires a contract execution status before continuing', async () => {
+            const draftContract = mockContractPackageUnlockedWithUnlockedType()
+            draftContract.draftRevision.formData.contractExecutionStatus = null
+            draftContract.draftRevision.formData.contractType = 'BASE'
+            draftContract.draftRevision.formData.populationCovered = 'MEDICAID'
+            draftContract.draftRevision.formData.managedCareEntities = ['PIHP']
+
+            renderWithProviders(
+                <Routes>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_CONTRACT_DETAILS}
+                        element={<EQROContractDetails />}
+                    />
+                </Routes>,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            fetchCurrentUserMock({ statusCode: 200 }),
+                            fetchContractMockSuccess({
+                                contract: {
+                                    ...draftContract,
+                                    id: '15',
+                                    contractSubmissionType: 'EQRO',
+                                },
+                            }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: '/submissions/eqro/15/edit/contract-details',
+                    },
+                }
+            )
+
+            await screen.findByText('EQRO Contract details')
+            await userEvent.click(
+                screen.getByRole('button', { name: 'Continue' })
+            )
+
+            await waitFor(() => {
+                expect(
+                    screen.getAllByText('You must select a contract status')
+                ).toHaveLength(2)
+            })
+        })
+    })
+
     describe('EQRO provisions questions - conditional rendering', () => {
         it('shows eqroNewContractor question for Base contract with MCO', async () => {
             const draftContract = mockContractPackageUnlockedWithUnlockedType()

--- a/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROContractDetails/EQROContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROContractDetails/EQROContractDetails.tsx
@@ -3,7 +3,9 @@ import {
     FileUpload,
     FileItemT,
     ErrorSummary,
+    FieldRadio,
     FieldYesNo,
+    PoliteErrorMessage,
     DynamicStepIndicator,
     LinkWithLogging,
     FormNotificationContainer,
@@ -48,6 +50,7 @@ import { useContractForm } from '../../../../hooks/useContractForm'
 import {
     UpdateContractDraftRevisionInput,
     ContractDraftRevisionFormDataInput,
+    ContractExecutionStatus,
 } from '../../../../gen/gqlClient'
 import { useFocusOnRender } from '../../../../hooks/useFocusOnRender'
 import { usePage } from '../../../../contexts/PageContext'
@@ -56,6 +59,7 @@ import { getSubmissionPath } from '../../../../routeHelpers'
 export type ContractDetailsFormValues = {
     contractDocuments: FileItemT[]
     supportingDocuments: FileItemT[]
+    contractExecutionStatus: ContractExecutionStatus | undefined
     contractDateStart: string
     contractDateEnd: string
     eqroNewContractor: string | undefined
@@ -176,6 +180,9 @@ export const EQROContractDetails = ({
                 draftSubmission.draftRevision.formData.supportingDocuments,
             getKey: getKey,
         }),
+        contractExecutionStatus:
+            draftSubmission.draftRevision.formData.contractExecutionStatus ??
+            undefined,
         contractDateStart:
             (draftSubmission &&
                 formatForForm(
@@ -277,6 +284,7 @@ export const EQROContractDetails = ({
         const updatedDraftSubmissionFormData: ContractDraftRevisionFormDataInput =
             {
                 ...formData,
+                contractExecutionStatus: values.contractExecutionStatus,
                 contractDateStart: formatFormDateForGQL(
                     values.contractDateStart
                 ),
@@ -585,6 +593,63 @@ export const EQROContractDetails = ({
                                                     )
                                                 }
                                             />
+                                        </FormGroup>
+
+                                        <FormGroup
+                                            error={Boolean(
+                                                showFieldErrors(
+                                                    'contractExecutionStatus',
+                                                    errors
+                                                )
+                                            )}
+                                        >
+                                            <Fieldset
+                                                role="radiogroup"
+                                                className={styles.radioGroup}
+                                                legend="Contract status"
+                                            >
+                                                <span
+                                                    className={
+                                                        styles.requiredOptionalText
+                                                    }
+                                                >
+                                                    Required
+                                                </span>
+                                                {Boolean(
+                                                    showFieldErrors(
+                                                        'contractExecutionStatus',
+                                                        errors
+                                                    )
+                                                ) && (
+                                                    <PoliteErrorMessage formFieldLabel="Contract status">
+                                                        {
+                                                            errors.contractExecutionStatus
+                                                        }
+                                                    </PoliteErrorMessage>
+                                                )}
+                                                <FieldRadio
+                                                    id="executedContract"
+                                                    name="contractExecutionStatus"
+                                                    label="Fully executed"
+                                                    aria-required
+                                                    value="EXECUTED"
+                                                    list_position={1}
+                                                    list_options={2}
+                                                    parent_component_heading="Contract status"
+                                                    radio_button_title="Fully executed"
+                                                />
+                                                <FieldRadio
+                                                    id="unexecutedContract"
+                                                    name="contractExecutionStatus"
+                                                    label="Unexecuted by some or all parties"
+                                                    aria-required
+                                                    value="UNEXECUTED"
+                                                    list_position={2}
+                                                    list_options={2}
+                                                    parent_component_heading="Contract status"
+                                                    radio_button_title="Unexecuted by some or all parties"
+                                                />
+                                            </Fieldset>
                                         </FormGroup>
 
                                         <FormGroup>

--- a/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROContractDetails/EQROContractDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROContractDetails/EQROContractDetailsSchema.ts
@@ -79,6 +79,9 @@ export const EQROContractDetailsFormSchema = (
     return Yup.object().shape({
         contractDocuments: validateFileItemsList({ required: true }),
         supportingDocuments: validateFileItemsList({ required: false }),
+        contractExecutionStatus: Yup.string().defined(
+            'You must select a contract status'
+        ),
 
         contractDateStart: Yup.date()
             // @ts-ignore-next-line

--- a/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROReviewSubmit/EQROReviewSubmit.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/EQROSubmission/EQROReviewSubmit/EQROReviewSubmit.test.tsx
@@ -75,6 +75,12 @@ it('renders EQRO fields', async () => {
         ).toBeInTheDocument()
     })
 
+    expect(
+        within(screen.getByTestId('contractExecutionStatus')).getByText(
+            'Fully executed'
+        )
+    ).toBeInTheDocument()
+
     const withinInclude = within(
         screen.getByLabelText(
             'This contract action includes new or modified provisions related to the following'

--- a/services/cypress/integration/cmsWorkflow/submissionReview.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/submissionReview.spec.ts
@@ -132,6 +132,11 @@ describe('CMS user can view submission', () => {
             const latestSubmission = contract.packageSubmissions[0]
             const contractName = latestSubmission.contractRevision.contractName
 
+            expect(
+                latestSubmission.contractRevision.formData
+                    .contractExecutionStatus
+            ).to.equal('EXECUTED')
+
             cy.logInAsCMSUser()
 
             cy.findByRole('link', { name: contractName })
@@ -148,6 +153,10 @@ describe('CMS user can view submission', () => {
             cy.findByTestId('submission-id').should(
                 'contain.text',
                 contractName
+            )
+            cy.findByTestId('contractExecutionStatus').should(
+                'contain.text',
+                'Fully executed'
             )
 
             //TODO: Add assertions for review determination once that is added.

--- a/services/cypress/integration/stateWorkflow/stateSubmissionForm/eqroSubmissionForm.spec.ts
+++ b/services/cypress/integration/stateWorkflow/stateSubmissionForm/eqroSubmissionForm.spec.ts
@@ -43,6 +43,10 @@ describe('state user in eqro submission form', () => {
         // continue to review and submit page
         cy.navigateContractForm('CONTINUE')
         cy.findByRole('heading', { level: 2, name: /Review and submit/ })
+        cy.findByTestId('contractExecutionStatus').should(
+            'contain.text',
+            'Fully executed'
+        )
 
         // go back to contacts page and save as draft
         cy.navigateContractForm('BACK')

--- a/services/cypress/support/stateSubmissionFormCommands.ts
+++ b/services/cypress/support/stateSubmissionFormCommands.ts
@@ -248,6 +248,12 @@ Cypress.Commands.add('fillOutBaseContractDetails', () => {
 })
 
 Cypress.Commands.add('fillOutEQROContractDetails', () => {
+    cy.findByRole('radiogroup', { name: 'Contract status' }).within(() => {
+        cy.findByRole('radio', { name: 'Fully executed' }).check({
+            force: true,
+        })
+    })
+
     cy.findAllByLabelText('Start date', { timeout: 2000 })
         .parents()
         .findByTestId('date-picker-external-input')

--- a/services/cypress/utils/apollo-test-utils.ts
+++ b/services/cypress/utils/apollo-test-utils.ts
@@ -103,6 +103,7 @@ const eqroFromData = (
     ],
     supportingDocuments: [],
     contractType: 'BASE',
+    contractExecutionStatus: 'EXECUTED',
     contractDocuments: [
         {
             name: 'Contract Cert.pdf',


### PR DESCRIPTION
## Summary
[MCR-6516](https://jiraent.cms.gov/browse/MCR-6516)

This word adds the contract execution status question to the EQRO contract details page. This was a request by the business to add it as it was originally decided to leave it out.

Work
- Add `contractExecutionStatus` to EQRO submit zod schema for submit validation. This is done in the `parseEQROContract`.
- Add input on the EQRO contract details page to collect this data
- Add unit tests, Cypress tests.

AC:
- EQRO Contract details page includes the required "Contract status" question
- Submit validations validate `contractExecutionStatus` is populated before allowing submit.
- Summary pages show the "Contract status" selection
   - Review and submit
   - Submission Summary
   - Previous submission summaries
- Submit, Unlock and Resubmit contain the selected "Contract status".
- Unit tests
- Cypress tests

#### Related issues

#### Screenshots
<img width="600" alt="Screenshot 2026-08-19 at 1 39 33 PM" src="https://github.com/user-attachments/assets/0251d7bb-917c-4a29-83bc-5b9c8b91c277" />

#### Test cases covered
Unit tests:
- `dataValidatorHelpers.test.ts`
   - **New:** should return an error if contract execution status is omitted
   - **Updated:** should succeed with other optional fields omitted
- `submitContract.test.ts`
   - **New:** returns an error if EQRO contract execution status is not populated
- `updateContractDraftRevision.test.ts`
   - **Updated:** updates valid EQRO scalar fields in the formData
- `EQROContractDetails.test.tsx`
   - **New:** displays the saved contract execution status
   - **New:** requires a contract execution status before continuing
- `EQROReviewSubmit.test.tsx`
   - **Updated:** renders EQRO fields

Cypress tests:
- `submissionReview.spec.ts`
   - **Updated:** and navigate to a specific EQRO submission from the submission dashboard
- `eqroSubmissionForm.spec.ts`
   - **Updated:** can navigate forward, back, and save as draft on each form page

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance
- Can update and submit contract execution status on EQRO
- Can unlock and resubmit contract execution status on EQRO
- Does error when submitting without contract execution status on EQRO
- Summary changes reflect contract execution status correctly
   - review and submit page
   - submission summary page
   - previous submission page
   - Unlocked EQRO contract details page retains previously selected contract execution status.
- Check accessibility for the UI input 

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Checked accessibility with ANDI and Wave tools as needed