### PR TITLE
Refactor Cypress feature flag command and remove deprecated code

### DIFF
--- a/docs/technical-design/launch-darkly-testing-approach.md
+++ b/docs/technical-design/launch-darkly-testing-approach.md
@@ -116,7 +116,7 @@ renderWithProviders(
         },
         featureFlags: {
             'rate-edit-unlock': false,
-            '438-attestation': true,
+            dsnp: true,
         },
     }
 )
@@ -210,7 +210,7 @@ The Cypress commands `cy.interceptFeatureFlags` and `cy.stubFeatureFlags` will g
 
 -   #### interceptFeatureFlags
 
-    This command allows you to intercept LD calls and set flag values. It also generates a `featureFlagStore.json` file in `services/cypress/fixtures/stores` with default feature flag values along with any specific values passed in.
+    This command allows you to intercept LD calls and set flag values. Every call creates a complete flag state using values passed in by the test first, then Cypress suite defaults, and finally defaults from `@mc-review/common-code`. Each call writes the resulting complete state to `services/cypress/fixtures/stores/featureFlagStore.json` and uses it for the LaunchDarkly client response.
 
     ```typescript
     //Intercept feature flag with flag values.
@@ -219,13 +219,14 @@ The Cypress commands `cy.interceptFeatureFlags` and `cy.stubFeatureFlags` will g
         'modal-countdown-duration': 3,
     })
 
-    //Intercept feature flag with default flag values.
+    //With no values, use the Cypress suite defaults and then common-code
+    //defaults for flags not configured by Cypress.
     cy.interceptFeatureFlags()
     ```
 
 -   #### stubFeatureFlags
 
-    This command intercepts all of LD api calls and returns our own response. This will remove the need for waiting on actual LaunchDarkly API calls to return. This command is being used on all specs in `beforeEach` to intercept requests on each test, set up default feature flag values in `featureFlagStore.json` and reset the LaunchDarkly feature flag store to default values before each test.
+    This command intercepts all LD API calls and returns our own response. It is used by every spec in `beforeEach` to establish the Cypress suite defaults in `featureFlagStore.json`. A later `interceptFeatureFlags()` call applies the values specified by that test while rebuilding omitted flags from the Cypress suite defaults and common-code defaults.
 
     ```typescript
     describe('rate details', () => {

--- a/services/cypress/README.md
+++ b/services/cypress/README.md
@@ -98,8 +98,6 @@ Using the app to navigate allows us to check a11y without injecting the runtime 
 
 ```typescript
     it('has not a11y errors with submission form and and form erros', () => {
-        // 438-attestation still needs to go through design, there is an a11y violation for links and spacing
-        cy.interceptFeatureFlags({'438-attestation': false})
         cy.logInAsStateUser()
 
         // Inject the axe run-time

--- a/services/cypress/integration/cmsWorkflow/submissionReview.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/submissionReview.spec.ts
@@ -165,7 +165,6 @@ describe('CMS user can view submission', () => {
 
     it('and can approve a submission via releasing it to the state', () => {
         cy.interceptFeatureFlags({
-            '438-attestation': true,
             'hide-supporting-docs-page': true,
             dsnp: true,
         })

--- a/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/services/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -8,7 +8,6 @@ describe('CMS user', () => {
 
     it('can unlock and see state resubmit with child rates', () => {
         cy.interceptFeatureFlags({
-            '438-attestation': true,
             dsnp: true,
             'cms-user-undo-unlock': true,
         })
@@ -261,7 +260,6 @@ describe('CMS user', () => {
     it.only('can unlock and resubmit a linked rate and change history updates', () => {
         // turn on feature flag
         cy.interceptFeatureFlags({
-            '438-attestation': true,
             'hide-supporting-docs-page': true,
             dsnp: true,
             'cms-user-undo-unlock': true,

--- a/services/cypress/integration/stateWorkflow/stateSubmissionForm/accessibility.spec.ts
+++ b/services/cypress/integration/stateWorkflow/stateSubmissionForm/accessibility.spec.ts
@@ -6,8 +6,6 @@ describe('state user in state submission form', () => {
         cy.interceptGraphQL()
     })
     it.only('has no a11y violations on submission form with form input errors', () => {
-        // 438-attestation still needs to go through design, there is an a11y violation for links and spacing
-        cy.interceptFeatureFlags({ '438-attestation': false })
         cy.logInAsStateUser()
 
         // Inject the axe run-time

--- a/services/cypress/integration/stateWorkflow/stateSubmissionForm/rateDetails.spec.ts
+++ b/services/cypress/integration/stateWorkflow/stateSubmissionForm/rateDetails.spec.ts
@@ -4,11 +4,6 @@ describe('rate details', () => {
         cy.interceptGraphQL()
     })
     it('can navigate back and save as draft from rate details page', () => {
-        cy.interceptFeatureFlags({
-            '438-attestation': true,
-            'contact-data-model-update': true,
-        })
-
         cy.logInAsStateUser()
         cy.startNewContractAndRatesSubmission()
 

--- a/services/cypress/integration/stateWorkflow/stateSubmissionForm/submissionForm.spec.ts
+++ b/services/cypress/integration/stateWorkflow/stateSubmissionForm/submissionForm.spec.ts
@@ -6,8 +6,6 @@ describe('state user in health plan submission form', () => {
     it('can navigate forward, back, and save as draft on each form page', () => {
         // goal of this test is to check every single form page and navigation (going backwards, forwards or save as draft with new info)
         cy.interceptFeatureFlags({
-            '438-attestation': true,
-            'contact-data-model-update': true,
             'hide-supporting-docs-page': true,
             dsnp: true,
         })

--- a/services/cypress/support/launchDarklyCommands.ts
+++ b/services/cypress/support/launchDarklyCommands.ts
@@ -9,29 +9,38 @@ import {
 } from '@mc-review/common-code'
 
 /**
- * interceptFeatureFlags sets the flag to what is passed into it and sets other flags to default values.
- * Passing in an empty object will default all flags.
+ * interceptFeatureFlags applies supplied values over the Cypress suite
+ * defaults. Flags without a Cypress default use their defaults from
+ * common-code.
  *
  * The code below was taken from this blog post and modified a bit for our use of Types in feature flags.
  * https://dev.to/muratkeremozcan/effective-test-strategies-for-testing-front-end-applications-using-launchdarkly-feature-flags-and-cypress-part2-testing-2c72#stubbing-a-feature-flag
  *
  */
 
+const cypressFeatureFlagDefaults: FeatureFlagSettings = {
+    'hide-supporting-docs-page': true,
+    dsnp: true,
+    'cms-user-undo-unlock': true,
+    'contact-data-model-update': true,
+}
+
 // Intercepting LD "GET" calls for feature flag values and returns our default flags and values.
 Cypress.Commands.add(
     'interceptFeatureFlags',
     (toggleFlags?: FeatureFlagSettings) => {
-        // Create feature flag object with default values and update values of flags passed in toggleFlags argument.
-        // defaultFeatureFlags contains all valid feature flags along with default values. toggleFlags is restricted to flag's
-        // contained in app-web/src/common-code/featureFlags/flags.ts.
+        // Build the complete LaunchDarkly response from explicit overrides,
+        // Cypress suite defaults, and finally common-code defaults. The
+        // complete object is required by the client SDK and getFeatureFlagStore.
         const featureFlagObject: FeatureFlagSettings = {}
 
         featureFlagKeys.forEach((flagEnum) => {
-            let key: FeatureFlagLDConstant = featureFlags[flagEnum].flag
-            let value =
-                toggleFlags && toggleFlags[key]
-                    ? toggleFlags[key]
-                    : featureFlags[flagEnum].defaultValue
+            const key: FeatureFlagLDConstant = featureFlags[flagEnum].flag
+            const value =
+                toggleFlags?.[key] ??
+                cypressFeatureFlagDefaults[key] ??
+                featureFlags[flagEnum].defaultValue
+
             featureFlagObject[key] = { value }
         })
 
@@ -92,15 +101,10 @@ Cypress.Commands.add('stubFeatureFlags', () => {
     ).as('LDClientStream')
 
     /**
-     * Setting default values for flags for Cypress E2E tests. Only call `interceptFeatureFlags` once.
+     * Setting default values for flags for Cypress E2E tests.
      * Useful if you want default feature flags for tests that are different than default values set in common-code featureFlags
      **/
-    cy.interceptFeatureFlags({
-        '438-attestation': true,
-        'hide-supporting-docs-page': true,
-        dsnp: true,
-        'cms-user-undo-unlock': true,
-    })
+    cy.interceptFeatureFlags(cypressFeatureFlagDefaults)
 })
 
 //Command to get feature flag values from the featureFlagStore.json file.

--- a/services/cypress/support/loginCommands.ts
+++ b/services/cypress/support/loginCommands.ts
@@ -97,7 +97,11 @@ Cypress.Commands.add('logInAsCMSUser', (args) => {
             cy.findByTestId('cms-dashboard-page', { timeout: 10_000 }).should(
                 'exist'
             )
-            cy.findByText(/rate reviews/).should('exist')
+            cy.findByRole('heading', {
+                name: 'Rate reviews',
+                level: 2,
+                timeout: 10_000,
+            }).should('exist')
         } else if (initialURL.match(submissionRateQAPattern)) {
             cy.wait('@fetchRateWithQuestionsQuery', { timeout: 80_000 })
         } else {

--- a/services/cypress/support/stateSubmissionFormCommands.ts
+++ b/services/cypress/support/stateSubmissionFormCommands.ts
@@ -156,15 +156,6 @@ Cypress.Commands.add('fillOutContractActionAndRateCertification', () => {
 })
 Cypress.Commands.add('fillOutBaseContractDetails', () => {
     // Must be on '/submissions/:id/edit/contract-details'
-    // Contract 438 attestation question
-    cy.findByText(
-        'No, the contract does not fully comply with all applicable requirements'
-    ).click()
-
-    cy.findByRole('textbox', {
-        name: 'Provide a brief description of any contractual or operational non-compliance, including regulatory citations and expected timeframe for remediation',
-    }).type('Non compliance explanation - base contract')
-
     cy.findByText('Fully executed').click()
     cy.findAllByLabelText('Start date', { timeout: 2000 })
         .parents()
@@ -301,14 +292,6 @@ Cypress.Commands.add('fillOutEQROContractDetails', () => {
 
 Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
     // Must be on '/submissions/:id/edit/contract-details'
-    // Contract 438 attestation question
-    cy.findByText(
-        'No, the contract does not fully comply with all applicable requirements'
-    ).click()
-    cy.findByRole('textbox', {
-        name: 'Provide a brief description of any contractual or operational non-compliance, including regulatory citations and expected timeframe for remediation',
-    }).type('Non compliance explanation - amendment')
-
     cy.findByText('Unexecuted by some or all parties').click()
 
     cy.findAllByLabelText('Start date', { timeout: 2000 })

--- a/skills/skills-cypress/references/04-launchdarkly.md
+++ b/skills/skills-cypress/references/04-launchdarkly.md
@@ -3,9 +3,11 @@
 LaunchDarkly is handled by request interception plus a test-side JSON store.
 
 Implementation file:
+
 - `services/cypress/support/launchDarklyCommands.ts`
 
 Commands:
+
 - `cy.interceptFeatureFlags(toggleFlags?)`
 - `cy.stubFeatureFlags()`
 - `cy.getFeatureFlagStore(featureFlags?)`
@@ -13,16 +15,27 @@ Commands:
 ## How it works
 
 `interceptFeatureFlags()`:
-- builds a complete feature-flag object from shared feature flag definitions in `@mc-review/common-code`
-- applies any overrides passed by the test
+
+- builds a complete feature-flag object on every call
+- applies overrides passed by the test first
+- uses the Cypress suite defaults for omitted flags configured there
+- falls back to shared defaults from `@mc-review/common-code` for all other flags
+- preserves explicit falsy overrides such as `false`, `0`, and an empty string
 - writes the effective state to `fixtures/stores/featureFlagStore.json`
 - intercepts LaunchDarkly client SDK requests and returns those values
 
 `stubFeatureFlags()`:
+
 - intercepts LaunchDarkly event and streaming requests so the app does not keep talking to LD during tests
-- then calls `interceptFeatureFlags()` with a few suite-level defaults
+- calls `interceptFeatureFlags()` with the suite-level defaults
+
+After `stubFeatureFlags()` establishes the suite defaults, a test can call
+`interceptFeatureFlags()` again to change individual flags. Every call rebuilds
+omitted flags from the Cypress suite defaults and then the defaults in
+`@mc-review/common-code`; it does not depend on state from an earlier call.
 
 `getFeatureFlagStore()`:
+
 - reads `fixtures/stores/featureFlagStore.json`
 - returns all flags or only the selected subset
 
@@ -31,6 +44,7 @@ Commands:
 This setup controls client-side flag values in Cypress, but it does not automatically synchronize server-side LaunchDarkly behavior.
 
 That means a test can end up with:
+
 - client-side flag off via intercept
 - server-side flag still on via backend/default behavior
 
@@ -39,6 +53,7 @@ When a test depends on client and server agreeing on a flag, be explicit about t
 ## Related design doc
 
 Read this with:
+
 - `docs/technical-design/launch-darkly-testing-approach.md`
 
 That document contains the deeper rationale, the client/server desync limitation, and the reason this workspace uses interception plus a JSON store instead of true LaunchDarkly mutation in test runs.


### PR DESCRIPTION
## Summary

This work refactors how the Cypress launch darkly commands store and set feature flags for tests.

- Before:
   - cy.stubFeatureFlags(), sets up the test file to intercept actual feature flag calls from the app and return
      - 1. flags from our flag store
      - 2. apply Cypress test defaults
   - cy.interceptFeatureFlags(), used in the tests to update the feature flags for the specific test
      - This would clear our any defaults for Cypress set in  stubFeatureFlags.
- After:
   - cy.stubFeatureFlags(), sets up the test file to intercept actual feature flag calls from the app and return
      - 1. flags from our flag store
      - 2. apply Cypress test defaults
   - cy.interceptFeatureFlags(), used in the tests to update the feature flags for the specific test
      - [NEW]: Now only updates the flag passed into the argument for command to update, all others remain whatever stubFeatureFlags had set for defaults.
    
The previous behavior of the commands blocked turning on the `contact-model-update` flag in dev. The API uses real feature flags in dev, but Cypress can toggle them dynamically in tests and cannot sync them with the API. This causes API validation issues when the flag is on, but Cypress runs a test with `contact-model-update` off. This in turn causes any PR to fail Cypress tests in CI because of API validations on distinct contact name fields.

So we would have to turn this flag on for all tests. This is when I found the issue with the previous behavior clearing out default Cypress flag values and not retaining default values if they were not passing into interceptFeatureFlags arguments.

It would be good to think about a way to sync the Cypress test flags with the API during these CI runs in the review apps. Out of scope for this PR though.

Other work:
- Fixed a small flaky test on the rate reviews dashboard page
   - Before it was looking for `rate reviews` text on the page, this correlates with the filter text, but what we really want to test is if we are looking at the `Rate reviews` tab.
   - Updated the assertion to look for a H2 element with `Rate reviews` text.
- Removed all `438-attestation` Cypress testing code. This was a field that was implemented but never completed and is no longer required. Future work will remove this field from the codebase

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

- Cypress tests pass in CI.

<!---These are developer instructions on how to test or validate the work -->