### PR TITLE
Add graphql query to get state user by email

### DIFF
--- a/services/app-api/src/postgres/postgresStore.ts
+++ b/services/app-api/src/postgres/postgresStore.ts
@@ -30,10 +30,14 @@ import type {
     SubmissionHistory,
 } from '../domain-models'
 import { findPrograms, findStatePrograms } from './'
-import type { InsertUserArgsType, UpdateUserInfoArgsType } from './user'
+import type {
+    InsertUserArgsType,
+    UpdateUserInfoArgsType,
+    FindStateUserArgsType,
+} from './user'
 import {
     findUser,
-    findStateUserByEmail,
+    findStateUser,
     insertUser,
     updateCmsUserProperties,
     updateUserInfo,
@@ -180,8 +184,8 @@ type Store = {
     ) => Promise<UserType[] | Error>
     findAllUsers: () => Promise<UserType[] | Error>
     findUser: (id: string) => Promise<UserType | undefined | Error>
-    findStateUserByEmail: (
-        email: string
+    findStateUser: (
+        args: FindStateUserArgsType
     ) => Promise<StateUserType | Error | undefined>
     findStateAssignedUsers: (
         stateCode: StateCodeType
@@ -395,7 +399,7 @@ function NewPostgresStore(client: ExtendedPrismaClient): Store {
         insertManyUsers: (args) => insertManyUsers(client, args),
         findAllUsers: () => findAllUsers(client),
         findUser: (id) => findUser(client, id),
-        findStateUserByEmail: (email) => findStateUserByEmail(client, email),
+        findStateUser: (args) => findStateUser(client, args),
         updateUserInfo: (userID, args) => updateUserInfo(client, userID, args),
         findStateAssignedUsers: (stateCode) =>
             findStateAssignedUsers(client, stateCode),

--- a/services/app-api/src/postgres/postgresStore.ts
+++ b/services/app-api/src/postgres/postgresStore.ts
@@ -33,6 +33,7 @@ import { findPrograms, findStatePrograms } from './'
 import type { InsertUserArgsType, UpdateUserInfoArgsType } from './user'
 import {
     findUser,
+    findStateUserByEmail,
     insertUser,
     updateCmsUserProperties,
     updateUserInfo,
@@ -179,6 +180,9 @@ type Store = {
     ) => Promise<UserType[] | Error>
     findAllUsers: () => Promise<UserType[] | Error>
     findUser: (id: string) => Promise<UserType | undefined | Error>
+    findStateUserByEmail: (
+        email: string
+    ) => Promise<StateUserType | Error | undefined>
     findStateAssignedUsers: (
         stateCode: StateCodeType
     ) => Promise<UserType[] | Error>
@@ -391,6 +395,7 @@ function NewPostgresStore(client: ExtendedPrismaClient): Store {
         insertManyUsers: (args) => insertManyUsers(client, args),
         findAllUsers: () => findAllUsers(client),
         findUser: (id) => findUser(client, id),
+        findStateUserByEmail: (email) => findStateUserByEmail(client, email),
         updateUserInfo: (userID, args) => updateUserInfo(client, userID, args),
         findStateAssignedUsers: (stateCode) =>
             findStateAssignedUsers(client, stateCode),

--- a/services/app-api/src/postgres/user/findStateUser.ts
+++ b/services/app-api/src/postgres/user/findStateUser.ts
@@ -4,16 +4,26 @@ import { includeUsersWithBaseData } from '../contractAndRates/prismaUserHelpers'
 import type { ExtendedPrismaClient } from '../prismaClient'
 import { domainUserFromPrismaUser } from './prismaDomainUser'
 
-export async function findStateUserByEmail(
-    client: ExtendedPrismaClient,
+export type FindStateUserArgsType = {
     email: string
+    givenName: string
+    familyName: string
+}
+
+export async function findStateUser(
+    client: ExtendedPrismaClient,
+    args: FindStateUserArgsType
 ): Promise<StateUserType | Error | undefined> {
+    const { email, givenName, familyName } = args
     try {
-        // email is not unique on the User table
+        // email is not unique on the User table, neither is givenName or familyName
+        // Use all 3 pieces of information to reduce duplicate records from being found
         // If there are duplicates, prefer the newest account
         const result = await client.user.findFirst({
             where: {
-                email: email,
+                email: { equals: email, mode: 'insensitive' },
+                givenName: { equals: givenName, mode: 'insensitive' },
+                familyName: { equals: familyName, mode: 'insensitive' },
                 role: 'STATE_USER',
             },
             include: includeUsersWithBaseData,

--- a/services/app-api/src/postgres/user/findStateUserByEmail.ts
+++ b/services/app-api/src/postgres/user/findStateUserByEmail.ts
@@ -1,0 +1,40 @@
+import { parseErrorToError } from '@mc-review/helpers'
+import type { StateUserType } from '../../domain-models'
+import { includeUsersWithBaseData } from '../contractAndRates/prismaUserHelpers'
+import type { ExtendedPrismaClient } from '../prismaClient'
+import { domainUserFromPrismaUser } from './prismaDomainUser'
+
+export async function findStateUserByEmail(
+    client: ExtendedPrismaClient,
+    email: string
+): Promise<StateUserType | Error | undefined> {
+    try {
+        // email is not unique on the User table
+        // If there are duplicates, prefer the newest account
+        const result = await client.user.findFirst({
+            where: {
+                email: email,
+                role: 'STATE_USER',
+            },
+            include: includeUsersWithBaseData,
+            orderBy: {
+                createdAt: 'desc',
+            },
+        })
+
+        if (!result) {
+            return undefined
+        }
+
+        let domainUserResult = domainUserFromPrismaUser(result)
+
+        if (domainUserResult instanceof Error) {
+            return domainUserResult
+        }
+
+        // The where condition guarantees this
+        return domainUserResult as StateUserType
+    } catch (err) {
+        return parseErrorToError(err)
+    }
+}

--- a/services/app-api/src/postgres/user/index.ts
+++ b/services/app-api/src/postgres/user/index.ts
@@ -1,4 +1,5 @@
 export { findUser } from './findUser'
+export { findStateUserByEmail } from './findStateUserByEmail'
 export type { InsertUserArgsType } from './insertUser'
 export { insertUser } from './insertUser'
 export { insertManyUsers } from './insertManyUsers'

--- a/services/app-api/src/postgres/user/index.ts
+++ b/services/app-api/src/postgres/user/index.ts
@@ -1,5 +1,6 @@
 export { findUser } from './findUser'
-export { findStateUserByEmail } from './findStateUserByEmail'
+export type { FindStateUserArgsType } from './findStateUser'
+export { findStateUser } from './findStateUser'
 export type { InsertUserArgsType } from './insertUser'
 export { insertUser } from './insertUser'
 export { insertManyUsers } from './insertManyUsers'

--- a/services/app-api/src/resolvers/configureResolvers.ts
+++ b/services/app-api/src/resolvers/configureResolvers.ts
@@ -20,6 +20,7 @@ import {
     stateUserResolver,
     cmsUserResolver,
     indexUsersResolver,
+    fetchStateUserResolver,
     cmsApproverUserResolver,
     updateStateAssignment,
 } from './user'
@@ -99,6 +100,7 @@ export function configureResolvers(
             indexContracts: indexContractsResolver(store, launchDarkly),
             indexContractsStripped: indexContractsStripped(store),
             indexUsers: indexUsersResolver(store),
+            fetchStateUser: fetchStateUserResolver(store),
             fetchMcReviewSettings: fetchMcReviewSettings(store, emailer),
             // Rates refactor
             indexRates: indexRatesResolver(store),

--- a/services/app-api/src/resolvers/user/fetchStateUser.test.ts
+++ b/services/app-api/src/resolvers/user/fetchStateUser.test.ts
@@ -56,7 +56,11 @@ describe('fetchStateUser', () => {
         const res = await executeGraphQLOperation(server, {
             query: FetchStateUserDocument,
             variables: {
-                input: { email: stateUserToInsert.email },
+                input: {
+                    email: stateUserToInsert.email,
+                    givenName: stateUserToInsert.givenName,
+                    familyName: stateUserToInsert.familyName,
+                },
             },
         })
 
@@ -75,7 +79,7 @@ describe('fetchStateUser', () => {
         expect(user.state.code).toBe(stateUserToInsert.stateCode)
     })
 
-    it('returns the most recent created user if email is found multiple times', async () => {
+    it('returns the most recent created user if multiple records are found', async () => {
         const { postgresStore, stateUserToInsert } = await insertTestUsers()
 
         const newerUser = await postgresStore.insertUser({
@@ -96,7 +100,11 @@ describe('fetchStateUser', () => {
         const res = await executeGraphQLOperation(server, {
             query: FetchStateUserDocument,
             variables: {
-                input: { email: stateUserToInsert.email },
+                input: {
+                    email: stateUserToInsert.email,
+                    givenName: stateUserToInsert.givenName,
+                    familyName: stateUserToInsert.familyName,
+                },
             },
         })
 

--- a/services/app-api/src/resolvers/user/fetchStateUser.test.ts
+++ b/services/app-api/src/resolvers/user/fetchStateUser.test.ts
@@ -1,0 +1,106 @@
+import { v4 as uuidv4 } from 'uuid'
+import { sharedTestPrismaClient } from '../../testHelpers/storeHelpers'
+import type { InsertUserArgsType } from '../../postgres'
+import { NewPostgresStore } from '../../postgres'
+import {
+    constructTestPostgresServer,
+    executeGraphQLOperation,
+} from '../../testHelpers/gqlHelpers'
+import { testAdminUser } from '../../testHelpers/userHelpers'
+import { FetchStateUserDocument } from '../../gen/gqlClient'
+
+describe('fetchStateUser', () => {
+    const insertTestUsers = async () => {
+        const prismaClient = await sharedTestPrismaClient()
+        const postgresStore = NewPostgresStore(prismaClient)
+
+        const stateUserToInsert: InsertUserArgsType = {
+            userID: uuidv4(),
+            role: 'STATE_USER',
+            givenName: 'Aang',
+            familyName: 'Avatar',
+            email: `aang+${uuidv4()}@example.com`,
+            stateCode: 'VA',
+        }
+
+        const cmsUserToInsert: InsertUserArgsType = {
+            userID: uuidv4(),
+            role: 'CMS_USER',
+            givenName: 'Zuko',
+            familyName: 'Firebender',
+            email: `zuko+${uuidv4()}@example.com`,
+        }
+
+        const newUsers = await postgresStore.insertManyUsers([
+            stateUserToInsert,
+            cmsUserToInsert,
+        ])
+
+        if (newUsers instanceof Error) {
+            throw newUsers
+        }
+
+        return { postgresStore, stateUserToInsert, cmsUserToInsert }
+    }
+
+    it('returns the state user matching the given email', async () => {
+        const { postgresStore, stateUserToInsert } = await insertTestUsers()
+
+        const server = await constructTestPostgresServer({
+            store: postgresStore,
+            context: {
+                user: testAdminUser(),
+            },
+        })
+
+        const res = await executeGraphQLOperation(server, {
+            query: FetchStateUserDocument,
+            variables: {
+                input: { email: stateUserToInsert.email },
+            },
+        })
+
+        expect(res.errors).toBeUndefined()
+
+        const user = res.data?.fetchStateUser.user
+        expect(user).toEqual(
+            expect.objectContaining({
+                id: stateUserToInsert.userID,
+                role: 'STATE_USER',
+                email: stateUserToInsert.email,
+                givenName: stateUserToInsert.givenName,
+                familyName: stateUserToInsert.familyName,
+            })
+        )
+        expect(user.state.code).toBe(stateUserToInsert.stateCode)
+    })
+
+    it('returns the most recent created user if email is found multiple times', async () => {
+        const { postgresStore, stateUserToInsert } = await insertTestUsers()
+
+        const newerUser = await postgresStore.insertUser({
+            ...stateUserToInsert,
+            userID: uuidv4(),
+        })
+        if (newerUser instanceof Error) {
+            throw newerUser
+        }
+
+        const server = await constructTestPostgresServer({
+            store: postgresStore,
+            context: {
+                user: testAdminUser(),
+            },
+        })
+
+        const res = await executeGraphQLOperation(server, {
+            query: FetchStateUserDocument,
+            variables: {
+                input: { email: stateUserToInsert.email },
+            },
+        })
+
+        expect(res.errors).toBeUndefined()
+        expect(res.data?.fetchStateUser.user.id).toBe(newerUser.id)
+    })
+})

--- a/services/app-api/src/resolvers/user/fetchStateUser.ts
+++ b/services/app-api/src/resolvers/user/fetchStateUser.ts
@@ -1,0 +1,59 @@
+import { GraphQLError } from 'graphql/error'
+import { hasReadPermissions } from '../../domain-models'
+import type { QueryResolvers } from '../../gen/gqlServer'
+import { logResolverError, logResolverSuccess } from '../../logger'
+import { canRead } from '../../oauth/oauthAuthorization'
+import type { Store } from '../../postgres'
+import { setResolverDetails, withResolverSpan } from '../attributeHelper'
+import { createForbiddenError, createNotFoundError } from '../errorUtils'
+
+export function fetchStateUserResolver(
+    store: Store
+): QueryResolvers['fetchStateUser'] {
+    return async (_parent, { input }, context) => {
+        const { user: currentUser } = context
+
+        return withResolverSpan(
+            context,
+            'indexUsers',
+            undefined,
+            async (span) => {
+                setResolverDetails(span, currentUser)
+
+                if (!canRead(context)) {
+                    const errMessage = `OAuth client does not have read permissions`
+                    logResolverError('fetchStateUser', errMessage, context)
+                    throw createForbiddenError(errMessage)
+                }
+
+                if (!hasReadPermissions(currentUser)) {
+                    const errMessage = 'user not authorized to fetch users'
+                    logResolverError('fetchStateUser', errMessage, context)
+                    throw createForbiddenError(errMessage)
+                }
+
+                const findResult = await store.findStateUserByEmail(input.email)
+
+                if (findResult instanceof Error) {
+                    const errMessage = `Error querying state user. ${findResult.message}`
+                    logResolverError('fetchStateUser', errMessage, context)
+                    throw new GraphQLError(errMessage, {
+                        extensions: {
+                            code: 'INTERNAL_SERVER_ERROR',
+                            cause: 'DB_ERROR',
+                        },
+                    })
+                }
+
+                if (findResult === undefined) {
+                    const errMessage = `No state user found with email: ${input.email}`
+                    logResolverError('fetchStateUser', errMessage, context)
+                    throw createNotFoundError(errMessage)
+                }
+
+                logResolverSuccess('fetchStateUser', context)
+                return { user: findResult }
+            }
+        )
+    }
+}

--- a/services/app-api/src/resolvers/user/fetchStateUser.ts
+++ b/services/app-api/src/resolvers/user/fetchStateUser.ts
@@ -32,7 +32,11 @@ export function fetchStateUserResolver(
                     throw createForbiddenError(errMessage)
                 }
 
-                const findResult = await store.findStateUserByEmail(input.email)
+                const findResult = await store.findStateUser({
+                    email: input.email,
+                    givenName: input.givenName,
+                    familyName: input.familyName,
+                })
 
                 if (findResult instanceof Error) {
                     const errMessage = `Error querying state user. ${findResult.message}`
@@ -46,7 +50,7 @@ export function fetchStateUserResolver(
                 }
 
                 if (findResult === undefined) {
-                    const errMessage = `No state user found with email: ${input.email}`
+                    const errMessage = `No state user found with email: ${input.email}, givenName: ${input.givenName}, familyName: ${input.familyName}`
                     logResolverError('fetchStateUser', errMessage, context)
                     throw createNotFoundError(errMessage)
                 }

--- a/services/app-api/src/resolvers/user/index.ts
+++ b/services/app-api/src/resolvers/user/index.ts
@@ -1,5 +1,6 @@
 export { updateDivisionAssignment } from './updateDivisionAssignment'
 export { fetchCurrentUserResolver } from './fetchCurrentUser'
+export { fetchStateUserResolver } from './fetchStateUser'
 export { updateStateAssignment } from './updateStateAssignment'
 export {
     stateUserResolver,

--- a/services/app-api/src/testHelpers/storeHelpers.ts
+++ b/services/app-api/src/testHelpers/storeHelpers.ts
@@ -59,7 +59,7 @@ function mockStoreThatErrors(): Store {
         findUser: async (_ID) => {
             return genericError
         },
-        findStateUserByEmail: async (_email) => {
+        findStateUser: async (_args) => {
             return genericError
         },
         insertUser: async (_args) => {

--- a/services/app-api/src/testHelpers/storeHelpers.ts
+++ b/services/app-api/src/testHelpers/storeHelpers.ts
@@ -59,6 +59,9 @@ function mockStoreThatErrors(): Store {
         findUser: async (_ID) => {
             return genericError
         },
+        findStateUserByEmail: async (_email) => {
+            return genericError
+        },
         insertUser: async (_args) => {
             return genericError
         },

--- a/services/app-graphql/src/queries/fetchStateUser.graphql
+++ b/services/app-graphql/src/queries/fetchStateUser.graphql
@@ -1,0 +1,7 @@
+query fetchStateUser($input: FetchStateUserInput!) {
+    fetchStateUser(input: $input) {
+        user {
+            ...stateUserFragment
+        }
+    }
+}

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -42,8 +42,9 @@ type Query {
     indexUsers: IndexUsersPayload!
 
     """
-    fetchStateUser returns a single StateUser, based on an email address
-    If multiple emails are found, returns the most recent one.
+    fetchStateUser returns a single StateUser, based on an email address, givenName, and familyName
+    Multiple pieces of data are used to reduce the frequency of multiple records being found
+    Returns the most recently created user in instances where multiple records are found
 
     Errors:
     - ForbiddenError: A user who doesn't have permission called this
@@ -1100,6 +1101,8 @@ type IndexUsersPayload {
 
 input FetchStateUserInput {
     email: String!
+    givenName: String!
+    familyName: String!
 }
 
 type FetchStateUserPayload {

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -42,6 +42,16 @@ type Query {
     indexUsers: IndexUsersPayload!
 
     """
+    fetchStateUser returns a single StateUser, based on an email address
+    If multiple emails are found, returns the most recent one.
+
+    Errors:
+    - ForbiddenError: A user who doesn't have permission called this
+    - NotFoundError: No StateUser exists with the given email
+    """
+    fetchStateUser(input: FetchStateUserInput!): FetchStateUserPayload!
+
+    """
     indexRates returns full submitted rates.
     indexRates can be called by CMS, admin users, and state users; also used in link rate dropdown.
     If called by a state user, the response will contain rate data from only their state.
@@ -1086,6 +1096,14 @@ type UserEdge {
 type IndexUsersPayload {
     totalCount: Int
     edges: [UserEdge!]!
+}
+
+input FetchStateUserInput {
+    email: String!
+}
+
+type FetchStateUserPayload {
+    user: StateUser!
 }
 
 input SubmitContractInput {


### PR DESCRIPTION
## Summary
- Adds graphql query to fetch state user based on an email (gets the latest record if there are multiple)
Note: emails aren't unique, but atm they only are duplicated within the same state.

#### Related issues
[MCR-6476](https://jiraent.cms.gov/browse/MCR-6476)

#### Screenshots
<img width="1758" height="1151" alt="Screenshot 2026-08-24 at 6 58 17 PM" src="https://github.com/user-attachments/assets/eeda324a-e673-42b4-8f99-4d4004194457" />



#### Test cases covered

- It only fetches state users
- it fetches the latest record if there are multiple matches

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

Use graphql explorer to test this new query

<!---These are developer instructions on how to test or validate the work -->

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed