### PR TITLE
[MCR-6386] Add a feature flag for the Procurement Attestation approach feature

### DIFF
--- a/packages/common-code/src/featureFlags/flags.ts
+++ b/packages/common-code/src/featureFlags/flags.ts
@@ -119,6 +119,13 @@ const featureFlags = {
         flag: 'revision-history-enhancements',
         defaultValue: false,
     },
+    /**
+     * This flag toggles on or off the procurement attestation feature
+     */
+    PROCUREMENT_ATTESTATION: {
+        flag: 'procurement-attestation',
+        defaultValue: false,
+    },
     // PERMANENT FLAGS for utilities features
     /**
      * This flag toggles the ability for external API users to send write requests.


### PR DESCRIPTION
## Summary
**User Story:**
As a State Portal Engineer, I want the Procurement Attestation Approach feature to be gated behind a feature flag so that we can control the feature code within each environment. 

**Acceptance Criteria:**

- Add a feature flag to LaunchDarkly
- Add the feature flag into the codebase
#### Related issues
[MCR-6386](https://jiraent.cms.gov/browse/MCR-6386)
#### Screenshots
<img width="285" height="582" alt="image" src="https://github.com/user-attachments/assets/d41c450a-750d-4269-a84f-f01b8a4f98dd" />