### PR TITLE
MCR-6517: Update email for chip only submissions

### DIFF
--- a/packages/constants/src/contract.ts
+++ b/packages/constants/src/contract.ts
@@ -1,6 +1,12 @@
-import { ContractReviewStatus } from './gen/gqlClient'
+import {
+    ConsolidatedContractStatus,
+    ContractReviewStatus,
+} from './gen/gqlClient'
 
-const ReviewDecisionRecord: Record<Extract<ContractReviewStatus, 'NOT_SUBJECT_TO_REVIEW' | 'UNDER_REVIEW'>, string> = {
+const ReviewDecisionRecord: Record<
+    Extract<ContractReviewStatus, 'NOT_SUBJECT_TO_REVIEW' | 'UNDER_REVIEW'>,
+    string
+> = {
     UNDER_REVIEW: 'Subject to review',
     NOT_SUBJECT_TO_REVIEW: 'Not subject to review',
 }
@@ -12,4 +18,21 @@ const SubmissionReviewStatusRecord: Record<ContractReviewStatus, string> = {
     NOT_SUBJECT_TO_REVIEW: ReviewDecisionRecord['NOT_SUBJECT_TO_REVIEW'],
 }
 
-export { SubmissionReviewStatusRecord, ReviewDecisionRecord }
+const ConsolidatedContractStatusRecord: Record<
+    ConsolidatedContractStatus,
+    string
+> = {
+    DRAFT: 'Draft',
+    UNLOCKED: 'Unlocked',
+    SUBMITTED: 'Submitted',
+    RESUBMITTED: 'Resubmitted',
+    APPROVED: 'Approved',
+    WITHDRAWN: 'Withdrawn',
+    NOT_SUBJECT_TO_REVIEW: ReviewDecisionRecord['NOT_SUBJECT_TO_REVIEW'],
+}
+
+export {
+    SubmissionReviewStatusRecord,
+    ReviewDecisionRecord,
+    ConsolidatedContractStatusRecord,
+}

--- a/services/app-api/src/emailer/emails/undoUnlockContractCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/undoUnlockContractCMSEmail.test.ts
@@ -81,3 +81,32 @@ it('has different content for EQRO', async () => {
     )
     expect(result.bodyText).not.toContain('Rate name:')
 })
+
+it('CHIP only content is similar to EQRO', async () => {
+    const contract = mockContract()
+    contract.packageSubmissions[0].contractRevision.formData.populationCovered =
+        'CHIP'
+    const info = contract.packageSubmissions[0].submitInfo
+    const updatedInfo = {
+        updatedAt: info.updatedAt,
+        updatedBy: info.updatedBy,
+        updatedReason: info.updatedReason,
+    }
+    const assignedUserEmails = ['roku@example.com', 'izumi@example.com']
+    const defaultStatePrograms = mockMNState().programs
+    const emailConfig = testEmailConfig()
+    const result = await undoUnlockContractCMSEmail(
+        contract,
+        updatedInfo,
+        assignedUserEmails,
+        defaultStatePrograms,
+        emailConfig
+    )
+
+    if (result instanceof Error) {
+        throw new Error(
+            `Unexpected error: email template returned an error. ${result.message}`
+        )
+    }
+    expect(result.bodyText).toContain('Review decision:')
+})

--- a/services/app-api/src/emailer/etaTemplates/undoUnlockContractCMSEmail.eta
+++ b/services/app-api/src/emailer/etaTemplates/undoUnlockContractCMSEmail.eta
@@ -4,7 +4,7 @@ CMS undid the unlock on <%= it.packageName %>. The submission returned to its pr
 <b>Updated on:</b> <%= it.updatedAt %><br />
 <b>Reason for undoing the unlock:</b> <%= it.reason %><br />
 <b>Status:</b> <%= it.status %><br />
