### PR TITLE
Update review decision text for undo unlock MCR CHIP only submissions

### DIFF
--- a/services/app-api/src/emailer/emails/undoUnlockContractCMSEmail.test.ts
+++ b/services/app-api/src/emailer/emails/undoUnlockContractCMSEmail.test.ts
@@ -76,7 +76,9 @@ it('has different content for EQRO', async () => {
                 ...emailConfig.dmcoEmails,
                 ...emailConfig.devReviewTeamEmails,
             ]),
-            bodyText: expect.stringContaining('Review decision:'),
+            bodyText: expect.stringContaining(
+                'Review decision: Subject to formal review and approval'
+            ),
         })
     )
     expect(result.bodyText).not.toContain('Rate name:')
@@ -108,5 +110,7 @@ it('CHIP only content is similar to EQRO', async () => {
             `Unexpected error: email template returned an error. ${result.message}`
         )
     }
-    expect(result.bodyText).toContain('Review decision:')
+    expect(result.bodyText).toContain(
+        'Review decision: Not subject to DMCO review and validation'
+    )
 })

--- a/services/app-api/src/emailer/etaTemplates/undoUnlockContractCMSEmail.eta
+++ b/services/app-api/src/emailer/etaTemplates/undoUnlockContractCMSEmail.eta
@@ -4,8 +4,10 @@ CMS undid the unlock on <%= it.packageName %>. The submission returned to its pr
 <b>Updated on:</b> <%= it.updatedAt %><br />
 <b>Reason for undoing the unlock:</b> <%= it.reason %><br />
 <b>Status:</b> <%= it.status %><br />
-<% if (it.isEQRO || it.isCHIPOnly) { %>
+<% if (it.isEQRO) { %>
     <b>Review decision:</b> <%= it.reviewDecisionText %><br />
+<% } else if (it.isCHIPOnly) { %>
+    <b>Review decision:</b> Not subject to DMCO review and validation<br />
 <% } %>
 <% if (it.shouldIncludeRates) { %>
     <% if (it.rateInfos.length > 1) { %>


### PR DESCRIPTION
## Summary
- Updates Review decision text for MCR CHIP only submissions, to better align with the text on the summary page

#### Related issues
[MCR-6528](https://jiraent.cms.gov/browse/MCR-6528)

#### Screenshots
<img width="847" height="491" alt="image" src="https://github.com/user-attachments/assets/257cb0a2-aa64-4615-8bb5-285642d364a4" />


#### Test cases covered

- ensures Review decision text for MCR CHIP only submissions is unique

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
- Create a Health plan that is CHIP only and trigger the undo unlock email. Verify the email contents. 
- Also tests a CHIP only EQRO to ensure that you get the correct email. 

## PR Reminders
- [ ] Updated the API Changelog (if this PR changes the API schema)
- [ ] Checked accessibility with ANDI and Wave tools as needed