-<% if (it.isEQRO) { %>
+<% if (it.isEQRO || it.isCHIPOnly) { %>
     <b>Review decision:</b> <%= it.reviewDecisionText %><br />
 <% } %>
 <% if (it.shouldIncludeRates) { %>

--- a/services/app-api/src/emailer/templateHelpers.ts
+++ b/services/app-api/src/emailer/templateHelpers.ts
@@ -27,6 +27,7 @@ import type {
     UpdateInfoType,
 } from '../domain-models/contractAndRates'
 import type { ReviewActionTypes } from '../domain-models/contractAndRates/contractReviewActionType'
+import { ConsolidatedContractStatusRecord } from '@mc-review/constants'
 
 // ETA SETUP
 Eta.configure({
@@ -532,6 +533,7 @@ export type UndoUnlockContractEtaData = {
     reason: string
     status: string
     isEQRO: boolean
+    isCHIPOnly: boolean
     isNotSubjectToReview: boolean
     reviewDecisionText: string
     shouldIncludeRates: boolean
@@ -571,11 +573,14 @@ const parseEmailDataUndoUnlockContract = (
         config.baseUrl
     )
 
-    const isEQRO = contract.contractSubmissionType === `EQRO`
-
+    const isEQRO = contract.contractSubmissionType === 'EQRO'
+    const isCHIPOnly = formData.populationCovered === 'CHIP'
+    contract.reviewStatusActions
     const isNotSubjectToReview =
-        isEQRO &&
-        eqroValidationAndReviewDetermination(contract.id, formData) === false
+        (isEQRO &&
+            eqroValidationAndReviewDetermination(contract.id, formData) ===
+                false) ||
+        isCHIPOnly
 
     return {
         packageName: contractPackageName,
@@ -585,8 +590,9 @@ const parseEmailDataUndoUnlockContract = (
         ),
         updatedBy: updateInfo.updatedBy.email,
         reason: updateInfo.updatedReason,
-        status: isNotSubjectToReview ? `Not subject to review` : `Submitted`,
+        status: ConsolidatedContractStatusRecord[contract.consolidatedStatus],
         isEQRO,
+        isCHIPOnly,
         isNotSubjectToReview,
         reviewDecisionText: isNotSubjectToReview
             ? `Not subject to formal review and approval`

--- a/services/app-api/src/emailer/templateHelpers.ts
+++ b/services/app-api/src/emailer/templateHelpers.ts
@@ -574,8 +574,7 @@ const parseEmailDataUndoUnlockContract = (
     )
 
     const isEQRO = contract.contractSubmissionType === 'EQRO'
-    const isCHIPOnly = formData.populationCovered === 'CHIP'
-    contract.reviewStatusActions
+    const isCHIPOnly = !isEQRO && formData.populationCovered === 'CHIP'
     const isNotSubjectToReview =
         (isEQRO &&
             eqroValidationAndReviewDetermination(contract.id, formData) ===
@@ -590,7 +589,9 @@ const parseEmailDataUndoUnlockContract = (
         ),
         updatedBy: updateInfo.updatedBy.email,
         reason: updateInfo.updatedReason,
-        status: ConsolidatedContractStatusRecord[contract.consolidatedStatus],
+        status: isNotSubjectToReview
+            ? ConsolidatedContractStatusRecord['NOT_SUBJECT_TO_REVIEW']
+            : ConsolidatedContractStatusRecord['SUBMITTED'],
         isEQRO,
         isCHIPOnly,
         isNotSubjectToReview,


### PR DESCRIPTION
## Summary
- Updates chip only submissions for undo-unlock (applies to both CMS and state emails)
- Generally updates how we determine status for undo unlock emails. Using actual consolidatedStatus instead of hard coding. 

#### Related issues
[MCR-6517](https://jiraent.cms.gov/browse/MCR-6517)

#### Screenshots
<img width="849" height="355" alt="image" src="https://github.com/user-attachments/assets/2eb286ee-ff3c-4653-8cd7-f7fbf05eab8b" />

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->
Ensures CHIP only email has review decision info. 

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
- Ensure CHIP only contracts have the review decision.
- Update status across all emails to use consolidatedStatus. Make sure this is a reasonable thing to do. (This status should match the status on the dashboard.)
- Validate existing emails don't have unintended changes.

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed